### PR TITLE
fix(core): preserve committed tools on blocked output

### DIFF
--- a/.changeset/calm-guardrails-persist.md
+++ b/.changeset/calm-guardrails-persist.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve committed tool effects when output guardrails block final output

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -128,6 +128,7 @@ export class RunToolCallOutputItem extends RunItemBase {
     public agent: Agent<any, any>,
     public output: string | unknown,
     public customData?: ToolOutputCustomData,
+    public executionStatus?: 'executed',
   ) {
     super();
   }
@@ -138,6 +139,7 @@ export class RunToolCallOutputItem extends RunItemBase {
       agent: this.agent.toJSON(),
       output: toSmartString(this.output),
       customData: this.customData,
+      executionStatus: this.executionStatus,
     };
   }
 

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -300,6 +300,27 @@ export class StreamedRunResult<
   extends RunResultBase<TContext, TAgent>
   implements AsyncIterable<RunStreamEvent>
 {
+  #finalOutputHidden = false;
+
+  override get finalOutput():
+    ResolvedAgentOutput<TAgent['outputType']> | undefined {
+    if (this.#finalOutputHidden) {
+      logger.warn('Accessed finalOutput before agent run is completed.');
+      return undefined;
+    }
+    return super.finalOutput;
+  }
+
+  /** @internal */
+  _hideFinalOutput(): void {
+    this.#finalOutputHidden = true;
+  }
+
+  /** @internal */
+  _revealFinalOutput(): void {
+    this.#finalOutputHidden = false;
+  }
+
   /**
    * The current agent that is running
    */
@@ -339,6 +360,8 @@ export class StreamedRunResult<
     } = {} as any,
   ) {
     super(result.state);
+    this.#finalOutputHidden =
+      result.state?._currentStep?.type === 'next_step_final_output';
 
     this.#abortController = new AbortController();
     const { signal: combinedSignal, cleanup: cleanupCombinedSignal } =

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1,6 +1,11 @@
 import { Agent, AgentOutputType } from './agent';
 import { RunAgentUpdatedStreamEvent, RunRawModelStreamEvent } from './events';
-import { AgentsError, ModelBehaviorError } from './errors';
+import {
+  AgentsError,
+  ModelBehaviorError,
+  OutputGuardrailTripwireTriggered,
+  UserError,
+} from './errors';
 import {
   defineInputGuardrail,
   defineOutputGuardrail,
@@ -68,14 +73,19 @@ import {
 } from './runner/streaming';
 import {
   createSessionPersistenceTracker,
+  captureSessionHistoryTransactionInputItems,
+  markSessionHistoryTransactionInputPersisted,
+  prepareSessionHistoryTransactionsForRun,
+  releaseProvisionalSessionHistoryTransactionBinding,
+  releaseUnusedSessionHistoryTransactionBinding,
   prepareInputItemsWithSession,
-  reconcileLegacyCompactionSessionBeforeResume,
   saveStreamInputToSession,
   saveStreamResultToSession,
   saveToSession,
   type SessionPersistenceOptions,
 } from './runner/sessionPersistence';
 import { resolveTurnAfterModelResponse } from './runner/turnResolution';
+import { hasBlockedOutputExecutionEffect } from './runner/blockedOutputPersistence';
 import { prepareTurn } from './runner/turnPreparation';
 import { prepareAgentArtifacts } from './runner/modelPreparation';
 import {
@@ -120,7 +130,7 @@ import type {
 } from './runner/types';
 import {
   attachRunStateToError,
-  tryHandleRunError,
+  prepareRunErrorFinalOutput,
 } from './runner/errorHandlers';
 import type { RunErrorHandlers } from './runner/errorHandlers';
 import {
@@ -153,6 +163,13 @@ function hasPersistedToolOutput(state: RunState<any, any>): boolean {
   return state._generatedItems
     .slice(0, state._currentTurnPersistedItemCount)
     .some((item) => item.type === 'tool_call_output_item');
+}
+
+function hasRetainableBlockedOutputEffect(state: RunState<any, any>): boolean {
+  return hasBlockedOutputExecutionEffect(
+    state._generatedItems,
+    state._currentTurnPersistedItemCount,
+  );
 }
 
 export type {
@@ -610,6 +627,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       resolvedOptions.toolErrorFormatter ?? this.config.toolErrorFormatter;
     const reasoningItemIdPolicy =
       resolvedOptions.reasoningItemIdPolicy ??
+      (input instanceof RunState ? input._reasoningItemIdPolicy : undefined) ??
       this.config.reasoningItemIdPolicy;
     const toolExecution = validateToolExecutionConfig(
       resolvedOptions.toolExecution ?? this.config.toolExecution,
@@ -664,17 +682,35 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // When the server tracks conversation history we defer to it for previous turns so local session
     // persistence can focus solely on the new delta being generated in this process.
     const session = effectiveOptions.session;
+    let provisionalSessionHistoryTransactionSessionId: string | undefined;
+    let provisionalSessionHistoryTransactionInputItems:
+      AgentInputItem[] | undefined;
     if (resumingFromState) {
-      await reconcileLegacyCompactionSessionBeforeResume(
-        session,
-        input as RunState<TContext, TAgent>,
-      );
+      const resumedState = input as RunState<TContext, TAgent>;
+      const hadSessionBinding =
+        resumedState._currentTurnSessionHistoryTransactionSessionId !==
+        undefined;
+      const portableInputItems =
+        resumedState._currentTurnSessionHistoryTransactionInputItems;
+      resumedState.setReasoningItemIdPolicy(reasoningItemIdPolicy);
+      await prepareSessionHistoryTransactionsForRun(session, resumedState, {
+        serverManagesConversation,
+      });
+      if (!hadSessionBinding) {
+        provisionalSessionHistoryTransactionSessionId =
+          resumedState._currentTurnSessionHistoryTransactionSessionId;
+        provisionalSessionHistoryTransactionInputItems = portableInputItems;
+      }
     }
     const sessionPersistence = createSessionPersistenceTracker({
       session,
       hasCallModelInputFilter,
       persistInput: saveStreamInputToSession,
       resumingFromState,
+      resumedSessionInputItems: resumingFromState
+        ? (input as RunState<TContext, TAgent>)
+            ._currentTurnSessionHistoryTransactionInputItems
+        : undefined,
     });
 
     let preparedInput: typeof input = input;
@@ -727,9 +763,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           sessionPersistence?.recordTurnItems,
           sessionPersistence?.getItemsForPersistence,
           preserveTurnPersistenceOnResume,
+          provisionalSessionHistoryTransactionSessionId,
+          provisionalSessionHistoryTransactionInputItems,
           {
             sdkSessionId: async () => await session?.getSessionId(),
-            inputOverride: () => sessionPersistence?.getItemsForPersistence(),
+            inputOverride: () =>
+              session
+                ? sessionPersistence?.getItemsForPersistence()
+                : undefined,
           },
           effectiveInvocationSpanParent,
         );
@@ -742,13 +783,17 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         taskSpanName,
         sessionPersistence?.setPreparedTurnItems,
         sessionPersistence?.recordTurnItems,
+        sessionPersistence?.getItemsForPersistence,
         preserveTurnPersistenceOnResume,
+        provisionalSessionHistoryTransactionSessionId,
+        provisionalSessionHistoryTransactionInputItems,
         {
           sdkSessionId: async () => await session?.getSessionId(),
-          inputOverride: () => sessionPersistence?.getItemsForPersistence(),
+          inputOverride: () =>
+            session ? sessionPersistence?.getItemsForPersistence() : undefined,
         },
         effectiveInvocationSpanParent,
-        sessionPersistence && !serverManagesConversation
+        session && sessionPersistence && !serverManagesConversation
           ? async (result, persistenceOptions) => {
               await saveToSession(
                 session,
@@ -960,7 +1005,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       sourceItems: (AgentInputItem | undefined)[],
       filteredItems?: AgentInputItem[],
     ) => void,
+    getSessionInputForPersistence?: () => AgentInputItem[] | undefined,
     preserveTurnPersistenceOnResume?: boolean,
+    provisionalSessionHistoryTransactionSessionId?: string,
+    provisionalSessionHistoryTransactionInputItems?: AgentInputItem[],
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
     invocationSpanParent?: Span<any> | Trace,
     persistResult?: (
@@ -1010,6 +1058,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       const resolvedPreviousResponseId =
         options.previousResponseId ??
         (isResumedState ? state._previousResponseId : undefined);
+
+      if (!isResumedState) {
+        await prepareSessionHistoryTransactionsForRun(options.session, state, {
+          serverManagesConversation: Boolean(
+            resolvedConversationId || resolvedPreviousResponseId,
+          ),
+        });
+      }
 
       if (!isResumedState) {
         state.setConversationContext(
@@ -1092,9 +1148,128 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         isResumedState && hasPersistedToolOutput(state);
       let approvedToolCheckpointModelResponseCount =
         state._modelResponses.length;
+      let completedResultPersisted = false;
       const completeResult = (result: RunResult<TContext, TAgent>) => {
         completedResult = result;
         return result;
+      };
+      const persistNonStreamingResult = async (
+        result: RunResult<TContext, TAgent>,
+      ) => {
+        const hasUnpersistedItems =
+          result.newItems.length > state._currentTurnPersistedItemCount;
+        const modelResponseAdvanced =
+          result.rawResponses.length > approvedToolCheckpointModelResponseCount;
+        const persistenceOptions =
+          approvedToolCheckpointRequiresLocalInputCompaction
+            ? approvedToolCheckpointCompacted &&
+              !hasUnpersistedItems &&
+              !modelResponseAdvanced
+              ? { runCompaction: false }
+              : { compactionMode: 'input' as const }
+            : undefined;
+        await persistResult?.(result, persistenceOptions);
+      };
+      const recordNonStreamingError = (error: unknown) => {
+        if (state._currentAgentSpan) {
+          state._currentAgentSpan.setError({
+            message: 'Error in agent run',
+            data: {
+              error: getRunnerSpanErrorDetails(
+                error,
+                this.config.traceIncludeSensitiveData,
+              ),
+            },
+          });
+        }
+        setRunnerSpanError(
+          currentTurnSpan,
+          error,
+          this.config.traceIncludeSensitiveData,
+        );
+        setRunnerSpanError(
+          taskSpan,
+          error,
+          this.config.traceIncludeSensitiveData,
+        );
+        runError = error;
+      };
+      const finalizeCurrentOutput = async (): Promise<
+        RunResult<TContext, TAgent>
+      > => {
+        const currentStep = state._currentStep;
+        if (currentStep?.type !== 'next_step_final_output') {
+          throw new ModelBehaviorError(
+            'Expected a final output step while finalizing the run.',
+            state,
+          );
+        }
+        try {
+          await runOutputGuardrails(
+            state,
+            this.outputGuardrailDefs,
+            currentStep.output,
+          );
+        } catch (error) {
+          if (
+            error instanceof OutputGuardrailTripwireTriggered &&
+            persistResult
+          ) {
+            try {
+              await persistResult(new RunResult<TContext, TAgent>(state), {
+                outputBlocked: true,
+              });
+            } catch (persistenceError) {
+              error.state ??= state;
+              (error as Error & { cause?: unknown }).cause = persistenceError;
+            }
+            releaseUnusedSessionHistoryTransactionBinding(state);
+          } else if (error instanceof OutputGuardrailTripwireTriggered) {
+            releaseUnusedSessionHistoryTransactionBinding(state);
+          } else {
+            try {
+              await persistNonStreamingResult(
+                new RunResult<TContext, TAgent>(state),
+              );
+              completedResultPersisted = true;
+            } catch (persistenceError) {
+              (error as Error & { cause?: unknown }).cause = persistenceError;
+            }
+          }
+          throw error;
+        }
+        if (
+          state._serializedCurrentStep === currentStep &&
+          hasRetainableBlockedOutputEffect(state)
+        ) {
+          releaseProvisionalSessionHistoryTransactionBinding(
+            state,
+            provisionalSessionHistoryTransactionSessionId,
+            provisionalSessionHistoryTransactionInputItems,
+          );
+          throw new UserError(
+            'Accepted final output cannot be resumed directly from serialized terminal state. Start a new run from persisted session history.',
+          );
+        }
+        finishRunnerSpan(currentTurnSpan);
+        setRunStateTurnSpanParent(state, undefined);
+        currentTurnSpan = undefined;
+        const result = new RunResult<TContext, TAgent>(state);
+        await persistNonStreamingResult(result);
+        completedResultPersisted = true;
+        state._currentTurnInProgress = false;
+        this.emit(
+          'agent_end',
+          state._context,
+          state._currentAgent,
+          currentStep.output,
+        );
+        state._currentAgent.emit(
+          'agent_end',
+          state._context,
+          currentStep.output,
+        );
+        return completeResult(result);
       };
 
       try {
@@ -1174,6 +1349,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           }
 
           if (state._currentStep.type === 'next_step_run_again') {
+            if (
+              approvedToolCheckpointCompacted &&
+              state._currentTurnSessionHistoryTransactionSessionId === undefined
+            ) {
+              await prepareSessionHistoryTransactionsForRun(
+                options.session,
+                state,
+                { serverManagesConversation: false },
+              );
+            }
             const wasContinuingInterruptedTurn = continuingInterruptedTurn;
             continuingInterruptedTurn = false;
             const guardrailTracker = createGuardrailTracker();
@@ -1245,6 +1430,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               preparedSandboxAgent.turnInput,
               serverConversationTracker,
               sessionInputUpdate,
+            );
+            captureSessionHistoryTransactionInputItems(
+              options.session,
+              state,
+              getSessionInputForPersistence?.(),
             );
 
             await guardrailTracker.throwIfError();
@@ -1361,27 +1551,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
           switch (currentStep.type) {
             case 'next_step_final_output':
-              await runOutputGuardrails(
-                state,
-                this.outputGuardrailDefs,
-                currentStep.output,
-              );
-              finishRunnerSpan(currentTurnSpan);
-              setRunStateTurnSpanParent(state, undefined);
-              currentTurnSpan = undefined;
-              state._currentTurnInProgress = false;
-              this.emit(
-                'agent_end',
-                state._context,
-                state._currentAgent,
-                currentStep.output,
-              );
-              state._currentAgent.emit(
-                'agent_end',
-                state._context,
-                currentStep.output,
-              );
-              return completeResult(new RunResult<TContext, TAgent>(state));
+              if (options.signal?.aborted) {
+                releaseProvisionalSessionHistoryTransactionBinding(
+                  state,
+                  provisionalSessionHistoryTransactionSessionId,
+                  provisionalSessionHistoryTransactionInputItems,
+                );
+              }
+              options.signal?.throwIfAborted();
+              return await finalizeCurrentOutput();
             case 'next_step_handoff':
               state.setCurrentAgent(currentStep.newAgent as TAgent);
               if (state._currentAgentSpan) {
@@ -1409,41 +1587,21 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       } catch (err) {
         state._currentTurnInProgress = false;
         attachRunStateToError(err, state);
-        const handledResult = await tryHandleRunError({
+        releaseUnusedSessionHistoryTransactionBinding(state);
+        const errorHandled = await prepareRunErrorFinalOutput({
           error: err,
           state,
           errorHandlers: options.errorHandlers,
-          outputGuardrailDefs: this.outputGuardrailDefs,
-          emitAgentEnd: (context, agent, outputText) => {
-            this.emit('agent_end', context, agent, outputText);
-            agent.emit('agent_end', context, outputText);
-          },
         });
-        if (handledResult) {
-          return completeResult(handledResult);
+        if (errorHandled) {
+          try {
+            return await finalizeCurrentOutput();
+          } catch (finalizationError) {
+            recordNonStreamingError(finalizationError);
+            throw finalizationError;
+          }
         }
-        if (state._currentAgentSpan) {
-          state._currentAgentSpan.setError({
-            message: 'Error in agent run',
-            data: {
-              error: getRunnerSpanErrorDetails(
-                err,
-                this.config.traceIncludeSensitiveData,
-              ),
-            },
-          });
-        }
-        setRunnerSpanError(
-          currentTurnSpan,
-          err,
-          this.config.traceIncludeSensitiveData,
-        );
-        setRunnerSpanError(
-          taskSpan,
-          err,
-          this.config.traceIncludeSensitiveData,
-        );
-        runError = err;
+        recordNonStreamingError(err);
         throw err;
       } finally {
         finishRunnerSpan(currentTurnSpan);
@@ -1480,23 +1638,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             await Promise.reject(error);
           }
           const resultToPersist = completedResult ?? persistenceCheckpoint;
-          if (resultToPersist) {
+          if (resultToPersist && !completedResultPersisted) {
             try {
-              const hasUnpersistedItems =
-                resultToPersist.newItems.length >
-                state._currentTurnPersistedItemCount;
-              const modelResponseAdvanced =
-                resultToPersist.rawResponses.length >
-                approvedToolCheckpointModelResponseCount;
-              const persistenceOptions =
-                approvedToolCheckpointRequiresLocalInputCompaction
-                  ? approvedToolCheckpointCompacted &&
-                    !hasUnpersistedItems &&
-                    !modelResponseAdvanced
-                    ? { runCompaction: false }
-                    : { compactionMode: 'input' as const }
-                  : undefined;
-              await persistResult?.(resultToPersist, persistenceOptions);
+              await persistNonStreamingResult(resultToPersist);
             } catch (error) {
               setRunnerSpanError(
                 taskSpan,
@@ -1536,6 +1680,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     ) => void,
     getStreamInputForPersistence?: () => AgentInputItem[] | undefined,
     preserveTurnPersistenceOnResume?: boolean,
+    provisionalSessionHistoryTransactionSessionId?: string,
+    provisionalSessionHistoryTransactionInputItems?: AgentInputItem[],
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
     taskSpan?: RunnerSpanLifecycle<TaskSpanData>,
     invocationSpanParent?: Span<any> | Trace,
@@ -1575,6 +1721,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       // Both success and error paths call this helper, so guard against multiple writes.
       await ensureStreamInputPersisted();
       streamInputPersisted = true;
+      markSessionHistoryTransactionInputPersisted(result.state);
     };
     let parallelGuardrailPromise: Promise<InputGuardrailResult[]> | undefined;
     const awaitInputGuardrails = async () => {
@@ -1617,19 +1764,22 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       parentUsageRecorder?.(usage);
     };
     setRunStateUsageRecorder(result.state, recordUsage);
-    const saveStreamResultWithCompactionOwnership = async () => {
+    const saveStreamResultWithCompactionOwnership = async (
+      overrideOptions?: SessionPersistenceOptions,
+    ) => {
       const hasUnpersistedItems =
         result.newItems.length > result.state._currentTurnPersistedItemCount;
       const modelResponseAdvanced =
         result.rawResponses.length > approvedToolCheckpointModelResponseCount;
       const persistenceOptions =
-        approvedToolCheckpointRequiresLocalInputCompaction
+        overrideOptions ??
+        (approvedToolCheckpointRequiresLocalInputCompaction
           ? approvedToolCheckpointCompacted &&
             !hasUnpersistedItems &&
             !modelResponseAdvanced
             ? { runCompaction: false }
             : { compactionMode: 'input' as const }
-          : undefined;
+          : undefined);
       const sessionInputItems = streamInputPersisted
         ? undefined
         : getStreamInputForPersistence?.();
@@ -1643,13 +1793,122 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         sessionInputItems,
       );
     };
+    const recordStreamingError = (error: unknown) => {
+      if (result.state._currentAgentSpan) {
+        result.state._currentAgentSpan.setError({
+          message: 'Error in agent run',
+          data: {
+            error: getRunnerSpanErrorDetails(
+              error,
+              this.config.traceIncludeSensitiveData,
+            ),
+          },
+        });
+      }
+      setRunnerSpanError(
+        currentTurnSpan,
+        error,
+        this.config.traceIncludeSensitiveData,
+      );
+      setRunnerSpanError(
+        taskSpan,
+        error,
+        this.config.traceIncludeSensitiveData,
+      );
+      runError = error;
+    };
+    const finalizeStreamOutput = async (): Promise<void> => {
+      const currentStep = result.state._currentStep;
+      if (currentStep?.type !== 'next_step_final_output') {
+        throw new ModelBehaviorError(
+          'Expected a final output step while finalizing the run.',
+          result.state,
+        );
+      }
+      result._hideFinalOutput();
+      try {
+        await runOutputGuardrails(
+          result.state,
+          this.outputGuardrailDefs,
+          currentStep.output,
+        );
+      } catch (error) {
+        if (
+          error instanceof OutputGuardrailTripwireTriggered &&
+          !serverManagesConversation
+        ) {
+          try {
+            await saveStreamResultWithCompactionOwnership({
+              outputBlocked: true,
+            });
+          } catch (persistenceError) {
+            error.state ??= result.state;
+            (error as Error & { cause?: unknown }).cause = persistenceError;
+          }
+          releaseUnusedSessionHistoryTransactionBinding(result.state);
+        } else if (error instanceof OutputGuardrailTripwireTriggered) {
+          releaseUnusedSessionHistoryTransactionBinding(result.state);
+        } else if (!serverManagesConversation) {
+          try {
+            await saveStreamResultWithCompactionOwnership();
+          } catch (persistenceError) {
+            (error as Error & { cause?: unknown }).cause = persistenceError;
+          }
+        }
+        throw error;
+      }
+      if (
+        result.state._serializedCurrentStep === currentStep &&
+        hasRetainableBlockedOutputEffect(result.state)
+      ) {
+        releaseProvisionalSessionHistoryTransactionBinding(
+          result.state,
+          provisionalSessionHistoryTransactionSessionId,
+          provisionalSessionHistoryTransactionInputItems,
+        );
+        throw new UserError(
+          'Accepted final output cannot be resumed directly from serialized terminal state. Start a new run from persisted session history.',
+        );
+      }
+      finishRunnerSpan(currentTurnSpan);
+      setRunStateTurnSpanParent(result.state, undefined);
+      currentTurnSpan = undefined;
+      result.state._currentTurnInProgress = false;
+      // Guardrails must succeed before persisting session memory to avoid storing blocked outputs.
+      if (!serverManagesConversation) {
+        await saveStreamResultWithCompactionOwnership();
+      }
+      result._revealFinalOutput();
+      this.emit(
+        'agent_end',
+        result.state._context,
+        result.state._currentAgent,
+        currentStep.output,
+      );
+      result.state._currentAgent.emit(
+        'agent_end',
+        result.state._context,
+        currentStep.output,
+      );
+    };
 
     try {
       while (true) {
         // Let the current action batch settle, but never start new work after
         // cancellation once a turn has already begun. Preserve the existing
         // first-request behavior for an initially aborted stream.
-        if (result.cancelled && result.state._currentTurn > 0) {
+        if (
+          result.cancelled &&
+          (result.state._currentTurn > 0 ||
+            result.state._currentStep?.type === 'next_step_final_output')
+        ) {
+          if (result.state._currentStep?.type === 'next_step_final_output') {
+            releaseProvisionalSessionHistoryTransactionBinding(
+              result.state,
+              provisionalSessionHistoryTransactionSessionId,
+              provisionalSessionHistoryTransactionInputItems,
+            );
+          }
           return;
         }
 
@@ -1732,6 +1991,17 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         }
 
         if (result.state._currentStep.type === 'next_step_run_again') {
+          if (
+            approvedToolCheckpointCompacted &&
+            result.state._currentTurnSessionHistoryTransactionSessionId ===
+              undefined
+          ) {
+            await prepareSessionHistoryTransactionsForRun(
+              options.session,
+              result.state,
+              { serverManagesConversation: false },
+            );
+          }
           parallelGuardrailPromise = undefined;
           guardrailTracker = createGuardrailTracker();
           const wasContinuingInterruptedTurn = continuingInterruptedTurn;
@@ -1814,6 +2084,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             preparedSandboxAgent.turnInput,
             serverConversationTracker,
             sessionInputUpdate,
+          );
+          captureSessionHistoryTransactionInputItems(
+            options.session,
+            result.state,
+            getStreamInputForPersistence?.(),
           );
 
           await guardrailTracker.throwIfError();
@@ -2064,37 +2339,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         const currentStep = result.state._currentStep;
         switch (currentStep.type) {
           case 'next_step_final_output':
-            try {
-              await runOutputGuardrails(
-                result.state,
-                this.outputGuardrailDefs,
-                currentStep.output,
-              );
-              finishRunnerSpan(currentTurnSpan);
-              setRunStateTurnSpanParent(result.state, undefined);
-              currentTurnSpan = undefined;
-            } catch (error) {
-              // Do not leave blocked output visible through StreamedRunResult.finalOutput.
-              result.state._currentStep = undefined;
-              result.state._finalOutputSource = undefined;
-              throw error;
-            }
-            result.state._currentTurnInProgress = false;
-            // Guardrails must succeed before persisting session memory to avoid storing blocked outputs.
-            if (!serverManagesConversation) {
-              await saveStreamResultWithCompactionOwnership();
-            }
-            this.emit(
-              'agent_end',
-              result.state._context,
-              currentAgent,
-              currentStep.output,
-            );
-            currentAgent.emit(
-              'agent_end',
-              result.state._context,
-              currentStep.output,
-            );
+            await finalizeStreamOutput();
             return;
           case 'next_step_interruption':
             // We are done for now. Don't run any output guardrails.
@@ -2131,50 +2376,28 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     } catch (error) {
       result.state._currentTurnInProgress = false;
       attachRunStateToError(error, result.state);
+      releaseUnusedSessionHistoryTransactionBinding(result.state);
       suppressStreamInputPersistence =
         error instanceof CompactionItemValidationError;
       if (guardrailTracker.pending) {
         await guardrailTracker.awaitCompletion({ suppressErrors: true });
       }
-      const handledResult = await tryHandleRunError({
+      const errorHandled = await prepareRunErrorFinalOutput({
         error,
         state: result.state,
         errorHandlers: options.errorHandlers,
-        outputGuardrailDefs: this.outputGuardrailDefs,
-        emitAgentEnd: (context, agent, outputText) => {
-          this.emit('agent_end', context, agent, outputText);
-          agent.emit('agent_end', context, outputText);
-        },
         streamResult: result,
       });
-      if (handledResult) {
-        if (!serverManagesConversation) {
-          await saveStreamResultWithCompactionOwnership();
+      if (errorHandled) {
+        try {
+          await finalizeStreamOutput();
+          return;
+        } catch (finalizationError) {
+          recordStreamingError(finalizationError);
+          throw finalizationError;
         }
-        return;
       }
-      if (result.state._currentAgentSpan) {
-        result.state._currentAgentSpan.setError({
-          message: 'Error in agent run',
-          data: {
-            error: getRunnerSpanErrorDetails(
-              error,
-              this.config.traceIncludeSensitiveData,
-            ),
-          },
-        });
-      }
-      setRunnerSpanError(
-        currentTurnSpan,
-        error,
-        this.config.traceIncludeSensitiveData,
-      );
-      setRunnerSpanError(
-        taskSpan,
-        error,
-        this.config.traceIncludeSensitiveData,
-      );
-      runError = error;
+      recordStreamingError(error);
       throw error;
     } finally {
       finishRunnerSpan(currentTurnSpan);
@@ -2252,6 +2475,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     ) => void,
     getStreamInputForPersistence?: () => AgentInputItem[] | undefined,
     preserveTurnPersistenceOnResume?: boolean,
+    provisionalSessionHistoryTransactionSessionId?: string,
+    provisionalSessionHistoryTransactionInputItems?: AgentInputItem[],
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
     invocationSpanParent?: Span<any> | Trace,
   ): Promise<StreamedRunResult<TContext, TAgent>> {
@@ -2276,6 +2501,24 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         if (options.maxTurns !== undefined) {
           state._maxTurns = options.maxTurns;
         }
+      }
+      const resolvedReasoningItemIdPolicy =
+        options.reasoningItemIdPolicy ??
+        (isResumedState ? state._reasoningItemIdPolicy : undefined) ??
+        this.config.reasoningItemIdPolicy;
+      state.setReasoningItemIdPolicy(resolvedReasoningItemIdPolicy);
+      const resolvedConversationId =
+        options.conversationId ??
+        (isResumedState ? state._conversationId : undefined);
+      const resolvedPreviousResponseId =
+        options.previousResponseId ??
+        (isResumedState ? state._previousResponseId : undefined);
+      if (!isResumedState) {
+        await prepareSessionHistoryTransactionsForRun(options.session, state, {
+          serverManagesConversation: Boolean(
+            resolvedConversationId || resolvedPreviousResponseId,
+          ),
+        });
       }
       const useTaskAndTurnSpans =
         !this.config.tracingDisabled &&
@@ -2316,12 +2559,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           ? (state as RunState<TContext, Agent<TContext, AgentOutputType>>)
           : undefined,
       });
-      const resolvedConversationId =
-        options.conversationId ??
-        (isResumedState ? state._conversationId : undefined);
-      const resolvedPreviousResponseId =
-        options.previousResponseId ??
-        (isResumedState ? state._previousResponseId : undefined);
       if (!isResumedState) {
         state.setConversationContext(
           resolvedConversationId,
@@ -2354,6 +2591,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         sessionInputUpdate,
         getStreamInputForPersistence,
         preserveTurnPersistenceOnResume,
+        provisionalSessionHistoryTransactionSessionId,
+        provisionalSessionHistoryTransactionInputItems,
         sandboxMemoryRunContext,
         taskSpan,
         invocationSpanParent,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { randomUUID } from '@openai/agents-core/_shims';
 import { Agent } from './agent';
 import type { Handoff } from './handoff';
 import { getAgentToolSourceAgent } from './agentToolSourceRegistry';
@@ -27,6 +28,7 @@ import {
 import { AgentToolUseTracker } from './runner/toolUseTracker';
 import { nextStepSchema, NextStep } from './runner/steps';
 import { createToolRunFunction, type ProcessedResponse } from './runner/types';
+import { hasBlockedOutputExecutionEffect } from './runner/blockedOutputPersistence';
 import type { AgentSpanData, Span } from './tracing/spans';
 import { SystemError, UserError } from './errors';
 import { getGlobalTraceProvider } from './tracing/provider';
@@ -123,8 +125,10 @@ import {
  *   session-state envelope version 2.
  * - 1.16: Adds compaction items, category-aware function tool keys, and agent-scoped
  *   function approvals, including aliases for legacy pending-run accessors.
+ * - 1.17: Adds durable local tool execution provenance and blocked-output session
+ *   persistence bookkeeping.
  */
-export const CURRENT_SCHEMA_VERSION = '1.16' as const;
+export const CURRENT_SCHEMA_VERSION = '1.17' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -142,12 +146,35 @@ const SUPPORTED_SCHEMA_VERSIONS = [
   '1.13',
   '1.14',
   '1.15',
+  '1.16',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
 const $schemaVersion = z.enum(SUPPORTED_SCHEMA_VERSIONS);
 
+function schemaVersionSupportsV116State(
+  schemaVersion: SupportedSchemaVersion,
+): boolean {
+  return schemaVersion === '1.16' || schemaVersion === CURRENT_SCHEMA_VERSION;
+}
+
 type ContextOverrideStrategy = 'merge' | 'replace';
+
+const pendingSessionHistoryTransactionSchema = z
+  .object({
+    operationId: z.string().min(1),
+    transactionKind: z.enum(['blocked_append', 'accepted_replace']),
+    runItemIndexes: z.array(z.number().int().min(0)),
+    replaceRunItemIndexes: z.array(z.number().int().min(0)),
+    alreadyPersistedCount: z.number().int().min(0),
+    persistedItemCount: z.number().int().min(0),
+    deferredItemIndexes: z.array(z.number().int().min(0)),
+  })
+  .strict();
+
+type PendingSessionHistoryTransaction = z.infer<
+  typeof pendingSessionHistoryTransactionSchema
+>;
 
 type RunStateContextOverrideOptions<TContext> = {
   contextOverride?: RunContext<TContext>;
@@ -243,6 +270,7 @@ const itemSchema = z.discriminatedUnion('type', [
     agent: serializedAgentSchema,
     output: z.string(),
     customData: z.record(z.string(), z.any()).optional(),
+    executionStatus: z.literal('executed').optional(),
   }),
   z.object({
     type: z.literal('reasoning_item'),
@@ -522,6 +550,14 @@ export const SerializedRunState = z.object({
     .default({}),
   lastProcessedResponse: serializedProcessedResponseSchema.optional(),
   currentTurnPersistedItemCount: z.number().int().min(0).optional(),
+  currentTurnDeferredSessionItemIndexes: z
+    .array(z.number().int().min(0))
+    .optional(),
+  currentTurnBlockedSessionStartIndex: z.number().int().min(0).optional(),
+  currentTurnExecutedWithSessionBinding: z.literal(true).optional(),
+  currentTurnSessionInputItems: z.array(protocol.ModelItem).optional(),
+  pendingSessionHistoryTransaction:
+    pendingSessionHistoryTransactionSchema.optional(),
   pendingLegacyCompactionSessionItems: z.array(protocol.ModelItem).optional(),
   conversationId: z.string().optional(),
   previousResponseId: z.string().optional(),
@@ -647,6 +683,50 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    */
   public _currentTurnPersistedItemCount: number;
   /**
+   * Current-turn item indexes intentionally deferred when a blocked output persisted only a
+   * replay-safe subset. A later accepted resume replaces the sparse suffix in original order.
+   */
+  public _currentTurnDeferredSessionItemIndexes: Set<number>;
+  /**
+   * First current-turn index governed by the sparse blocked-output session suffix.
+   */
+  public _currentTurnBlockedSessionStartIndex: number | undefined;
+  /**
+   * Logical session bound to the current turn before a transaction-aware tool effect can occur.
+   */
+  public _currentTurnSessionHistoryTransactionSessionId: string | undefined;
+  /**
+   * Effective reasoning-item ID policy frozen for the current transaction-aware session turn.
+   */
+  public _currentTurnSessionReasoningItemIdPolicy:
+    ReasoningItemIdPolicy | undefined;
+  /**
+   * Normalized session input frozen before the current transaction-aware model request.
+   */
+  public _currentTurnSessionHistoryTransactionInputItems:
+    AgentInputItem[] | undefined;
+  /**
+   * Whether the current live batch may later replace its sparse suffix with accepted output.
+   */
+  public _currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput:
+    boolean | undefined;
+  /**
+   * Current step reconstructed from serialized state. This reference is not serialized and is
+   * cleared implicitly when the live runner installs another step.
+   */
+  public _serializedCurrentStep: NextStep | undefined;
+  /**
+   * Stable per-run identifier used to derive idempotent session history transaction IDs.
+   */
+  public _sessionHistoryTransactionId: string;
+  /**
+   * Transaction reconstruction data awaiting confirmation from the session backend. Its
+   * generated-item indexes, operation identity, and post-commit bookkeeping remain stable across
+   * retries on the same live RunState; input stays in the separately frozen current-turn snapshot.
+   */
+  public _pendingSessionHistoryTransaction:
+    PendingSessionHistoryTransaction | undefined;
+  /**
    * Compaction marker and persisted suffix that an ordinary session must reconcile once after a
    * pre-1.16 snapshot is restored. The field remains serialized until reconciliation succeeds.
    */
@@ -729,6 +809,16 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._pendingAgentToolRunAliases = new Map();
     this._generatedItems = [];
     this._currentTurnPersistedItemCount = 0;
+    this._currentTurnDeferredSessionItemIndexes = new Set();
+    this._currentTurnBlockedSessionStartIndex = undefined;
+    this._currentTurnSessionHistoryTransactionSessionId = undefined;
+    this._currentTurnSessionReasoningItemIdPolicy = undefined;
+    this._currentTurnSessionHistoryTransactionInputItems = undefined;
+    this._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput =
+      undefined;
+    this._serializedCurrentStep = undefined;
+    this._sessionHistoryTransactionId = randomUUID();
+    this._pendingSessionHistoryTransaction = undefined;
     this._pendingLegacyCompactionSessionItems = undefined;
     this._maxTurns = maxTurns;
     this._inputGuardrailResults = [];
@@ -881,6 +971,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    */
   public resetTurnPersistence(): void {
     this._currentTurnPersistedItemCount = 0;
+    this._currentTurnDeferredSessionItemIndexes.clear();
   }
 
   /**
@@ -1116,6 +1207,33 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
         this._pendingAgentToolRunAliases.entries(),
       ),
       currentTurnPersistedItemCount: this._currentTurnPersistedItemCount,
+      currentTurnDeferredSessionItemIndexes:
+        this._currentTurnDeferredSessionItemIndexes.size > 0
+          ? [...this._currentTurnDeferredSessionItemIndexes].sort(
+              (left, right) => left - right,
+            )
+          : undefined,
+      currentTurnBlockedSessionStartIndex:
+        this._currentTurnBlockedSessionStartIndex,
+      currentTurnExecutedWithSessionBinding:
+        this._currentTurnSessionHistoryTransactionSessionId !== undefined &&
+        hasBlockedOutputExecutionEffect(
+          this._generatedItems,
+          this._currentTurnPersistedItemCount,
+        )
+          ? true
+          : undefined,
+      currentTurnSessionInputItems:
+        this._currentTurnSessionHistoryTransactionSessionId === undefined &&
+        this._currentTurnSessionHistoryTransactionInputItems !== undefined &&
+        this._currentTurnSessionHistoryTransactionInputItems.length > 0 &&
+        hasBlockedOutputExecutionEffect(
+          this._generatedItems,
+          this._currentTurnPersistedItemCount,
+        )
+          ? this._currentTurnSessionHistoryTransactionInputItems
+          : undefined,
+      pendingSessionHistoryTransaction: this._pendingSessionHistoryTransaction,
       pendingLegacyCompactionSessionItems:
         this._pendingLegacyCompactionSessionItems,
       lastProcessedResponse: this._lastProcessedResponse
@@ -1235,6 +1353,10 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
+  assertSchemaVersionSupportsOutputGuardrailSessionPersistence(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   const normalizedState = rehydrateLegacyCompactionRunItems(
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
@@ -1280,7 +1402,7 @@ function validateFunctionApprovalEnvelope(
   if (!hasFunctionApprovals && !hasLegacyFunctionApprovals) {
     return;
   }
-  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+  if (!schemaVersionSupportsV116State(schemaVersion)) {
     throw new UserError(
       `Run state schema version ${schemaVersion} does not support owner-scoped function approvals. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
     );
@@ -1305,6 +1427,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
     schemaVersion === '1.15' ||
+    schemaVersion === '1.16' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1327,6 +1450,7 @@ function assertSchemaVersionSupportsCustomData(
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
     schemaVersion === '1.15' ||
+    schemaVersion === '1.16' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1351,6 +1475,7 @@ function schemaVersionSupportsAgentIdentity(
     schemaVersion === '1.13' ||
     schemaVersion === '1.14' ||
     schemaVersion === '1.15' ||
+    schemaVersion === '1.16' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   );
 }
@@ -1362,6 +1487,7 @@ function assertSchemaVersionSupportsProgrammaticToolCalling(
   if (
     schemaVersion === '1.14' ||
     schemaVersion === '1.15' ||
+    schemaVersion === '1.16' ||
     schemaVersion === CURRENT_SCHEMA_VERSION
   ) {
     return;
@@ -1382,7 +1508,7 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
 ): void {
   if (
     schemaVersion === '1.15' ||
-    schemaVersion === CURRENT_SCHEMA_VERSION ||
+    schemaVersionSupportsV116State(schemaVersion) ||
     !stateJson.sandbox
   ) {
     return;
@@ -1416,7 +1542,7 @@ function assertSchemaVersionSupportsCompactionItems(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): void {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (schemaVersionSupportsV116State(schemaVersion)) {
     return;
   }
 
@@ -1430,6 +1556,78 @@ function assertSchemaVersionSupportsCompactionItems(
   throw new UserError(
     `Run state schema version ${schemaVersion} does not support compaction items. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
   );
+}
+
+function assertSchemaVersionSupportsOutputGuardrailSessionPersistence(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+    validateOutputGuardrailSessionPersistenceState(stateJson);
+    return;
+  }
+
+  const hasExecutionProvenance = [
+    ...stateJson.generatedItems,
+    ...(stateJson.lastProcessedResponse?.newItems ?? []),
+  ].some(
+    (item) =>
+      item.type === 'tool_call_output_item' &&
+      item.executionStatus !== undefined,
+  );
+  const hasV117PersistenceEnvelope =
+    stateJson.currentTurnDeferredSessionItemIndexes !== undefined ||
+    stateJson.currentTurnBlockedSessionStartIndex !== undefined ||
+    stateJson.currentTurnExecutedWithSessionBinding !== undefined ||
+    stateJson.currentTurnSessionInputItems !== undefined ||
+    stateJson.pendingSessionHistoryTransaction !== undefined;
+  if (!hasV117PersistenceEnvelope && !hasExecutionProvenance) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support output guardrail session persistence state. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function validateOutputGuardrailSessionPersistenceState(
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  const persistedItemCount = stateJson.currentTurnPersistedItemCount ?? 0;
+  const deferredIndexes = stateJson.currentTurnDeferredSessionItemIndexes ?? [];
+  if (
+    deferredIndexes.length > 0 ||
+    stateJson.currentTurnBlockedSessionStartIndex !== undefined ||
+    stateJson.currentTurnExecutedWithSessionBinding === true ||
+    stateJson.pendingSessionHistoryTransaction !== undefined
+  ) {
+    throw new UserError(
+      'Serialized output guardrail session transaction authority cannot be resumed safely. Start a new run from the persisted session history.',
+    );
+  }
+  if (persistedItemCount > stateJson.generatedItems.length) {
+    throw new UserError(
+      'Run state contains unsupported serialized output guardrail session transaction state.',
+    );
+  }
+
+  const hasUnsupportedExecutionProvenance = [
+    ...stateJson.generatedItems,
+    ...(stateJson.lastProcessedResponse?.newItems ?? []),
+  ].some(
+    (item) =>
+      item.type === 'tool_call_output_item' &&
+      item.executionStatus === 'executed' &&
+      item.rawItem.type !== 'function_call_result' &&
+      item.rawItem.type !== 'shell_call_output' &&
+      item.rawItem.type !== 'computer_call_result' &&
+      item.rawItem.type !== 'apply_patch_call_output',
+  );
+  if (hasUnsupportedExecutionProvenance) {
+    throw new UserError(
+      'Run state contains execution provenance for an unsupported tool output type.',
+    );
+  }
 }
 
 function containsSerializedCompactionRunItems(
@@ -1500,7 +1698,7 @@ function rehydrateLegacyCompactionRunItems(
   schemaVersion: SupportedSchemaVersion,
   stateJson: z.infer<typeof SerializedRunState>,
 ): LegacyCompactionRehydration {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (schemaVersionSupportsV116State(schemaVersion)) {
     return { stateJson };
   }
 
@@ -3134,7 +3332,7 @@ async function rehydrateToolSearchRuntimeTools<
   });
 
   if (
-    options.schemaVersion === CURRENT_SCHEMA_VERSION &&
+    schemaVersionSupportsV116State(options.schemaVersion) &&
     options.serializedProcessedResponse
   ) {
     const currentAgent = state._currentAgent as Agent<TContext, any>;
@@ -3332,14 +3530,15 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   stateJson: z.infer<typeof SerializedRunState>,
   options: RunStateContextOverrideOptions<TContext> = {},
 ): Promise<RunState<TContext, TAgent>> {
-  const agentMap = schemaVersionSupportsAgentIdentity(
-    stateJson.$schemaVersion as SupportedSchemaVersion,
-  )
+  const schemaVersion = stateJson.$schemaVersion as SupportedSchemaVersion;
+  const agentMap = schemaVersionSupportsAgentIdentity(schemaVersion)
     ? buildAgentIdentityMap(initialAgent).byIdentity
     : buildAgentMap(initialAgent);
+  const generatedItems = stateJson.generatedItems.map((item) =>
+    deserializeItem(item, agentMap),
+  );
   const contextOverride = options.contextOverride;
   const contextStrategy = options.contextStrategy ?? 'merge';
-  const schemaVersion = stateJson.$schemaVersion as SupportedSchemaVersion;
   let deferredLegacyApprovalContext: RunContext<TContext> | undefined;
 
   //
@@ -3354,7 +3553,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   );
   if (contextOverride) {
     if (contextStrategy === 'merge') {
-      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+      if (schemaVersionSupportsV116State(schemaVersion)) {
         context._mergeApprovals(stateJson.context.approvals);
         context._mergeFunctionApprovals(
           stateJson.context.functionApprovals ?? [],
@@ -3382,7 +3581,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       agentMap,
     );
     context._rebuildLegacyFunctionApprovals(
-      schemaVersion === CURRENT_SCHEMA_VERSION
+      schemaVersionSupportsV116State(schemaVersion)
         ? (stateJson.context.legacyFunctionApprovals ?? {})
         : stateJson.context.approvals,
     );
@@ -3490,11 +3689,28 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     ? deserializeModelResponse(stateJson.lastModelResponse)
     : undefined;
 
-  state._generatedItems = stateJson.generatedItems.map((item) =>
-    deserializeItem(item, agentMap),
-  );
+  state._generatedItems = generatedItems;
   state._currentTurnPersistedItemCount =
     stateJson.currentTurnPersistedItemCount ?? 0;
+  const supportsOutputGuardrailSessionPersistence =
+    schemaVersion === CURRENT_SCHEMA_VERSION;
+  const deferredSessionItemIndexes = supportsOutputGuardrailSessionPersistence
+    ? (stateJson.currentTurnDeferredSessionItemIndexes ?? [])
+    : [];
+  state._currentTurnDeferredSessionItemIndexes = new Set(
+    deferredSessionItemIndexes,
+  );
+  state._currentTurnBlockedSessionStartIndex = undefined;
+  state._currentTurnSessionHistoryTransactionSessionId = undefined;
+  state._currentTurnSessionReasoningItemIdPolicy = undefined;
+  state._currentTurnSessionHistoryTransactionInputItems =
+    schemaVersion === CURRENT_SCHEMA_VERSION
+      ? stateJson.currentTurnSessionInputItems
+      : undefined;
+  state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput =
+    undefined;
+  state._sessionHistoryTransactionId = randomUUID();
+  state._pendingSessionHistoryTransaction = undefined;
   state._pendingLegacyCompactionSessionItems =
     stateJson.pendingLegacyCompactionSessionItems;
   state._sandbox = stateJson.sandbox ?? undefined;
@@ -3505,7 +3721,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       schemaVersion,
       serializedProcessedResponse: stateJson.lastProcessedResponse,
       prepareCurrentAgentForLegacyApprovals:
-        schemaVersion !== CURRENT_SCHEMA_VERSION &&
+        !schemaVersionSupportsV116State(schemaVersion) &&
         shouldRestoreSerializedContext &&
         Object.keys(stateJson.context.approvals).length > 0,
     },
@@ -3582,7 +3798,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     legacyAvailableToolsByAgent,
   );
   const legacyApprovalContext = deferredLegacyApprovalContext ?? context;
-  if (schemaVersion !== CURRENT_SCHEMA_VERSION) {
+  if (!schemaVersionSupportsV116State(schemaVersion)) {
     legacyApprovalContext._retainLegacyFunctionApprovals(
       legacyFunctionApprovalKeys,
     );
@@ -3605,6 +3821,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       legacyFunctionApprovalKeys,
     );
   }
+  state._serializedCurrentStep = state._currentStep;
   return state;
 }
 
@@ -3892,6 +4109,7 @@ export function deserializeItem(
         resolveSerializedAgent(serializedItem.agent, agentMap),
         serializedItem.output,
         serializedItem.customData,
+        serializedItem.executionStatus,
       );
     case 'reasoning_item':
       return new RunReasoningItem(
@@ -4081,7 +4299,7 @@ function rebindInterruptionFunctionToolStateKeys<TContext>(
         state,
         interruption,
       );
-      if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+      if (schemaVersionSupportsV116State(schemaVersion)) {
         const rawStateKey = getFunctionToolStateKeyForCall(
           interruption.rawItem,
         );
@@ -4282,7 +4500,7 @@ function migrateLegacyFunctionToolState<TContext>(
     readonly Tool<TContext>[]
   > = new Map(),
 ): Set<string> {
-  if (schemaVersion === CURRENT_SCHEMA_VERSION) {
+  if (schemaVersionSupportsV116State(schemaVersion)) {
     return new Set();
   }
 

--- a/packages/agents-core/src/runner/blockedOutputPersistence.ts
+++ b/packages/agents-core/src/runner/blockedOutputPersistence.ts
@@ -1,0 +1,734 @@
+import { UserError } from '../errors';
+import {
+  RunHandoffOutputItem,
+  RunItem,
+  RunToolCallOutputItem,
+  RunToolSearchCallItem,
+  RunToolSearchOutputItem,
+} from '../items';
+import {
+  getToolCallName,
+  getToolCallNamespace,
+  getToolCallQualifiedName,
+} from '../toolIdentity';
+import {
+  getToolSearchExecution,
+  getToolSearchMatchKey,
+  getToolSearchOutputReplacementKey,
+  getToolSearchProviderCallId,
+} from '../tooling';
+import { AgentInputItem } from '../types';
+import type { ToolSearchOutputItem } from '../types/protocol';
+import {
+  getToolResultCorrelationForCall,
+  getToolResultCorrelationForResult,
+  getToolResultCorrelationKey,
+} from './toolResultCorrelation';
+import { addLoadedToolNamesFromToolSearchOutput } from './toolSearch';
+
+type BlockedPairKind = 'tool' | 'handoff';
+
+type BlockedToolRecord = Readonly<{
+  key: string;
+  role: 'call' | 'result';
+  terminal: boolean;
+  kind?: BlockedPairKind;
+  committed: boolean;
+  programCallerId?: string;
+  programOwnerId?: string;
+}>;
+
+type BlockedPairMember = Readonly<{
+  index: number;
+  programCallerId?: string;
+  agent: RunToolCallOutputItem['agent'];
+}>;
+
+type BlockedToolSearchPair = Readonly<{
+  callIndex?: number;
+  outputIndex: number;
+  output: ToolSearchOutputItem;
+  agent: RunToolSearchCallItem['agent'];
+  replacementKey?: string;
+  valid: boolean;
+}>;
+
+export type RunItemPersistencePlan = Readonly<{
+  alreadyPersistedCount: number;
+  runItemsToPersist: RunItem[];
+  runItemsToReplace: RunItem[];
+  processedRunItemCount: number;
+  deferredRunItemIndexes: number[];
+  useHistoryTransaction: boolean;
+  transactionKind?: 'blocked_append' | 'accepted_replace';
+}>;
+
+const REPLAY_SAFE_HOSTED_TOOL_TYPES = new Set([
+  'web_search_call',
+  'web_search',
+  'file_search_call',
+  'file_search',
+  'image_generation_call',
+  'image_generation',
+  'code_interpreter_call',
+  'code_interpreter',
+  'mcp_call',
+  'mcp_list_tools',
+]);
+
+function getProgramCallerId(item: AgentInputItem): string | undefined {
+  if (!item || typeof item !== 'object' || !('caller' in item)) {
+    return undefined;
+  }
+  const caller = (item as { caller?: unknown }).caller;
+  if (!caller || typeof caller !== 'object') {
+    return undefined;
+  }
+  const candidate = caller as { type?: unknown; callerId?: unknown };
+  return candidate.type === 'program' && typeof candidate.callerId === 'string'
+    ? candidate.callerId
+    : undefined;
+}
+
+function getProviderStatus(item: AgentInputItem): unknown {
+  const providerData = (item as { providerData?: unknown }).providerData;
+  return providerData && typeof providerData === 'object'
+    ? (providerData as { status?: unknown }).status
+    : undefined;
+}
+
+function hasOnlyCompletedStatusEvidence(
+  itemStatus: unknown,
+  providerStatus: unknown,
+  allowMissing: boolean,
+): boolean {
+  if (itemStatus === undefined && providerStatus === undefined) {
+    return allowMissing;
+  }
+  return (
+    (itemStatus === undefined || itemStatus === 'completed') &&
+    (providerStatus === undefined || providerStatus === 'completed')
+  );
+}
+
+function supportsLocalExecutionProvenance(
+  type: AgentInputItem['type'],
+): boolean {
+  return (
+    type === 'function_call_result' ||
+    type === 'shell_call_output' ||
+    type === 'computer_call_result' ||
+    type === 'apply_patch_call_output'
+  );
+}
+
+function getBlockedPairKind(
+  item: RunItem,
+  role: BlockedToolRecord['role'],
+): BlockedPairKind | undefined {
+  if (role === 'call') {
+    if (item.type === 'tool_call_item') {
+      return 'tool';
+    }
+    if (item.type === 'handoff_call_item') {
+      return 'handoff';
+    }
+    return undefined;
+  }
+  if (item instanceof RunToolCallOutputItem) {
+    return 'tool';
+  }
+  if (item instanceof RunHandoffOutputItem) {
+    return 'handoff';
+  }
+  return undefined;
+}
+
+function classifyBlockedToolRecord(
+  item: RunItem,
+): BlockedToolRecord | undefined {
+  const rawItem = (item as { rawItem?: AgentInputItem }).rawItem;
+  if (!rawItem) {
+    return undefined;
+  }
+  const type = (rawItem as { type?: unknown }).type;
+  const status = (rawItem as { status?: unknown }).status;
+  let role: BlockedToolRecord['role'];
+  let terminal: boolean;
+
+  switch (type) {
+    case 'program':
+    case 'function_call':
+    case 'shell_call':
+    case 'computer_call':
+    case 'apply_patch_call':
+      role = 'call';
+      // A locally executed call can retain an in-progress provider status. The matching result's
+      // durable execution provenance is the authoritative side-effect boundary.
+      terminal = true;
+      break;
+    case 'function_call_result':
+    case 'program_output':
+      role = 'result';
+      terminal = status === 'completed';
+      break;
+    case 'computer_call_result': {
+      role = 'result';
+      const providerData = (rawItem as { providerData?: unknown }).providerData;
+      const providerStatus =
+        providerData && typeof providerData === 'object'
+          ? (providerData as { status?: unknown }).status
+          : undefined;
+      terminal = providerStatus === undefined || providerStatus === 'completed';
+      break;
+    }
+    case 'shell_call_output': {
+      role = 'result';
+      terminal = hasOnlyCompletedStatusEvidence(
+        status,
+        getProviderStatus(rawItem),
+        true,
+      );
+      break;
+    }
+    case 'apply_patch_call_output':
+      role = 'result';
+      terminal = status === 'completed' || status === 'failed';
+      break;
+    default:
+      return undefined;
+  }
+
+  const correlation =
+    role === 'call'
+      ? getToolResultCorrelationForCall(rawItem)
+      : getToolResultCorrelationForResult(rawItem);
+  const kind = getBlockedPairKind(item, role);
+  return correlation
+    ? {
+        key: getToolResultCorrelationKey(correlation),
+        role,
+        terminal,
+        kind,
+        committed:
+          kind === 'handoff' ||
+          (kind === 'tool' &&
+            role === 'result' &&
+            supportsLocalExecutionProvenance(type) &&
+            (item as RunToolCallOutputItem).executionStatus === 'executed'),
+        programCallerId: getProgramCallerId(rawItem),
+        programOwnerId:
+          type === 'program' &&
+          typeof (rawItem as { callId?: unknown }).callId === 'string'
+            ? (rawItem as { callId: string }).callId
+            : undefined,
+      }
+    : undefined;
+}
+
+function getBlockedRunItemAgent(item: RunItem): RunToolCallOutputItem['agent'] {
+  return item instanceof RunHandoffOutputItem ? item.sourceAgent : item.agent;
+}
+
+function isReplaySafeTerminalHostedToolCall(item: RunItem): boolean {
+  const rawItem = (item as { rawItem?: AgentInputItem }).rawItem;
+  const providerData =
+    rawItem?.type === 'hosted_tool_call' &&
+    rawItem.providerData &&
+    typeof rawItem.providerData === 'object'
+      ? (rawItem.providerData as { status?: unknown; type?: unknown })
+      : undefined;
+  const itemStatus =
+    rawItem?.type === 'hosted_tool_call' ? rawItem.status : undefined;
+  const providerStatus = providerData?.status;
+  if (
+    item.type !== 'tool_call_item' ||
+    rawItem?.type !== 'hosted_tool_call' ||
+    !hasOnlyCompletedStatusEvidence(itemStatus, providerStatus, false)
+  ) {
+    return false;
+  }
+  const providerType = providerData?.type;
+  if (providerType !== undefined) {
+    return (
+      typeof providerType === 'string' &&
+      REPLAY_SAFE_HOSTED_TOOL_TYPES.has(providerType)
+    );
+  }
+  return REPLAY_SAFE_HOSTED_TOOL_TYPES.has(rawItem.name);
+}
+
+function collectBlockedToolSearchPairs(
+  items: RunItem[],
+): BlockedToolSearchPair[] {
+  type ToolSearchCallOccurrence = {
+    callIndex: number;
+    call: RunToolSearchCallItem;
+  };
+  const latestCallByAgentAndKey = new Map<
+    RunToolSearchCallItem['agent'],
+    Map<string, ToolSearchCallOccurrence>
+  >();
+  const pendingClientCalls = new Map<
+    RunToolSearchCallItem['agent'],
+    ToolSearchCallOccurrence[]
+  >();
+  const pendingServerCalls = new Map<
+    RunToolSearchCallItem['agent'],
+    ToolSearchCallOccurrence[]
+  >();
+  const pairs: BlockedToolSearchPair[] = [];
+
+  for (const [index, item] of items.entries()) {
+    if (item instanceof RunToolSearchCallItem) {
+      const key = getToolSearchMatchKey(item.rawItem);
+      if (!key) {
+        continue;
+      }
+      const server = getToolSearchExecution(item.rawItem) === 'server';
+      const pairKey = `${server ? 'server' : 'client'}:${key}`;
+      const occurrence = { callIndex: index, call: item };
+      const byKey = latestCallByAgentAndKey.get(item.agent) ?? new Map();
+      byKey.set(pairKey, occurrence);
+      latestCallByAgentAndKey.set(item.agent, byKey);
+      const pending = server ? pendingServerCalls : pendingClientCalls;
+      const occurrences = pending.get(item.agent) ?? [];
+      occurrences.push(occurrence);
+      pending.set(item.agent, occurrences);
+      continue;
+    }
+
+    if (!(item instanceof RunToolSearchOutputItem)) {
+      continue;
+    }
+    const server = getToolSearchExecution(item.rawItem) === 'server';
+    const pending = server ? pendingServerCalls : pendingClientCalls;
+    const pendingOccurrences = pending.get(item.agent) ?? [];
+    const explicitKey = getToolSearchProviderCallId(item.rawItem);
+    const occurrence = explicitKey
+      ? latestCallByAgentAndKey
+          .get(item.agent)
+          ?.get(`${server ? 'server' : 'client'}:${explicitKey}`)
+      : pendingOccurrences.shift();
+    if (explicitKey && occurrence) {
+      const pendingIndex = pendingOccurrences.indexOf(occurrence);
+      if (pendingIndex >= 0) {
+        pendingOccurrences.splice(pendingIndex, 1);
+      }
+    }
+    pairs.push({
+      callIndex: occurrence?.callIndex,
+      outputIndex: index,
+      output: item.rawItem,
+      agent: item.agent,
+      replacementKey: getToolSearchOutputReplacementKey(item.rawItem),
+      valid:
+        occurrence !== undefined &&
+        item.rawItem.status === 'completed' &&
+        (!server || occurrence.call.rawItem.status === 'completed'),
+    });
+  }
+  return pairs;
+}
+
+function toolSearchOutputLoadsRetainedCall(
+  output: ToolSearchOutputItem,
+  call: AgentInputItem,
+): boolean {
+  const loadedToolNames = new Set<string>();
+  addLoadedToolNamesFromToolSearchOutput(output, loadedToolNames);
+  if (call.type === 'function_call') {
+    const qualifiedName = getToolCallQualifiedName(call);
+    if (qualifiedName && loadedToolNames.has(qualifiedName)) {
+      return true;
+    }
+    const name = getToolCallName(call);
+    const namespace = getToolCallNamespace(call);
+    return (
+      name !== undefined &&
+      (!namespace || namespace === name) &&
+      loadedToolNames.has(name)
+    );
+  }
+
+  const providerData =
+    call.type === 'hosted_tool_call' &&
+    call.providerData &&
+    typeof call.providerData === 'object'
+      ? (call.providerData as { type?: unknown; server_label?: unknown })
+      : undefined;
+  return (
+    (providerData?.type === 'mcp_call' ||
+      providerData?.type === 'mcp_list_tools') &&
+    typeof providerData.server_label === 'string' &&
+    loadedToolNames.has(providerData.server_label)
+  );
+}
+
+function isToolSearchDependentRetainedCall(call: AgentInputItem): boolean {
+  if (call.type === 'function_call') {
+    return true;
+  }
+  const providerData =
+    call.type === 'hosted_tool_call' &&
+    call.providerData &&
+    typeof call.providerData === 'object'
+      ? (call.providerData as { type?: unknown; server_label?: unknown })
+      : undefined;
+  return (
+    (providerData?.type === 'mcp_call' ||
+      providerData?.type === 'mcp_list_tools') &&
+    typeof providerData.server_label === 'string'
+  );
+}
+
+/**
+ * Selects replay-safe tool effects when an assistant's final output is blocked.
+ *
+ * Unknown run-item kinds are excluded. Reasoning is retained only when the next non-reasoning
+ * item is a retained tool call or one of its required provenance records.
+ */
+export function selectRunItemIndexesForBlockedOutput(
+  items: RunItem[],
+  unpersistedStartIndex = 0,
+): number[] {
+  type BlockedPair = {
+    valid: boolean;
+    kind?: BlockedPairKind;
+    calls: BlockedPairMember[];
+    results: Array<BlockedPairMember & { committed: boolean }>;
+  };
+  const pairsByAgent = new Map<
+    RunToolCallOutputItem['agent'],
+    Map<string, BlockedPair>
+  >();
+  const programOwnerIndexesByAgent = new Map<
+    RunToolCallOutputItem['agent'],
+    Map<string, number[]>
+  >();
+  const standaloneCalls: BlockedPairMember[] = [];
+  const toolSearchPairs = collectBlockedToolSearchPairs(items);
+
+  for (const [index, item] of items.entries()) {
+    if (isReplaySafeTerminalHostedToolCall(item)) {
+      standaloneCalls.push({
+        index,
+        programCallerId: getProgramCallerId(item.rawItem as AgentInputItem),
+        agent: getBlockedRunItemAgent(item),
+      });
+      continue;
+    }
+    const record = classifyBlockedToolRecord(item);
+    if (!record) {
+      continue;
+    }
+    const itemAgent = getBlockedRunItemAgent(item);
+    const pairs = pairsByAgent.get(itemAgent) ?? new Map();
+    pairsByAgent.set(itemAgent, pairs);
+    let pair = pairs.get(record.key);
+    if (!pair) {
+      pair = { valid: true, calls: [], results: [] };
+      pairs.set(record.key, pair);
+    }
+    if (
+      !record.terminal ||
+      !record.kind ||
+      (pair.kind !== undefined && pair.kind !== record.kind)
+    ) {
+      pair.valid = false;
+      continue;
+    }
+    pair.kind = record.kind;
+    if (record.programOwnerId !== undefined && record.kind === 'tool') {
+      const ownersById = programOwnerIndexesByAgent.get(itemAgent) ?? new Map();
+      const ownerIndexes = ownersById.get(record.programOwnerId) ?? [];
+      ownerIndexes.push(index);
+      ownersById.set(record.programOwnerId, ownerIndexes);
+      programOwnerIndexesByAgent.set(itemAgent, ownersById);
+    }
+    const member = {
+      index,
+      programCallerId: record.programCallerId,
+      agent: itemAgent,
+    };
+    if (record.role === 'call') {
+      pair.calls.push(member);
+    } else {
+      pair.results.push({ ...member, committed: record.committed });
+    }
+  }
+
+  const retainedIndexes = new Set<number>();
+  const retainedCallIndexes = new Set<number>();
+  const directlyRetainedCallIndexes = new Set<number>();
+  const retainedResultIndexByCallIndex = new Map<number, number>();
+  const programOwnerIndexByCallIndex = new Map<number, number>();
+  const retainCallWithProgramOwner = (call: BlockedPairMember): boolean => {
+    if (call.programCallerId !== undefined) {
+      const ownerIndexes =
+        programOwnerIndexesByAgent.get(call.agent)?.get(call.programCallerId) ??
+        [];
+      if (ownerIndexes.length !== 1 || ownerIndexes[0]! >= call.index) {
+        return false;
+      }
+      retainedIndexes.add(ownerIndexes[0]!);
+      retainedCallIndexes.add(ownerIndexes[0]!);
+      programOwnerIndexByCallIndex.set(call.index, ownerIndexes[0]!);
+    }
+    retainedIndexes.add(call.index);
+    retainedCallIndexes.add(call.index);
+    return true;
+  };
+
+  for (const pairs of pairsByAgent.values()) {
+    for (const pair of pairs.values()) {
+      if (!pair.valid || pair.calls.length !== 1 || pair.results.length !== 1) {
+        continue;
+      }
+      const call = pair.calls[0]!;
+      const result = pair.results[0]!;
+      if (
+        call.index >= result.index ||
+        call.programCallerId !== result.programCallerId ||
+        (!result.committed && call.index >= unpersistedStartIndex)
+      ) {
+        continue;
+      }
+      if (retainCallWithProgramOwner(call)) {
+        directlyRetainedCallIndexes.add(call.index);
+        retainedIndexes.add(result.index);
+        retainedResultIndexByCallIndex.set(call.index, result.index);
+      }
+    }
+  }
+
+  for (const standaloneCall of standaloneCalls) {
+    if (retainCallWithProgramOwner(standaloneCall)) {
+      directlyRetainedCallIndexes.add(standaloneCall.index);
+    }
+  }
+
+  for (const retainedCallIndex of [...retainedCallIndexes]) {
+    const retainedCall = items[retainedCallIndex] as {
+      rawItem?: AgentInputItem;
+      agent?: unknown;
+    };
+    const rawItem = retainedCall.rawItem;
+    if (!rawItem || !isToolSearchDependentRetainedCall(rawItem)) {
+      continue;
+    }
+    const precedingOccurrences = toolSearchPairs.filter(
+      (pair) =>
+        pair.agent === retainedCall.agent &&
+        pair.outputIndex < retainedCallIndex,
+    );
+    const hasMatchingOutput = precedingOccurrences.some((pair) =>
+      toolSearchOutputLoadsRetainedCall(pair.output, rawItem),
+    );
+    if (!hasMatchingOutput) {
+      continue;
+    }
+    const latestByReplacementKey = new Map<string, BlockedToolSearchPair>();
+    const additiveOccurrences: BlockedToolSearchPair[] = [];
+    for (const occurrence of precedingOccurrences) {
+      if (occurrence.replacementKey === undefined) {
+        additiveOccurrences.push(occurrence);
+      } else {
+        latestByReplacementKey.set(occurrence.replacementKey, occurrence);
+      }
+    }
+    const supplier = [
+      ...latestByReplacementKey.values(),
+      ...additiveOccurrences,
+    ]
+      .filter(
+        (occurrence) =>
+          occurrence.valid &&
+          occurrence.callIndex !== undefined &&
+          toolSearchOutputLoadsRetainedCall(occurrence.output, rawItem),
+      )
+      .sort((left, right) => left.outputIndex - right.outputIndex)
+      .at(-1);
+    if (!supplier) {
+      retainedIndexes.delete(retainedCallIndex);
+      retainedCallIndexes.delete(retainedCallIndex);
+      directlyRetainedCallIndexes.delete(retainedCallIndex);
+      const resultIndex = retainedResultIndexByCallIndex.get(retainedCallIndex);
+      if (resultIndex !== undefined) {
+        retainedIndexes.delete(resultIndex);
+      }
+      continue;
+    }
+    retainedIndexes.add(supplier.callIndex!);
+    retainedIndexes.add(supplier.outputIndex);
+    retainedCallIndexes.add(supplier.callIndex!);
+  }
+
+  const neededProgramOwnerIndexes = new Set(
+    [...programOwnerIndexByCallIndex]
+      .filter(([callIndex]) => retainedCallIndexes.has(callIndex))
+      .map(([, ownerIndex]) => ownerIndex),
+  );
+  for (const ownerIndex of programOwnerIndexByCallIndex.values()) {
+    if (
+      !directlyRetainedCallIndexes.has(ownerIndex) &&
+      !neededProgramOwnerIndexes.has(ownerIndex)
+    ) {
+      retainedIndexes.delete(ownerIndex);
+      retainedCallIndexes.delete(ownerIndex);
+    }
+  }
+
+  if (retainedIndexes.size === 0) {
+    return [];
+  }
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    if (items[index]?.type !== 'reasoning_item') {
+      continue;
+    }
+    for (let nextIndex = index + 1; nextIndex < items.length; nextIndex += 1) {
+      if (items[nextIndex]?.type === 'reasoning_item') {
+        continue;
+      }
+      if (retainedCallIndexes.has(nextIndex)) {
+        retainedIndexes.add(index);
+      }
+      break;
+    }
+  }
+
+  return [...retainedIndexes]
+    .filter((index) => index >= unpersistedStartIndex)
+    .sort((left, right) => left - right);
+}
+
+export function hasBlockedOutputExecutionEffect(
+  items: RunItem[],
+  unpersistedStartIndex = 0,
+): boolean {
+  return (
+    selectRunItemIndexesForBlockedOutput(items, unpersistedStartIndex).length >
+      0 ||
+    items
+      .slice(unpersistedStartIndex)
+      .some(
+        (item) =>
+          item instanceof RunToolCallOutputItem &&
+          item.executionStatus === 'executed',
+      )
+  );
+}
+
+export function buildRunItemPersistencePlan(options: {
+  items: RunItem[];
+  alreadyPersistedCount: number;
+  currentDeferredIndexes: Iterable<number>;
+  outputBlocked: boolean;
+  canUseHistoryTransactions: boolean;
+}): RunItemPersistencePlan {
+  const {
+    items,
+    alreadyPersistedCount,
+    currentDeferredIndexes,
+    outputBlocked,
+    canUseHistoryTransactions,
+  } = options;
+  const newRunItemIndexes = Array.from(
+    { length: Math.max(0, items.length - alreadyPersistedCount) },
+    (_value, offset) => alreadyPersistedCount + offset,
+  );
+
+  if (outputBlocked) {
+    if (!canUseHistoryTransactions) {
+      return {
+        alreadyPersistedCount,
+        runItemsToPersist: [],
+        runItemsToReplace: [],
+        processedRunItemCount: 0,
+        deferredRunItemIndexes: [],
+        useHistoryTransaction: false,
+      };
+    }
+    const retainedIndexes = selectRunItemIndexesForBlockedOutput(
+      items,
+      alreadyPersistedCount,
+    );
+    if (retainedIndexes.length === 0) {
+      return {
+        alreadyPersistedCount,
+        runItemsToPersist: [],
+        runItemsToReplace: [],
+        processedRunItemCount: 0,
+        deferredRunItemIndexes: [],
+        useHistoryTransaction: false,
+      };
+    }
+    const retainedIndexSet = new Set(retainedIndexes);
+    const deferredRunItemIndexes = [
+      ...new Set([
+        ...currentDeferredIndexes,
+        ...newRunItemIndexes.filter((index) => !retainedIndexSet.has(index)),
+      ]),
+    ]
+      .filter((index) => index < items.length)
+      .sort((left, right) => left - right);
+    return {
+      alreadyPersistedCount,
+      runItemsToPersist: retainedIndexes.map((index) => items[index]!),
+      runItemsToReplace: [],
+      processedRunItemCount: newRunItemIndexes.length,
+      deferredRunItemIndexes,
+      useHistoryTransaction: true,
+      transactionKind: 'blocked_append',
+    };
+  }
+
+  const deferredIndexes = [...currentDeferredIndexes]
+    .filter((index) => index < items.length)
+    .sort((left, right) => left - right);
+  if (deferredIndexes.length === 0) {
+    return {
+      alreadyPersistedCount,
+      runItemsToPersist: items.slice(alreadyPersistedCount),
+      runItemsToReplace: [],
+      processedRunItemCount: newRunItemIndexes.length,
+      deferredRunItemIndexes: [],
+      useHistoryTransaction: false,
+    };
+  }
+  if (!canUseHistoryTransactions) {
+    throw new UserError(
+      'Cannot persist accepted output from this RunState because its blocked output was saved by a transaction-aware session. Resume with the same transaction-aware session.',
+    );
+  }
+
+  const firstDeferredIndex = deferredIndexes[0]!;
+  const deferredIndexSet = new Set(deferredIndexes);
+  const processedEndIndex = Math.min(alreadyPersistedCount, items.length);
+  const runItemsToReplace: RunItem[] = [];
+  for (let index = firstDeferredIndex; index < processedEndIndex; index += 1) {
+    if (!deferredIndexSet.has(index)) {
+      runItemsToReplace.push(items[index]!);
+    }
+  }
+  let replacementStartIndex = firstDeferredIndex;
+  if (runItemsToReplace.length === 0) {
+    const anchorIndex = firstDeferredIndex - 1;
+    if (anchorIndex < 0) {
+      throw new UserError(
+        'Cannot persist accepted output because the blocked session suffix has no retained anchor.',
+      );
+    }
+    runItemsToReplace.push(items[anchorIndex]!);
+    replacementStartIndex = anchorIndex;
+  }
+  return {
+    alreadyPersistedCount,
+    runItemsToPersist: items.slice(replacementStartIndex),
+    runItemsToReplace,
+    processedRunItemCount: newRunItemIndexes.length,
+    deferredRunItemIndexes: [],
+    useHistoryTransaction: true,
+    transactionKind: 'accepted_replace',
+  };
+}

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -11,7 +11,7 @@ import {
 import { assistant } from '../helpers/message';
 import { RunItem, RunMessageOutputItem } from '../items';
 import { ModelResponse } from '../model';
-import { RunResult, StreamedRunResult } from '../result';
+import { StreamedRunResult } from '../result';
 import { RunContext } from '../runContext';
 import { RunState } from '../runState';
 import type {
@@ -19,11 +19,6 @@ import type {
   AgentOutputItem,
   ResolvedAgentOutput,
 } from '../types';
-import type {
-  OutputGuardrailDefinition,
-  OutputGuardrailMetadata,
-} from '../guardrail';
-import { runOutputGuardrails } from './guardrails';
 import { getTurnInput } from './items';
 import { streamStepItemsToRunResult } from './streaming';
 
@@ -83,15 +78,6 @@ type TryHandleRunErrorArgs<TContext, TAgent extends Agent<any, any>> = {
   error: unknown;
   state: RunState<TContext, TAgent>;
   errorHandlers?: RunErrorHandlers<TContext, TAgent>;
-  outputGuardrailDefs: OutputGuardrailDefinition<
-    OutputGuardrailMetadata,
-    AgentOutputType<unknown>
-  >[];
-  emitAgentEnd: (
-    context: RunContext<TContext>,
-    agent: TAgent,
-    outputText: string,
-  ) => void;
   streamResult?: StreamedRunResult<TContext, TAgent>;
 };
 
@@ -220,19 +206,15 @@ export const resolveRunErrorHandler = async <
   return handlerResult || undefined;
 };
 
-export const tryHandleRunError = async <
+export const prepareRunErrorFinalOutput = async <
   TContext,
   TAgent extends Agent<TContext, AgentOutputType>,
 >({
   error,
   state,
   errorHandlers,
-  outputGuardrailDefs,
-  emitAgentEnd,
   streamResult,
-}: TryHandleRunErrorArgs<TContext, TAgent>): Promise<
-  RunResult<TContext, TAgent> | undefined
-> => {
+}: TryHandleRunErrorArgs<TContext, TAgent>): Promise<boolean> => {
   const handlerResult = await resolveRunErrorHandler({
     error,
     errorHandlers,
@@ -240,7 +222,7 @@ export const tryHandleRunError = async <
     runData: buildRunData(state),
   });
   if (!handlerResult) {
-    return undefined;
+    return false;
   }
   const includeInHistory = handlerResult.includeInHistory !== false;
   const outputText = formatFinalOutput(
@@ -248,6 +230,7 @@ export const tryHandleRunError = async <
     handlerResult.finalOutput,
   );
   validateRunErrorFinalOutput(state._currentAgent, outputText);
+  streamResult?._hideFinalOutput();
   state._lastTurnResponse = undefined;
   state._lastProcessedResponse = undefined;
   const item = createFinalOutputItem(state._currentAgent, outputText);
@@ -262,8 +245,5 @@ export const tryHandleRunError = async <
     output: outputText,
   };
   state._finalOutputSource = 'error_handler';
-  await runOutputGuardrails(state, outputGuardrailDefs, outputText);
-  state._currentTurnInProgress = false;
-  emitAgentEnd(state._context, state._currentAgent, outputText);
-  return new RunResult<TContext, TAgent>(state);
+  return true;
 };

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -1,14 +1,17 @@
 import { UserError } from '../errors';
 import {
   isOpenAIResponsesCompactionAwareSession,
+  isSessionHistoryTransactionAwareSession,
   type OpenAIResponsesCompactionArgs,
   type Session,
+  type SessionHistoryTransaction,
   type SessionInputCallback,
 } from '../memory/session';
 import { RunResult, StreamedRunResult } from '../result';
 import { RunState } from '../runState';
 import { RunItem } from '../items';
 import { AgentInputItem } from '../types';
+import { ModelItem } from '../types/protocol';
 import { Usage } from '../usage';
 import { encodeUint8ArrayToBase64 } from '../utils/base64';
 import { toUint8ArrayFromBinary } from '../utils/binary';
@@ -27,6 +30,13 @@ import {
 } from './items';
 import logger, { logModelAndToolActionWarning } from '../logger';
 import { getRunStateUsageRecorder } from './usageTracking';
+import {
+  buildRunItemPersistencePlan as buildCanonicalRunItemPersistencePlan,
+  hasBlockedOutputExecutionEffect,
+  selectRunItemIndexesForBlockedOutput,
+} from './blockedOutputPersistence';
+
+export { selectRunItemIndexesForBlockedOutput } from './blockedOutputPersistence';
 
 export type PreparedInputWithSessionResult = {
   preparedInput: string | AgentInputItem[];
@@ -36,7 +46,360 @@ export type PreparedInputWithSessionResult = {
 export type SessionPersistenceOptions = {
   runCompaction?: boolean;
   compactionMode?: OpenAIResponsesCompactionArgs['compactionMode'];
+  outputBlocked?: boolean;
 };
+
+function canonicalizeSessionHistoryTransaction(
+  transaction: SessionHistoryTransaction,
+): SessionHistoryTransaction {
+  let decoded: unknown;
+  try {
+    const encoded = JSON.stringify(transaction);
+    if (encoded === undefined) {
+      throw new Error('Missing JSON transaction.');
+    }
+    decoded = JSON.parse(encoded);
+  } catch {
+    throw new UserError(
+      'Session history transaction cannot be represented in durable RunState JSON.',
+    );
+  }
+  if (!decoded || typeof decoded !== 'object') {
+    throw new UserError('Session history transaction is invalid.');
+  }
+  const record = decoded as Record<string, unknown>;
+  const parseItems = (value: unknown): AgentInputItem[] => {
+    if (!Array.isArray(value)) {
+      throw new UserError('Session history transaction items are invalid.');
+    }
+    return value.map((item) => ModelItem.parse(item) as AgentInputItem);
+  };
+  if (record.type === 'append_items') {
+    return {
+      type: record.type,
+      items: parseItems(record.items),
+    };
+  }
+  if (record.type === 'replace_suffix') {
+    return {
+      type: record.type,
+      expectedSuffix: parseItems(record.expectedSuffix),
+      replacement: parseItems(record.replacement),
+    };
+  }
+  throw new UserError('Session history transaction is invalid.');
+}
+
+function getRunItemIndexesForPendingTransaction(
+  state: RunState<any, any>,
+  runItems: RunItem[],
+): number[] {
+  const indexes = runItems.map((item) => state._generatedItems.indexOf(item));
+  if (
+    indexes.some((index) => index < 0) ||
+    new Set(indexes).size !== indexes.length
+  ) {
+    throw new UserError(
+      'Session history transaction run items do not belong to the current RunState.',
+    );
+  }
+  return indexes;
+}
+
+function getSessionHistoryTransactionOperationId(
+  state: RunState<any, any>,
+  transactionKind: 'blocked_append' | 'accepted_replace',
+  alreadyPersistedCount: number,
+  persistedItemCount: number,
+): string {
+  return [
+    state._sessionHistoryTransactionId,
+    state._currentTurn,
+    transactionKind,
+    alreadyPersistedCount,
+    persistedItemCount,
+  ].join(':');
+}
+
+function buildPendingSessionHistoryTransaction(
+  state: RunState<any, any>,
+): SessionHistoryTransaction {
+  const pending = state._pendingSessionHistoryTransaction;
+  if (!pending) {
+    throw new UserError('Session history transaction state is missing.');
+  }
+  const reasoningItemIdPolicy = state._currentTurnSessionReasoningItemIdPolicy;
+  if (reasoningItemIdPolicy === undefined) {
+    throw new UserError(
+      'Session history transaction reasoning-item policy is missing.',
+    );
+  }
+  const runItems = pending.runItemIndexes.map(
+    (index) => state._generatedItems[index]!,
+  );
+  const replacementItems = pending.replaceRunItemIndexes.map(
+    (index) => state._generatedItems[index]!,
+  );
+  const items = normalizeItemsForSessionPersistence([
+    ...(state._currentTurnSessionHistoryTransactionInputItems ?? []),
+    ...extractOutputItemsFromRunItems(runItems, reasoningItemIdPolicy),
+  ]);
+  if (pending.transactionKind === 'blocked_append') {
+    if (items.length === 0) {
+      throw new UserError(
+        'Pending blocked session history transaction cannot be empty.',
+      );
+    }
+    return canonicalizeSessionHistoryTransaction({
+      type: 'append_items',
+      items,
+    });
+  }
+
+  const expectedSuffix = normalizeItemsForSessionPersistence(
+    extractOutputItemsFromRunItems(replacementItems, reasoningItemIdPolicy),
+  );
+  if (expectedSuffix.length === 0 || items.length === 0) {
+    throw new UserError(
+      'Pending accepted session history transaction requires a non-empty suffix and replacement.',
+    );
+  }
+  return canonicalizeSessionHistoryTransaction({
+    type: 'replace_suffix',
+    expectedSuffix,
+    replacement: items,
+  });
+}
+
+function getEffectiveSessionReasoningItemIdPolicy(
+  session: Session,
+  state: RunState<any, any>,
+): ReasoningItemIdPolicy {
+  return session.preserveReasoningItemIdsForPersistence?.() === true
+    ? 'preserve'
+    : (state._reasoningItemIdPolicy ?? 'preserve');
+}
+
+export function selectRunItemsForBlockedOutput(
+  items: RunItem[],
+  unpersistedStartIndex = 0,
+): RunItem[] {
+  return selectRunItemIndexesForBlockedOutput(items, unpersistedStartIndex).map(
+    (index) => items[index]!,
+  );
+}
+
+export function canPersistBlockedOutputToSession(
+  session: Session | undefined,
+  state: RunState<any, any>,
+): boolean {
+  return (
+    isSessionHistoryTransactionAwareSession(session) &&
+    selectRunItemIndexesForBlockedOutput(
+      state._generatedItems,
+      state._currentTurnPersistedItemCount,
+    ).length > 0
+  );
+}
+
+export async function prepareSessionHistoryTransactionsForRun(
+  session: Session | undefined,
+  state: RunState<any, any>,
+  options: { serverManagesConversation: boolean },
+): Promise<void> {
+  const boundSessionId = state._currentTurnSessionHistoryTransactionSessionId;
+  const hasTransactionAuthority =
+    boundSessionId !== undefined ||
+    state._pendingSessionHistoryTransaction !== undefined ||
+    state._currentTurnDeferredSessionItemIndexes.size > 0;
+
+  if (
+    hasTransactionAuthority &&
+    state._pendingLegacyCompactionSessionItems !== undefined
+  ) {
+    throw new UserError(
+      'RunState cannot combine legacy compaction reconciliation with output guardrail transaction authority.',
+    );
+  }
+  if (!hasTransactionAuthority) {
+    await reconcileLegacyCompactionSessionBeforeResume(session, state);
+  }
+
+  if (
+    options.serverManagesConversation ||
+    !isSessionHistoryTransactionAwareSession(session)
+  ) {
+    if (hasTransactionAuthority) {
+      throw new UserError(
+        'Output guardrail session persistence must resume with the same transaction-aware local session.',
+      );
+    }
+    return;
+  }
+
+  const sessionId = await session.getSessionId();
+  if (boundSessionId !== undefined && boundSessionId !== sessionId) {
+    throw new UserError(
+      'Output guardrail session persistence belongs to a different session and cannot be resumed safely.',
+    );
+  }
+  state._currentTurnSessionHistoryTransactionSessionId = sessionId;
+  state._currentTurnSessionReasoningItemIdPolicy ??=
+    getEffectiveSessionReasoningItemIdPolicy(session, state);
+  state._currentTurnSessionHistoryTransactionInputItems ??= [];
+  await flushPendingSessionHistoryTransaction(session, state);
+  await assertBlockedSessionSuffixMatches(session, state);
+}
+
+export function captureSessionHistoryTransactionInputItems(
+  session: Session | undefined,
+  state: RunState<any, any>,
+  items: AgentInputItem[] | undefined,
+): void {
+  if (session === undefined) {
+    state._currentTurnSessionHistoryTransactionInputItems =
+      normalizeItemsForSessionPersistence(items ?? []);
+    return;
+  }
+  if (!isSessionHistoryTransactionAwareSession(session)) {
+    return;
+  }
+  if (state._currentTurnSessionHistoryTransactionSessionId === undefined) {
+    return;
+  }
+  state._currentTurnSessionHistoryTransactionInputItems =
+    normalizeItemsForSessionPersistence(items ?? []);
+}
+
+export function markSessionHistoryTransactionInputPersisted(
+  state: RunState<any, any>,
+): void {
+  if (state._currentTurnSessionHistoryTransactionInputItems !== undefined) {
+    state._currentTurnSessionHistoryTransactionInputItems = [];
+  }
+}
+
+export function releaseUnusedSessionHistoryTransactionBinding(
+  state: RunState<any, any>,
+): void {
+  if (
+    state._pendingSessionHistoryTransaction !== undefined ||
+    state._currentTurnBlockedSessionStartIndex !== undefined ||
+    state._currentTurnDeferredSessionItemIndexes.size > 0 ||
+    hasBlockedOutputExecutionEffect(
+      state._generatedItems,
+      state._currentTurnPersistedItemCount,
+    )
+  ) {
+    return;
+  }
+  clearSessionHistoryTransactionBinding(state);
+}
+
+export function releaseProvisionalSessionHistoryTransactionBinding(
+  state: RunState<any, any>,
+  provisionalSessionId: string | undefined,
+  portableInputItems: AgentInputItem[] | undefined,
+): void {
+  if (
+    provisionalSessionId === undefined ||
+    state._currentTurnSessionHistoryTransactionSessionId !==
+      provisionalSessionId ||
+    state._pendingSessionHistoryTransaction !== undefined ||
+    state._currentTurnBlockedSessionStartIndex !== undefined ||
+    state._currentTurnDeferredSessionItemIndexes.size > 0
+  ) {
+    return;
+  }
+  clearSessionHistoryTransactionBinding(state);
+  state._currentTurnSessionHistoryTransactionInputItems = portableInputItems;
+}
+
+function clearSessionHistoryTransactionBinding(
+  state: RunState<any, any>,
+): void {
+  state._currentTurnSessionHistoryTransactionSessionId = undefined;
+  state._currentTurnSessionReasoningItemIdPolicy = undefined;
+  state._currentTurnSessionHistoryTransactionInputItems = undefined;
+  state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput =
+    undefined;
+}
+
+async function assertBlockedSessionSuffixMatches(
+  session: Session,
+  state: RunState<any, any>,
+): Promise<void> {
+  const blockedStartIndex = state._currentTurnBlockedSessionStartIndex;
+  if (blockedStartIndex === undefined) {
+    return;
+  }
+  const canReplaceAcceptedOutput =
+    state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput;
+  if (canReplaceAcceptedOutput !== true) {
+    throw new UserError(
+      'Accepted output cannot replace a sparse session suffix created from a serialized final step. Start a new run from the persisted session history.',
+    );
+  }
+  const reasoningItemIdPolicy = state._currentTurnSessionReasoningItemIdPolicy;
+  if (reasoningItemIdPolicy === undefined) {
+    throw new UserError(
+      'Blocked session history replacement authority is incomplete.',
+    );
+  }
+  const hasDeferredItems =
+    state._currentTurnDeferredSessionItemIndexes.size > 0;
+  const plan = hasDeferredItems
+    ? buildRunItemPersistencePlan(state, state._generatedItems, false, true)
+    : undefined;
+  if (hasDeferredItems && plan?.transactionKind !== 'accepted_replace') {
+    throw new UserError(
+      'Blocked session history replacement authority is incomplete.',
+    );
+  }
+  const suffixRunItems = hasDeferredItems
+    ? plan!.runItemsToReplace
+    : state._generatedItems.slice(
+        blockedStartIndex,
+        state._currentTurnPersistedItemCount,
+      );
+  const expectedSuffix = normalizeItemsForSessionPersistence(
+    extractOutputItemsFromRunItems(suffixRunItems, reasoningItemIdPolicy),
+  );
+  const currentItems = await session.getItems();
+  const comparableCurrentItems =
+    session.prepareHistoryItemsForPersistenceComparison?.(currentItems) ??
+    currentItems;
+  const comparableExpectedSuffix =
+    session.prepareHistoryItemsForPersistenceComparison?.(expectedSuffix) ??
+    expectedSuffix;
+  if (
+    comparableExpectedSuffix.length === 0 ||
+    !agentItemRangeMatches(
+      comparableCurrentItems,
+      comparableExpectedSuffix,
+      comparableCurrentItems.length - comparableExpectedSuffix.length,
+    )
+  ) {
+    throw new UserError(
+      'Session history suffix no longer matches the transaction precondition.',
+    );
+  }
+}
+
+function buildRunItemPersistencePlan(
+  state: RunState<any, any>,
+  items: RunItem[],
+  outputBlocked: boolean,
+  canUseHistoryTransactions: boolean,
+) {
+  return buildCanonicalRunItemPersistencePlan({
+    items,
+    alreadyPersistedCount: state._currentTurnPersistedItemCount ?? 0,
+    currentDeferredIndexes: state._currentTurnDeferredSessionItemIndexes,
+    outputBlocked,
+    canUseHistoryTransactions,
+  });
+}
 
 class SessionReconciliationRecoveryError extends Error {
   readonly errors: readonly [unknown, unknown];
@@ -92,12 +455,8 @@ export function createSessionPersistenceTracker(options: {
   hasCallModelInputFilter: boolean;
   persistInput?: typeof saveStreamInputToSession;
   resumingFromState?: boolean;
+  resumedSessionInputItems?: AgentInputItem[];
 }): SessionPersistenceTracker | undefined {
-  const { session } = options;
-  if (!session) {
-    return undefined;
-  }
-
   class SessionPersistenceTrackerImpl implements SessionPersistenceTracker {
     private readonly session?: Session;
     private readonly hasCallModelInputFilter: boolean;
@@ -115,8 +474,12 @@ export function createSessionPersistenceTracker(options: {
       this.session = options.session;
       this.hasCallModelInputFilter = options.hasCallModelInputFilter;
       this.persistInput = options.persistInput;
-      this.originalSnapshot = options.resumingFromState ? [] : undefined;
-      this.filteredSnapshot = undefined;
+      this.originalSnapshot = options.resumingFromState
+        ? cloneItems(options.resumedSessionInputItems ?? [])
+        : undefined;
+      this.filteredSnapshot = options.resumedSessionInputItems
+        ? cloneItems(options.resumedSessionInputItems)
+        : undefined;
       this.preparedSources = options.resumingFromState ? [] : undefined;
       this.initialPreparedItems = options.resumingFromState ? [] : undefined;
       this.initialSourcePositions = options.resumingFromState ? [] : undefined;
@@ -126,7 +489,11 @@ export function createSessionPersistenceTracker(options: {
       items?: AgentInputItem[],
       preparedInput?: string | AgentInputItem[],
     ) => {
-      const sessionItems = items ?? [];
+      const sessionItems =
+        items ??
+        (this.session === undefined && preparedInput !== undefined
+          ? toAgentInputList(preparedInput)
+          : []);
       this.originalSnapshot = cloneItems(
         deduplicateAgentInputItemsPreferringLatest(sessionItems),
       );
@@ -135,6 +502,13 @@ export function createSessionPersistenceTracker(options: {
         this.initialPreparedItems = preparedInput;
         this.initialSourcePositions = findOwnedItemIndexes(
           preparedInput,
+          sessionItems,
+        );
+      } else if (typeof preparedInput === 'string') {
+        this.preparedSources = undefined;
+        this.initialPreparedItems = sessionItems;
+        this.initialSourcePositions = findOwnedItemIndexes(
+          sessionItems,
           sessionItems,
         );
       } else {
@@ -625,8 +999,15 @@ export async function saveToSession(
   options: SessionPersistenceOptions = {},
 ): Promise<void> {
   const state = result.state;
-  const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
-  const newRunItems = result.newItems.slice(alreadyPersisted);
+  await prepareSessionHistoryTransactionsForRun(session, state, {
+    serverManagesConversation: false,
+  });
+  const persistencePlan = buildRunItemPersistencePlan(
+    state,
+    result.newItems,
+    options.outputBlocked === true,
+    isSessionHistoryTransactionAwareSession(session),
+  );
 
   if (
     typeof process !== 'undefined' &&
@@ -634,18 +1015,32 @@ export async function saveToSession(
   ) {
     console.debug(
       'saveToSession:newRunItems',
-      newRunItems.map((item) => item.type),
+      persistencePlan.runItemsToPersist.map((item) => item.type),
     );
+  }
+
+  if (
+    options.outputBlocked === true &&
+    !persistencePlan.useHistoryTransaction
+  ) {
+    await saveStreamInputToSession(session, sessionInputItems);
+    return;
   }
 
   await persistRunItemsToSession({
     session,
     state,
-    newRunItems,
+    newRunItems: persistencePlan.runItemsToPersist,
+    runItemsToReplace: persistencePlan.runItemsToReplace,
+    processedRunItemCount: persistencePlan.processedRunItemCount,
+    deferredRunItemIndexes: persistencePlan.deferredRunItemIndexes,
+    useHistoryTransaction: persistencePlan.useHistoryTransaction,
+    transactionKind: persistencePlan.transactionKind,
     extraInputItems: sessionInputItems,
-    lastResponseId: result.lastResponseId,
-    alreadyPersistedCount: alreadyPersisted,
-    runCompaction: options.runCompaction ?? true,
+    lastResponseId: options.outputBlocked ? undefined : result.lastResponseId,
+    alreadyPersistedCount: persistencePlan.alreadyPersistedCount,
+    runCompaction:
+      options.outputBlocked === true ? false : (options.runCompaction ?? true),
     compactionMode: options.compactionMode,
   });
 }
@@ -682,17 +1077,38 @@ export async function saveStreamResultToSession(
   sessionInputItems?: AgentInputItem[],
 ): Promise<void> {
   const state = result.state;
-  const alreadyPersisted = state._currentTurnPersistedItemCount ?? 0;
-  const newRunItems = result.newItems.slice(alreadyPersisted);
+  await prepareSessionHistoryTransactionsForRun(session, state, {
+    serverManagesConversation: false,
+  });
+  const persistencePlan = buildRunItemPersistencePlan(
+    state,
+    result.newItems,
+    options.outputBlocked === true,
+    isSessionHistoryTransactionAwareSession(session),
+  );
+
+  if (
+    options.outputBlocked === true &&
+    !persistencePlan.useHistoryTransaction
+  ) {
+    await saveStreamInputToSession(session, sessionInputItems);
+    return;
+  }
 
   await persistRunItemsToSession({
     session,
     state,
-    newRunItems,
+    newRunItems: persistencePlan.runItemsToPersist,
+    runItemsToReplace: persistencePlan.runItemsToReplace,
+    processedRunItemCount: persistencePlan.processedRunItemCount,
+    deferredRunItemIndexes: persistencePlan.deferredRunItemIndexes,
+    useHistoryTransaction: persistencePlan.useHistoryTransaction,
+    transactionKind: persistencePlan.transactionKind,
     extraInputItems: sessionInputItems,
-    lastResponseId: result.lastResponseId,
-    alreadyPersistedCount: alreadyPersisted,
-    runCompaction: options.runCompaction ?? true,
+    lastResponseId: options.outputBlocked ? undefined : result.lastResponseId,
+    alreadyPersistedCount: persistencePlan.alreadyPersistedCount,
+    runCompaction:
+      options.outputBlocked === true ? false : (options.runCompaction ?? true),
     compactionMode: options.compactionMode,
   });
 }
@@ -1094,6 +1510,11 @@ async function persistRunItemsToSession(options: {
   session?: Session;
   state: RunState<any, any>;
   newRunItems: RunItem[];
+  runItemsToReplace: RunItem[];
+  processedRunItemCount: number;
+  deferredRunItemIndexes: number[];
+  useHistoryTransaction: boolean;
+  transactionKind?: 'blocked_append' | 'accepted_replace';
   extraInputItems?: AgentInputItem[] | undefined;
   lastResponseId?: string;
   alreadyPersistedCount: number;
@@ -1104,6 +1525,11 @@ async function persistRunItemsToSession(options: {
     session,
     state,
     newRunItems,
+    runItemsToReplace,
+    processedRunItemCount,
+    deferredRunItemIndexes,
+    useHistoryTransaction,
+    transactionKind,
     extraInputItems = [],
     lastResponseId,
     alreadyPersistedCount,
@@ -1117,18 +1543,44 @@ async function persistRunItemsToSession(options: {
 
   await reconcileLegacyCompactionSessionBeforeResume(session, state);
 
-  const reasoningItemIdPolicy =
-    session.preserveReasoningItemIdsForPersistence?.() === true
-      ? undefined
-      : state._reasoningItemIdPolicy;
+  const effectiveReasoningItemIdPolicy =
+    getEffectiveSessionReasoningItemIdPolicy(session, state);
+  const frozenReasoningItemIdPolicy = useHistoryTransaction
+    ? (state._currentTurnSessionReasoningItemIdPolicy ??
+      effectiveReasoningItemIdPolicy)
+    : effectiveReasoningItemIdPolicy;
+  if (
+    useHistoryTransaction &&
+    transactionKind === 'accepted_replace' &&
+    (state._currentTurnBlockedSessionStartIndex === undefined ||
+      state._currentTurnSessionReasoningItemIdPolicy === undefined)
+  ) {
+    throw new UserError(
+      'Accepted session history replacement is missing its blocked-output persistence authority.',
+    );
+  }
   const itemsToSave = [
     ...extraInputItems,
-    ...extractOutputItemsFromRunItems(newRunItems, reasoningItemIdPolicy),
+    ...extractOutputItemsFromRunItems(newRunItems, frozenReasoningItemIdPolicy),
   ];
+  const commitPersistenceState = () => {
+    state._currentTurnPersistedItemCount =
+      alreadyPersistedCount + processedRunItemCount;
+    state._currentTurnDeferredSessionItemIndexes = new Set(
+      deferredRunItemIndexes,
+    );
+    if (deferredRunItemIndexes.length === 0) {
+      state._currentTurnBlockedSessionStartIndex = undefined;
+      state._currentTurnSessionHistoryTransactionSessionId = undefined;
+      state._currentTurnSessionReasoningItemIdPolicy = undefined;
+      state._currentTurnSessionHistoryTransactionInputItems = undefined;
+      state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput =
+        undefined;
+    }
+  };
 
   if (itemsToSave.length === 0) {
-    state._currentTurnPersistedItemCount =
-      alreadyPersistedCount + newRunItems.length;
+    commitPersistenceState();
     if (runCompaction) {
       await runCompactionOnSession(
         session,
@@ -1141,6 +1593,67 @@ async function persistRunItemsToSession(options: {
   }
 
   const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
+  if (useHistoryTransaction) {
+    if (
+      !isSessionHistoryTransactionAwareSession(session) ||
+      transactionKind === undefined ||
+      state._currentTurnSessionHistoryTransactionSessionId === undefined ||
+      state._currentTurnSessionReasoningItemIdPolicy === undefined
+    ) {
+      throw new UserError(
+        'Session history transaction capability was lost while persisting run items.',
+      );
+    }
+    const normalizedInputItems =
+      normalizeItemsForSessionPersistence(extraInputItems);
+    const frozenInputItems =
+      state._currentTurnSessionHistoryTransactionInputItems;
+    if (
+      frozenInputItems === undefined ||
+      frozenInputItems.length !== normalizedInputItems.length ||
+      !agentItemRangeMatches(normalizedInputItems, frozenInputItems, 0)
+    ) {
+      throw new UserError(
+        'Session history transaction input no longer matches the pre-execution snapshot.',
+      );
+    }
+    const persistedItemCount = alreadyPersistedCount + processedRunItemCount;
+    state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput ??=
+      state._serializedCurrentStep === undefined ||
+      state._currentStep !== state._serializedCurrentStep;
+    const operationId = getSessionHistoryTransactionOperationId(
+      state,
+      transactionKind,
+      alreadyPersistedCount,
+      persistedItemCount,
+    );
+    state._currentTurnBlockedSessionStartIndex ??= alreadyPersistedCount;
+    state._pendingSessionHistoryTransaction = structuredClone({
+      operationId,
+      transactionKind,
+      runItemIndexes: getRunItemIndexesForPendingTransaction(
+        state,
+        newRunItems,
+      ),
+      replaceRunItemIndexes: getRunItemIndexesForPendingTransaction(
+        state,
+        runItemsToReplace,
+      ),
+      alreadyPersistedCount,
+      persistedItemCount,
+      deferredItemIndexes: deferredRunItemIndexes,
+    });
+    await flushPendingSessionHistoryTransaction(session, state);
+    if (runCompaction) {
+      await runCompactionOnSession(
+        session,
+        lastResponseId,
+        state,
+        compactionMode,
+      );
+    }
+    return;
+  }
   const compactedItems = trimToLatestCompaction(sanitizedItems);
   assertPersistableCompactionBoundary(compactedItems);
   if (compactedItems[0]?.type === 'compaction') {
@@ -1153,8 +1666,7 @@ async function persistRunItemsToSession(options: {
   } else {
     await session.addItems(sanitizedItems);
   }
-  state._currentTurnPersistedItemCount =
-    alreadyPersistedCount + newRunItems.length;
+  commitPersistenceState();
   if (runCompaction) {
     await runCompactionOnSession(
       session,
@@ -1162,6 +1674,60 @@ async function persistRunItemsToSession(options: {
       state,
       compactionMode,
     );
+  }
+}
+
+async function flushPendingSessionHistoryTransaction(
+  session: Session | undefined,
+  state: RunState<any, any>,
+): Promise<void> {
+  const pending = state._pendingSessionHistoryTransaction;
+  if (!pending) {
+    return;
+  }
+  if (!isSessionHistoryTransactionAwareSession(session)) {
+    throw new UserError(
+      'A pending session history transaction requires the same transaction-aware session to resume safely.',
+    );
+  }
+  const boundSessionId = state._currentTurnSessionHistoryTransactionSessionId;
+  if (boundSessionId === undefined) {
+    throw new UserError(
+      'A pending session history transaction is missing its session binding.',
+    );
+  }
+  const sessionId = await session.getSessionId();
+  if (sessionId !== boundSessionId) {
+    throw new UserError(
+      'A pending session history transaction belongs to a different session and cannot be resumed safely.',
+    );
+  }
+
+  if (
+    state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput ===
+    undefined
+  ) {
+    throw new UserError(
+      'A pending session history transaction is missing its accepted-output replacement authority.',
+    );
+  }
+  await session.applyHistoryTransaction({
+    operationId: pending.operationId,
+    transaction: buildPendingSessionHistoryTransaction(state),
+  });
+  state._currentTurnPersistedItemCount = pending.persistedItemCount;
+  state._currentTurnDeferredSessionItemIndexes = new Set(
+    pending.deferredItemIndexes,
+  );
+  state._pendingSessionHistoryTransaction = undefined;
+  state._currentTurnSessionHistoryTransactionInputItems = [];
+  if (pending.transactionKind === 'accepted_replace') {
+    state._currentTurnBlockedSessionStartIndex = undefined;
+    state._currentTurnSessionHistoryTransactionSessionId = undefined;
+    state._currentTurnSessionReasoningItemIdPolicy = undefined;
+    state._currentTurnSessionHistoryTransactionInputItems = undefined;
+    state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput =
+      undefined;
   }
 }
 

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1035,6 +1035,7 @@ async function runApprovedFunctionTool<TContext>(
       let executedInput = approvalArgs;
       let toolDetails: ToolCallDetails = { toolCall: toolRun.toolCall };
       let shouldValidateToolOutput = false;
+      let executionStatus: 'executed' | undefined;
       if (inputGuardrailResult.type === 'reject') {
         toolOutput = await resolveFunctionFailureOutput(
           deps,
@@ -1082,6 +1083,7 @@ async function runApprovedFunctionTool<TContext>(
           input: toolRun.toolCall.arguments,
           details: toolDetails,
         });
+        executionStatus = 'executed';
         throwIfRedactionPromoted(redactedBeforeInvocation);
         const redactedBeforeOutputGuardrails = refreshRedaction();
         const outputGuardrailResults: ToolOutputGuardrailResult[] = [];
@@ -1187,6 +1189,7 @@ async function runApprovedFunctionTool<TContext>(
           agent,
           toolOutput,
           customData,
+          executionStatus,
         ),
       };
 
@@ -1720,7 +1723,13 @@ export async function executeShellActions(
           rawItem.providerData = providerMeta;
         }
 
-        return new RunToolCallOutputItem(rawItem, agent, rawItem.output);
+        return new RunToolCallOutputItem(
+          rawItem,
+          agent,
+          rawItem.output,
+          undefined,
+          'executed',
+        );
       },
     );
 
@@ -1892,7 +1901,13 @@ export async function executeApplyPatchOperations(
           span.spanData.output = output;
         }
 
-        return new RunToolCallOutputItem(rawItem, agent, output, customData);
+        return new RunToolCallOutputItem(
+          rawItem,
+          agent,
+          output,
+          customData,
+          'executed',
+        );
       },
     );
 
@@ -2095,7 +2110,13 @@ export async function executeComputerActions(
           span.spanData.output = imageUrl;
         }
 
-        return new RunToolCallOutputItem(rawItem, agent, imageUrl, customData);
+        return new RunToolCallOutputItem(
+          rawItem,
+          agent,
+          imageUrl,
+          customData,
+          'executed',
+        );
       },
     );
 

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -1,14 +1,21 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import {
   Agent,
+  InputGuardrailTripwireTriggered,
+  ToolGuardrailFunctionOutputFactory,
   MemorySession,
   OutputGuardrailTripwireTriggered,
+  RunContext,
+  Runner,
   RunState,
+  RunToolCallItem,
+  RunToolCallOutputItem,
   Usage,
   run,
   setTracingDisabled,
   tool,
+  defineToolInputGuardrail,
   type AgentInputItem,
   type CallModelInputFilterArgs,
   type Model,
@@ -16,10 +23,14 @@ import {
   type ModelResponse,
   type OpenAIResponsesCompactionArgs,
   type OpenAIResponsesCompactionResult,
+  type SessionHistoryTransactionArgs,
   type StreamEvent,
+  type ToolUseBehavior,
 } from '../src';
 import * as protocol from '../src/types/protocol';
 import { fakeModelMessage } from './stubs';
+import logger from '../src/logger';
+import { allowConsole } from '../../../helpers/tests/console-guard';
 
 type RunMode = 'non_streamed' | 'streamed';
 
@@ -130,10 +141,2495 @@ function getPersistedToolItems(items: AgentInputItem[]) {
   );
 }
 
+const finalToolBehaviors: Array<{
+  name: string;
+  value: ToolUseBehavior;
+}> = [
+  { name: 'stop_on_first_tool', value: 'stop_on_first_tool' },
+  {
+    name: 'stopAtToolNames',
+    value: { stopAtToolNames: ['commit_tool'] },
+  },
+  {
+    name: 'custom finalizer',
+    value: async (_context, results) => {
+      const result = results.find((item) => item.type === 'function_output');
+      return {
+        isFinalOutput: true,
+        isInterrupted: undefined,
+        finalOutput: String(result?.output),
+      };
+    },
+  },
+];
+
+function reasoningItem(id: string, text: string): protocol.ReasoningItem {
+  return {
+    type: 'reasoning',
+    id,
+    content: [{ type: 'input_text', text }],
+  };
+}
+
+describe('committed tool output guardrail session persistence', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  it('binds transaction-aware streaming state before exposing the result', async () => {
+    let markSessionIdRequested!: () => void;
+    let releaseSessionId!: () => void;
+    const sessionIdRequested = new Promise<void>((resolve) => {
+      markSessionIdRequested = resolve;
+    });
+    const sessionIdAvailable = new Promise<void>((resolve) => {
+      releaseSessionId = resolve;
+    });
+    class DeferredSessionIdSession extends MemorySession {
+      override async getSessionId(): Promise<string> {
+        markSessionIdRequested();
+        await sessionIdAvailable;
+        return await super.getSessionId();
+      }
+    }
+
+    let markModelStarted!: () => void;
+    let releaseModel!: () => void;
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    const modelCanFinish = new Promise<void>((resolve) => {
+      releaseModel = resolve;
+    });
+    const model: Model = {
+      async getResponse(): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming request.');
+      },
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        markModelStarted();
+        await modelCanFinish;
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'bound-stream-response',
+            output: [fakeModelMessage('done')],
+            usage: new Usage(),
+          },
+        } as StreamEvent;
+      },
+    };
+    const agent = new Agent({ name: 'Bound streaming state agent', model });
+    const session = new DeferredSessionIdSession({
+      sessionId: 'bound-stream-session',
+    });
+
+    let resultExposed = false;
+    const resultPromise = run(agent, 'hello', { session, stream: true });
+    void resultPromise.then(() => {
+      resultExposed = true;
+    });
+    await sessionIdRequested;
+    await Promise.resolve();
+    expect(resultExposed).toBe(false);
+
+    releaseSessionId();
+    const result = await resultPromise;
+    await modelStarted;
+    expect(result.state._currentTurnSessionHistoryTransactionSessionId).toBe(
+      'bound-stream-session',
+    );
+    expect(result.state._currentTurnSessionReasoningItemIdPolicy).toBe(
+      'preserve',
+    );
+
+    releaseModel();
+    await result.completed;
+    expect(
+      result.state._currentTurnSessionHistoryTransactionSessionId,
+    ).toBeUndefined();
+    expect(
+      result.state._currentTurnSessionReasoningItemIdPolicy,
+    ).toBeUndefined();
+  });
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'rejects a $mode blocked transaction when the logical session changes before persistence',
+    async (mode) => {
+      class ChangingSessionIdSession extends MemorySession {
+        sessionIdCalls = 0;
+        transactionCalls = 0;
+
+        override async getSessionId(): Promise<string> {
+          this.sessionIdCalls += 1;
+          return this.sessionIdCalls === 1
+            ? 'session-before-execution'
+            : 'session-before-persistence';
+        }
+
+        override async applyHistoryTransaction(
+          _args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          this.transactionCalls += 1;
+        }
+      }
+
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'session_identity_tool',
+        description: 'Commits before the logical session identity changes.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall('session_identity_tool', 'call-session-identity'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Changing logical session agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'block after logical session change',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new ChangingSessionIdSession();
+
+      let blockedError: OutputGuardrailTripwireTriggered<any> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use session_identity_tool', {
+          session,
+          stream: true,
+        });
+        try {
+          await result.completed;
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedError = error as OutputGuardrailTripwireTriggered<any>;
+        }
+      } else {
+        try {
+          await run(agent, 'Use session_identity_tool', { session });
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedError = error as OutputGuardrailTripwireTriggered<any>;
+        }
+      }
+
+      expect((blockedError as Error & { cause?: unknown }).cause).toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining('different session'),
+        }),
+      );
+      expect(session.sessionIdCalls).toBeGreaterThanOrEqual(2);
+      expect(session.transactionCalls).toBe(0);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(await session.getItems()).toEqual([]);
+    },
+  );
+
+  it.each(
+    finalToolBehaviors.flatMap(({ name, value }) =>
+      (['non_streamed', 'streamed'] as const).map((mode) => ({
+        behaviorName: name,
+        toolUseBehavior: value,
+        mode,
+      })),
+    ),
+  )(
+    'persists a direct final tool once for $behaviorName in $mode mode when guardrails trip',
+    async ({ toolUseBehavior, mode }) => {
+      const execute = vi.fn(async () => 'committed-result');
+      let guardrailShouldTrip = true;
+      const commitTool = tool({
+        name: 'commit_tool',
+        description: 'Commits a side effect.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [functionToolCall('commit_tool', 'call-committed')],
+          usage: new Usage(),
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Committed tool agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior,
+        outputGuardrails: [
+          {
+            name: 'block committed result',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: guardrailShouldTrip,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+
+      const runOnce = async (input: string) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, input, { session });
+      };
+
+      await expect(runOnce('Use commit_tool')).rejects.toBeInstanceOf(
+        OutputGuardrailTripwireTriggered,
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(
+        (await session.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual(['message:user', 'function_call', 'function_call_result']);
+
+      guardrailShouldTrip = false;
+      const followup = await runOnce('Continue');
+      expect(followup.finalOutput).toBe('done');
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(
+        getPersistedToolItems(model.requests.at(-1)?.input as AgentInputItem[]),
+      ).toMatchObject([
+        { type: 'function_call', callId: 'call-committed' },
+        { type: 'function_call_result', callId: 'call-committed' },
+      ]);
+      expect(getPersistedToolItems(await session.getItems())).toHaveLength(2);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'keeps a full-subset blocked $mode transaction bound to its session',
+    async (mode) => {
+      let guardrailShouldTrip = true;
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'bound_commit_tool',
+        description: 'Commits before a session ownership check.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall('bound_commit_tool', 'call-bound-committed'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const outputGuardrail = vi.fn(async () => ({
+        outputInfo: null,
+        tripwireTriggered: guardrailShouldTrip,
+      }));
+      const agent = new Agent({
+        name: 'Bound committed tool agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          { name: 'toggle bound committed result', execute: outputGuardrail },
+        ],
+      });
+      const originalSession = new MemorySession({
+        sessionId: 'full-subset-original-session',
+      });
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use bound_commit_tool', {
+          session: originalSession,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'Use bound_commit_tool', {
+            session: originalSession,
+          });
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+
+      expect(blockedState).toBeDefined();
+      expect(blockedState!._currentTurnDeferredSessionItemIndexes.size).toBe(0);
+      expect(blockedState!._currentTurnSessionHistoryTransactionSessionId).toBe(
+        'full-subset-original-session',
+      );
+      await expect(
+        RunState.fromString(agent, blockedState!.toString()),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+
+      guardrailShouldTrip = false;
+      const differentSession = new MemorySession({
+        sessionId: 'full-subset-different-session',
+      });
+      const differentSessionResume =
+        mode === 'streamed'
+          ? run(agent, blockedState!, {
+              session: differentSession,
+              stream: true,
+            })
+          : run(agent, blockedState!, { session: differentSession });
+      await expect(differentSessionResume).rejects.toThrow(
+        'Output guardrail session persistence belongs to a different session',
+      );
+      expect(outputGuardrail).toHaveBeenCalledTimes(1);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(await differentSession.getItems()).toEqual([]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'releases an unused provisional session binding after a message-only $mode tripwire',
+    async (mode) => {
+      let guardrailShouldTrip = true;
+      const model = new ApprovalSessionModel([
+        {
+          output: [fakeModelMessage('accepted after session switch')],
+          usage: new Usage(),
+        },
+      ]);
+      const outputGuardrail = vi.fn(async () => ({
+        outputInfo: null,
+        tripwireTriggered: guardrailShouldTrip,
+      }));
+      const agent = new Agent({
+        name: 'Message-only session switch agent',
+        model,
+        outputGuardrails: [
+          { name: 'toggle message-only output', execute: outputGuardrail },
+        ],
+      });
+      const originalSession = new MemorySession({
+        sessionId: 'message-only-original-session',
+      });
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'hello', {
+          session: originalSession,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'hello', { session: originalSession });
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+
+      expect(
+        blockedState!._currentTurnSessionHistoryTransactionSessionId,
+      ).toBeUndefined();
+      expect(
+        (await originalSession.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual(['message:user']);
+      guardrailShouldTrip = false;
+      const replacementSession = new MemorySession({
+        sessionId: 'message-only-replacement-session',
+      });
+      if (mode === 'streamed') {
+        const resumed = await run(agent, blockedState!, {
+          session: replacementSession,
+          stream: true,
+        });
+        await resumed.completed;
+        expect(resumed.finalOutput).toBe('accepted after session switch');
+      } else {
+        const resumed = await run(agent, blockedState!, {
+          session: replacementSession,
+        });
+        expect(resumed.finalOutput).toBe('accepted after session switch');
+      }
+
+      expect(outputGuardrail).toHaveBeenCalledTimes(2);
+      expect(model.requests).toHaveLength(1);
+      expect(
+        (await replacementSession.getItems()).map((item) => item.type),
+      ).toEqual(['message']);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'releases an unused provisional session binding after a $mode input tripwire',
+    async (mode) => {
+      let shouldTrip = true;
+      const model = new ApprovalSessionModel([
+        {
+          output: [fakeModelMessage('accepted after input tripwire')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Input tripwire session switch agent',
+        model,
+        inputGuardrails: [
+          {
+            name: 'toggle input tripwire',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: shouldTrip,
+            }),
+          },
+        ],
+      });
+      const originalSession = new MemorySession({
+        sessionId: 'input-tripwire-original-session',
+      });
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'hello', {
+          session: originalSession,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          InputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'hello', { session: originalSession });
+        } catch (error) {
+          expect(error).toBeInstanceOf(InputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+
+      expect(
+        blockedState!._currentTurnSessionHistoryTransactionSessionId,
+      ).toBeUndefined();
+      shouldTrip = false;
+      const replacementSession = new MemorySession({
+        sessionId: 'input-tripwire-replacement-session',
+      });
+      if (mode === 'streamed') {
+        const resumed = await run(agent, blockedState!, {
+          session: replacementSession,
+          stream: true,
+        });
+        await resumed.completed;
+        expect(resumed.finalOutput).toBe('accepted after input tripwire');
+      } else {
+        const resumed = await run(agent, blockedState!, {
+          session: replacementSession,
+        });
+        expect(resumed.finalOutput).toBe('accepted after input tripwire');
+      }
+
+      expect(model.requests).toHaveLength(1);
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) => [
+      {
+        mode,
+        name: 'error',
+        createError: () => new Error('guardrail failed'),
+      },
+      {
+        mode,
+        name: 'cancellation',
+        createError: () => {
+          const error = new Error('guardrail cancelled');
+          error.name = 'AbortError';
+          return error;
+        },
+      },
+    ]),
+  )(
+    'preserves the full $mode final turn after output guardrail $name',
+    async ({ mode, createError }) => {
+      const commitTool = tool({
+        name: 'guardrail_error_commit_tool',
+        description: 'Commits before the output guardrail fails.',
+        parameters: z.object({}),
+        execute: async () => 'committed-before-guardrail-error',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            fakeModelMessage('replayable final output'),
+            functionToolCall(
+              'guardrail_error_commit_tool',
+              'call-before-guardrail-error',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Replayable guardrail failure agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'fail final output check',
+            execute: async () => {
+              throw createError();
+            },
+          },
+        ],
+      });
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'hello', { session, stream: true });
+        await expect(result.completed).rejects.toThrow(
+          'Output guardrail failed to complete',
+        );
+      } else {
+        await expect(run(agent, 'hello', { session })).rejects.toThrow(
+          'Output guardrail failed to complete',
+        );
+      }
+      expect(
+        (await session.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'message:assistant',
+        'function_call',
+        'function_call_result',
+      ]);
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) => [
+      {
+        mode,
+        name: 'error',
+        errorName: 'Error',
+        createError: () => new Error('guardrail failed'),
+      },
+      {
+        mode,
+        name: 'cancellation',
+        errorName: 'AbortError',
+        createError: () => {
+          const error = new Error('guardrail cancelled');
+          error.name = 'AbortError';
+          return error;
+        },
+      },
+    ]),
+  )(
+    'keeps the $mode guardrail $name primary when full-turn persistence fails',
+    async ({ mode, errorName, createError }) => {
+      class RejectingGuardrailErrorSession extends MemorySession {
+        override async addItems(_items: AgentInputItem[]): Promise<void> {
+          throw new Error('guardrail error persistence failed');
+        }
+      }
+
+      const model = new ApprovalSessionModel([
+        {
+          output: [fakeModelMessage('replayable final output')],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Guardrail primary error agent',
+        model,
+        outputGuardrails: [
+          {
+            name: 'fail final output before persistence failure',
+            execute: async () => {
+              throw createError();
+            },
+          },
+        ],
+      });
+      const session = new RejectingGuardrailErrorSession();
+
+      let guardrailError: Error | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'hello', { session, stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'hello', { session });
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        guardrailError = error as Error;
+      }
+
+      expect(guardrailError?.message).toContain(
+        'Output guardrail failed to complete',
+      );
+      expect((guardrailError as Error & { error?: Error }).error?.name).toBe(
+        errorName,
+      );
+      expect((guardrailError as Error & { cause?: unknown }).cause).toEqual(
+        new Error('guardrail error persistence failed'),
+      );
+      expect(await session.getItems()).toEqual([]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'persists a committed tool when a $mode error-handler final output is blocked',
+    async (mode) => {
+      const execute = vi.fn(async () => 'committed-before-max-turns');
+      const commitTool = tool({
+        name: 'error_handler_commit_tool',
+        description: 'Commits before max-turn handling.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              'error_handler_commit_tool',
+              'call-before-error-handler',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Blocked error-handler output agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'run_llm_again',
+        outputGuardrails: [
+          {
+            name: 'block error-handler output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+      const options = {
+        session,
+        maxTurns: 1,
+        errorHandlers: {
+          maxTurns: () => ({ finalOutput: 'blocked fallback' }),
+        },
+      } as const;
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use error_handler_commit_tool', {
+          ...options,
+          stream: true,
+        });
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        expect(result.finalOutput).toBeUndefined();
+        warnSpy.mockRestore();
+      } else {
+        await expect(
+          run(agent, 'Use error_handler_commit_tool', options),
+        ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      }
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.requests).toHaveLength(1);
+      expect(
+        (await session.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual(['message:user', 'function_call', 'function_call_result']);
+    },
+  );
+
+  it('hides streamed error-handler output before the finalizer microtask', async () => {
+    allowConsole(['warn']);
+    let resolveHandler: ((value: { finalOutput: string }) => void) | undefined;
+    let resolveGuardrail:
+      | ((value: { outputInfo: null; tripwireTriggered: boolean }) => void)
+      | undefined;
+    const commitTool = tool({
+      name: 'error_handler_visibility_tool',
+      description: 'Commits before a suspended error handler.',
+      parameters: z.object({}),
+      execute: async () => 'committed-before-error-handler',
+    });
+    const model = new ApprovalSessionModel([
+      {
+        output: [
+          functionToolCall(
+            'error_handler_visibility_tool',
+            'call-error-handler-visibility',
+          ),
+        ],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'Error-handler visibility agent',
+      model,
+      tools: [commitTool],
+      toolUseBehavior: 'run_llm_again',
+      outputGuardrails: [
+        {
+          name: 'suspend error-handler output',
+          execute: async () =>
+            await new Promise((resolve) => {
+              resolveGuardrail = resolve;
+            }),
+        },
+      ],
+    });
+    const result = await run(agent, 'Use error_handler_visibility_tool', {
+      stream: true,
+      maxTurns: 1,
+      errorHandlers: {
+        maxTurns: async () =>
+          await new Promise((resolve) => {
+            resolveHandler = resolve;
+          }),
+      },
+    });
+    await vi.waitFor(() => expect(resolveHandler).toBeDefined());
+
+    resolveHandler!({ finalOutput: 'guarded fallback' });
+    const observedBeforeFinalizer = await new Promise<string | undefined>(
+      (resolve) => queueMicrotask(() => resolve(result.finalOutput)),
+    );
+    expect(observedBeforeFinalizer).toBeUndefined();
+    await vi.waitFor(() => expect(resolveGuardrail).toBeDefined());
+    expect(result.finalOutput).toBeUndefined();
+
+    resolveGuardrail!({ outputInfo: null, tripwireTriggered: false });
+    await result.completed;
+    expect(result.finalOutput).toBe('guarded fallback');
+  });
+
+  it.each([
+    {
+      ownership: 'conversationId',
+      options: { conversationId: 'conversation-blocked-output' },
+    },
+    {
+      ownership: 'previousResponseId',
+      options: { previousResponseId: 'response-before-blocked-output' },
+    },
+  ])(
+    'does not persist blocked streaming tool history when $ownership owns conversation state',
+    async ({ options }) => {
+      class TransactionTrackingSession extends MemorySession {
+        transactionCount = 0;
+
+        override async applyHistoryTransaction(
+          args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          this.transactionCount += 1;
+          await super.applyHistoryTransaction(args);
+        }
+      }
+
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'server_owned_commit_tool',
+        description: 'Commits while the server owns conversation state.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              'server_owned_commit_tool',
+              'call-server-owned-commit',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Server-owned blocked output agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'block server-owned tool output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new TransactionTrackingSession();
+
+      const result = await run(agent, 'Use server_owned_commit_tool', {
+        ...options,
+        session,
+        stream: true,
+      });
+      await expect(result.completed).rejects.toBeInstanceOf(
+        OutputGuardrailTripwireTriggered,
+      );
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(session.transactionCount).toBe(0);
+      expect(await session.getItems()).toEqual([]);
+    },
+  );
+
+  it('keeps blocked streaming final output hidden when session persistence fails', async () => {
+    class RejectingTransactionSession extends MemorySession {
+      override async applyHistoryTransaction(
+        _args: SessionHistoryTransactionArgs,
+      ): Promise<void> {
+        throw new Error('blocked transaction failed');
+      }
+    }
+
+    const commitTool = tool({
+      name: 'failing_persistence_tool',
+      description: 'Commits before blocked persistence fails.',
+      parameters: z.object({}),
+      execute: async () => 'committed-result',
+    });
+    const model = new ApprovalSessionModel([
+      {
+        output: [
+          functionToolCall(
+            'failing_persistence_tool',
+            'call-failing-persistence',
+          ),
+        ],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'Failing persistence agent',
+      model,
+      tools: [commitTool],
+      toolUseBehavior: 'stop_on_first_tool',
+      outputGuardrails: [
+        {
+          name: 'block before persistence failure',
+          execute: async () => ({
+            outputInfo: null,
+            tripwireTriggered: true,
+          }),
+        },
+      ],
+    });
+    const result = await run(agent, 'Use failing_persistence_tool', {
+      session: new RejectingTransactionSession(),
+      stream: true,
+    });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    let blockedError: OutputGuardrailTripwireTriggered<any> | undefined;
+    try {
+      await result.completed;
+    } catch (error) {
+      expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      blockedError = error as OutputGuardrailTripwireTriggered<any>;
+    }
+    expect((blockedError as Error & { cause?: unknown }).cause).toEqual(
+      new Error('blocked transaction failed'),
+    );
+    expect(result.finalOutput).toBeUndefined();
+
+    warnSpy.mockRestore();
+  });
+
+  it('keeps a streaming message-only tripwire primary when input persistence fails', async () => {
+    class RejectingInputSession extends MemorySession {
+      addItemsCalls = 0;
+
+      override async addItems(_items: AgentInputItem[]): Promise<void> {
+        this.addItemsCalls += 1;
+        throw new Error('blocked input persistence failed');
+      }
+    }
+
+    const model = new ApprovalSessionModel([
+      {
+        output: [fakeModelMessage('blocked message')],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'Message-only persistence failure agent',
+      model,
+      outputGuardrails: [
+        {
+          name: 'block before input persistence failure',
+          execute: async () => ({
+            outputInfo: null,
+            tripwireTriggered: true,
+          }),
+        },
+      ],
+    });
+    const session = new RejectingInputSession();
+    const result = await run(agent, 'Reject this message', {
+      session,
+      stream: true,
+    });
+
+    let blockedError: OutputGuardrailTripwireTriggered<any> | undefined;
+    try {
+      await result.completed;
+    } catch (error) {
+      expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      blockedError = error as OutputGuardrailTripwireTriggered<any>;
+    }
+
+    expect((blockedError as Error & { cause?: unknown }).cause).toEqual(
+      new Error('blocked input persistence failed'),
+    );
+    expect(session.addItemsCalls).toBe(1);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    expect(result.finalOutput).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Accessed finalOutput before agent run is completed.',
+    );
+    warnSpy.mockRestore();
+    expect(await session.getItems()).toEqual([]);
+  });
+
+  it('keeps an error-handler output hidden when blocked persistence fails', async () => {
+    class RejectingTransactionSession extends MemorySession {
+      override async applyHistoryTransaction(
+        _args: SessionHistoryTransactionArgs,
+      ): Promise<void> {
+        throw new Error('error-handler transaction failed');
+      }
+    }
+
+    const execute = vi.fn(async () => 'committed-before-error-handler');
+    const commitTool = tool({
+      name: 'error_handler_persistence_tool',
+      description: 'Commits before error-handler persistence fails.',
+      parameters: z.object({}),
+      execute,
+    });
+    const model = new ApprovalSessionModel([
+      {
+        output: [
+          functionToolCall(
+            'error_handler_persistence_tool',
+            'call-error-handler-persistence',
+          ),
+        ],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'Error-handler persistence failure agent',
+      model,
+      tools: [commitTool],
+      toolUseBehavior: 'run_llm_again',
+      outputGuardrails: [
+        {
+          name: 'block error-handler persistence output',
+          execute: async () => ({
+            outputInfo: null,
+            tripwireTriggered: true,
+          }),
+        },
+      ],
+    });
+    const session = new RejectingTransactionSession();
+    const result = await run(agent, 'Use error_handler_persistence_tool', {
+      session,
+      stream: true,
+      maxTurns: 1,
+      errorHandlers: {
+        maxTurns: () => ({ finalOutput: 'blocked fallback' }),
+      },
+    });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    let blockedError: OutputGuardrailTripwireTriggered<any> | undefined;
+    try {
+      await result.completed;
+    } catch (error) {
+      expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      blockedError = error as OutputGuardrailTripwireTriggered<any>;
+    }
+
+    expect((blockedError as Error & { cause?: unknown }).cause).toEqual(
+      new Error('error-handler transaction failed'),
+    );
+    expect(result.finalOutput).toBeUndefined();
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(await session.getItems()).toEqual([]);
+
+    warnSpy.mockRestore();
+  });
+
+  it.each(['ordinary final output', 'error-handler final output'] as const)(
+    'does not emit agent_end before non-streamed %s persistence succeeds',
+    async (finalOutputSource) => {
+      class RejectingAcceptedSession extends MemorySession {
+        override async addItems(_items: AgentInputItem[]): Promise<void> {
+          throw new Error('accepted persistence failed');
+        }
+      }
+
+      const commitTool = tool({
+        name: 'accepted_persistence_tool',
+        description: 'Produces an error-handler final output.',
+        parameters: z.object({}),
+        execute: async () => 'committed-before-handler',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output:
+            finalOutputSource === 'ordinary final output'
+              ? [fakeModelMessage('accepted output')]
+              : [
+                  functionToolCall(
+                    'accepted_persistence_tool',
+                    'call-accepted-persistence',
+                  ),
+                ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Accepted persistence lifecycle agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'run_llm_again',
+      });
+      const runner = new Runner();
+      const runnerEnd = vi.fn();
+      const agentEnd = vi.fn();
+      runner.on('agent_end', runnerEnd);
+      agent.on('agent_end', agentEnd);
+
+      await expect(
+        runner.run(agent, 'Produce final output', {
+          session: new RejectingAcceptedSession(),
+          ...(finalOutputSource === 'error-handler final output'
+            ? {
+                maxTurns: 1,
+                errorHandlers: {
+                  maxTurns: () => ({ finalOutput: 'handled output' }),
+                },
+              }
+            : {}),
+        }),
+      ).rejects.toThrow('accepted persistence failed');
+      expect(runnerEnd).not.toHaveBeenCalled();
+      expect(agentEnd).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'retries an uncertain $mode blocked transaction with its frozen reasoning policy',
+    async (mode) => {
+      class CommitThenThrowSession extends MemorySession {
+        operationIds: string[] = [];
+        private throwAfterFirstCommit = true;
+
+        override async applyHistoryTransaction(
+          args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          this.operationIds.push(args.operationId);
+          await super.applyHistoryTransaction(args);
+          if (this.throwAfterFirstCommit) {
+            this.throwAfterFirstCommit = false;
+            throw new Error('blocked transaction outcome unknown');
+          }
+        }
+      }
+
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'uncertain_persistence_tool',
+        description: 'Commits before the session transaction outcome is known.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            reasoningItem(
+              'reasoning-uncertain-persistence',
+              'run the committed tool',
+            ),
+            functionToolCall(
+              'uncertain_persistence_tool',
+              'call-uncertain-persistence',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const outputGuardrail = vi.fn(async () => ({
+        outputInfo: null,
+        tripwireTriggered: true,
+      }));
+      const agent = new Agent({
+        name: 'Uncertain persistence agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'block uncertain persistence output',
+            execute: outputGuardrail,
+          },
+        ],
+      });
+      const session = new CommitThenThrowSession({
+        sessionId: 'uncertain-persistence-session',
+      });
+
+      let blockedError: OutputGuardrailTripwireTriggered<any> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use uncertain_persistence_tool', {
+          session,
+          stream: true,
+          reasoningItemIdPolicy: 'omit',
+        });
+        try {
+          await result.completed;
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedError = error as OutputGuardrailTripwireTriggered<any>;
+        }
+      } else {
+        try {
+          await run(agent, 'Use uncertain_persistence_tool', {
+            session,
+            reasoningItemIdPolicy: 'omit',
+          });
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedError = error as OutputGuardrailTripwireTriggered<any>;
+        }
+      }
+      expect(blockedError?.state).toBeDefined();
+      expect((blockedError as Error & { cause?: unknown }).cause).toEqual(
+        new Error('blocked transaction outcome unknown'),
+      );
+
+      await expect(
+        RunState.fromString(agent, blockedError!.state!.toString()),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely',
+      );
+      expect(outputGuardrail).toHaveBeenCalledTimes(1);
+
+      const pendingState = blockedError!.state!;
+      const differentSession = new MemorySession({
+        sessionId: 'different-uncertain-persistence-session',
+      });
+      const wrongSessionResume =
+        mode === 'streamed'
+          ? run(agent, pendingState, {
+              session: differentSession,
+              stream: true,
+            })
+          : run(agent, pendingState, { session: differentSession });
+      await expect(wrongSessionResume).rejects.toThrow(
+        'Output guardrail session persistence belongs to a different session',
+      );
+      const serverManagedResume =
+        mode === 'streamed'
+          ? run(agent, pendingState, {
+              session,
+              conversationId: 'server-owned-uncertain-resume',
+              stream: true,
+            })
+          : run(agent, pendingState, {
+              session,
+              conversationId: 'server-owned-uncertain-resume',
+            });
+      await expect(serverManagedResume).rejects.toThrow(
+        'Output guardrail session persistence must resume with the same transaction-aware local session',
+      );
+      expect(outputGuardrail).toHaveBeenCalledTimes(1);
+      if (mode === 'streamed') {
+        const resumed = await run(agent, pendingState, {
+          session,
+          stream: true,
+          reasoningItemIdPolicy: 'preserve',
+        });
+        await expect(resumed.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(
+          run(agent, pendingState, {
+            session,
+            reasoningItemIdPolicy: 'preserve',
+          }),
+        ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      }
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.requests).toHaveLength(1);
+      expect(outputGuardrail).toHaveBeenCalledTimes(2);
+      expect(session.operationIds).toHaveLength(2);
+      expect(session.operationIds[1]).toBe(session.operationIds[0]);
+      const persistedItems = await session.getItems();
+      expect(
+        persistedItems.map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'reasoning',
+        'function_call',
+        'function_call_result',
+      ]);
+      expect(
+        persistedItems.find((item) => item.type === 'reasoning'),
+      ).not.toHaveProperty('id');
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'keeps only causal reasoning and committed tool history for blocked $mode mixed output',
+    async (mode) => {
+      const commitTool = tool({
+        name: 'commit_tool',
+        description: 'Commits a side effect.',
+        parameters: z.object({}),
+        execute: async () => 'committed-result',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            reasoningItem('reasoning-message', 'draft the rejected message'),
+            fakeModelMessage('rejected assistant message'),
+            reasoningItem('reasoning-tool', 'run the committed tool'),
+            functionToolCall('commit_tool', 'call-mixed'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Mixed blocked output agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'block mixed output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use commit_tool', {
+          session,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(
+          run(agent, 'Use commit_tool', { session }),
+        ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      }
+
+      const items = await session.getItems();
+      expect(
+        items.map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'reasoning',
+        'function_call',
+        'function_call_result',
+      ]);
+      expect(
+        items.some(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'assistant' &&
+            JSON.stringify(item.content).includes('rejected assistant'),
+        ),
+      ).toBe(false);
+      expect(items.find((item) => item.type === 'reasoning')).toMatchObject({
+        id: 'reasoning-tool',
+      });
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves the full ordered batch when $mode output guardrails pass',
+    async (mode) => {
+      const commitTool = tool({
+        name: 'commit_tool',
+        description: 'Commits a side effect.',
+        parameters: z.object({}),
+        execute: async () => 'committed-result',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            reasoningItem('reasoning-message-pass', 'draft the message'),
+            fakeModelMessage('accepted assistant message'),
+            reasoningItem('reasoning-tool-pass', 'run the tool'),
+            functionToolCall('commit_tool', 'call-pass-order'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Ordered pass output agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'allow ordered output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use commit_tool', {
+          session,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, 'Use commit_tool', { session });
+      }
+
+      expect(
+        (await session.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'reasoning',
+        'message:assistant',
+        'reasoning',
+        'function_call',
+        'function_call_result',
+      ]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'persists serialized $mode execution provenance when a session is attached later',
+    async (mode) => {
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'serialized_commit_tool',
+        description: 'Commits before state serialization.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            fakeModelMessage('rejected serialized assistant output'),
+            functionToolCall('serialized_commit_tool', 'call-serialized'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Serialized committed tool agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'keep blocking serialized result',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use serialized_commit_tool', {
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'Use serialized_commit_tool');
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+      expect(blockedState).toBeDefined();
+      expect(
+        blockedState!._currentTurnSessionHistoryTransactionInputItems,
+      ).toMatchObject([{ type: 'message', role: 'user' }]);
+      expect(blockedState!.toJSON().currentTurnSessionInputItems).toMatchObject(
+        [{ type: 'message', role: 'user' }],
+      );
+
+      const restored = await RunState.fromString(
+        agent,
+        blockedState!.toString(),
+      );
+      const session = new MemorySession();
+      if (mode === 'streamed') {
+        const resumed = await run(agent, restored, { session, stream: true });
+        await expect(resumed.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(run(agent, restored, { session })).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      }
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.requests).toHaveLength(1);
+      const persistedItems = await session.getItems();
+      expect(
+        persistedItems.map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual(['message:user', 'function_call', 'function_call_result']);
+      expect(getPersistedToolItems(persistedItems)).toMatchObject([
+        { type: 'function_call', callId: 'call-serialized' },
+        { type: 'function_call_result', callId: 'call-serialized' },
+      ]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'persists each serialized multi-turn $mode tool pair exactly once when a session is attached later',
+    async (mode) => {
+      const firstExecute = vi.fn(async () => 'first-result');
+      const finalExecute = vi.fn(async () => 'final-result');
+      const firstTool = tool({
+        name: 'serialized_first_tool',
+        description: 'Runs before the final tool turn.',
+        parameters: z.object({}),
+        execute: firstExecute,
+      });
+      const finalTool = tool({
+        name: 'serialized_final_tool',
+        description: 'Produces the blocked final tool result.',
+        parameters: z.object({}),
+        execute: finalExecute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall('serialized_first_tool', 'call-serialized-first'),
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [
+            fakeModelMessage('rejected multi-turn assistant output'),
+            functionToolCall('serialized_final_tool', 'call-serialized-final'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Serialized multi-turn committed tool agent',
+        model,
+        tools: [firstTool, finalTool],
+        toolUseBehavior: { stopAtToolNames: ['serialized_final_tool'] },
+        outputGuardrails: [
+          {
+            name: 'keep blocking serialized multi-turn result',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use both serialized tools', {
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'Use both serialized tools');
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+
+      expect(blockedState).toBeDefined();
+      expect(
+        blockedState!._currentTurnSessionHistoryTransactionInputItems,
+      ).toMatchObject([{ type: 'message', role: 'user' }]);
+
+      const restored = await RunState.fromString(
+        agent,
+        blockedState!.toString(),
+      );
+      const session = new MemorySession();
+      if (mode === 'streamed') {
+        const resumed = await run(agent, restored, { session, stream: true });
+        await expect(resumed.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(run(agent, restored, { session })).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      }
+
+      expect(firstExecute).toHaveBeenCalledTimes(1);
+      expect(finalExecute).toHaveBeenCalledTimes(1);
+      expect(model.requests).toHaveLength(2);
+      const persistedItems = await session.getItems();
+      expect(
+        persistedItems.map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'function_call',
+        'function_call_result',
+        'function_call',
+        'function_call_result',
+      ]);
+      expect(getPersistedToolItems(persistedItems)).toMatchObject([
+        { type: 'function_call', callId: 'call-serialized-first' },
+        { type: 'function_call_result', callId: 'call-serialized-first' },
+        { type: 'function_call', callId: 'call-serialized-final' },
+        { type: 'function_call_result', callId: 'call-serialized-final' },
+      ]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'rejects accepted $mode final output restored from serialized terminal state',
+    async (mode) => {
+      let guardrailShouldTrip = true;
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'serialized_accept_tool',
+        description: 'Commits before terminal state serialization.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            fakeModelMessage('serialized assistant output'),
+            functionToolCall(
+              'serialized_accept_tool',
+              'call-serialized-accept',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Serialized accepted output agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'toggle serialized final output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: guardrailShouldTrip,
+            }),
+          },
+        ],
+      });
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use serialized_accept_tool', {
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'Use serialized_accept_tool');
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+
+      const restored = await RunState.fromString(
+        agent,
+        blockedState!.toString(),
+      );
+      const session = new MemorySession();
+      guardrailShouldTrip = false;
+      if (mode === 'streamed') {
+        const resumed = await run(agent, restored, { session, stream: true });
+        await expect(resumed.completed).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      } else {
+        await expect(run(agent, restored, { session })).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      }
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.requests).toHaveLength(1);
+      expect(await session.getItems()).toEqual([]);
+      expect(
+        restored._currentTurnSessionHistoryTransactionSessionId,
+      ).toBeUndefined();
+      expect(
+        restored.toJSON().currentTurnExecutedWithSessionBinding,
+      ).toBeUndefined();
+
+      const replacementSession = new MemorySession();
+      if (mode === 'streamed') {
+        const resumed = await run(agent, restored, {
+          session: replacementSession,
+          stream: true,
+        });
+        await expect(resumed.completed).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      } else {
+        await expect(
+          run(agent, restored, { session: replacementSession }),
+        ).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      }
+      expect(await replacementSession.getItems()).toEqual([]);
+      expect(
+        restored._currentTurnSessionHistoryTransactionSessionId,
+      ).toBeUndefined();
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'rejects accepted $mode terminal output after an excluded executed result',
+    async (mode) => {
+      const agent = new Agent({ name: 'Excluded executed result agent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems = [
+        new RunToolCallItem(
+          {
+            type: 'shell_call',
+            callId: 'excluded-executed-shell',
+            status: 'completed',
+            action: { commands: ['echo committed'] },
+          },
+          agent,
+        ),
+        new RunToolCallOutputItem(
+          {
+            type: 'shell_call_output',
+            callId: 'excluded-executed-shell',
+            output: [],
+            providerData: { status: 'incomplete' },
+          },
+          agent,
+          [],
+          undefined,
+          'executed',
+        ),
+      ];
+      state._currentStep = {
+        type: 'next_step_final_output',
+        output: 'accepted excluded execution',
+      };
+      const restored = await RunState.fromString(agent, state.toString());
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, restored, { session, stream: true });
+        await expect(result.completed).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      } else {
+        await expect(run(agent, restored, { session })).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      }
+
+      expect(await session.getItems()).toEqual([]);
+      expect(
+        restored._currentTurnSessionHistoryTransactionSessionId,
+      ).toBeUndefined();
+    },
+  );
+
+  it('does not finalize a pre-aborted turn-zero serialized streaming terminal state', async () => {
+    let guardrailShouldTrip = true;
+    const outputGuardrail = vi.fn(async () => ({
+      outputInfo: null,
+      tripwireTriggered: guardrailShouldTrip,
+    }));
+    const model = new ApprovalSessionModel([
+      {
+        output: [fakeModelMessage('blocked turn-zero terminal output')],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'Pre-aborted turn-zero terminal agent',
+      model,
+      outputGuardrails: [
+        {
+          name: 'toggle turn-zero terminal output',
+          execute: outputGuardrail,
+        },
+      ],
+    });
+    const runner = new Runner();
+    const runnerEnd = vi.fn();
+    const agentEnd = vi.fn();
+    runner.on('agent_end', runnerEnd);
+    agent.on('agent_end', agentEnd);
+
+    const first = await runner.run(agent, 'hello', { stream: true });
+    await expect(first.completed).rejects.toBeInstanceOf(
+      OutputGuardrailTripwireTriggered,
+    );
+    const serialized = first.state.toJSON();
+    serialized.currentTurn = 0;
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    guardrailShouldTrip = false;
+    outputGuardrail.mockClear();
+    const session = new MemorySession();
+    const controller = new AbortController();
+    controller.abort(new Error('cancel turn-zero terminal resume'));
+
+    const resumed = await runner.run(agent, restored, {
+      session,
+      signal: controller.signal,
+      stream: true,
+    });
+    await resumed.completed;
+
+    expect(resumed.cancelled).toBe(true);
+    expect(outputGuardrail).not.toHaveBeenCalled();
+    expect(model.requests).toHaveLength(1);
+    expect(runnerEnd).not.toHaveBeenCalled();
+    expect(agentEnd).not.toHaveBeenCalled();
+    expect(await session.getItems()).toEqual([]);
+  });
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'does not finalize a pre-aborted serialized $mode terminal state',
+    async (mode) => {
+      let guardrailShouldTrip = true;
+      const execute = vi.fn(async () => 'pre-aborted-result');
+      const commitTool = tool({
+        name: 'pre_aborted_serialized_tool',
+        description: 'Commits before the serialized terminal resume.',
+        parameters: z.object({}),
+        execute,
+      });
+      const outputGuardrail = vi.fn(async () => ({
+        outputInfo: null,
+        tripwireTriggered: guardrailShouldTrip,
+      }));
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            fakeModelMessage('blocked terminal output'),
+            functionToolCall(
+              'pre_aborted_serialized_tool',
+              'call-pre-aborted-serialized',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Pre-aborted serialized terminal agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'toggle terminal output',
+            execute: outputGuardrail,
+          },
+        ],
+      });
+      const runner = new Runner();
+      const runnerEnd = vi.fn();
+      const agentEnd = vi.fn();
+      runner.on('agent_end', runnerEnd);
+      agent.on('agent_end', agentEnd);
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const first = await runner.run(agent, 'hello', { stream: true });
+        await expect(first.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = first.state;
+      } else {
+        try {
+          await runner.run(agent, 'hello');
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+
+      const restored = await RunState.fromString(
+        agent,
+        blockedState!.toString(),
+      );
+      guardrailShouldTrip = false;
+      outputGuardrail.mockClear();
+      const session = new MemorySession();
+      const controller = new AbortController();
+      const abortReason = new Error('cancel terminal resume');
+      controller.abort(abortReason);
+
+      if (mode === 'streamed') {
+        const resumed = await runner.run(agent, restored, {
+          session,
+          signal: controller.signal,
+          stream: true,
+        });
+        await resumed.completed;
+        expect(resumed.cancelled).toBe(true);
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+        expect(resumed.finalOutput).toBeUndefined();
+        warnSpy.mockRestore();
+      } else {
+        await expect(
+          runner.run(agent, restored, {
+            session,
+            signal: controller.signal,
+          }),
+        ).rejects.toBe(abortReason);
+      }
+
+      expect(outputGuardrail).not.toHaveBeenCalled();
+      expect(model.requests).toHaveLength(1);
+      expect(runnerEnd).not.toHaveBeenCalled();
+      expect(agentEnd).not.toHaveBeenCalled();
+      expect(await session.getItems()).toEqual([]);
+      expect(
+        restored._currentTurnSessionHistoryTransactionSessionId,
+      ).toBeUndefined();
+      expect(
+        restored.toJSON().currentTurnExecutedWithSessionBinding,
+      ).toBeUndefined();
+
+      guardrailShouldTrip = true;
+      if (mode === 'streamed') {
+        const retried = await runner.run(agent, restored, {
+          session,
+          stream: true,
+        });
+        await expect(retried.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(
+          runner.run(agent, restored, { session }),
+        ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      }
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.requests).toHaveLength(1);
+      const persistedItems = await session.getItems();
+      expect(
+        persistedItems.map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual(['message:user', 'function_call', 'function_call_result']);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'rejects accepted $mode hosted work restored from serialized terminal state',
+    async (mode) => {
+      const model = new ApprovalSessionModel([]);
+      const agent = new Agent({
+        name: 'Serialized hosted work agent',
+        model,
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems = [
+        new RunToolCallItem(
+          {
+            type: 'hosted_tool_call',
+            id: 'serialized-hosted-call',
+            name: 'web_search_call',
+            status: 'completed',
+            providerData: { type: 'web_search_call', status: 'completed' },
+          },
+          agent,
+        ),
+      ];
+      state._currentStep = {
+        type: 'next_step_final_output',
+        output: 'accepted hosted output',
+      };
+      const restored = await RunState.fromString(agent, state.toString());
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, restored, { session, stream: true });
+        await expect(result.completed).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      } else {
+        await expect(run(agent, restored, { session })).rejects.toThrow(
+          'Accepted final output cannot be resumed directly from serialized terminal state.',
+        );
+      }
+
+      expect(model.requests).toHaveLength(0);
+      expect(await session.getItems()).toEqual([]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'replaces a blocked $mode sparse suffix with the full accepted order on RunState resume',
+    async (mode) => {
+      let guardrailShouldTrip = true;
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'resume_commit_tool',
+        description: 'Commits before an accepted state resume.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            reasoningItem('reasoning-message-resume', 'draft the message'),
+            fakeModelMessage('accepted after resume'),
+            reasoningItem('reasoning-tool-resume', 'run the tool'),
+            functionToolCall('resume_commit_tool', 'call-resume-ordered'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const outputGuardrail = vi.fn(async () => ({
+        outputInfo: null,
+        tripwireTriggered: guardrailShouldTrip,
+      }));
+      const agent = new Agent({
+        name: 'Accepted resume agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'toggle blocked output',
+            execute: outputGuardrail,
+          },
+        ],
+      });
+      const session = new CompactionTrackingSession();
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use resume_commit_tool', {
+          session,
+          stream: true,
+          reasoningItemIdPolicy: 'omit',
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'Use resume_commit_tool', {
+            session,
+            reasoningItemIdPolicy: 'omit',
+          });
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+      expect(blockedState).toBeDefined();
+      await expect(
+        RunState.fromString(agent, blockedState!.toString()),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+      expect(outputGuardrail).toHaveBeenCalledTimes(1);
+      expect(
+        (await session.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'reasoning',
+        'function_call',
+        'function_call_result',
+      ]);
+      expect(session.compactionSnapshots).toHaveLength(0);
+
+      guardrailShouldTrip = false;
+      let resumedFinalOutput: string | undefined;
+      if (mode === 'streamed') {
+        const resumed = await run(agent, blockedState!, {
+          session,
+          stream: true,
+          reasoningItemIdPolicy: 'preserve',
+        });
+        await resumed.completed;
+        resumedFinalOutput = resumed.finalOutput;
+      } else {
+        const resumed = await run(agent, blockedState!, {
+          session,
+          reasoningItemIdPolicy: 'preserve',
+        });
+        resumedFinalOutput = resumed.finalOutput;
+      }
+      expect(resumedFinalOutput).toBe('committed-result');
+      expect(outputGuardrail).toHaveBeenCalledTimes(2);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.requests).toHaveLength(1);
+      expect(
+        (await session.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'reasoning',
+        'message:assistant',
+        'reasoning',
+        'function_call',
+        'function_call_result',
+      ]);
+      expect(blockedState!._currentTurnDeferredSessionItemIndexes.size).toBe(0);
+      expect(
+        (await session.getItems())
+          .filter((item) => item.type === 'reasoning')
+          .every((item) => !('id' in item)),
+      ).toBe(true);
+      expect(session.compactionSnapshots).toHaveLength(1);
+      expect(session.compactionArgs[0]?.responseId).toBe(
+        mode === 'streamed' ? 'stream-response' : undefined,
+      );
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'uses the session comparison hook before a $mode sparse resume guardrail',
+    async (mode) => {
+      class BackendMetadataSession extends MemorySession {
+        override async getItems(limit?: number): Promise<AgentInputItem[]> {
+          return (await super.getItems(limit)).map((item) => ({
+            ...item,
+            providerData: { backend_revision: 'stored' },
+          })) as AgentInputItem[];
+        }
+
+        prepareHistoryItemsForPersistenceComparison(
+          items: AgentInputItem[],
+        ): AgentInputItem[] {
+          return items.map((item) => {
+            const comparable = { ...item } as AgentInputItem & {
+              providerData?: unknown;
+            };
+            delete comparable.providerData;
+            return comparable;
+          });
+        }
+      }
+
+      let guardrailShouldTrip = true;
+      const execute = vi.fn(async () => 'committed-result');
+      const commitTool = tool({
+        name: 'metadata_resume_tool',
+        description: 'Commits before a metadata-normalized resume.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            fakeModelMessage('accepted after metadata normalization'),
+            functionToolCall('metadata_resume_tool', 'call-metadata-resume'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const outputGuardrail = vi.fn(async () => ({
+        outputInfo: null,
+        tripwireTriggered: guardrailShouldTrip,
+      }));
+      const agent = new Agent({
+        name: 'Metadata-normalized resume agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          { name: 'toggle metadata resume', execute: outputGuardrail },
+        ],
+      });
+      const session = new BackendMetadataSession();
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use metadata_resume_tool', {
+          session,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'Use metadata_resume_tool', { session });
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+
+      guardrailShouldTrip = false;
+      if (mode === 'streamed') {
+        const resumed = await run(agent, blockedState!, {
+          session,
+          stream: true,
+        });
+        await resumed.completed;
+        expect(resumed.finalOutput).toBe('committed-result');
+      } else {
+        const resumed = await run(agent, blockedState!, { session });
+        expect(resumed.finalOutput).toBe('committed-result');
+      }
+      expect(outputGuardrail).toHaveBeenCalledTimes(2);
+      expect(execute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'rejects a $mode resume before its output guardrail when the blocked suffix advances',
+    async (mode) => {
+      let guardrailShouldTrip = true;
+      const commitTool = tool({
+        name: 'stale_resume_tool',
+        description: 'Commits before a stale accepted resume.',
+        parameters: z.object({}),
+        execute: async () => 'committed-result',
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall('stale_resume_tool', 'call-stale-resume'),
+            fakeModelMessage('accepted after resume'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const outputGuardrail = vi.fn(async () => ({
+        outputInfo: null,
+        tripwireTriggered: guardrailShouldTrip,
+      }));
+      const agent = new Agent({
+        name: 'Stale accepted resume agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'toggle stale resume output',
+            execute: outputGuardrail,
+          },
+        ],
+      });
+      const session = new CompactionTrackingSession();
+
+      let blockedState: RunState<undefined, typeof agent> | undefined;
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Use stale_resume_tool', {
+          session,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        blockedState = result.state;
+      } else {
+        try {
+          await run(agent, 'Use stale_resume_tool', { session });
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          blockedState = (
+            error as { state?: RunState<undefined, typeof agent> }
+          ).state;
+        }
+      }
+      expect(blockedState).toBeDefined();
+      await session.addItems([fakeModelMessage('independent session advance')]);
+
+      guardrailShouldTrip = false;
+      const resumed =
+        mode === 'streamed'
+          ? run(agent, blockedState!, { session, stream: true })
+          : run(agent, blockedState!, { session });
+      await expect(resumed).rejects.toThrow(
+        'Session history suffix no longer matches the transaction precondition.',
+      );
+      expect(outputGuardrail).toHaveBeenCalledTimes(1);
+      expect(
+        (await session.getItems()).map((item) =>
+          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
+        ),
+      ).toEqual([
+        'message:user',
+        'function_call',
+        'function_call_result',
+        'message:assistant',
+      ]);
+    },
+  );
+});
+
 describe('approved tool output guardrail session persistence', () => {
   beforeAll(() => {
     setTracingDisabled(true);
   });
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'persists a terminal $mode rejection for a previously checkpointed approval call',
+    async (mode) => {
+      const execute = vi.fn(async () => 'should-not-run');
+      const approvalTool = tool({
+        name: 'approved_input_guarded_tool',
+        description: 'Rejects approved input before execution.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute,
+        inputGuardrails: [
+          defineToolInputGuardrail({
+            name: 'reject approved input',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.rejectContent(
+                'approved-input-rejected',
+              ),
+          }),
+        ],
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              'approved_input_guarded_tool',
+              'call-approved-input-rejected',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Approved input rejection agent',
+        model,
+        tools: [approvalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'block approved rejection',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new CompactionTrackingSession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, input, { session });
+      };
+
+      const first = await runOnce('Use approved_input_guarded_tool');
+      expect(first.interruptions).toHaveLength(1);
+      first.state.approve(first.interruptions[0]);
+      await expect(runOnce(first.state)).rejects.toBeInstanceOf(
+        OutputGuardrailTripwireTriggered,
+      );
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(
+        getPersistedToolItems(await session.getItems()).map((item) => [
+          item.type,
+          item.callId,
+        ]),
+      ).toEqual([
+        ['function_call', 'call-approved-input-rejected'],
+        ['function_call_result', 'call-approved-input-rejected'],
+      ]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'closes a previously persisted $mode approval call after user rejection',
+    async (mode) => {
+      const execute = vi.fn(async () => 'should-not-run');
+      const approvalTool = tool({
+        name: 'user_rejected_tool',
+        description: 'Requires approval and is rejected by the user.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall('user_rejected_tool', 'call-user-rejected'),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'User rejection agent',
+        model,
+        tools: [approvalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'block user rejection output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, input, { session });
+      };
+
+      const first = await runOnce('Use user_rejected_tool');
+      expect(first.interruptions).toHaveLength(1);
+      first.state.reject(first.interruptions[0], {
+        message: 'Rejected by user.',
+      });
+      await expect(runOnce(first.state)).rejects.toBeInstanceOf(
+        OutputGuardrailTripwireTriggered,
+      );
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(
+        getPersistedToolItems(await session.getItems()).map((item) => [
+          item.type,
+          item.callId,
+        ]),
+      ).toEqual([
+        ['function_call', 'call-user-rejected'],
+        ['function_call_result', 'call-user-rejected'],
+      ]);
+    },
+  );
 
   it.each<{
     mode: RunMode;
@@ -746,6 +3242,119 @@ describe('approved tool output guardrail session persistence', () => {
         ['function_call', 'call-before-empty-response'],
         ['function_call_result', 'call-before-empty-response'],
       ]);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'rebinds $mode transaction authority before a post-approval final tool executes',
+    async (mode) => {
+      class MutableReasoningPolicySession extends MemorySession {
+        preserveReasoningIds = false;
+
+        preserveReasoningItemIdsForPersistence(): boolean {
+          return this.preserveReasoningIds;
+        }
+      }
+
+      const session = new MutableReasoningPolicySession();
+      const approvalTool = tool({
+        name: 'checkpoint_approval_tool',
+        description: 'Requires approval before the next model turn.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved-result',
+      });
+      const executeFinalTool = vi.fn(async () => {
+        session.preserveReasoningIds = true;
+        return 'committed-after-checkpoint';
+      });
+      const finalTool = tool({
+        name: 'post_checkpoint_final_tool',
+        description: 'Commits after the approval checkpoint.',
+        parameters: z.object({}),
+        execute: executeFinalTool,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              'checkpoint_approval_tool',
+              'call-checkpoint-approval',
+            ),
+          ],
+          usage: new Usage(),
+        },
+        {
+          output: [
+            reasoningItem('post-checkpoint-reasoning-id', 'run the final tool'),
+            functionToolCall(
+              'post_checkpoint_final_tool',
+              'call-post-checkpoint-final',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Post-approval authority agent',
+        model,
+        tools: [approvalTool, finalTool],
+        toolUseBehavior: {
+          stopAtToolNames: ['post_checkpoint_final_tool'],
+        },
+        outputGuardrails: [
+          {
+            name: 'block post-checkpoint final output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+
+      const first =
+        mode === 'streamed'
+          ? await (async () => {
+              const result = await run(agent, 'Use the approval tool', {
+                session,
+                stream: true,
+                reasoningItemIdPolicy: 'preserve',
+              });
+              await result.completed;
+              return result;
+            })()
+          : await run(agent, 'Use the approval tool', {
+              session,
+              reasoningItemIdPolicy: 'preserve',
+            });
+      expect(first.interruptions).toHaveLength(1);
+      first.state.approve(first.interruptions[0]);
+
+      if (mode === 'streamed') {
+        const resumed = await run(agent, first.state, {
+          session,
+          stream: true,
+          reasoningItemIdPolicy: 'omit',
+        });
+        await expect(resumed.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(
+          run(agent, first.state, {
+            session,
+            reasoningItemIdPolicy: 'omit',
+          }),
+        ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      }
+
+      expect(executeFinalTool).toHaveBeenCalledTimes(1);
+      const persistedReasoning = (await session.getItems()).find(
+        (item) => item.type === 'reasoning',
+      );
+      expect(persistedReasoning).toBeDefined();
+      expect(persistedReasoning).not.toHaveProperty('id');
     },
   );
 

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -27,6 +27,7 @@ import {
   Session,
   InputGuardrailTripwireTriggered,
   OutputGuardrailTripwireTriggered,
+  RunContext,
   RunState,
   shellTool,
 } from '../src';
@@ -2727,6 +2728,54 @@ describe('Runner.run (streaming)', () => {
     }
   });
 
+  it('keeps an error-handler final output hidden while its guardrail is pending', async () => {
+    let signalGuardrailStarted!: () => void;
+    const guardrailStarted = new Promise<void>((resolve) => {
+      signalGuardrailStarted = resolve;
+    });
+    let releaseGuardrail!: () => void;
+    const guardrailResult = new Promise<GuardrailFunctionOutput>((resolve) => {
+      releaseGuardrail = () =>
+        resolve({
+          tripwireTriggered: false,
+          outputInfo: null,
+        });
+    });
+    const agent = new Agent({
+      name: 'Pending error-handler guardrail stream',
+      model: new FakeModel([]),
+      outputGuardrails: [
+        {
+          name: 'suspend error-handler output',
+          execute: async () => {
+            signalGuardrailStarted();
+            return guardrailResult;
+          },
+        },
+      ],
+    });
+    const result = await run(agent, 'x', {
+      stream: true,
+      maxTurns: 0,
+      errorHandlers: {
+        maxTurns: () => ({ finalOutput: 'guarded fallback' }),
+      },
+    });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await guardrailStarted;
+    expect(result.finalOutput).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Accessed finalOutput before agent run is completed.',
+    );
+
+    releaseGuardrail();
+    await result.completed;
+    expect(result.finalOutput).toBe('guarded fallback');
+
+    warnSpy.mockRestore();
+  });
+
   it('handles model refusal errors with an error handler', async () => {
     class RefusalStreamingModel implements Model {
       async getResponse(_req: ModelRequest): Promise<ModelResponse> {
@@ -4363,7 +4412,7 @@ describe('Runner.run (streaming)', () => {
     expect(model.calls).toBe(0);
   });
 
-  it('persists streaming input but drops the result when an output guardrail trips', async () => {
+  it('persists streaming input through the blocked result save when an output guardrail trips', async () => {
     const saveInputSpy = vi
       .spyOn(sessionPersistence, 'saveStreamInputToSession')
       .mockResolvedValue();
@@ -4396,14 +4445,108 @@ describe('Runner.run (streaming)', () => {
       OutputGuardrailTripwireTriggered,
     );
 
-    expect(saveInputSpy).toHaveBeenCalledTimes(1);
-    expect(saveResultSpy).not.toHaveBeenCalled();
+    expect(saveInputSpy).not.toHaveBeenCalled();
+    expect(saveResultSpy).toHaveBeenCalledTimes(1);
+    expect(saveResultSpy).toHaveBeenCalledWith(
+      session,
+      result,
+      { outputBlocked: true },
+      expect.any(Array),
+    );
     expect(guardrail.execute).toHaveBeenCalledTimes(1);
-    expect(result.state._currentStep?.type).not.toBe('next_step_final_output');
+    expect(result.state._currentStep?.type).toBe('next_step_final_output');
     expect(result.finalOutput).toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(
       'Accessed finalOutput before agent run is completed.',
     );
+  });
+
+  it('keeps streamed final output hidden while output guardrails are pending', async () => {
+    let signalGuardrailStarted!: () => void;
+    const guardrailStarted = new Promise<void>((resolve) => {
+      signalGuardrailStarted = resolve;
+    });
+    let releaseGuardrail!: () => void;
+    const guardrailResult = new Promise<GuardrailFunctionOutput>((resolve) => {
+      releaseGuardrail = () =>
+        resolve({
+          tripwireTriggered: false,
+          outputInfo: null,
+        });
+    });
+    const agent = new Agent({
+      name: 'Pending output guardrail',
+      model: new ImmediateStreamingModel({
+        output: [fakeModelMessage('guarded candidate')],
+        usage: new Usage(),
+      }),
+      outputGuardrails: [
+        {
+          name: 'suspended output guardrail',
+          execute: async () => {
+            signalGuardrailStarted();
+            return guardrailResult;
+          },
+        },
+      ],
+    });
+    const result = await run(agent, 'hello', { stream: true });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await guardrailStarted;
+    expect(result.finalOutput).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Accessed finalOutput before agent run is completed.',
+    );
+
+    releaseGuardrail();
+    await result.completed;
+    expect(result.finalOutput).toBe('guarded candidate');
+
+    warnSpy.mockRestore();
+  });
+
+  it('keeps a serialized final output hidden when streamed resume is pre-aborted', async () => {
+    const guardrail = vi.fn().mockResolvedValue({
+      tripwireTriggered: false,
+      outputInfo: null,
+    });
+    const agent = new Agent({
+      name: 'Pre-aborted final output resume',
+      model: new FakeModel([]),
+      outputGuardrails: [
+        {
+          name: 'should not run after pre-abort',
+          execute: guardrail,
+        },
+      ],
+    });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    state._currentTurn = 1;
+    state._currentTurnInProgress = true;
+    state._currentStep = {
+      type: 'next_step_final_output',
+      output: 'blocked secret',
+    };
+    const restored = await RunState.fromString(agent, state.toString());
+    const controller = new AbortController();
+    controller.abort('cancel before resume');
+    const result = await run(agent, restored, {
+      stream: true,
+      signal: controller.signal,
+    });
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await result.completed;
+
+    expect(result.cancelled).toBe(true);
+    expect(result.finalOutput).toBeUndefined();
+    expect(guardrail).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Accessed finalOutput before agent run is completed.',
+    );
+
+    warnSpy.mockRestore();
   });
 
   it('does not persist streaming result when the consumer cancels early', async () => {

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -1336,14 +1336,25 @@ export function registerRunStateCoreTests(): void {
       };
       const state = new RunState(context, 'input', agent, 1);
       state._generatedItems.push(
-        new RunToolCallOutputItem(rawShellOutput, agent, rawShellOutput.output),
+        new RunToolCallOutputItem(
+          rawShellOutput,
+          agent,
+          rawShellOutput.output,
+          undefined,
+          'executed',
+        ),
       );
-
       const restored = await RunState.fromString(agent, state.toString());
       const restoredItem = restored._generatedItems[0];
       expect(restoredItem).toBeInstanceOf(RunToolCallOutputItem);
       expect((restoredItem as RunToolCallOutputItem).rawItem).toEqual(
         rawShellOutput,
+      );
+      expect((restoredItem as RunToolCallOutputItem).executionStatus).toBe(
+        'executed',
+      );
+      expect(restored._sessionHistoryTransactionId).not.toBe(
+        state._sessionHistoryTransactionId,
       );
     });
 
@@ -4085,6 +4096,712 @@ export function registerRunStateMigrationTests(): void {
       );
     });
 
+    it('rejects local execution provenance on program output', async () => {
+      const agent = new Agent({ name: 'ProgramExecutionProvenanceAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(
+        new RunToolCallOutputItem(
+          {
+            type: 'program_output',
+            callId: 'program-execution-provenance',
+            status: 'completed',
+            output: 'done',
+          },
+          agent,
+          'done',
+          undefined,
+          'executed',
+        ),
+      );
+
+      await expect(
+        RunState.fromString(agent, state.toString()),
+      ).rejects.toThrow(
+        'Run state contains execution provenance for an unsupported tool output type.',
+      );
+    });
+
+    it.each([
+      {
+        schemaVersion: '1.16',
+        field: 'currentTurnDeferredSessionItemIndexes',
+        value: [0],
+      },
+      {
+        schemaVersion: '1.16',
+        field: 'currentTurnBlockedSessionStartIndex',
+        value: 0,
+      },
+      {
+        schemaVersion: '1.15',
+        field: 'currentTurnDeferredSessionItemIndexes',
+        value: [0],
+      },
+      {
+        schemaVersion: '1.15',
+        field: 'pendingSessionHistoryTransaction',
+        value: {
+          operationId: 'v117-operation',
+          transactionKind: 'blocked_append',
+          runItemIndexes: [],
+          replaceRunItemIndexes: [],
+          alreadyPersistedCount: 0,
+          persistedItemCount: 0,
+          deferredItemIndexes: [],
+        },
+      },
+      {
+        schemaVersion: '1.16',
+        field: 'currentTurnExecutedWithSessionBinding',
+        value: true,
+      },
+      {
+        schemaVersion: '1.16',
+        field: 'currentTurnSessionInputItems',
+        value: [{ type: 'message', role: 'user', content: 'portable input' }],
+      },
+    ])(
+      'rejects schema $schemaVersion payloads with $field',
+      async ({ schemaVersion, field, value }) => {
+        const agent = new Agent({ name: 'V116PersistenceEnvelopeAgent' });
+        const serialized = new RunState(
+          new RunContext(),
+          'input',
+          agent,
+          1,
+        ).toJSON() as any;
+        serialized.$schemaVersion = schemaVersion;
+        delete serialized.currentTurnDeferredSessionItemIndexes;
+        delete serialized.currentTurnBlockedSessionStartIndex;
+        delete serialized.currentTurnSessionHistoryTransactionSessionId;
+        delete serialized.currentTurnSessionReasoningItemIdPolicy;
+        delete serialized.currentTurnSessionHistoryTransactionInputItems;
+        delete serialized.sessionHistoryTransactionId;
+        delete serialized.pendingSessionHistoryTransaction;
+        serialized[field] = value;
+
+        await expect(
+          RunState.fromString(agent, JSON.stringify(serialized)),
+        ).rejects.toThrow(
+          `Run state schema version ${schemaVersion} does not support output guardrail session persistence state.`,
+        );
+      },
+    );
+
+    it('rejects schema 1.16 execution provenance', async () => {
+      const agent = new Agent({ name: 'V116ExecutionProvenanceAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(
+        new RunToolCallOutputItem(
+          {
+            type: 'function_call_result',
+            name: 'commit',
+            callId: 'call-v117-execution',
+            status: 'completed',
+            output: 'committed',
+          },
+          agent,
+          'committed',
+          undefined,
+          'executed',
+        ),
+      );
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.16';
+      delete serialized.currentTurnDeferredSessionItemIndexes;
+      delete serialized.sessionHistoryTransactionId;
+      delete serialized.pendingSessionHistoryTransaction;
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Run state schema version 1.16 does not support output guardrail session persistence state.',
+      );
+    });
+
+    it('rejects serialized local execution that was bound to a session', async () => {
+      const agent = new Agent({ name: 'BoundExecutionAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(
+        new RunToolCallItem(
+          {
+            type: 'function_call',
+            name: 'commit',
+            callId: 'call-bound-execution',
+            status: 'completed',
+            arguments: '{}',
+          },
+          agent,
+        ),
+      );
+      state._generatedItems.push(
+        new RunToolCallOutputItem(
+          {
+            type: 'function_call_result',
+            name: 'commit',
+            callId: 'call-bound-execution',
+            status: 'completed',
+            output: 'committed',
+          },
+          agent,
+          'committed',
+          undefined,
+          'executed',
+        ),
+      );
+      state._currentTurnSessionHistoryTransactionSessionId =
+        'original-bound-session';
+      const serialized = state.toJSON() as any;
+      expect(serialized.currentTurnExecutedWithSessionBinding).toBe(true);
+
+      const overrideContext = new RunContext({ source: 'override' });
+      const before = overrideContext.toJSON();
+      await expect(
+        RunState.fromStringWithContext(
+          agent,
+          JSON.stringify(serialized),
+          overrideContext,
+          { contextStrategy: 'merge' },
+        ),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+      expect(overrideContext.toJSON()).toEqual(before);
+    });
+
+    it('rejects serialized retained hosted work that was bound to a session', async () => {
+      const agent = new Agent({ name: 'BoundHostedExecutionAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(
+        new RunToolCallItem(
+          {
+            type: 'hosted_tool_call',
+            id: 'bound-hosted-execution',
+            name: 'web_search_call',
+            status: 'completed',
+            providerData: { type: 'web_search_call' },
+          },
+          agent,
+        ),
+      );
+      state._currentTurnSessionHistoryTransactionSessionId =
+        'original-hosted-session';
+
+      const serialized = state.toJSON() as any;
+      expect(serialized.currentTurnExecutedWithSessionBinding).toBe(true);
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+    });
+
+    it('rejects a serialized terminal result for a bound persisted approval call', async () => {
+      const agent = new Agent({ name: 'BoundApprovalResultAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems = [
+        new RunToolCallItem(
+          {
+            type: 'function_call',
+            name: 'approval_tool',
+            callId: 'call-bound-approval',
+            status: 'completed',
+            arguments: '{}',
+          },
+          agent,
+        ),
+        new RunToolCallOutputItem(
+          {
+            type: 'function_call_result',
+            name: 'approval_tool',
+            callId: 'call-bound-approval',
+            status: 'completed',
+            output: 'rejected',
+          },
+          agent,
+          'rejected',
+        ),
+      ];
+      state._currentTurnPersistedItemCount = 1;
+      state._currentTurnSessionHistoryTransactionSessionId =
+        'original-approval-session';
+
+      const serialized = state.toJSON() as any;
+      expect(serialized.currentTurnExecutedWithSessionBinding).toBe(true);
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+    });
+
+    it('rejects schema 1.16 execution provenance in the processed response', async () => {
+      const agent = new Agent({
+        name: 'V116ProcessedExecutionProvenanceAgent',
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const outputItem = new RunToolCallOutputItem(
+        {
+          type: 'function_call_result',
+          name: 'commit',
+          callId: 'call-v117-processed-execution',
+          status: 'completed',
+          output: 'committed',
+        },
+        agent,
+        'committed',
+        undefined,
+        'executed',
+      );
+      state._lastProcessedResponse = {
+        newItems: [outputItem],
+        toolsUsed: [],
+        handoffs: [],
+        functions: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.16';
+      delete serialized.currentTurnDeferredSessionItemIndexes;
+      delete serialized.sessionHistoryTransactionId;
+      delete serialized.pendingSessionHistoryTransaction;
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Run state schema version 1.16 does not support output guardrail session persistence state.',
+      );
+    });
+
+    it('validates persistence authority before mutating an override context', async () => {
+      const agent = new Agent({ name: 'InvalidPersistenceAuthorityAgent' });
+      const approvalItem = new ToolApprovalItem(
+        {
+          type: 'function_call',
+          name: 'secure_tool',
+          callId: 'call-invalid-persistence-authority',
+          status: 'completed',
+          arguments: '{}',
+        } as any,
+        agent,
+      );
+      const serializedContext = new RunContext({ source: 'serialized' });
+      serializedContext.toolInput = { source: 'serialized' };
+      serializedContext.approveTool(approvalItem);
+      const serialized = new RunState(
+        serializedContext,
+        'input',
+        agent,
+        1,
+      ).toJSON() as any;
+      serialized.currentTurnPersistedItemCount = 1;
+      serialized.currentTurnDeferredSessionItemIndexes = [0];
+
+      const overrideContext = new RunContext({ source: 'override' });
+      const before = overrideContext.toJSON();
+      await expect(
+        RunState.fromStringWithContext(
+          agent,
+          JSON.stringify(serialized),
+          overrideContext,
+          { contextStrategy: 'merge' },
+        ),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+      expect(overrideContext.toJSON()).toEqual(before);
+      expect(
+        overrideContext.isToolApproved({
+          toolName: 'secure_tool',
+          callId: 'call-invalid-persistence-authority',
+        }),
+      ).toBeUndefined();
+      expect(overrideContext.toolInput).toBeUndefined();
+    });
+
+    it.each([
+      {
+        name: 'empty blocked transaction source',
+        operationId: undefined,
+        runItemIndexes: [] as number[],
+      },
+      {
+        name: 'mismatched operation id',
+        operationId: 'mismatched-operation-id',
+        runItemIndexes: [0],
+      },
+    ])(
+      'rejects a pending $name before mutating an override context',
+      async ({ operationId, runItemIndexes }) => {
+        const agent = new Agent({ name: 'InvalidPendingAuthorityAgent' });
+        const serializedContext = new RunContext({ source: 'serialized' });
+        serializedContext.toolInput = { source: 'serialized' };
+        const state = new RunState(serializedContext, 'input', agent, 1);
+        state._generatedItems.push(
+          new RunMessageOutputItem(
+            {
+              type: 'message',
+              role: 'assistant',
+              status: 'completed',
+              content: [{ type: 'output_text', text: 'generated' }],
+            },
+            agent,
+          ),
+        );
+        const serialized = state.toJSON() as any;
+        const expectedOperationId = [
+          serialized.sessionHistoryTransactionId,
+          serialized.currentTurn,
+          'blocked_append',
+          0,
+          1,
+        ].join(':');
+        serialized.pendingSessionHistoryTransaction = {
+          operationId: operationId ?? expectedOperationId,
+          transactionKind: 'blocked_append',
+          runItemIndexes,
+          replaceRunItemIndexes: [],
+          alreadyPersistedCount: 0,
+          persistedItemCount: 1,
+          deferredItemIndexes: [],
+        };
+        serialized.currentTurnBlockedSessionStartIndex = 0;
+        serialized.currentTurnSessionHistoryTransactionSessionId =
+          'pending-authority-session';
+        serialized.currentTurnSessionReasoningItemIdPolicy = 'preserve';
+        serialized.currentTurnSessionHistoryTransactionInputItems = [];
+        const overrideContext = new RunContext({ source: 'override' });
+        const before = overrideContext.toJSON();
+        await expect(
+          RunState.fromStringWithContext(
+            agent,
+            JSON.stringify(serialized),
+            overrideContext,
+            { contextStrategy: 'merge' },
+          ),
+        ).rejects.toThrow(
+          'Serialized output guardrail session transaction authority cannot be resumed safely.',
+        );
+        expect(overrideContext.toJSON()).toEqual(before);
+      },
+    );
+
+    it.each([
+      {
+        name: 'a rejected message inside the processed interval',
+        runItemIndexes: [0],
+        deferredItemIndexes: [1, 2],
+        persistedItemCount: 3,
+      },
+      {
+        name: 'an item at the processed interval boundary',
+        runItemIndexes: [2],
+        deferredItemIndexes: [0, 1],
+        persistedItemCount: 2,
+      },
+    ])(
+      'rejects a pending blocked append sourced from $name before context mutation',
+      async ({ runItemIndexes, deferredItemIndexes, persistedItemCount }) => {
+        const agent = new Agent({ name: 'CanonicalPendingPlanAgent' });
+        const call: protocol.FunctionCallItem = {
+          type: 'function_call',
+          name: 'commit',
+          callId: 'call-canonical-pending',
+          status: 'completed',
+          arguments: '{}',
+        };
+        const result: protocol.FunctionCallResultItem = {
+          type: 'function_call_result',
+          name: 'commit',
+          callId: call.callId,
+          status: 'completed',
+          output: 'committed',
+        };
+        const state = new RunState(
+          new RunContext({ source: 'serialized' }),
+          'input',
+          agent,
+          1,
+        );
+        state._generatedItems = [
+          new RunMessageOutputItem(
+            {
+              type: 'message',
+              role: 'assistant',
+              status: 'completed',
+              content: [{ type: 'output_text', text: 'rejected' }],
+            },
+            agent,
+          ),
+          new RunToolCallItem(call, agent),
+          new RunToolCallOutputItem(
+            result,
+            agent,
+            result.output,
+            undefined,
+            'executed',
+          ),
+        ];
+        const serialized = state.toJSON() as any;
+        serialized.currentTurnBlockedSessionStartIndex = 0;
+        serialized.currentTurnSessionHistoryTransactionSessionId =
+          'canonical-pending-session';
+        serialized.currentTurnSessionReasoningItemIdPolicy = 'preserve';
+        serialized.currentTurnSessionHistoryTransactionInputItems = [];
+        serialized.pendingSessionHistoryTransaction = {
+          operationId: [
+            serialized.sessionHistoryTransactionId,
+            serialized.currentTurn,
+            'blocked_append',
+            0,
+            persistedItemCount,
+          ].join(':'),
+          transactionKind: 'blocked_append',
+          runItemIndexes,
+          replaceRunItemIndexes: [],
+          alreadyPersistedCount: 0,
+          persistedItemCount,
+          deferredItemIndexes,
+        };
+
+        const overrideContext = new RunContext({ source: 'override' });
+        const before = overrideContext.toJSON();
+        await expect(
+          RunState.fromStringWithContext(
+            agent,
+            JSON.stringify(serialized),
+            overrideContext,
+            { contextStrategy: 'merge' },
+          ),
+        ).rejects.toThrow(
+          'Serialized output guardrail session transaction authority cannot be resumed safely.',
+        );
+        expect(overrideContext.toJSON()).toEqual(before);
+      },
+    );
+
+    it('rejects a pending accepted replacement that differs from the canonical sparse plan', async () => {
+      const agent = new Agent({ name: 'CanonicalAcceptedPlanAgent' });
+      const call: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'commit',
+        callId: 'call-canonical-accepted',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const result: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: 'commit',
+        callId: call.callId,
+        status: 'completed',
+        output: 'committed',
+      };
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems = [
+        new RunMessageOutputItem(
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'accepted' }],
+          },
+          agent,
+        ),
+        new RunToolCallItem(call, agent),
+        new RunToolCallOutputItem(
+          result,
+          agent,
+          result.output,
+          undefined,
+          'executed',
+        ),
+      ];
+      state._currentTurnPersistedItemCount = 3;
+      state._currentTurnDeferredSessionItemIndexes = new Set([0]);
+      state._currentTurnBlockedSessionStartIndex = 0;
+      state._currentTurnSessionHistoryTransactionSessionId =
+        'canonical-accepted-session';
+      state._currentTurnSessionReasoningItemIdPolicy = 'preserve';
+      state._currentTurnSessionHistoryTransactionInputItems = [];
+      state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput = true;
+      const serialized = state.toJSON() as any;
+      serialized.pendingSessionHistoryTransaction = {
+        operationId: [
+          serialized.sessionHistoryTransactionId,
+          serialized.currentTurn,
+          'accepted_replace',
+          3,
+          3,
+        ].join(':'),
+        transactionKind: 'accepted_replace',
+        runItemIndexes: [1, 2],
+        replaceRunItemIndexes: [1, 2],
+        alreadyPersistedCount: 3,
+        persistedItemCount: 3,
+        deferredItemIndexes: [],
+      };
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+    });
+
+    it('rejects generated items outside acknowledged sparse authority', async () => {
+      const agent = new Agent({ name: 'ClosedSparseAuthorityAgent' });
+      const call: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'commit',
+        callId: 'call-closed-sparse-authority',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const result: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: 'commit',
+        callId: call.callId,
+        status: 'completed',
+        output: 'committed',
+      };
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems = [
+        new RunMessageOutputItem(
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'guarded output' }],
+          },
+          agent,
+        ),
+        new RunToolCallItem(call, agent),
+        new RunToolCallOutputItem(
+          result,
+          agent,
+          result.output,
+          undefined,
+          'executed',
+        ),
+        new RunMessageOutputItem(
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'unguarded tail' }],
+          },
+          agent,
+        ),
+      ];
+      state._currentTurnPersistedItemCount = 3;
+      state._currentTurnDeferredSessionItemIndexes = new Set([0]);
+      state._currentTurnBlockedSessionStartIndex = 0;
+      state._currentTurnSessionHistoryTransactionSessionId =
+        'closed-sparse-authority-session';
+      state._currentTurnSessionReasoningItemIdPolicy = 'preserve';
+      state._currentTurnSessionHistoryTransactionInputItems = [];
+
+      await expect(
+        RunState.fromString(agent, state.toString()),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+    });
+
+    it('rejects generated items outside pending sparse authority', async () => {
+      const agent = new Agent({ name: 'ClosedPendingAuthorityAgent' });
+      const call: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'commit',
+        callId: 'call-closed-pending-authority',
+        status: 'completed',
+        arguments: '{}',
+      };
+      const result: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: 'commit',
+        callId: call.callId,
+        status: 'completed',
+        output: 'committed',
+      };
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems = [
+        new RunToolCallItem(call, agent),
+        new RunToolCallOutputItem(
+          result,
+          agent,
+          result.output,
+          undefined,
+          'executed',
+        ),
+        new RunMessageOutputItem(
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'unguarded tail' }],
+          },
+          agent,
+        ),
+      ];
+      const serialized = state.toJSON() as any;
+      serialized.currentTurnBlockedSessionStartIndex = 0;
+      serialized.currentTurnSessionHistoryTransactionSessionId =
+        'closed-pending-authority-session';
+      serialized.currentTurnSessionReasoningItemIdPolicy = 'preserve';
+      serialized.currentTurnSessionHistoryTransactionInputItems = [];
+      serialized.pendingSessionHistoryTransaction = {
+        operationId: [
+          serialized.sessionHistoryTransactionId,
+          serialized.currentTurn,
+          'blocked_append',
+          0,
+          2,
+        ].join(':'),
+        transactionKind: 'blocked_append',
+        runItemIndexes: [0, 1],
+        replaceRunItemIndexes: [],
+        alreadyPersistedCount: 0,
+        persistedItemCount: 2,
+        deferredItemIndexes: [],
+      };
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      );
+    });
+
+    it('defaults output guardrail persistence state for a genuine schema 1.16 payload', async () => {
+      const agent = new Agent({ name: 'GenuineV116PersistenceAgent' });
+      const serialized = new RunState(
+        new RunContext(),
+        'input',
+        agent,
+        1,
+      ).toJSON() as any;
+      serialized.$schemaVersion = '1.16';
+      delete serialized.currentTurnDeferredSessionItemIndexes;
+      delete serialized.currentTurnSessionInputItems;
+      delete serialized.currentTurnSessionHistoryTransactionInputItems;
+      delete serialized.sessionHistoryTransactionId;
+      delete serialized.pendingSessionHistoryTransaction;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._currentTurnDeferredSessionItemIndexes.size).toBe(0);
+      expect(restored._sessionHistoryTransactionId).toBeTruthy();
+      expect(restored._pendingSessionHistoryTransaction).toBeUndefined();
+    });
+
     it('rejects schema version 1.12 payloads with tool output customData', async () => {
       const context = new RunContext();
       const agent = new Agent({ name: 'CustomDataVersionAgent' });
@@ -4113,7 +4830,7 @@ export function registerRunStateMigrationTests(): void {
       );
     });
 
-    it('reads schema 1.15 approval keys and emits category-aware schema 1.16 state', async () => {
+    it('reads schema 1.15 approval keys and emits the current category-aware state', async () => {
       const context = new RunContext();
       const agent = new Agent({ name: 'ApprovalKeyMigrationAgent' });
       const state = new RunState(context, 'input', agent, 2);
@@ -4147,7 +4864,7 @@ export function registerRunStateMigrationTests(): void {
           callId: 'legacy-call',
         }),
       ).toBe(false);
-      expect(restored.toJSON().$schemaVersion).toBe('1.16');
+      expect(restored.toJSON().$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     });
 
     it('rehydrates schema 1.15 approval identity from enabled prepared tools', async () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src';
 import { Agent, AgentOutputType } from '../../src/agent';
 import {
+  RunHandoffCallItem as HandoffCallItem,
   RunHandoffOutputItem as HandoffOutputItem,
   RunCompactionItem as CompactionItem,
   RunMessageOutputItem as MessageOutputItem,
@@ -20,9 +21,11 @@ import {
 import { ModelResponse } from '../../src/model';
 import {
   prepareInputItemsWithSession,
+  releaseUnusedSessionHistoryTransactionBinding,
   saveStreamInputToSession,
   saveStreamResultToSession,
   saveToSession,
+  selectRunItemsForBlockedOutput,
 } from '../../src/runner/sessionPersistence';
 import { ServerConversationTracker } from '../../src/runner/conversation';
 import { getToolCallOutputItem } from '../../src/runner/toolExecution';
@@ -37,7 +40,9 @@ import type {
   OpenAIResponsesCompactionArgs,
   OpenAIResponsesCompactionResult,
   Session,
+  SessionHistoryTransactionArgs,
 } from '../../src/memory/session';
+import { MemorySession as TransactionMemorySession } from '../../src/memory/memorySession';
 import { toAgentInputList } from '../../src/runner/items';
 import { tool } from '../../src/tool';
 import type { FunctionTool } from '../../src/tool';
@@ -107,6 +112,1207 @@ function functionResult(
     output,
   );
 }
+
+function executedFunctionResult(
+  call: protocol.FunctionCallItem,
+  output: string,
+  agent: Agent<any, any> = TEST_AGENT,
+): ToolCallOutputItem {
+  return new ToolCallOutputItem(
+    {
+      type: 'function_call_result',
+      callId: call.callId,
+      name: call.name,
+      status: 'completed',
+      output,
+      ...(call.caller ? { caller: call.caller } : {}),
+    },
+    agent,
+    output,
+    undefined,
+    'executed',
+  );
+}
+
+describe('selectRunItemsForBlockedOutput', () => {
+  it('retains a committed pair and only reasoning tied to its call', () => {
+    const call = functionCall('call-retained');
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const rejectedReasoning = new ReasoningItem(
+      {
+        type: 'reasoning',
+        id: 'reasoning-rejected',
+        content: [{ type: 'input_text', text: 'draft message' }],
+      },
+      TEST_AGENT,
+    );
+    const rejectedMessage = new MessageOutputItem(
+      fakeModelMessage('blocked'),
+      TEST_AGENT,
+    );
+    const retainedReasoning = new ReasoningItem(
+      {
+        type: 'reasoning',
+        id: 'reasoning-retained',
+        content: [{ type: 'input_text', text: 'call tool' }],
+      },
+      TEST_AGENT,
+    );
+    const result = executedFunctionResult(call, 'done');
+
+    expect(
+      selectRunItemsForBlockedOutput([
+        rejectedReasoning,
+        rejectedMessage,
+        retainedReasoning,
+        callItem,
+        result,
+      ]),
+    ).toEqual([retainedReasoning, callItem, result]);
+  });
+
+  it('retains a terminal result for a previously persisted approval call', () => {
+    const call = functionCall('call-rejected-after-approval');
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const rejectedResult = functionResult(call, 'rejected');
+
+    expect(
+      selectRunItemsForBlockedOutput([callItem, rejectedResult], 1),
+    ).toEqual([rejectedResult]);
+    expect(
+      selectRunItemsForBlockedOutput([callItem, rejectedResult], 0),
+    ).toEqual([]);
+  });
+
+  it('uses provider shell result status and execution provenance', () => {
+    const call = new ToolCallItem(
+      {
+        type: 'shell_call',
+        callId: 'shell-call',
+        status: 'in_progress',
+        action: { commands: ['echo committed'] },
+      },
+      TEST_AGENT,
+    );
+    const result = new ToolCallOutputItem(
+      {
+        type: 'shell_call_output',
+        callId: 'shell-call',
+        output: [],
+        providerData: { status: 'completed' },
+      },
+      TEST_AGENT,
+      [],
+      undefined,
+      'executed',
+    );
+    const incompleteResult = new ToolCallOutputItem(
+      {
+        type: 'shell_call_output',
+        callId: 'shell-call',
+        output: [],
+        providerData: { status: 'incomplete' },
+      },
+      TEST_AGENT,
+      [],
+      undefined,
+      'executed',
+    );
+    const providerIncompleteResult = new ToolCallOutputItem(
+      {
+        type: 'shell_call_output',
+        callId: 'shell-call',
+        status: 'completed',
+        output: [],
+        providerData: { status: 'incomplete' },
+      },
+      TEST_AGENT,
+      [],
+      undefined,
+      'executed',
+    );
+    const itemIncompleteResult = new ToolCallOutputItem(
+      {
+        type: 'shell_call_output',
+        callId: 'shell-call',
+        status: 'incomplete',
+        output: [],
+        providerData: { status: 'completed' },
+      },
+      TEST_AGENT,
+      [],
+      undefined,
+      'executed',
+    );
+    const statuslessExecutedResult = new ToolCallOutputItem(
+      {
+        type: 'shell_call_output',
+        callId: 'shell-call',
+        output: [],
+      },
+      TEST_AGENT,
+      [],
+      undefined,
+      'executed',
+    );
+
+    expect(selectRunItemsForBlockedOutput([call, result])).toEqual([
+      call,
+      result,
+    ]);
+    expect(selectRunItemsForBlockedOutput([call, incompleteResult])).toEqual(
+      [],
+    );
+    expect(
+      selectRunItemsForBlockedOutput([call, providerIncompleteResult]),
+    ).toEqual([]);
+    expect(
+      selectRunItemsForBlockedOutput([call, itemIncompleteResult]),
+    ).toEqual([]);
+    expect(
+      selectRunItemsForBlockedOutput([call, statuslessExecutedResult]),
+    ).toEqual([call, statuslessExecutedResult]);
+  });
+
+  it('retains session authority for an executed result excluded from blocked history', async () => {
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state._generatedItems = [
+      new ToolCallItem(
+        {
+          type: 'shell_call',
+          callId: 'excluded-bound-shell',
+          status: 'completed',
+          action: { commands: ['echo committed'] },
+        },
+        TEST_AGENT,
+      ),
+      new ToolCallOutputItem(
+        {
+          type: 'shell_call_output',
+          callId: 'excluded-bound-shell',
+          output: [],
+          providerData: { status: 'incomplete' },
+        },
+        TEST_AGENT,
+        [],
+        undefined,
+        'executed',
+      ),
+    ];
+    state._currentTurnSessionHistoryTransactionSessionId =
+      'excluded-bound-session';
+
+    releaseUnusedSessionHistoryTransactionBinding(state);
+
+    expect(state._currentTurnSessionHistoryTransactionSessionId).toBe(
+      'excluded-bound-session',
+    );
+    const serialized = state.toJSON();
+    expect(serialized.currentTurnExecutedWithSessionBinding).toBe(true);
+    await expect(
+      RunState.fromString(TEST_AGENT, JSON.stringify(serialized)),
+    ).rejects.toThrow(
+      'Serialized output guardrail session transaction authority cannot be resumed safely.',
+    );
+  });
+
+  it('does not treat program output as locally executed provenance', () => {
+    const program = new ToolCallItem(
+      {
+        type: 'program',
+        callId: 'program-untrusted-execution',
+        code: 'return "done";',
+        fingerprint: 'program-untrusted-execution-fingerprint',
+      },
+      TEST_AGENT,
+    );
+    const output = new ToolCallOutputItem(
+      {
+        type: 'program_output',
+        callId: 'program-untrusted-execution',
+        status: 'completed',
+        output: 'done',
+      },
+      TEST_AGENT,
+      'done',
+      undefined,
+      'executed',
+    );
+
+    expect(selectRunItemsForBlockedOutput([program, output])).toEqual([]);
+  });
+
+  it('retains completed handoff context and a pending program owner', () => {
+    const handoffCall = {
+      ...functionCall('call-handoff'),
+      name: 'transfer_to_target',
+    };
+    const handoffCallItem = new HandoffCallItem(handoffCall, TEST_AGENT);
+    const handoffOutputItem = new HandoffOutputItem(
+      {
+        type: 'function_call_result',
+        callId: handoffCall.callId,
+        name: handoffCall.name,
+        status: 'completed',
+        output: 'Transferred',
+      },
+      TEST_AGENT,
+      TEST_AGENT,
+    );
+    const program = new ToolCallItem(
+      {
+        type: 'program',
+        callId: 'program-owner',
+        code: 'return await tools.test({});',
+        fingerprint: 'program-owner-fingerprint',
+      },
+      TEST_AGENT,
+    );
+    const childCall = {
+      ...functionCall('program-child'),
+      caller: { type: 'program' as const, callerId: 'program-owner' },
+    };
+    const child = new ToolCallItem(childCall, TEST_AGENT);
+    const childResult = executedFunctionResult(childCall, 'committed');
+
+    expect(
+      selectRunItemsForBlockedOutput([
+        handoffCallItem,
+        handoffOutputItem,
+        program,
+        child,
+        childResult,
+      ]),
+    ).toEqual([
+      handoffCallItem,
+      handoffOutputItem,
+      program,
+      child,
+      childResult,
+    ]);
+  });
+
+  it('retains classified hosted tools and drops unknown completed kinds', () => {
+    const hosted = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-completed',
+        name: 'web_search_call',
+        status: 'completed',
+        providerData: { type: 'web_search_call' },
+      },
+      TEST_AGENT,
+    );
+    const unknown = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-future',
+        name: 'future_hosted_call',
+        status: 'completed',
+        providerData: { type: 'future_hosted_call' },
+      },
+      TEST_AGENT,
+    );
+    const legacyMcp = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'legacy-mcp-completed',
+        name: 'hosted_mcp',
+        providerData: { type: 'mcp_call', status: 'completed' },
+      },
+      TEST_AGENT,
+    );
+    const incompleteLegacyMcp = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'legacy-mcp-incomplete',
+        name: 'hosted_mcp',
+        providerData: { type: 'mcp_call', status: 'incomplete' },
+      },
+      TEST_AGENT,
+    );
+    const conflictingStatus = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-conflicting-status',
+        name: 'web_search_call',
+        status: 'completed',
+        providerData: {
+          type: 'web_search_call',
+          status: 'incomplete',
+        },
+      },
+      TEST_AGENT,
+    );
+    const conflictingType = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-conflicting-type',
+        name: 'web_search_call',
+        status: 'completed',
+        providerData: { type: 'future_hosted_call' },
+      },
+      TEST_AGENT,
+    );
+
+    expect(selectRunItemsForBlockedOutput([hosted])).toEqual([hosted]);
+    expect(selectRunItemsForBlockedOutput([legacyMcp])).toEqual([legacyMcp]);
+    expect(selectRunItemsForBlockedOutput([incompleteLegacyMcp])).toEqual([]);
+    expect(selectRunItemsForBlockedOutput([conflictingStatus])).toEqual([]);
+    expect(selectRunItemsForBlockedOutput([conflictingType])).toEqual([]);
+    expect(selectRunItemsForBlockedOutput([unknown])).toEqual([]);
+  });
+
+  it('retains tool-search provenance that loaded a committed dynamic tool', () => {
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        arguments: { paths: ['dynamic_commit'] },
+        execution: 'client',
+        providerData: {
+          call_id: 'call-tool-search-dynamic',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const searchOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        execution: 'client',
+        tools: [{ type: 'function', name: 'dynamic_commit' }],
+        providerData: {
+          call_id: 'call-tool-search-dynamic',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const call = {
+      ...functionCall('call-dynamic-commit'),
+      name: 'dynamic_commit',
+    };
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const result = executedFunctionResult(call, 'committed');
+
+    expect(
+      selectRunItemsForBlockedOutput([
+        searchCall,
+        searchOutput,
+        callItem,
+        result,
+      ]),
+    ).toEqual([searchCall, searchOutput, callItem, result]);
+  });
+
+  it('retains tool-search provenance that loaded a completed hosted MCP call', () => {
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        arguments: { paths: ['inventory'] },
+        execution: 'client',
+        providerData: {
+          call_id: 'call-tool-search-hosted-mcp',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const searchOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        execution: 'client',
+        tools: [
+          {
+            type: 'mcp',
+            server_label: 'inventory',
+            server_url: 'https://inventory.example.com/mcp',
+            defer_loading: true,
+            require_approval: 'never',
+          },
+        ],
+        providerData: {
+          call_id: 'call-tool-search-hosted-mcp',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const hostedMcpCall = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-mcp-call',
+        name: 'hosted_mcp',
+        status: 'completed',
+        providerData: {
+          type: 'mcp_call',
+          server_label: 'inventory',
+        },
+      },
+      TEST_AGENT,
+    );
+
+    expect(
+      selectRunItemsForBlockedOutput([searchCall, searchOutput, hostedMcpCall]),
+    ).toEqual([searchCall, searchOutput, hostedMcpCall]);
+  });
+
+  it('keeps an earlier committed tool when an unrelated matching search appears later', () => {
+    const call = {
+      ...functionCall('call-dynamic-before-search'),
+      name: 'dynamic_commit',
+    };
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const result = executedFunctionResult(call, 'committed');
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        arguments: { paths: ['dynamic_commit'] },
+        execution: 'client',
+        providerData: {
+          call_id: 'call-late-dynamic-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const searchOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        execution: 'client',
+        tools: [{ type: 'function', name: 'dynamic_commit' }],
+        providerData: {
+          call_id: 'call-late-dynamic-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+
+    expect(
+      selectRunItemsForBlockedOutput([
+        callItem,
+        result,
+        searchCall,
+        searchOutput,
+      ]),
+    ).toEqual([callItem, result]);
+  });
+
+  it('keeps an earlier hosted MCP call when a matching search appears later', () => {
+    const hostedMcpCall = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-mcp-before-search',
+        name: 'hosted_mcp',
+        status: 'completed',
+        providerData: {
+          type: 'mcp_call',
+          server_label: 'inventory',
+        },
+      },
+      TEST_AGENT,
+    );
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        arguments: { paths: ['inventory'] },
+        execution: 'client',
+        providerData: {
+          call_id: 'call-late-hosted-mcp-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const searchOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        execution: 'client',
+        tools: [
+          {
+            type: 'mcp',
+            server_label: 'inventory',
+            server_url: 'https://inventory.example.com/mcp',
+            defer_loading: true,
+            require_approval: 'never',
+          },
+        ],
+        providerData: {
+          call_id: 'call-late-hosted-mcp-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+
+    expect(
+      selectRunItemsForBlockedOutput([hostedMcpCall, searchCall, searchOutput]),
+    ).toEqual([hostedMcpCall]);
+  });
+
+  it('keeps explicit server tool-search outputs out of the FIFO fallback queue', () => {
+    const firstCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        call_id: 'server-search-a',
+        execution: 'server',
+        status: 'completed',
+        arguments: { paths: ['alpha'] },
+      } as any,
+      TEST_AGENT,
+    );
+    const secondCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        call_id: 'server-search-b',
+        execution: 'server',
+        status: 'completed',
+        arguments: { paths: ['beta'] },
+      } as any,
+      TEST_AGENT,
+    );
+    const firstOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        call_id: 'server-search-a',
+        execution: 'server',
+        status: 'completed',
+        tools: [],
+      } as any,
+      TEST_AGENT,
+    );
+    const secondOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        execution: 'server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'mcp',
+            server_label: 'beta',
+            server_url: 'https://beta.example.com/mcp',
+            defer_loading: true,
+            require_approval: 'never',
+          },
+        ],
+      } as any,
+      TEST_AGENT,
+    );
+    const hostedMcpCall = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-mcp-beta',
+        name: 'hosted_mcp',
+        status: 'completed',
+        providerData: { type: 'mcp_call', server_label: 'beta' },
+      },
+      TEST_AGENT,
+    );
+
+    expect(
+      selectRunItemsForBlockedOutput([
+        firstCall,
+        secondCall,
+        firstOutput,
+        secondOutput,
+        hostedMcpCall,
+      ]),
+    ).toEqual([secondCall, secondOutput, hostedMcpCall]);
+  });
+
+  it('drops completed server tool-search output from an incomplete call', () => {
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        call_id: 'server-incomplete-search',
+        execution: 'server',
+        status: 'incomplete',
+        arguments: { paths: ['inventory'] },
+      },
+      TEST_AGENT,
+    );
+    const searchOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        call_id: 'server-incomplete-search',
+        execution: 'server',
+        status: 'completed',
+        tools: [
+          {
+            type: 'mcp',
+            server_label: 'inventory',
+            server_url: 'https://inventory.example.com/mcp',
+            defer_loading: true,
+            require_approval: 'never',
+          },
+        ],
+      },
+      TEST_AGENT,
+    );
+    const hostedMcpCall = new ToolCallItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'hosted-mcp-incomplete-search-call',
+        name: 'hosted_mcp',
+        status: 'completed',
+        providerData: {
+          type: 'mcp_call',
+          server_label: 'inventory',
+        },
+      },
+      TEST_AGENT,
+    );
+
+    expect(
+      selectRunItemsForBlockedOutput([searchCall, searchOutput, hostedMcpCall]),
+    ).toEqual([]);
+  });
+
+  it.each([
+    { label: 'missing', status: undefined },
+    { label: 'incomplete', status: 'incomplete' as const },
+  ])(
+    'drops a defer-loaded hosted MCP call with $label tool-search provenance',
+    ({ status }) => {
+      const searchCall = new ToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          arguments: { paths: ['inventory'] },
+          execution: 'client',
+          providerData: {
+            call_id: 'call-incomplete-hosted-mcp-search',
+            execution: 'client',
+          },
+        },
+        TEST_AGENT,
+      );
+      const searchOutput = new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          status,
+          execution: 'client',
+          tools: [
+            {
+              type: 'mcp',
+              server_label: 'inventory',
+              server_url: 'https://inventory.example.com/mcp',
+              defer_loading: true,
+              require_approval: 'never',
+            },
+          ],
+          providerData: {
+            call_id: 'call-incomplete-hosted-mcp-search',
+            execution: 'client',
+          },
+        },
+        TEST_AGENT,
+      );
+      const hostedMcpCall = new ToolCallItem(
+        {
+          type: 'hosted_tool_call',
+          id: 'hosted-mcp-incomplete-supplier',
+          name: 'hosted_mcp',
+          status: 'completed',
+          providerData: {
+            type: 'mcp_call',
+            server_label: 'inventory',
+          },
+        },
+        TEST_AGENT,
+      );
+
+      expect(
+        selectRunItemsForBlockedOutput([
+          searchCall,
+          searchOutput,
+          hostedMcpCall,
+        ]),
+      ).toEqual([]);
+    },
+  );
+
+  it.each([
+    {
+      name: 'incomplete supplier',
+      buildSearchItems: () => {
+        const searchCall = new ToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            arguments: { paths: ['dynamic_commit'] },
+            execution: 'client',
+            providerData: {
+              call_id: 'call-incomplete-search',
+              execution: 'client',
+            },
+          },
+          TEST_AGENT,
+        );
+        const searchOutput = new ToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            status: 'incomplete',
+            execution: 'client',
+            tools: [{ type: 'function', name: 'dynamic_commit' }],
+            providerData: {
+              call_id: 'call-incomplete-search',
+              execution: 'client',
+            },
+          },
+          TEST_AGENT,
+        );
+        return [searchCall, searchOutput];
+      },
+    },
+    {
+      name: 'out-of-order supplier',
+      buildSearchItems: () => [
+        new ToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            status: 'completed',
+            execution: 'client',
+            tools: [{ type: 'function', name: 'dynamic_commit' }],
+            providerData: {
+              call_id: 'call-out-of-order-search',
+              execution: 'client',
+            },
+          },
+          TEST_AGENT,
+        ),
+        new ToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            arguments: { paths: ['dynamic_commit'] },
+            execution: 'client',
+            providerData: {
+              call_id: 'call-out-of-order-search',
+              execution: 'client',
+            },
+          },
+          TEST_AGENT,
+        ),
+      ],
+    },
+  ])('drops a dynamic tool pair with a $name', ({ buildSearchItems }) => {
+    const call = {
+      ...functionCall('call-unresolved-dynamic-commit'),
+      name: 'dynamic_commit',
+    };
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const result = executedFunctionResult(call, 'committed');
+
+    expect(
+      selectRunItemsForBlockedOutput([...buildSearchItems(), callItem, result]),
+    ).toEqual([]);
+  });
+
+  it('retains the latest same-call-id tool-search replacement for a committed dynamic tool', () => {
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        arguments: { paths: ['dynamic_commit'] },
+        execution: 'client',
+        providerData: {
+          call_id: 'call-replaced-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const firstOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        execution: 'client',
+        tools: [{ type: 'function', name: 'dynamic_commit' }],
+        providerData: {
+          call_id: 'call-replaced-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const replacementOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        execution: 'client',
+        tools: [{ type: 'function', name: 'dynamic_commit' }],
+        providerData: {
+          call_id: 'call-replaced-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const call = {
+      ...functionCall('call-after-replaced-search'),
+      name: 'dynamic_commit',
+    };
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const result = executedFunctionResult(call, 'committed');
+
+    expect(
+      selectRunItemsForBlockedOutput([
+        searchCall,
+        firstOutput,
+        replacementOutput,
+        callItem,
+        result,
+      ]),
+    ).toEqual([searchCall, replacementOutput, callItem, result]);
+  });
+
+  it.each(['client', 'server'] as const)(
+    'matches an explicit %s tool-search output to the latest repeated call occurrence',
+    (execution) => {
+      const searchCall = (path: string) =>
+        new ToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            arguments: { paths: [path] },
+            execution,
+            ...(execution === 'server'
+              ? { call_id: 'call-repeated-search', status: 'completed' }
+              : {
+                  providerData: {
+                    call_id: 'call-repeated-search',
+                    execution,
+                  },
+                }),
+          } as any,
+          TEST_AGENT,
+        );
+      const firstCall = searchCall('first_search');
+      const latestCall = searchCall('dynamic_commit');
+      const explicitOutput = new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          status: 'completed',
+          execution,
+          tools: [{ type: 'function', name: 'dynamic_commit' }],
+          ...(execution === 'server'
+            ? { call_id: 'call-repeated-search' }
+            : {
+                providerData: {
+                  call_id: 'call-repeated-search',
+                  execution,
+                },
+              }),
+        } as any,
+        TEST_AGENT,
+      );
+      const call = {
+        ...functionCall(`call-after-repeated-${execution}-search`),
+        name: 'dynamic_commit',
+      };
+      const callItem = new ToolCallItem(call, TEST_AGENT);
+      const result = executedFunctionResult(call, 'committed');
+
+      expect(
+        selectRunItemsForBlockedOutput([
+          firstCall,
+          latestCall,
+          explicitOutput,
+          callItem,
+          result,
+        ]),
+      ).toEqual([latestCall, explicitOutput, callItem, result]);
+    },
+  );
+
+  it.each(['client', 'server'] as const)(
+    'matches an anonymous %s tool-search output to the oldest occurrence left by an explicit output',
+    (execution) => {
+      const searchCall = (path: string) =>
+        new ToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            arguments: { paths: [path] },
+            execution,
+            ...(execution === 'server'
+              ? { call_id: 'call-mixed-search', status: 'completed' }
+              : {
+                  providerData: {
+                    call_id: 'call-mixed-search',
+                    execution,
+                  },
+                }),
+          } as any,
+          TEST_AGENT,
+        );
+      const firstCall = searchCall('dynamic_commit');
+      const latestCall = searchCall('other_tool');
+      const explicitOutput = new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          status: 'completed',
+          execution,
+          tools: [{ type: 'function', name: 'other_tool' }],
+          ...(execution === 'server'
+            ? { call_id: 'call-mixed-search' }
+            : {
+                providerData: {
+                  call_id: 'call-mixed-search',
+                  execution,
+                },
+              }),
+        } as any,
+        TEST_AGENT,
+      );
+      const anonymousOutput = new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          status: 'completed',
+          execution,
+          tools: [{ type: 'function', name: 'dynamic_commit' }],
+        } as any,
+        TEST_AGENT,
+      );
+      const call = {
+        ...functionCall(`call-after-mixed-${execution}-search`),
+        name: 'dynamic_commit',
+      };
+      const callItem = new ToolCallItem(call, TEST_AGENT);
+      const result = executedFunctionResult(call, 'committed');
+
+      expect(
+        selectRunItemsForBlockedOutput([
+          firstCall,
+          latestCall,
+          explicitOutput,
+          anonymousOutput,
+          callItem,
+          result,
+        ]),
+      ).toEqual([firstCall, anonymousOutput, callItem, result]);
+    },
+  );
+
+  it('retains the latest completed tool-search refresh for a committed dynamic tool', () => {
+    const searchItems = ['first', 'second'].flatMap((suffix) => [
+      new ToolSearchCallItem(
+        {
+          type: 'tool_search_call',
+          arguments: { paths: ['dynamic_commit'] },
+          execution: 'client',
+          providerData: {
+            call_id: `call-${suffix}-refresh`,
+            execution: 'client',
+          },
+        },
+        TEST_AGENT,
+      ),
+      new ToolSearchOutputItem(
+        {
+          type: 'tool_search_output',
+          status: 'completed',
+          execution: 'client',
+          tools: [{ type: 'function', name: 'dynamic_commit' }],
+          providerData: {
+            call_id: `call-${suffix}-refresh`,
+            execution: 'client',
+          },
+        },
+        TEST_AGENT,
+      ),
+    ]);
+    const call = {
+      ...functionCall('call-after-refreshed-search'),
+      name: 'dynamic_commit',
+    };
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const result = executedFunctionResult(call, 'committed');
+
+    expect(
+      selectRunItemsForBlockedOutput([...searchItems, callItem, result]),
+    ).toEqual([...searchItems.slice(2), callItem, result]);
+  });
+
+  it.each([
+    ['client', 'incomplete'],
+    ['client', 'out_of_order'],
+    ['server', 'incomplete'],
+    ['server', 'out_of_order'],
+  ] as const)(
+    'keeps a completed %s supplier when a different-key occurrence is %s',
+    (execution, invalidKind) => {
+      const searchCall = (key: string) =>
+        new ToolSearchCallItem(
+          {
+            type: 'tool_search_call',
+            arguments: { paths: ['dynamic_commit'] },
+            execution,
+            ...(execution === 'server'
+              ? { call_id: key, status: 'completed' }
+              : {
+                  providerData: { call_id: key, execution },
+                }),
+          } as any,
+          TEST_AGENT,
+        );
+      const searchOutput = (key: string, status: 'completed' | 'incomplete') =>
+        new ToolSearchOutputItem(
+          {
+            type: 'tool_search_output',
+            status,
+            execution,
+            tools: [{ type: 'function', name: 'dynamic_commit' }],
+            ...(execution === 'server'
+              ? { call_id: key }
+              : {
+                  providerData: { call_id: key, execution },
+                }),
+          } as any,
+          TEST_AGENT,
+        );
+      const firstCall = searchCall('call-effective-first');
+      const firstOutput = searchOutput('call-effective-first', 'completed');
+      const invalidCall = searchCall('call-ineffective-second');
+      const invalidOutput = searchOutput(
+        'call-ineffective-second',
+        invalidKind === 'incomplete' ? 'incomplete' : 'completed',
+      );
+      const invalidItems =
+        invalidKind === 'out_of_order'
+          ? [invalidOutput, invalidCall]
+          : [invalidCall, invalidOutput];
+      const call = {
+        ...functionCall('call-after-ineffective-search'),
+        name: 'dynamic_commit',
+      };
+      const callItem = new ToolCallItem(call, TEST_AGENT);
+      const result = executedFunctionResult(call, 'committed');
+
+      expect(
+        selectRunItemsForBlockedOutput([
+          firstCall,
+          firstOutput,
+          ...invalidItems,
+          callItem,
+          result,
+        ]),
+      ).toEqual([firstCall, firstOutput, callItem, result]);
+    },
+  );
+
+  it('invalidates an earlier supplier when a same-key replacement is incomplete', () => {
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        arguments: { paths: ['dynamic_commit'] },
+        execution: 'client',
+        providerData: {
+          call_id: 'call-invalidated-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const completedOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'completed',
+        execution: 'client',
+        tools: [{ type: 'function', name: 'dynamic_commit' }],
+        providerData: {
+          call_id: 'call-invalidated-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const incompleteReplacement = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        status: 'incomplete',
+        execution: 'client',
+        tools: [{ type: 'function', name: 'dynamic_commit' }],
+        providerData: {
+          call_id: 'call-invalidated-search',
+          execution: 'client',
+        },
+      },
+      TEST_AGENT,
+    );
+    const call = {
+      ...functionCall('call-after-invalidated-search'),
+      name: 'dynamic_commit',
+    };
+
+    expect(
+      selectRunItemsForBlockedOutput([
+        searchCall,
+        completedOutput,
+        incompleteReplacement,
+        new ToolCallItem(call, TEST_AGENT),
+        executedFunctionResult(call, 'committed'),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('rejects serialized pending blocked-output transaction authority', async () => {
+    const call = {
+      ...functionCall('call-serialized-before-search'),
+      name: 'dynamic_commit',
+    };
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const result = executedFunctionResult(call, 'committed');
+    const searchCall = new ToolSearchCallItem(
+      {
+        type: 'tool_search_call',
+        call_id: 'call-serialized-late-search',
+        status: 'completed',
+        execution: 'server',
+        arguments: { paths: ['dynamic_commit'] },
+      } as any,
+      TEST_AGENT,
+    );
+    const searchOutput = new ToolSearchOutputItem(
+      {
+        type: 'tool_search_output',
+        call_id: 'call-serialized-late-search',
+        status: 'completed',
+        execution: 'server',
+        tools: [{ type: 'function', name: 'dynamic_commit' }],
+      } as any,
+      TEST_AGENT,
+    );
+    const state = new RunState(
+      new RunContext(undefined),
+      'input',
+      TEST_AGENT,
+      10,
+    );
+    state._generatedItems = [callItem, result, searchCall, searchOutput];
+    state._currentTurnBlockedSessionStartIndex = 0;
+    state._currentTurnSessionHistoryTransactionSessionId =
+      'serialized-plan-session';
+    state._currentTurnSessionReasoningItemIdPolicy = 'preserve';
+    state._currentTurnSessionHistoryTransactionInputItems = [];
+    state._currentTurnSessionHistoryTransactionCanReplaceAcceptedOutput = true;
+    state._pendingSessionHistoryTransaction = {
+      operationId: `${state._sessionHistoryTransactionId}:${state._currentTurn}:blocked_append:0:4`,
+      transactionKind: 'blocked_append',
+      runItemIndexes: [0, 1],
+      replaceRunItemIndexes: [],
+      alreadyPersistedCount: 0,
+      persistedItemCount: 4,
+      deferredItemIndexes: [2, 3],
+    };
+
+    await expect(
+      RunState.fromString(TEST_AGENT, state.toString()),
+    ).rejects.toThrow(
+      'Serialized output guardrail session transaction authority cannot be resumed safely.',
+    );
+  });
+});
 
 function shellCall(callId: string, command: string): protocol.ShellCallItem {
   return {
@@ -2541,6 +3747,109 @@ describe('saveToSession', () => {
       compaction,
     ]);
     expect(state._currentTurnPersistedItemCount).toBe(2);
+  });
+
+  it('retries a blocked-output transaction without duplicating committed tool effects', async () => {
+    class AcceptedBlockedThenThrowSession extends TransactionMemorySession {
+      operationIds: string[] = [];
+      transactions: SessionHistoryTransactionArgs['transaction'][] = [];
+      preserveReasoningIds = false;
+      private throwAfterFirstCommit = true;
+
+      preserveReasoningItemIdsForPersistence(): boolean {
+        return this.preserveReasoningIds;
+      }
+
+      override async applyHistoryTransaction(
+        args: SessionHistoryTransactionArgs,
+      ): Promise<void> {
+        this.operationIds.push(args.operationId);
+        this.transactions.push(structuredClone(args.transaction));
+        await super.applyHistoryTransaction(args);
+        if (this.throwAfterFirstCommit) {
+          this.throwAfterFirstCommit = false;
+          throw new Error('write outcome unknown');
+        }
+      }
+    }
+
+    const call = {
+      ...functionCall('call-blocked-retry'),
+      providerData: undefined,
+    };
+    const callItem = new ToolCallItem(call, TEST_AGENT);
+    const resultItem = executedFunctionResult(call, 'committed');
+    const session = new AcceptedBlockedThenThrowSession();
+    const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+    state.setReasoningItemIdPolicy('omit');
+    state._generatedItems = [
+      new ReasoningItem(
+        {
+          type: 'reasoning',
+          id: 'reasoning-blocked-retry',
+          content: [{ type: 'input_text', text: 'run the committed tool' }],
+        },
+        TEST_AGENT,
+      ),
+      callItem,
+      resultItem,
+    ];
+    const result = new RunResult(state as any);
+    const input = fakeModelMessage('blocked transaction input');
+    state._currentTurnSessionHistoryTransactionInputItems = [input];
+
+    await expect(
+      saveToSession(session, [input], result, {
+        outputBlocked: true,
+      }),
+    ).rejects.toThrow('write outcome unknown');
+    expect(state._currentTurnPersistedItemCount).toBe(0);
+    expect(state._pendingSessionHistoryTransaction).toBeDefined();
+    expect(
+      (session.transactions[0] as { items: AgentInputItem[] }).items.find(
+        (item) => item.type === 'function_call',
+      ),
+    ).not.toHaveProperty('providerData');
+    session.preserveReasoningIds = true;
+
+    const differentSession = new TransactionMemorySession({
+      sessionId: 'different-session',
+    });
+
+    await expect(
+      saveToSession(differentSession, [], new RunResult(state as any), {
+        outputBlocked: true,
+      }),
+    ).rejects.toThrow(
+      'Output guardrail session persistence belongs to a different session',
+    );
+    expect(await differentSession.getItems()).toEqual([]);
+    expect(state._pendingSessionHistoryTransaction).toBeDefined();
+
+    await expect(
+      saveToSession(session, [], new RunResult(state as any), {
+        outputBlocked: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(session.operationIds).toHaveLength(2);
+    expect(session.operationIds[1]).toBe(session.operationIds[0]);
+    const persistedItems = await session.getItems();
+    expect(persistedItems).toEqual(
+      JSON.parse(
+        JSON.stringify([
+          input,
+          {
+            type: 'reasoning',
+            content: [{ type: 'input_text', text: 'run the committed tool' }],
+          },
+          call,
+          resultItem.rawItem,
+        ]),
+      ),
+    );
+    expect(state._currentTurnPersistedItemCount).toBe(3);
+    expect(state._pendingSessionHistoryTransaction).toBeUndefined();
   });
 
   it('does not require a process global for debug session logging', async () => {


### PR DESCRIPTION
This pull request completes the second stage of output-guardrail session persistence https://github.com/openai/openai-agents-js/pull/1572 now that idempotent session history transactions have landed on main.

Previously, a final tool could execute before an output guardrail trip, while the rejected assistant message prevented the ordinary session save and caused the committed tool effect to disappear from replayable history.

The change:

- defers non-stream final-turn persistence until output guardrails settle
- persists committed tool call/result pairs exactly once when final output is blocked
- retains only causally related reasoning and excludes the rejected assistant message
- preserves the full ordered final turn when guardrails pass or fail with an error or cancellation
- aligns streaming and non-streaming behavior while preserving approved-tool checkpoints, RunState resume safety, and compaction ownership

Documentation is intentionally deferred to a release follow-up.