### PR TITLE
fix(realtime): clean up failed connections

### DIFF
--- a/.changeset/clean-realtime-connections.md
+++ b/.changeset/clean-realtime-connections.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: clean up failed Realtime connection attempts

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -107,6 +107,30 @@ export class OpenAIRealtimeWebRTC
     (error) => this._onError(error),
   );
 
+  #reportError(error: unknown) {
+    try {
+      this._onError(error);
+    } catch {
+      // Error observers must not interrupt connection state cleanup.
+    }
+  }
+
+  #cleanupFailedConnection(error: unknown) {
+    let cleanupFailed = false;
+    let cleanupError: unknown;
+    try {
+      this.close();
+    } catch (caughtError) {
+      cleanupFailed = true;
+      cleanupError = caughtError;
+    }
+
+    this.#reportError(error);
+    if (cleanupFailed) {
+      this.#reportError(cleanupError);
+    }
+  }
+
   constructor(private readonly options: OpenAIRealtimeWebRTCOptions = {}) {
     if (typeof RTCPeerConnection === 'undefined') {
       throw new Error('WebRTC is not supported in this environment');
@@ -229,6 +253,12 @@ export class OpenAIRealtimeWebRTC
           callId,
         };
         this.emit('connection_change', this.#state.status);
+        if (
+          this.#connectAttemptId !== attemptId ||
+          this.#state.dataChannel !== dataChannel
+        ) {
+          throw new Error('Connection closed before setup completed');
+        }
 
         dataChannel.addEventListener('open', () => {
           if (
@@ -248,15 +278,33 @@ export class OpenAIRealtimeWebRTC
           // Wait for session.updated acknowledgement before resolving connect().
           // Without this, audio can flow to the server before config (instructions,
           // tools, modalities) is applied, causing the server to use defaults.
-          let resolved = false;
+          let settled = false;
           // eslint-disable-next-line prefer-const -- declared before finish() to avoid TDZ if a callback fires synchronously
           let timeoutId: ReturnType<typeof setTimeout> | undefined;
-          const finish = () => {
-            if (resolved) return;
-            resolved = true;
+          const removeConfigAckListeners = () => {
             if (timeoutId !== undefined) clearTimeout(timeoutId);
             dataChannel.removeEventListener('message', onConfigAck);
             dataChannel.removeEventListener('close', onClose);
+          };
+          const fail = (error: unknown) => {
+            if (settled) return;
+            settled = true;
+            removeConfigAckListeners();
+            rejectConnection(error);
+            if (this.#state.dataChannel === dataChannel) {
+              this.#cleanupFailedConnection(error);
+            } else {
+              this.#reportError(error);
+            }
+          };
+          const isActiveConnection = () =>
+            this.#connectAttemptId === attemptId &&
+            this.#state.status === 'connected' &&
+            this.#state.dataChannel === dataChannel &&
+            dataChannel.readyState === 'open';
+          const finish = () => {
+            if (settled) return;
+            removeConfigAckListeners();
             // Reject if the transport was closed/errored while waiting,
             // the dataChannel is no longer open, or a different connection
             // attempt is now active (stale timeout from an earlier connect).
@@ -265,17 +313,10 @@ export class OpenAIRealtimeWebRTC
               this.#state.dataChannel !== dataChannel ||
               dataChannel.readyState !== 'open'
             ) {
-              // Transition to disconnected if this attempt is still the
-              // active one so that callers can retry connect() without
-              // needing to call close() first.
-              if (this.#state.dataChannel === dataChannel) {
-                this.close();
-              }
-              rejectConnection(
-                new Error(
-                  'Connection closed before session config was acknowledged',
-                ),
+              const error = new Error(
+                'Connection closed before session config was acknowledged',
               );
+              fail(error);
               return;
             }
             this.#state = {
@@ -284,8 +325,30 @@ export class OpenAIRealtimeWebRTC
               dataChannel,
               callId,
             };
-            this.emit('connection_change', this.#state.status);
-            this._onOpen();
+            try {
+              this.emit('connection_change', this.#state.status);
+              if (!isActiveConnection()) {
+                fail(
+                  new Error(
+                    'Connection closed before session config was acknowledged',
+                  ),
+                );
+                return;
+              }
+              this._onOpen();
+              if (!isActiveConnection()) {
+                fail(
+                  new Error(
+                    'Connection closed before session config was acknowledged',
+                  ),
+                );
+                return;
+              }
+            } catch (error) {
+              fail(error);
+              return;
+            }
+            settled = true;
             resolveConnection();
           };
           const onConfigAck = (ackEvent: MessageEvent) => {
@@ -298,7 +361,7 @@ export class OpenAIRealtimeWebRTC
             finish();
           };
           timeoutId = setTimeout(() => {
-            if (!resolved) {
+            if (!settled) {
               logger.warn(
                 'Timed out waiting for session.updated ack — resolving connect() anyway',
               );
@@ -312,7 +375,19 @@ export class OpenAIRealtimeWebRTC
           // finish() resolves connect() before _onMessage emits the
           // session.updated event to external listeners.
           dataChannel.addEventListener('message', (event) => {
+            if (
+              this.#connectAttemptId !== attemptId ||
+              this.#state.dataChannel !== dataChannel
+            ) {
+              return;
+            }
             this._onMessage(event);
+            if (
+              this.#connectAttemptId !== attemptId ||
+              this.#state.dataChannel !== dataChannel
+            ) {
+              return;
+            }
             const { data: parsed, isGeneric } = parseRealtimeEvent(event);
             if (!parsed || isGeneric) {
               return;
@@ -341,7 +416,11 @@ export class OpenAIRealtimeWebRTC
             }
           });
 
-          this.updateSessionConfig(userSessionConfig);
+          try {
+            this.updateSessionConfig(userSessionConfig);
+          } catch (error) {
+            fail(error);
+          }
         });
 
         dataChannel.addEventListener('error', (event) => {
@@ -351,9 +430,8 @@ export class OpenAIRealtimeWebRTC
           ) {
             return;
           }
-          this.close();
-          this._onError(event);
           rejectConnection(event);
+          this.#cleanupFailedConnection(event);
         });
 
         // set up audio playback
@@ -420,9 +498,8 @@ export class OpenAIRealtimeWebRTC
 
         await peerConnection.setRemoteDescription(answer);
       } catch (error) {
-        this.close();
-        this._onError(error);
         rejectConnection(error);
+        this.#cleanupFailedConnection(error);
       }
     };
 
@@ -556,30 +633,51 @@ export class OpenAIRealtimeWebRTC
    */
   close() {
     this.#clearPeerConnectionDisconnectedTimeout();
-    this.#responseCreateSequencer.releaseWaiters();
+    const { dataChannel, peerConnection } = this.#state;
+    const shouldNotify = this.#state.status !== 'disconnected';
+    this.#state = {
+      status: 'disconnected',
+      peerConnection: undefined,
+      dataChannel: undefined,
+      callId: undefined,
+    };
+
+    let cleanupError: unknown;
+    const runCleanup = (cleanup: () => void) => {
+      try {
+        cleanup();
+      } catch (error) {
+        cleanupError ??= error;
+      }
+    };
+
+    runCleanup(() => this.#responseCreateSequencer.releaseWaiters());
     this.#cancelOngoingResponse = false;
-    if (this.#state.dataChannel) {
-      this.#state.dataChannel.close();
+    if (dataChannel) {
+      runCleanup(() => dataChannel.close());
     }
 
-    if (this.#state.peerConnection) {
-      const peerConnection = this.#state.peerConnection;
-      peerConnection.onconnectionstatechange = null;
-      peerConnection.getSenders().forEach((sender) => {
-        sender.track?.stop();
+    if (peerConnection) {
+      runCleanup(() => {
+        peerConnection.onconnectionstatechange = null;
       });
-      peerConnection.close();
+      let senders: RTCRtpSender[] = [];
+      runCleanup(() => {
+        senders = peerConnection.getSenders();
+      });
+      for (const sender of senders) {
+        runCleanup(() => sender.track?.stop());
+      }
+      runCleanup(() => peerConnection.close());
     }
 
-    if (this.#state.status !== 'disconnected') {
-      this.#state = {
-        status: 'disconnected',
-        peerConnection: undefined,
-        dataChannel: undefined,
-        callId: undefined,
-      };
-      this.emit('connection_change', this.#state.status);
-      this._onClose();
+    if (shouldNotify) {
+      runCleanup(() => this.emit('connection_change', this.#state.status));
+      runCleanup(() => this._onClose());
+    }
+
+    if (cleanupError) {
+      throw cleanupError;
     }
   }
 

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -231,6 +231,9 @@ export class OpenAIRealtimeWebRTC
         rejectConnection(error);
         return;
       }
+      if (!isActiveAttempt()) {
+        return;
+      }
 
       const isClientKey =
         typeof apiKey === 'string' && apiKey.startsWith('ek_');
@@ -580,6 +583,7 @@ export class OpenAIRealtimeWebRTC
     };
 
     this.#cancelConnectionAttempt = () => {
+      rejectConnection(new Error('Connection closed before setup completed'));
       releaseConnectionAttempt();
     };
     this.#connectPromise = connectionReady.finally(() => {

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -100,6 +100,7 @@ export class OpenAIRealtimeWebRTC
   #cancelOngoingResponse = false;
   #muted = false;
   #connectPromise: Promise<void> | undefined;
+  #cancelConnectionAttempt: (() => void) | undefined;
   #connectAttemptId = 0;
   #peerConnectionDisconnectedTimeout: ReturnType<typeof setTimeout> | undefined;
   #responseCreateSequencer = new ResponseCreateSequencer(
@@ -194,7 +195,8 @@ export class OpenAIRealtimeWebRTC
       return;
     }
 
-    const model = options.model ?? this.currentModel;
+    const previousModel = this.currentModel;
+    const model = options.model ?? previousModel;
     this.currentModel = model;
     const baseUrl = options.url ?? this.#url;
     const attemptId = ++this.#connectAttemptId;
@@ -204,12 +206,28 @@ export class OpenAIRealtimeWebRTC
       resolveConnection = resolve;
       rejectConnection = reject;
     });
+    let shouldRestoreModel = true;
+    const isActiveAttempt = () => this.#connectAttemptId === attemptId;
+    const releaseConnectionAttempt = () => {
+      if (!isActiveAttempt()) {
+        return false;
+      }
+
+      if (shouldRestoreModel) {
+        this.currentModel = previousModel;
+      }
+      this.#connectPromise = undefined;
+      this.#cancelConnectionAttempt = undefined;
+      this.#connectAttemptId += 1;
+      return true;
+    };
 
     const prepareConnection = async () => {
       let apiKey: string | undefined;
       try {
         apiKey = await this._getApiKey(options);
       } catch (error) {
+        releaseConnectionAttempt();
         rejectConnection(error);
         return;
       }
@@ -217,6 +235,7 @@ export class OpenAIRealtimeWebRTC
       const isClientKey =
         typeof apiKey === 'string' && apiKey.startsWith('ek_');
       if (isBrowserEnvironment() && !this.#useInsecureApiKey && !isClientKey) {
+        releaseConnectionAttempt();
         rejectConnection(
           new UserError(
             'Using the WebRTC connection in a browser environment requires an ephemeral client key. If you need to use a regular API key, use the WebSocket transport or set the `useInsecureApiKey` option to true.',
@@ -286,16 +305,29 @@ export class OpenAIRealtimeWebRTC
             dataChannel.removeEventListener('message', onConfigAck);
             dataChannel.removeEventListener('close', onClose);
           };
-          const fail = (error: unknown) => {
+          const fail = (error: unknown, cleanupTransport = true) => {
             if (settled) return;
             settled = true;
             removeConfigAckListeners();
             rejectConnection(error);
-            if (this.#state.dataChannel === dataChannel) {
+            const released = releaseConnectionAttempt();
+            if (
+              cleanupTransport &&
+              released &&
+              this.#state.dataChannel === dataChannel
+            ) {
               this.#cleanupFailedConnection(error);
-            } else {
+            } else if (cleanupTransport) {
               this.#reportError(error);
             }
+          };
+          this.#cancelConnectionAttempt = () => {
+            fail(
+              new Error(
+                'Connection closed before session config was acknowledged',
+              ),
+              false,
+            );
           };
           const isActiveConnection = () =>
             this.#connectAttemptId === attemptId &&
@@ -325,6 +357,9 @@ export class OpenAIRealtimeWebRTC
               dataChannel,
               callId,
             };
+            if (this.#connectAttemptId === attemptId) {
+              this.#connectPromise = undefined;
+            }
             try {
               this.emit('connection_change', this.#state.status);
               if (!isActiveConnection()) {
@@ -347,6 +382,10 @@ export class OpenAIRealtimeWebRTC
             } catch (error) {
               fail(error);
               return;
+            }
+            shouldRestoreModel = false;
+            if (isActiveAttempt()) {
+              this.#cancelConnectionAttempt = undefined;
             }
             settled = true;
             resolveConnection();
@@ -431,6 +470,7 @@ export class OpenAIRealtimeWebRTC
             return;
           }
           rejectConnection(event);
+          releaseConnectionAttempt();
           this.#cleanupFailedConnection(event);
         });
 
@@ -448,12 +488,28 @@ export class OpenAIRealtimeWebRTC
           (await navigator.mediaDevices.getUserMedia({
             audio: true,
           }));
+        if (!isActiveAttempt()) {
+          if (!this.options.mediaStream) {
+            for (const track of stream.getAudioTracks()) {
+              try {
+                track.stop();
+              } catch (error) {
+                this.#reportError(error);
+              }
+            }
+          }
+          return;
+        }
         peerConnection.addTrack(stream.getAudioTracks()[0]);
 
         if (this.options.changePeerConnection) {
           const originalPeerConnection = peerConnection;
-          peerConnection =
+          const changedPeerConnection =
             await this.options.changePeerConnection(peerConnection);
+          if (!isActiveAttempt()) {
+            return;
+          }
+          peerConnection = changedPeerConnection;
           if (originalPeerConnection !== peerConnection) {
             originalPeerConnection.onconnectionstatechange = null;
           }
@@ -462,7 +518,13 @@ export class OpenAIRealtimeWebRTC
         }
 
         const offer = await peerConnection.createOffer();
+        if (!isActiveAttempt()) {
+          return;
+        }
         await peerConnection.setLocalDescription(offer);
+        if (!isActiveAttempt()) {
+          return;
+        }
 
         if (!offer.sdp) {
           throw new Error('Failed to create offer');
@@ -477,12 +539,18 @@ export class OpenAIRealtimeWebRTC
             'X-OpenAI-Agents-SDK': HEADERS['X-OpenAI-Agents-SDK'],
           },
         });
+        if (!isActiveAttempt()) {
+          return;
+        }
 
         if (!sdpResponse.ok) {
           // Without this the error body is passed to setRemoteDescription and
           // surfaces as an opaque "Failed to parse SessionDescription", hiding
           // the real cause (e.g. insufficient_quota, invalid ephemeral key).
           const detail = await readSdpErrorDetail(sdpResponse);
+          if (!isActiveAttempt()) {
+            return;
+          }
           throw new Error(
             `Realtime call request failed with status ${sdpResponse.status}${detail}`,
           );
@@ -491,23 +559,35 @@ export class OpenAIRealtimeWebRTC
         callId = sdpResponse.headers?.get('Location')?.split('/').pop();
         this.#state = { ...this.#state, callId };
 
+        const answerSdp = await sdpResponse.text();
+        if (!isActiveAttempt()) {
+          return;
+        }
         const answer: RTCSessionDescriptionInit = {
           type: 'answer',
-          sdp: await sdpResponse.text(),
+          sdp: answerSdp,
         };
 
         await peerConnection.setRemoteDescription(answer);
       } catch (error) {
         rejectConnection(error);
-        this.#cleanupFailedConnection(error);
+        if (releaseConnectionAttempt()) {
+          this.#cleanupFailedConnection(error);
+        } else {
+          this.#reportError(error);
+        }
       }
     };
 
+    this.#cancelConnectionAttempt = () => {
+      releaseConnectionAttempt();
+    };
     this.#connectPromise = connectionReady.finally(() => {
       // Only clear if this is still the active connection attempt.
       // A newer connect() may have already replaced #connectPromise.
       if (this.#connectAttemptId === attemptId) {
         this.#connectPromise = undefined;
+        this.#cancelConnectionAttempt = undefined;
       }
     });
     void prepareConnection();
@@ -633,6 +713,7 @@ export class OpenAIRealtimeWebRTC
    */
   close() {
     this.#clearPeerConnectionDisconnectedTimeout();
+    this.#cancelConnectionAttempt?.();
     const { dataChannel, peerConnection } = this.#state;
     const shouldNotify = this.#state.status !== 'disconnected';
     this.#state = {

--- a/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
@@ -178,6 +178,16 @@ export class OpenAIRealtimeWebSocket
     this.#defaultUrl = attempt.previousDefaultUrl;
   }
 
+  #releaseConnectionAttempt(attempt: WebSocketConnectionAttempt) {
+    if (this.#connectionAttempt !== attempt) {
+      return false;
+    }
+
+    this.#restoreConnectionConfig(attempt);
+    this.#connectionAttempt = undefined;
+    return true;
+  }
+
   #selectConnectionFailure(
     attempt: WebSocketConnectionAttempt,
     failure: unknown,
@@ -381,9 +391,7 @@ export class OpenAIRealtimeWebSocket
       }
 
       reject(error);
-      if (this.#connectionAttempt === attempt) {
-        this.#restoreConnectionConfig(attempt);
-      }
+      this.#releaseConnectionAttempt(attempt);
       this.#reportError(error);
       try {
         this.#closeWebSocket(ws);
@@ -485,9 +493,7 @@ export class OpenAIRealtimeWebSocket
       if (closedBeforeOpen) {
         reject(new Error('WebSocket closed before the connection was ready.'));
       }
-      if (this.#connectionAttempt === attempt) {
-        this.#restoreConnectionConfig(attempt);
-      }
+      this.#releaseConnectionAttempt(attempt);
       try {
         this.#transitionToDisconnected(ws);
       } catch (cleanupError) {
@@ -587,7 +593,7 @@ export class OpenAIRealtimeWebSocket
         this.#selectConnectionFailure(attempt, error);
         if (this.#connectionAttempt === attempt) {
           const websocket = this.#state.websocket;
-          this.#restoreConnectionConfig(attempt);
+          this.#releaseConnectionAttempt(attempt);
           try {
             this.#closeWebSocket(websocket);
           } catch (cleanupError) {
@@ -649,9 +655,8 @@ export class OpenAIRealtimeWebSocket
   close() {
     const attempt = this.#connectionAttempt;
     if (attempt) {
-      this.#connectionAttempt = undefined;
-      this.#restoreConnectionConfig(attempt);
       const failure = this.#getConnectionFailure(attempt);
+      this.#releaseConnectionAttempt(attempt);
       attempt.rejectSetup?.(failure);
       attempt.rejectCancellation(failure);
     }

--- a/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebsocket.ts
@@ -41,6 +41,18 @@ export interface CreateWebSocketOptions {
   apiKey: string;
 }
 
+type WebSocketConnectionAttempt = {
+  previousModel: OpenAIRealtimeBase['currentModel'];
+  previousApiKey: string | undefined;
+  previousUrl: string | undefined;
+  previousDefaultUrl: string | undefined;
+  cancellationError: Error;
+  failureSelected: boolean;
+  selectedFailure?: unknown;
+  rejectCancellation: (reason?: unknown) => void;
+  rejectSetup?: (reason?: unknown) => void;
+};
+
 /**
  * The options for the OpenAI Realtime WebSocket transport layer.
  */
@@ -105,6 +117,7 @@ export class OpenAIRealtimeWebSocket
   protected _audioLengthMs: number = 0;
   #createWebSocket?: (options: CreateWebSocketOptions) => Promise<WebSocket>;
   #skipOpenEventListeners?: boolean;
+  #connectionAttempt: WebSocketConnectionAttempt | undefined;
   #responseCreateSequencer = new ResponseCreateSequencer(
     (event) => this.#sendEventNow(event),
     (error) => this._onError(error),
@@ -114,6 +127,91 @@ export class OpenAIRealtimeWebSocket
     this._firstAudioTimestamp = undefined;
     this._audioLengthMs = 0;
     this.#currentAudioContentIndex = undefined;
+  }
+
+  #transitionToDisconnected(websocket?: WebSocket) {
+    if (websocket && this.#state.websocket !== websocket) {
+      return;
+    }
+
+    this.#responseCreateSequencer.releaseWaiters();
+    this.#resetAudioPlaybackState();
+
+    if (this.#state.status === 'disconnected') {
+      return;
+    }
+
+    this.#state = {
+      status: 'disconnected',
+      websocket: undefined,
+    };
+
+    let notificationError: unknown;
+    try {
+      this.emit('connection_change', this.#state.status);
+    } catch (error) {
+      notificationError = error;
+    }
+    try {
+      this._onClose();
+    } catch (error) {
+      notificationError ??= error;
+    }
+
+    if (notificationError) {
+      throw notificationError;
+    }
+  }
+
+  #reportError(error: unknown) {
+    try {
+      this._onError(error);
+    } catch {
+      // Error observers must not interrupt connection state cleanup.
+    }
+  }
+
+  #restoreConnectionConfig(attempt: WebSocketConnectionAttempt) {
+    this.currentModel = attempt.previousModel;
+    this.#apiKey = attempt.previousApiKey;
+    this.#url = attempt.previousUrl;
+    this.#defaultUrl = attempt.previousDefaultUrl;
+  }
+
+  #selectConnectionFailure(
+    attempt: WebSocketConnectionAttempt,
+    failure: unknown,
+  ) {
+    if (!attempt.failureSelected) {
+      attempt.failureSelected = true;
+      attempt.selectedFailure = failure;
+    }
+  }
+
+  #getConnectionFailure(attempt: WebSocketConnectionAttempt) {
+    return attempt.failureSelected
+      ? attempt.selectedFailure
+      : attempt.cancellationError;
+  }
+
+  #closeWebSocket(websocket: WebSocket | undefined) {
+    let cleanupError: unknown;
+
+    try {
+      this.#transitionToDisconnected(websocket);
+    } catch (error) {
+      cleanupError = error;
+    }
+
+    try {
+      websocket?.close();
+    } catch (error) {
+      cleanupError ??= error;
+    }
+
+    if (cleanupError) {
+      throw cleanupError;
+    }
   }
 
   constructor(options: OpenAIRealtimeWebSocketOptions = {}) {
@@ -177,10 +275,10 @@ export class OpenAIRealtimeWebSocket
     resolve: (value: void) => void,
     reject: (reason?: any) => void,
     sessionConfig: Partial<RealtimeSessionConfig>,
+    attempt: WebSocketConnectionAttempt,
   ) {
     if (this.#state.websocket) {
-      resolve();
-      return;
+      throw new UserError('WebSocket is already connected or connecting.');
     }
 
     if (!this.#apiKey) {
@@ -225,6 +323,16 @@ export class OpenAIRealtimeWebSocket
 
       ws = new WebSocket(this.#url!, websocketArguments as any);
     }
+
+    if (this.#connectionAttempt !== attempt) {
+      try {
+        ws.close();
+      } catch (cleanupError) {
+        this.#reportError(cleanupError);
+      }
+      throw attempt.cancellationError;
+    }
+
     this.#state = {
       status: 'connecting',
       websocket: ws,
@@ -232,12 +340,32 @@ export class OpenAIRealtimeWebSocket
     this.emit('connection_change', this.#state.status);
 
     const onSocketOpenReady = () => {
+      const isActiveConnection = () =>
+        this.#connectionAttempt === attempt && this.#state.websocket === ws;
+      if (!isActiveConnection()) {
+        return;
+      }
+
       this.#state = {
         status: 'connected',
         websocket: ws,
       };
-      this.emit('connection_change', this.#state.status);
-      this._onOpen();
+
+      try {
+        this.emit('connection_change', this.#state.status);
+        if (!isActiveConnection()) {
+          reject(attempt.cancellationError);
+          return;
+        }
+        this._onOpen();
+        if (!isActiveConnection()) {
+          reject(attempt.cancellationError);
+          return;
+        }
+      } catch (error) {
+        reject(error);
+        return;
+      }
       resolve();
     };
 
@@ -248,17 +376,31 @@ export class OpenAIRealtimeWebSocket
     }
 
     ws.addEventListener('error', (error) => {
-      this._onError(error);
-      this.#state = {
-        status: 'disconnected',
-        websocket: undefined,
-      };
-      this.emit('connection_change', this.#state.status);
+      if (this.#state.websocket !== ws) {
+        return;
+      }
+
       reject(error);
+      if (this.#connectionAttempt === attempt) {
+        this.#restoreConnectionConfig(attempt);
+      }
+      this.#reportError(error);
+      try {
+        this.#closeWebSocket(ws);
+      } catch (cleanupError) {
+        this.#reportError(cleanupError);
+      }
     });
 
     ws.addEventListener('message', (message) => {
+      if (this.#state.websocket !== ws) {
+        return;
+      }
+
       this._onMessage(message);
+      if (this.#state.websocket !== ws) {
+        return;
+      }
       const { data: parsed, isGeneric } = parseRealtimeEvent(message);
       if (!parsed || isGeneric) {
         return;
@@ -335,44 +477,134 @@ export class OpenAIRealtimeWebSocket
     });
 
     ws.addEventListener('close', () => {
-      this.#state = {
-        status: 'disconnected',
-        websocket: undefined,
-      };
-      this.#responseCreateSequencer.releaseWaiters();
-      this.emit('connection_change', this.#state.status);
-      this._onClose();
+      if (this.#state.websocket !== ws) {
+        return;
+      }
+
+      const closedBeforeOpen = this.#state.status === 'connecting';
+      if (closedBeforeOpen) {
+        reject(new Error('WebSocket closed before the connection was ready.'));
+      }
+      if (this.#connectionAttempt === attempt) {
+        this.#restoreConnectionConfig(attempt);
+      }
+      try {
+        this.#transitionToDisconnected(ws);
+      } catch (cleanupError) {
+        this.#reportError(cleanupError);
+      }
     });
   }
 
   async connect(options: RealtimeTransportLayerConnectOptions) {
-    const model = options.model ?? this.currentModel;
-    this.currentModel = model;
-    this.#apiKey = await this._getApiKey(options);
-    const callId = options.callId;
-    let url: string;
-    if (options.url) {
-      url = options.url;
-      this.#defaultUrl = options.url;
-    } else if (callId) {
-      url = `wss://api.openai.com/v1/realtime?call_id=${callId}`;
-    } else if (this.#defaultUrl) {
-      url = this.#defaultUrl;
-    } else {
-      url = `wss://api.openai.com/v1/realtime?model=${this.currentModel}`;
+    if (this.#connectionAttempt || this.#state.status !== 'disconnected') {
+      throw new UserError('WebSocket is already connected or connecting.');
     }
-    this.#url = url;
 
-    const sessionConfig: Partial<RealtimeSessionConfig> = {
-      ...(options.initialSessionConfig || {}),
-      model: this.currentModel,
+    let rejectCancellation!: (reason?: unknown) => void;
+    const cancellation = new Promise<never>((_resolve, reject) => {
+      rejectCancellation = reject;
+    });
+    const attempt: WebSocketConnectionAttempt = {
+      previousModel: this.currentModel,
+      previousApiKey: this.#apiKey,
+      previousUrl: this.#url,
+      previousDefaultUrl: this.#defaultUrl,
+      cancellationError: new Error(
+        'WebSocket connection was closed before setup completed.',
+      ),
+      failureSelected: false,
+      rejectCancellation,
+    };
+    this.#connectionAttempt = attempt;
+
+    const prepareConnection = async () => {
+      try {
+        const model = options.model ?? this.currentModel;
+        this.currentModel = model;
+        const apiKey = await this._getApiKey(options);
+        if (this.#connectionAttempt !== attempt) {
+          throw this.#getConnectionFailure(attempt);
+        }
+        this.#apiKey = apiKey;
+
+        const callId = options.callId;
+        let url: string;
+        if (options.url) {
+          url = options.url;
+          this.#defaultUrl = options.url;
+        } else if (callId) {
+          url = `wss://api.openai.com/v1/realtime?call_id=${callId}`;
+        } else if (this.#defaultUrl) {
+          url = this.#defaultUrl;
+        } else {
+          url = `wss://api.openai.com/v1/realtime?model=${this.currentModel}`;
+        }
+        this.#url = url;
+
+        const sessionConfig: Partial<RealtimeSessionConfig> = {
+          ...(options.initialSessionConfig || {}),
+          model: this.currentModel,
+        };
+
+        await new Promise<void>((resolve, reject) => {
+          const resolveSetup = () => {
+            if (attempt.rejectSetup === rejectSetup) {
+              attempt.rejectSetup = undefined;
+            }
+            resolve();
+          };
+          const rejectSetup = (reason?: unknown) => {
+            this.#selectConnectionFailure(attempt, reason);
+            if (attempt.rejectSetup === rejectSetup) {
+              attempt.rejectSetup = undefined;
+            }
+            reject(reason);
+          };
+          attempt.rejectSetup = rejectSetup;
+          this.#setupWebSocket(
+            resolveSetup,
+            rejectSetup,
+            sessionConfig,
+            attempt,
+          ).catch(rejectSetup);
+        });
+
+        if (
+          this.#connectionAttempt !== attempt ||
+          this.#state.status !== 'connected'
+        ) {
+          throw this.#getConnectionFailure(attempt);
+        }
+        await this.updateSessionConfig(sessionConfig);
+        if (
+          this.#connectionAttempt !== attempt ||
+          this.#state.status !== 'connected'
+        ) {
+          throw this.#getConnectionFailure(attempt);
+        }
+      } catch (error) {
+        this.#selectConnectionFailure(attempt, error);
+        if (this.#connectionAttempt === attempt) {
+          const websocket = this.#state.websocket;
+          this.#restoreConnectionConfig(attempt);
+          try {
+            this.#closeWebSocket(websocket);
+          } catch (cleanupError) {
+            this.#reportError(cleanupError);
+          }
+        }
+        throw this.#getConnectionFailure(attempt);
+      }
     };
 
-    await new Promise<void>((resolve, reject) => {
-      this.#setupWebSocket(resolve, reject, sessionConfig).catch(reject);
-    });
-
-    await this.updateSessionConfig(sessionConfig);
+    try {
+      await Promise.race([prepareConnection(), cancellation]);
+    } finally {
+      if (this.#connectionAttempt === attempt) {
+        this.#connectionAttempt = undefined;
+      }
+    }
   }
 
   /**
@@ -415,12 +647,17 @@ export class OpenAIRealtimeWebSocket
    * This will also reset any internal connection tracking used for interruption handling.
    */
   close() {
-    this.#responseCreateSequencer.releaseWaiters();
-    this.#state.websocket?.close();
-    this.#currentItemId = undefined;
-    this._firstAudioTimestamp = undefined;
-    this._audioLengthMs = 0;
-    this.#currentAudioContentIndex = undefined;
+    const attempt = this.#connectionAttempt;
+    if (attempt) {
+      this.#connectionAttempt = undefined;
+      this.#restoreConnectionConfig(attempt);
+      const failure = this.#getConnectionFailure(attempt);
+      attempt.rejectSetup?.(failure);
+      attempt.rejectCancellation(failure);
+    }
+
+    const websocket = this.#state.websocket;
+    this.#closeWebSocket(websocket);
   }
 
   /**

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -478,6 +478,113 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(rtc.status).toBe('connected');
   });
 
+  it('rejects initial session config send failures and retries', async () => {
+    const setupError = new Error('initial session config send failed');
+    let instanceCount = 0;
+    let failedChannel: FakeRTCDataChannel | undefined;
+
+    class ThrowingSendPeerConnection extends FakeRTCPeerConnection {
+      override createDataChannel(_name: string) {
+        const dataChannel = new FakeRTCDataChannel();
+        lastChannel = dataChannel;
+        instanceCount += 1;
+        if (instanceCount === 1) {
+          failedChannel = dataChannel;
+          dataChannel.send = () => {
+            throw setupError;
+          };
+        }
+        setTimeout(() => {
+          this._simulateStateChange('connected');
+          dataChannel.dispatchEvent(new Event('open'));
+        }, 0);
+        return dataChannel as unknown as RTCDataChannel;
+      }
+    }
+
+    (global as any).RTCPeerConnection = ThrowingSendPeerConnection as any;
+    const rtc = new OpenAIRealtimeWebRTC();
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toBe(setupError);
+    expect(failedChannel?.readyState).toBe('closed');
+    expect(rtc.status).toBe('disconnected');
+
+    await rtc.connect({ apiKey: 'ek_retry' });
+    expect(rtc.status).toBe('connected');
+  });
+
+  it('reports setup failures after transitioning to disconnected', async () => {
+    const setupError = new Error('connection setup failed');
+    const statuses: string[] = [];
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async () => {
+        throw setupError;
+      },
+    });
+    rtc.on('error', () => statuses.push(rtc.status));
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toBe(setupError);
+    expect(statuses).toEqual(['disconnected']);
+  });
+
+  it('rejects and cleans up when a connected-state observer throws', async () => {
+    const rtc = new OpenAIRealtimeWebRTC();
+    const observerError = new Error('connected-state observer failed');
+    let shouldThrow = true;
+    rtc.on('connection_change', (status) => {
+      if (status === 'connected' && shouldThrow) {
+        shouldThrow = false;
+        throw observerError;
+      }
+    });
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toBe(
+      observerError,
+    );
+    expect(rtc.status).toBe('disconnected');
+
+    await rtc.connect({ apiKey: 'ek_retry' });
+    expect(rtc.status).toBe('connected');
+  });
+
+  it('rejects when a connected observer closes the active attempt', async () => {
+    const rtc = new OpenAIRealtimeWebRTC();
+    let shouldClose = true;
+    rtc.on('connected', () => {
+      if (shouldClose) {
+        shouldClose = false;
+        rtc.close();
+      }
+    });
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toThrow(
+      'closed before session config was acknowledged',
+    );
+    expect(rtc.status).toBe('disconnected');
+
+    await rtc.connect({ apiKey: 'ek_retry' });
+    expect(rtc.status).toBe('connected');
+  });
+
+  it('rejects when a connecting observer closes the active attempt', async () => {
+    const rtc = new OpenAIRealtimeWebRTC();
+    let shouldClose = true;
+    rtc.on('connection_change', (status) => {
+      if (status === 'connecting' && shouldClose) {
+        shouldClose = false;
+        rtc.close();
+      }
+    });
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toThrow(
+      'closed before setup completed',
+    );
+    expect(rtc.status).toBe('disconnected');
+
+    await rtc.connect({ apiKey: 'ek_retry' });
+    expect(rtc.status).toBe('connected');
+  });
+
   it('ignores stale data channel errors after a failed connect is retried', async () => {
     let shouldFailConnection = true;
     const rtc = new OpenAIRealtimeWebRTC({
@@ -563,6 +670,77 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(stop).toHaveBeenCalled();
     expect(rtc.status).toBe('disconnected');
     expect(rtc.callId).toBeUndefined();
+  });
+
+  it('preserves setup failure and retries when every cleanup step throws', async () => {
+    const setupError = new Error('connection setup failed');
+    let instanceCount = 0;
+    let dataChannelCloseCalls = 0;
+    let trackStopCalls = 0;
+    let peerConnectionCloseCalls = 0;
+
+    class ThrowingCleanupPeerConnection extends FakeRTCPeerConnection {
+      readonly instance = ++instanceCount;
+
+      override createDataChannel(name: string) {
+        const dataChannel = super.createDataChannel(
+          name,
+        ) as unknown as FakeRTCDataChannel;
+        if (this.instance === 1) {
+          dataChannel.close = () => {
+            dataChannelCloseCalls += 1;
+            throw new Error('data channel close failed');
+          };
+        }
+        return dataChannel as unknown as RTCDataChannel;
+      }
+
+      override getSenders() {
+        if (this.instance !== 1) {
+          return [] as any;
+        }
+        return [
+          {
+            track: {
+              stop: () => {
+                trackStopCalls += 1;
+                throw new Error('track stop failed');
+              },
+            },
+          } as any,
+        ];
+      }
+
+      override close() {
+        peerConnectionCloseCalls += 1;
+        if (this.instance === 1) {
+          throw new Error('peer connection close failed');
+        }
+        super.close();
+      }
+    }
+
+    (global as any).RTCPeerConnection = ThrowingCleanupPeerConnection as any;
+    let failSetup = true;
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async (peerConnection) => {
+        if (failSetup) {
+          failSetup = false;
+          throw setupError;
+        }
+        return peerConnection;
+      },
+    });
+
+    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toBe(setupError);
+    expect(dataChannelCloseCalls).toBe(1);
+    expect(trackStopCalls).toBe(1);
+    expect(peerConnectionCloseCalls).toBe(1);
+    expect(rtc.status).toBe('disconnected');
+    expect(rtc.callId).toBeUndefined();
+
+    await rtc.connect({ apiKey: 'ek_test' });
+    expect(rtc.status).toBe('connected');
   });
 
   it('mute toggles sender tracks', async () => {

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -5,6 +5,7 @@ import { OpenAIRealtimeWebRTC } from '../src/openaiRealtimeWebRtc';
 class FakeRTCDataChannel extends EventTarget {
   sent: string[] = [];
   readyState = 'open';
+  emitCloseOnClose = true;
   send(data: string) {
     this.sent.push(data);
     // Simulate server acking session.update with session.updated
@@ -21,7 +22,9 @@ class FakeRTCDataChannel extends EventTarget {
   }
   close() {
     this.readyState = 'closed';
-    this.dispatchEvent(new Event('close'));
+    if (this.emitCloseOnClose) {
+      this.dispatchEvent(new Event('close'));
+    }
   }
 }
 
@@ -504,13 +507,55 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
 
     (global as any).RTCPeerConnection = ThrowingSendPeerConnection as any;
     const rtc = new OpenAIRealtimeWebRTC();
+    const previousModel = rtc.currentModel;
+    let modelBeforeRetry: string | undefined;
+    let retry: Promise<void> | undefined;
+    rtc.on('connection_change', (status) => {
+      if (status === 'disconnected' && !retry) {
+        modelBeforeRetry = rtc.currentModel;
+        retry = rtc.connect({ apiKey: 'ek_retry' });
+      }
+    });
 
-    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toBe(setupError);
+    await expect(
+      rtc.connect({ apiKey: 'ek_test', model: 'failed-model' }),
+    ).rejects.toBe(setupError);
     expect(failedChannel?.readyState).toBe('closed');
-    expect(rtc.status).toBe('disconnected');
-
-    await rtc.connect({ apiKey: 'ek_retry' });
+    await retry;
+    expect(instanceCount).toBe(2);
+    expect(modelBeforeRetry).toBe(previousModel);
+    expect(rtc.currentModel).toBe(previousModel);
     expect(rtc.status).toBe('connected');
+  });
+
+  it('restores the model when API key resolution fails', async () => {
+    const apiKeyError = new Error('API key resolution failed');
+    const rtc = new OpenAIRealtimeWebRTC();
+    const previousModel = rtc.currentModel;
+
+    await expect(
+      rtc.connect({
+        apiKey: async () => {
+          throw apiKeyError;
+        },
+        model: 'failed-model',
+      }),
+    ).rejects.toBe(apiKeyError);
+
+    expect(rtc.currentModel).toBe(previousModel);
+    await rtc.connect({ apiKey: 'ek_retry' });
+    expect(rtc.currentModel).toBe(previousModel);
+  });
+
+  it('keeps the successful model after a later transport error', async () => {
+    const rtc = new OpenAIRealtimeWebRTC();
+    rtc.on('error', () => {});
+
+    await rtc.connect({ apiKey: 'ek_test', model: 'successful-model' });
+    (lastChannel as FakeRTCDataChannel).dispatchEvent(new Event('error'));
+
+    expect(rtc.status).toBe('disconnected');
+    expect(rtc.currentModel).toBe('successful-model');
   });
 
   it('reports setup failures after transitioning to disconnected', async () => {
@@ -548,21 +593,50 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
   });
 
   it('rejects when a connected observer closes the active attempt', async () => {
+    let peerConnectionCount = 0;
+    class NonEmittingClosePeerConnection extends FakeRTCPeerConnection {
+      constructor() {
+        super();
+        peerConnectionCount += 1;
+      }
+
+      override createDataChannel(name: string) {
+        const dataChannel = super.createDataChannel(
+          name,
+        ) as unknown as FakeRTCDataChannel;
+        if (peerConnectionCount === 1) {
+          dataChannel.emitCloseOnClose = false;
+        }
+        return dataChannel as unknown as RTCDataChannel;
+      }
+    }
+
+    (global as any).RTCPeerConnection = NonEmittingClosePeerConnection as any;
     const rtc = new OpenAIRealtimeWebRTC();
+    const previousModel = rtc.currentModel;
     let shouldClose = true;
+    let modelBeforeRetry: string | undefined;
+    let retry: Promise<void> | undefined;
     rtc.on('connected', () => {
       if (shouldClose) {
         shouldClose = false;
         rtc.close();
       }
     });
+    rtc.on('connection_change', (status) => {
+      if (status === 'disconnected' && !retry) {
+        modelBeforeRetry = rtc.currentModel;
+        retry = rtc.connect({ apiKey: 'ek_retry' });
+      }
+    });
 
-    await expect(rtc.connect({ apiKey: 'ek_test' })).rejects.toThrow(
-      'closed before session config was acknowledged',
-    );
-    expect(rtc.status).toBe('disconnected');
-
-    await rtc.connect({ apiKey: 'ek_retry' });
+    await expect(
+      rtc.connect({ apiKey: 'ek_test', model: 'failed-model' }),
+    ).rejects.toThrow('closed before session config was acknowledged');
+    await retry;
+    expect(peerConnectionCount).toBe(2);
+    expect(modelBeforeRetry).toBe(previousModel);
+    expect(rtc.currentModel).toBe(previousModel);
     expect(rtc.status).toBe('connected');
   });
 
@@ -611,6 +685,88 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
 
     expect(rtc.status).toBe('connected');
     expect(rtc.connectionState.dataChannel).toBe(survivingChannel);
+  });
+
+  it('does not let abandoned preparation close a retry', async () => {
+    const replacement = createDeferred<RTCPeerConnection>();
+    const changeStarted = createDeferred<void>();
+    const lateError = new Error('abandoned preparation failed');
+    let changeCalls = 0;
+    let retry: Promise<void> | undefined;
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async (peerConnection) => {
+        changeCalls += 1;
+        if (changeCalls === 1) {
+          changeStarted.resolve();
+          return replacement.promise;
+        }
+        return peerConnection;
+      },
+    });
+    rtc.on('connection_change', (status) => {
+      if (status === 'disconnected' && !retry) {
+        retry = rtc.connect({ apiKey: 'ek_retry' });
+      }
+    });
+
+    const firstConnect = rtc.connect({ apiKey: 'ek_test' });
+    const failedConnect = expect(firstConnect).rejects.toBeInstanceOf(Event);
+    await changeStarted.promise;
+    const failedChannel = lastChannel as FakeRTCDataChannel;
+    failedChannel.dispatchEvent(new Event('error'));
+    await failedConnect;
+
+    replacement.reject(lateError);
+    await Promise.resolve();
+    await Promise.resolve();
+    await retry;
+
+    expect(changeCalls).toBe(2);
+    expect(rtc.status).toBe('connected');
+    expect(rtc.connectionState.dataChannel).not.toBe(failedChannel);
+  });
+
+  it('does not close a shared peer returned by abandoned preparation', async () => {
+    const firstReplacement = createDeferred<RTCPeerConnection>();
+    const changeStarted = createDeferred<void>();
+    const sharedPeerConnection = new FakeRTCPeerConnection();
+    const closeSharedPeer = vi.spyOn(sharedPeerConnection, 'close');
+    let changeCalls = 0;
+    let retry: Promise<void> | undefined;
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async () => {
+        changeCalls += 1;
+        if (changeCalls === 1) {
+          changeStarted.resolve();
+          return firstReplacement.promise;
+        }
+        return sharedPeerConnection as unknown as RTCPeerConnection;
+      },
+    });
+    rtc.on('connection_change', (status) => {
+      if (status === 'disconnected' && !retry) {
+        retry = rtc.connect({ apiKey: 'ek_retry' });
+      }
+    });
+
+    const firstConnect = rtc.connect({ apiKey: 'ek_test' });
+    const failedConnect = expect(firstConnect).rejects.toBeInstanceOf(Event);
+    await changeStarted.promise;
+    const failedChannel = lastChannel as FakeRTCDataChannel;
+    failedChannel.dispatchEvent(new Event('error'));
+    await failedConnect;
+    await retry;
+
+    firstReplacement.resolve(
+      sharedPeerConnection as unknown as RTCPeerConnection,
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(changeCalls).toBe(2);
+    expect(rtc.status).toBe('connected');
+    expect(rtc.connectionState.peerConnection).toBe(sharedPeerConnection);
+    expect(closeSharedPeer).not.toHaveBeenCalled();
   });
 
   it('resets state on connection failure', async () => {
@@ -1051,12 +1207,15 @@ describe('OpenAIRealtimeWebRTC session.updated ack', () => {
   class NoAckRTCDataChannel extends EventTarget {
     sent: string[] = [];
     readyState = 'open';
+    emitCloseOnClose = true;
     send(data: string) {
       this.sent.push(data);
     }
     close() {
       this.readyState = 'closed';
-      this.dispatchEvent(new Event('close'));
+      if (this.emitCloseOnClose) {
+        this.dispatchEvent(new Event('close'));
+      }
     }
   }
 
@@ -1227,8 +1386,20 @@ describe('OpenAIRealtimeWebRTC session.updated ack', () => {
 
   it('rejects connect() when close() is called during ack wait', async () => {
     const rtc = new OpenAIRealtimeWebRTC();
+    const previousModel = rtc.currentModel;
     rtc.on('error', () => {});
-    const connectPromise = rtc.connect({ apiKey: 'ek_test' });
+    let modelBeforeRetry: string | undefined;
+    let retry: Promise<void> | undefined;
+    rtc.on('connection_change', (status) => {
+      if (status === 'disconnected' && !retry) {
+        modelBeforeRetry = rtc.currentModel;
+        retry = rtc.connect({ apiKey: 'ek_retry' });
+      }
+    });
+    const connectPromise = rtc.connect({
+      apiKey: 'ek_test',
+      model: 'failed-model',
+    });
 
     // Attach rejection handler before advancing timers to avoid unhandled rejection
     const rejection = expect(connectPromise).rejects.toThrow(
@@ -1237,15 +1408,27 @@ describe('OpenAIRealtimeWebRTC session.updated ack', () => {
 
     // Flush microtasks so the data channel 'open' fires
     await vi.advanceTimersByTimeAsync(0);
+    const failedChannel = noAckChannel!;
+    failedChannel.emitCloseOnClose = false;
 
-    // close() while waiting for session.updated ack — the dataChannel 'close'
-    // event triggers immediate rejection instead of waiting for the 5s timeout
+    // close() while waiting for session.updated ack without relying on a
+    // synchronous dataChannel close event.
     rtc.close();
 
-    // Flush microtasks
+    expect(modelBeforeRetry).toBe(previousModel);
+
+    // Flush microtasks so the retry creates and opens a fresh data channel.
     await vi.advanceTimersByTimeAsync(0);
+    expect(noAckChannel).not.toBe(failedChannel);
+    noAckChannel!.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({ type: 'session.updated', session: {} }),
+      }),
+    );
 
     await rejection;
-    expect(rtc.status).toBe('disconnected');
+    await retry;
+    expect(rtc.currentModel).toBe(previousModel);
+    expect(rtc.status).toBe('connected');
   });
 });

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -481,6 +481,38 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(rtc.status).toBe('connected');
   });
 
+  it('rejects close while API key resolution is pending', async () => {
+    const apiKey = createDeferred<string>();
+    let peerConnectionCount = 0;
+
+    class CountingPeerConnection extends FakeRTCPeerConnection {
+      constructor() {
+        super();
+        peerConnectionCount += 1;
+      }
+    }
+
+    (global as any).RTCPeerConnection = CountingPeerConnection as any;
+    const rtc = new OpenAIRealtimeWebRTC();
+    const connectPromise = rtc.connect({
+      apiKey: () => apiKey.promise,
+      model: 'failed-model',
+    });
+    const rejection = expect(connectPromise).rejects.toThrow(
+      'Connection closed before setup completed',
+    );
+
+    rtc.close();
+
+    await rejection;
+    const retry = rtc.connect({ apiKey: 'ek_retry' });
+    apiKey.resolve('ek_late');
+    await retry;
+
+    expect(peerConnectionCount).toBe(1);
+    expect(rtc.status).toBe('connected');
+  });
+
   it('rejects initial session config send failures and retries', async () => {
     const setupError = new Error('initial session config send failed');
     let instanceCount = 0;
@@ -724,6 +756,41 @@ describe('OpenAIRealtimeWebRTC.interrupt', () => {
     expect(changeCalls).toBe(2);
     expect(rtc.status).toBe('connected');
     expect(rtc.connectionState.dataChannel).not.toBe(failedChannel);
+  });
+
+  it('rejects close while peer replacement is pending', async () => {
+    const replacement = createDeferred<RTCPeerConnection>();
+    const changeStarted = createDeferred<void>();
+    let changeCalls = 0;
+    const rtc = new OpenAIRealtimeWebRTC({
+      changePeerConnection: async (peerConnection) => {
+        changeCalls += 1;
+        if (changeCalls === 1) {
+          changeStarted.resolve();
+          return replacement.promise;
+        }
+        return peerConnection;
+      },
+    });
+    const connectPromise = rtc.connect({ apiKey: 'ek_test' });
+    const rejection = expect(connectPromise).rejects.toThrow(
+      'Connection closed before setup completed',
+    );
+    await changeStarted.promise;
+    const failedChannel = lastChannel as FakeRTCDataChannel;
+
+    rtc.close();
+
+    await rejection;
+    expect(failedChannel.readyState).toBe('closed');
+    const retry = rtc.connect({ apiKey: 'ek_retry' });
+    replacement.resolve(
+      new FakeRTCPeerConnection() as unknown as RTCPeerConnection,
+    );
+    await retry;
+
+    expect(changeCalls).toBe(2);
+    expect(rtc.status).toBe('connected');
   });
 
   it('does not close a shared peer returned by abandoned preparation', async () => {

--- a/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
@@ -323,7 +323,6 @@ describe('OpenAIRealtimeWebSocket', () => {
     let retry: Promise<void> | undefined;
     ws.on('connection_change', (status) => {
       if (status === 'disconnected' && !retry) {
-        ws.close();
         retry = ws.connect({ apiKey: 'ek_retry' });
       }
     });

--- a/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebsocket.test.ts
@@ -5,6 +5,15 @@ import { OpenAIRealtimeSIP } from '../src/openaiRealtimeSip';
 import { RealtimeAgent } from '../src/realtimeAgent';
 
 let lastFakeSocket: any;
+let fakeSockets: any[] = [];
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
 
 function sentPayloads() {
   return (lastFakeSocket?.sent ?? []).map((payload: string) =>
@@ -18,10 +27,15 @@ vi.mock('ws', () => {
       url: string;
       listeners: Record<string, ((ev: any) => void)[]> = {};
       sent: any[] = [];
+      closeCalls = 0;
+      closeError: Error | undefined;
+      emitCloseOnClose = true;
+      sendHook: (() => void) | undefined;
       constructor(url: string, _args?: any) {
         this.url = url;
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         lastFakeSocket = this;
+        fakeSockets.push(this);
         setTimeout(() => this.emit('open', {}));
       }
       addEventListener(type: string, listener: (ev: any) => void) {
@@ -30,9 +44,16 @@ vi.mock('ws', () => {
       }
       send(data: any) {
         this.sent.push(data);
+        this.sendHook?.();
       }
       close() {
-        this.emit('close', {});
+        this.closeCalls += 1;
+        if (this.closeError) {
+          throw this.closeError;
+        }
+        if (this.emitCloseOnClose) {
+          this.emit('close', {});
+        }
       }
       emit(type: string, ev: any) {
         (this.listeners[type] || []).forEach((fn) => fn(ev));
@@ -46,6 +67,7 @@ describe('OpenAIRealtimeWebSocket', () => {
     vi.useFakeTimers();
     vi.restoreAllMocks();
     lastFakeSocket = undefined;
+    fakeSockets = [];
   });
 
   afterEach(() => {
@@ -65,6 +87,457 @@ describe('OpenAIRealtimeWebSocket', () => {
     await vi.runAllTimersAsync();
     await p;
     expect(statuses).toEqual(['connecting', 'connected']);
+  });
+
+  it('rejects and cleans up when a connected-state observer throws', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const observerError = new Error('connected-state observer failed');
+    let shouldThrow = true;
+    ws.on('connection_change', (status) => {
+      if (status === 'connected' && shouldThrow) {
+        shouldThrow = false;
+        throw observerError;
+      }
+    });
+
+    const failedConnect = expect(
+      ws.connect({ apiKey: 'ek_test', model: 'first-model' }),
+    ).rejects.toBe(observerError);
+    await vi.runAllTimersAsync();
+    await failedConnect;
+
+    expect(fakeSockets[0].closeCalls).toBe(1);
+    expect(ws.status).toBe('disconnected');
+
+    const retry = ws.connect({ apiKey: 'ek_retry', model: 'retry-model' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+  });
+
+  it('rejects when a connected observer closes the active attempt', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    let shouldClose = true;
+    ws.on('connected', () => {
+      if (shouldClose) {
+        shouldClose = false;
+        ws.close();
+      }
+    });
+
+    const failedConnect = expect(
+      ws.connect({ apiKey: 'ek_test', model: 'first-model' }),
+    ).rejects.toThrow('closed before setup completed');
+    await vi.runAllTimersAsync();
+    await failedConnect;
+    expect(ws.status).toBe('disconnected');
+
+    const retry = ws.connect({ apiKey: 'ek_retry', model: 'retry-model' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+  });
+
+  it('attempts both disconnection notifications when the first throws', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const notificationError = new Error('connection change failed');
+    const disconnected = vi.fn();
+    ws.on('disconnected', disconnected);
+    ws.on('connection_change', (status) => {
+      if (status === 'disconnected') {
+        throw notificationError;
+      }
+    });
+
+    const connect = ws.connect({ apiKey: 'ek_test', model: 'first-model' });
+    await vi.runAllTimersAsync();
+    await connect;
+
+    expect(() => ws.close()).toThrow(notificationError);
+    expect(disconnected).toHaveBeenCalledOnce();
+    expect(ws.status).toBe('disconnected');
+    expect(fakeSockets[0].closeCalls).toBe(1);
+  });
+
+  it('cleans up failed session setup and restores connection options for retry', async () => {
+    const ws = new OpenAIRealtimeWebSocket({ model: 'initial-model' });
+    const setupError = new Error('session setup failed');
+    vi.spyOn(ws, 'updateSessionConfig').mockImplementationOnce(() => {
+      throw setupError;
+    });
+
+    const failedConnect = expect(
+      ws.connect({
+        apiKey: 'ek_test',
+        model: 'failed-model',
+        url: 'ws://failed-attempt',
+      }),
+    ).rejects.toBe(setupError);
+    await vi.runAllTimersAsync();
+    await failedConnect;
+
+    const failedSocket = fakeSockets[0];
+    expect(failedSocket.closeCalls).toBe(1);
+    expect(ws.status).toBe('disconnected');
+    expect(ws.currentModel).toBe('initial-model');
+
+    const retry = ws.connect({ apiKey: 'ek_test' });
+    await vi.runAllTimersAsync();
+    await retry;
+
+    expect(fakeSockets).toHaveLength(2);
+    expect(lastFakeSocket.url).toBe(
+      'wss://api.openai.com/v1/realtime?model=initial-model',
+    );
+    expect(ws.status).toBe('connected');
+  });
+
+  it('preserves the setup error when failed connection cleanup throws', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const setupError = new Error('session setup failed');
+    const cleanupError = new Error('socket close failed');
+    const errors: unknown[] = [];
+    ws.on('error', (event) => errors.push(event.error));
+    ws.on('error', () => {
+      throw new Error('cleanup error listener failed');
+    });
+    vi.spyOn(ws, 'updateSessionConfig').mockImplementationOnce(() => {
+      lastFakeSocket.closeError = cleanupError;
+      throw setupError;
+    });
+
+    const failedConnect = expect(
+      ws.connect({ apiKey: 'ek_test', model: 'failed-model' }),
+    ).rejects.toBe(setupError);
+    await vi.runAllTimersAsync();
+    await failedConnect;
+
+    expect(fakeSockets[0].closeCalls).toBe(1);
+    expect(errors).toContain(cleanupError);
+    expect(ws.status).toBe('disconnected');
+
+    const retry = ws.connect({ apiKey: 'ek_test' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+  });
+
+  it('preserves the setup error when cleanup observers close again', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const setupError = new Error('session setup failed');
+    let closeAgain = true;
+    ws.on('connection_change', (status) => {
+      if (status === 'disconnected' && closeAgain) {
+        closeAgain = false;
+        ws.close();
+      }
+    });
+    vi.spyOn(ws, 'updateSessionConfig').mockImplementationOnce(() => {
+      throw setupError;
+    });
+
+    const failedConnect = expect(
+      ws.connect({ apiKey: 'ek_test', model: 'failed-model' }),
+    ).rejects.toBe(setupError);
+    await vi.runAllTimersAsync();
+    await failedConnect;
+
+    expect(ws.status).toBe('disconnected');
+
+    const retry = ws.connect({ apiKey: 'ek_retry', model: 'retry-model' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+  });
+
+  it.each([undefined, null])(
+    'preserves a %s setup failure when cleanup observers close again',
+    async (setupFailure) => {
+      const ws = new OpenAIRealtimeWebSocket();
+      let closeAgain = true;
+      ws.on('connection_change', (status) => {
+        if (status === 'disconnected' && closeAgain) {
+          closeAgain = false;
+          ws.close();
+        }
+      });
+      vi.spyOn(ws, 'updateSessionConfig').mockImplementationOnce(() => {
+        throw setupFailure;
+      });
+
+      const result = ws
+        .connect({ apiKey: 'ek_test', model: 'failed-model' })
+        .then(
+          () => ({ rejected: false, error: undefined }),
+          (error) => ({ rejected: true, error }),
+        );
+      await vi.runAllTimersAsync();
+
+      await expect(result).resolves.toEqual({
+        rejected: true,
+        error: setupFailure,
+      });
+      expect(ws.status).toBe('disconnected');
+    },
+  );
+
+  it('does not roll back a retry started by a cleanup observer', async () => {
+    const ws = new OpenAIRealtimeWebSocket({ model: 'initial-model' });
+    const setupError = new Error('session setup failed');
+    let retry: Promise<void> | undefined;
+    ws.on('connection_change', (status) => {
+      if (status === 'disconnected' && !retry) {
+        ws.close();
+        retry = ws.connect({
+          apiKey: 'ek_retry',
+          model: 'retry-model',
+        });
+      }
+    });
+    vi.spyOn(ws, 'updateSessionConfig').mockImplementationOnce(() => {
+      throw setupError;
+    });
+
+    const failedConnect = expect(
+      ws.connect({ apiKey: 'ek_test', model: 'failed-model' }),
+    ).rejects.toBe(setupError);
+    await vi.runAllTimersAsync();
+    await failedConnect;
+    await retry;
+
+    expect(fakeSockets).toHaveLength(2);
+    expect(fakeSockets[1].url).toBe(
+      'wss://api.openai.com/v1/realtime?model=retry-model',
+    );
+    expect(JSON.parse(fakeSockets[1].sent[0])).toMatchObject({
+      type: 'session.update',
+      session: { model: 'retry-model' },
+    });
+    expect(ws.currentModel).toBe('retry-model');
+    expect(ws.status).toBe('connected');
+  });
+
+  it('restores connection defaults before a cleanup observer retries', async () => {
+    const ws = new OpenAIRealtimeWebSocket({ model: 'initial-model' });
+    const setupError = new Error('session setup failed');
+    let retry: Promise<void> | undefined;
+    ws.on('connection_change', (status) => {
+      if (status === 'disconnected' && !retry) {
+        ws.close();
+        retry = ws.connect({ apiKey: 'ek_retry' });
+      }
+    });
+    vi.spyOn(ws, 'updateSessionConfig').mockImplementationOnce(() => {
+      throw setupError;
+    });
+
+    const failedConnect = expect(
+      ws.connect({
+        apiKey: 'ek_test',
+        model: 'failed-model',
+        url: 'ws://failed-attempt',
+      }),
+    ).rejects.toBe(setupError);
+    await vi.runAllTimersAsync();
+    await failedConnect;
+    await retry;
+
+    expect(fakeSockets).toHaveLength(2);
+    expect(fakeSockets[1].url).toBe(
+      'wss://api.openai.com/v1/realtime?model=initial-model',
+    );
+    expect(JSON.parse(fakeSockets[1].sent[0])).toMatchObject({
+      type: 'session.update',
+      session: { model: 'initial-model' },
+    });
+    expect(ws.currentModel).toBe('initial-model');
+    expect(ws.status).toBe('connected');
+  });
+
+  it('rejects overlapping connection attempts before opening another socket', async () => {
+    const apiKey = createDeferred<string>();
+    const ws = new OpenAIRealtimeWebSocket();
+    const firstConnect = ws.connect({
+      apiKey: () => apiKey.promise,
+      model: 'first-model',
+    });
+
+    await expect(
+      ws.connect({ apiKey: 'ek_second', model: 'second-model' }),
+    ).rejects.toThrow('already connected or connecting');
+    expect(fakeSockets).toHaveLength(0);
+
+    apiKey.resolve('ek_first');
+    await vi.runAllTimersAsync();
+    await firstConnect;
+
+    expect(fakeSockets).toHaveLength(1);
+    expect(ws.currentModel).toBe('first-model');
+  });
+
+  it('rejects and cleans up socket errors without an error listener', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const socketError = new Error('socket failed');
+    const connect = ws.connect({ apiKey: 'ek_test', model: 'first-model' });
+    const failedConnect = expect(connect).rejects.toBe(socketError);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    const socket = fakeSockets[0];
+    socket.emit('error', socketError);
+
+    await failedConnect;
+    await vi.runAllTimersAsync();
+    expect(socket.closeCalls).toBe(1);
+    expect(ws.status).toBe('disconnected');
+  });
+
+  it('preserves a socket error raised during initial session setup', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const socketError = new Error('socket failed during session setup');
+    const connect = ws.connect({ apiKey: 'ek_test', model: 'first-model' });
+    const failedConnect = expect(connect).rejects.toBe(socketError);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    const failedSocket = fakeSockets[0];
+    failedSocket.sendHook = () => failedSocket.emit('error', socketError);
+
+    await vi.runAllTimersAsync();
+    await failedConnect;
+    expect(failedSocket.closeCalls).toBe(1);
+    expect(ws.status).toBe('disconnected');
+
+    const retry = ws.connect({ apiKey: 'ek_retry', model: 'retry-model' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+  });
+
+  it('preserves a socket error when its observer closes the transport', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const socketError = new Error('socket setup failed');
+    ws.on('error', () => ws.close());
+    const connect = ws.connect({ apiKey: 'ek_test', model: 'first-model' });
+    const failedConnect = expect(connect).rejects.toBe(socketError);
+
+    await Promise.resolve();
+    await Promise.resolve();
+    fakeSockets[0].emit('error', socketError);
+
+    await failedConnect;
+    await vi.runAllTimersAsync();
+    expect(ws.status).toBe('disconnected');
+  });
+
+  it('preserves a pre-open close error when its observer closes again', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    ws.on('connection_change', (status) => {
+      if (status === 'disconnected') {
+        ws.close();
+      }
+    });
+    const connect = ws.connect({ apiKey: 'ek_test', model: 'first-model' });
+    const failedConnect = expect(connect).rejects.toThrow(
+      'WebSocket closed before the connection was ready.',
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    fakeSockets[0].emit('close', {});
+
+    await failedConnect;
+    await vi.runAllTimersAsync();
+    expect(ws.status).toBe('disconnected');
+  });
+
+  it('close invalidates an attempt waiting for its API key', async () => {
+    const apiKey = createDeferred<string>();
+    const ws = new OpenAIRealtimeWebSocket({ model: 'initial-model' });
+    const connect = ws.connect({
+      apiKey: () => apiKey.promise,
+      model: 'failed-model',
+    });
+    const closedConnect = expect(connect).rejects.toThrow(
+      'closed before setup completed',
+    );
+
+    ws.close();
+    await closedConnect;
+    expect(ws.status).toBe('disconnected');
+    expect(ws.currentModel).toBe('initial-model');
+
+    apiKey.resolve('ek_stale');
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fakeSockets).toHaveLength(0);
+
+    const retry = ws.connect({ apiKey: 'ek_retry' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+  });
+
+  it('close rejects an attempt waiting for the socket to open', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const connect = ws.connect({ apiKey: 'ek_test', model: 'first-model' });
+    const closedConnect = expect(connect).rejects.toThrow(
+      'closed before setup completed',
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    const socket = fakeSockets[0];
+    ws.close();
+
+    await closedConnect;
+    await vi.runAllTimersAsync();
+    expect(socket.closeCalls).toBe(1);
+    expect(ws.status).toBe('disconnected');
+
+    const retry = ws.connect({ apiKey: 'ek_retry' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+  });
+
+  it('rejects connect while already connected', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const firstConnect = ws.connect({
+      apiKey: 'ek_test',
+      model: 'first-model',
+    });
+    await vi.runAllTimersAsync();
+    await firstConnect;
+
+    await expect(
+      ws.connect({ apiKey: 'ek_second', model: 'second-model' }),
+    ).rejects.toThrow('already connected or connecting');
+    expect(fakeSockets).toHaveLength(1);
+    expect(ws.currentModel).toBe('first-model');
+  });
+
+  it('stays disconnected when close does not emit and ignores a stale close event', async () => {
+    const ws = new OpenAIRealtimeWebSocket();
+    const firstConnect = ws.connect({
+      apiKey: 'ek_test',
+      model: 'first-model',
+    });
+    await vi.runAllTimersAsync();
+    await firstConnect;
+
+    const firstSocket = fakeSockets[0];
+    firstSocket.emitCloseOnClose = false;
+    ws.close();
+    expect(ws.status).toBe('disconnected');
+
+    const retry = ws.connect({ apiKey: 'ek_test', model: 'second-model' });
+    await vi.runAllTimersAsync();
+    await retry;
+    expect(ws.status).toBe('connected');
+
+    firstSocket.emit('close', {});
+    expect(ws.status).toBe('connected');
   });
 
   it('uses custom url from constructor', async () => {


### PR DESCRIPTION
This pull request fixes Realtime connection attempts that could remain connected after initial session setup failed. WebSocket attempts now reject overlapping reuse, restore transient connection configuration before cleanup observers run, preserve the exact original failure, and synchronously disconnect before fallible cleanup. It also cleans up equivalent post-open WebRTC setup failures while preserving coalesced connect behavior and normal event ordering.