### PR TITLE
feat(core): pass run context to custom sessions

### DIFF
--- a/.changeset/kind-sessions-share-context.md
+++ b/.changeset/kind-sessions-share-context.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: pass run context to opted-in custom sessions

--- a/docs/src/content/docs/guides/sessions.mdx
+++ b/docs/src/content/docs/guides/sessions.mdx
@@ -7,6 +7,7 @@ import { Code } from '@astrojs/starlight/components';
 import sessionsQuickstart from '../../../../../examples/docs/sessions/basicSession.ts?raw';
 import manageHistory from '../../../../../examples/docs/sessions/manageHistory.ts?raw';
 import customSession from '../../../../../examples/docs/sessions/customSession.ts?raw';
+import contextAwareSession from '../../../../../examples/docs/sessions/contextAwareSession.ts?raw';
 import sessionInputCallback from '../../../../../examples/docs/sessions/sessionInputCallback.ts?raw';
 import responsesCompactionSession from '../../../../../examples/docs/sessions/responsesCompactionSession.ts?raw';
 import manualCompactionSession from '../../../../../examples/docs/sessions/responsesCompactionManualSession.ts?raw';
@@ -116,6 +117,18 @@ Implement the `Session` interface to back memory with Redis, DynamoDB, SQLite, o
 />
 
 Custom sessions let you enforce retention policies, add encryption, or attach metadata to each conversation turn before persisting it.
+
+### Scope custom sessions with the run context
+
+Implement `RunContextAwareSession<TContext>` and set `acceptsRunContext` to `true` when a custom session needs the active `RunContext` for storage routing or metadata. The runner passes the same context instance to all history operations during a run, including streamed persistence and resumed runs. Sessions that only implement `Session` keep the existing method signatures and are called without the additional argument.
+
+<Code
+  lang="typescript"
+  code={contextAwareSession}
+  title="Partition session history with the run context"
+/>
+
+`OpenAIResponsesCompactionSession` does not forward a run context to its underlying session. Keep one compaction-session instance per context scope if you combine these capabilities.
 
 ---
 

--- a/examples/docs/sessions/contextAwareSession.ts
+++ b/examples/docs/sessions/contextAwareSession.ts
@@ -1,0 +1,79 @@
+import {
+  Agent,
+  run,
+  type AgentInputItem,
+  type RunContext,
+  type RunContextAwareSession,
+} from '@openai/agents';
+
+type TenantContext = {
+  tenantId: string;
+};
+
+class TenantSession implements RunContextAwareSession<TenantContext> {
+  readonly acceptsRunContext = true;
+  private readonly itemsByTenant = new Map<string, AgentInputItem[]>();
+
+  async getSessionId(): Promise<string> {
+    return 'shared-tenant-session';
+  }
+
+  async getItems(
+    limit?: number,
+    runContext?: RunContext<TenantContext>,
+  ): Promise<AgentInputItem[]> {
+    const items = this.getTenantItems(runContext);
+    return limit === undefined ? [...items] : items.slice(-limit);
+  }
+
+  async addItems(
+    items: AgentInputItem[],
+    runContext?: RunContext<TenantContext>,
+  ): Promise<void> {
+    this.getTenantItems(runContext).push(...items);
+  }
+
+  async popItem(
+    runContext?: RunContext<TenantContext>,
+  ): Promise<AgentInputItem | undefined> {
+    return this.getTenantItems(runContext).pop();
+  }
+
+  async clearSession(runContext?: RunContext<TenantContext>): Promise<void> {
+    this.itemsByTenant.set(this.getTenantId(runContext), []);
+  }
+
+  private getTenantItems(
+    runContext: RunContext<TenantContext> | undefined,
+  ): AgentInputItem[] {
+    const tenantId = this.getTenantId(runContext);
+    const items = this.itemsByTenant.get(tenantId) ?? [];
+    this.itemsByTenant.set(tenantId, items);
+    return items;
+  }
+
+  private getTenantId(
+    runContext: RunContext<TenantContext> | undefined,
+  ): string {
+    if (!runContext) {
+      throw new Error('TenantSession requires a run context.');
+    }
+    return runContext.context.tenantId;
+  }
+}
+
+const agent = new Agent<TenantContext>({
+  name: 'Assistant',
+  instructions: 'Reply concisely.',
+});
+const session = new TenantSession();
+
+await run(agent, 'Remember that my favorite color is green.', {
+  context: { tenantId: 'tenant-a' },
+  session,
+});
+
+await run(agent, 'What is my favorite color?', {
+  context: { tenantId: 'tenant-a' },
+  session,
+});

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -327,6 +327,7 @@ export { RequestUsage, Usage } from './usage';
 export type { RequestUsageInput, UsageInput } from './usage';
 export type {
   Session,
+  RunContextAwareSession,
   SessionInputCallback,
   SessionHistoryMutation,
   SessionHistoryRewriteArgs,
@@ -342,6 +343,7 @@ export type {
 } from './memory/session';
 export {
   isOpenAIResponsesCompactionAwareSession,
+  isRunContextAwareSession,
   isSessionHistoryRewriteAwareSession,
   isSessionHistoryTransactionAwareSession,
 } from './memory/session';

--- a/packages/agents-core/src/memory/session.ts
+++ b/packages/agents-core/src/memory/session.ts
@@ -1,4 +1,5 @@
 import type { AgentInputItem } from '../types';
+import type { RunContext } from '../runContext';
 import type { RequestUsage } from '../usage';
 
 /**
@@ -94,6 +95,37 @@ export interface Session {
   clearSession(): Promise<void>;
 }
 
+/**
+ * Optional session capability for receiving the active run context.
+ *
+ * Sessions opt in explicitly so existing implementations keep their legacy method call shapes.
+ * The runner passes the same {@link RunContext} instance to every history operation in a run.
+ */
+export interface RunContextAwareSession<TContext = unknown> extends Session {
+  readonly acceptsRunContext: true;
+
+  getItems(
+    limit?: number,
+    runContext?: RunContext<TContext>,
+  ): Promise<AgentInputItem[]>;
+
+  addItems(
+    items: AgentInputItem[],
+    runContext?: RunContext<TContext>,
+  ): Promise<void>;
+
+  replaceHistoryWithCompaction?(
+    items: AgentInputItem[],
+    runContext?: RunContext<TContext>,
+  ): Promise<void>;
+
+  popItem(
+    runContext?: RunContext<TContext>,
+  ): Promise<AgentInputItem | undefined>;
+
+  clearSession(runContext?: RunContext<TContext>): Promise<void>;
+}
+
 export interface SessionHistoryRewriteAwareSession extends Session {
   applyHistoryMutations(args: SessionHistoryRewriteArgs): Promise<void> | void;
 }
@@ -134,6 +166,7 @@ export type SessionHistoryTransactionArgs = {
 export interface SessionHistoryTransactionAwareSession extends Session {
   applyHistoryTransaction(
     args: SessionHistoryTransactionArgs,
+    runContext?: RunContext<any>,
   ): Promise<void> | void;
 }
 
@@ -181,6 +214,7 @@ export interface OpenAIResponsesCompactionAwareSession extends Session {
    */
   runCompaction(
     args?: OpenAIResponsesCompactionArgs,
+    runContext?: RunContext<any>,
   ):
     | Promise<OpenAIResponsesCompactionResult | null>
     | OpenAIResponsesCompactionResult
@@ -194,6 +228,16 @@ export function isOpenAIResponsesCompactionAwareSession(
     !!session &&
     typeof (session as OpenAIResponsesCompactionAwareSession).runCompaction ===
       'function'
+  );
+}
+
+export function isRunContextAwareSession(
+  session: Session | undefined,
+): session is RunContextAwareSession<unknown> {
+  return (
+    !!session &&
+    (session as Partial<RunContextAwareSession<unknown>>).acceptsRunContext ===
+      true
   );
 }
 

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -644,6 +644,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       this.config.tracing,
       resolvedOptions.tracing,
     );
+    const runContext =
+      input instanceof RunState
+        ? input._context
+        : resolvedOptions.context instanceof RunContext
+          ? resolvedOptions.context
+          : new RunContext(resolvedOptions.context);
     const traceOverrides = {
       ...this.traceOverrides,
       ...(resolvedOptions.tracing?.apiKey !== undefined
@@ -652,6 +658,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     };
     const effectiveOptions = {
       ...resolvedOptions,
+      context: runContext,
       sessionInputCallback,
       callModelInputFilter,
       toolErrorFormatter,
@@ -704,6 +711,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     }
     const sessionPersistence = createSessionPersistenceTracker({
       session,
+      runContext,
       hasCallModelInputFilter,
       persistInput: saveStreamInputToSession,
       resumingFromState,
@@ -726,6 +734,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           preserveDroppedNewItems: serverManagesConversation,
           reasoningItemIdPolicy,
         },
+        runContext,
       );
       if (serverManagesConversation && session) {
         // When the server manages memory we only persist the new turn inputs locally so the

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -1,6 +1,7 @@
 import { UserError } from '../errors';
 import {
   isOpenAIResponsesCompactionAwareSession,
+  isRunContextAwareSession,
   isSessionHistoryTransactionAwareSession,
   type OpenAIResponsesCompactionArgs,
   type Session,
@@ -9,6 +10,7 @@ import {
 } from '../memory/session';
 import { RunResult, StreamedRunResult } from '../result';
 import { RunState } from '../runState';
+import type { RunContext } from '../runContext';
 import { RunItem } from '../items';
 import { AgentInputItem } from '../types';
 import { ModelItem } from '../types/protocol';
@@ -48,6 +50,47 @@ export type SessionPersistenceOptions = {
   compactionMode?: OpenAIResponsesCompactionArgs['compactionMode'];
   outputBlocked?: boolean;
 };
+
+const SESSION_LIMIT_UNSET = Symbol('sessionLimitUnset');
+
+async function getSessionItems(
+  session: Session,
+  runContext: RunContext<any> | undefined,
+  limit: number | typeof SESSION_LIMIT_UNSET = SESSION_LIMIT_UNSET,
+): Promise<AgentInputItem[]> {
+  if (runContext && isRunContextAwareSession(session)) {
+    return session.getItems(
+      limit === SESSION_LIMIT_UNSET ? undefined : limit,
+      runContext,
+    );
+  }
+  return limit === SESSION_LIMIT_UNSET
+    ? session.getItems()
+    : session.getItems(limit);
+}
+
+async function addSessionItems(
+  session: Session,
+  items: AgentInputItem[],
+  runContext: RunContext<any> | undefined,
+): Promise<void> {
+  if (runContext && isRunContextAwareSession(session)) {
+    await session.addItems(items, runContext);
+    return;
+  }
+  await session.addItems(items);
+}
+
+async function clearSession(
+  session: Session,
+  runContext: RunContext<any> | undefined,
+): Promise<void> {
+  if (runContext && isRunContextAwareSession(session)) {
+    await session.clearSession(runContext);
+    return;
+  }
+  await session.clearSession();
+}
 
 function canonicalizeSessionHistoryTransaction(
   transaction: SessionHistoryTransaction,
@@ -365,7 +408,7 @@ async function assertBlockedSessionSuffixMatches(
   const expectedSuffix = normalizeItemsForSessionPersistence(
     extractOutputItemsFromRunItems(suffixRunItems, reasoningItemIdPolicy),
   );
-  const currentItems = await session.getItems();
+  const currentItems = await getSessionItems(session, state._context);
   const comparableCurrentItems =
     session.prepareHistoryItemsForPersistenceComparison?.(currentItems) ??
     currentItems;
@@ -452,6 +495,7 @@ export type SessionPersistenceTracker = {
 
 export function createSessionPersistenceTracker(options: {
   session?: Session;
+  runContext?: RunContext<any>;
   hasCallModelInputFilter: boolean;
   persistInput?: typeof saveStreamInputToSession;
   resumingFromState?: boolean;
@@ -459,6 +503,7 @@ export function createSessionPersistenceTracker(options: {
 }): SessionPersistenceTracker | undefined {
   class SessionPersistenceTrackerImpl implements SessionPersistenceTracker {
     private readonly session?: Session;
+    private readonly runContext?: RunContext<any>;
     private readonly hasCallModelInputFilter: boolean;
     private readonly persistInput?: typeof saveStreamInputToSession;
     private originalSnapshot: AgentInputItem[] | undefined;
@@ -472,6 +517,7 @@ export function createSessionPersistenceTracker(options: {
 
     constructor() {
       this.session = options.session;
+      this.runContext = options.runContext;
       this.hasCallModelInputFilter = options.hasCallModelInputFilter;
       this.persistInput = options.persistInput;
       this.originalSnapshot = options.resumingFromState
@@ -600,7 +646,7 @@ export function createSessionPersistenceTracker(options: {
           return;
         }
         this.persistedInput = true;
-        await persistInput(this.session, itemsToPersist);
+        await persistInput(this.session, itemsToPersist, this.runContext);
       };
     };
   }
@@ -1023,7 +1069,7 @@ export async function saveToSession(
     options.outputBlocked === true &&
     !persistencePlan.useHistoryTransaction
   ) {
-    await saveStreamInputToSession(session, sessionInputItems);
+    await saveStreamInputToSession(session, sessionInputItems, state._context);
     return;
   }
 
@@ -1048,6 +1094,7 @@ export async function saveToSession(
 export async function saveStreamInputToSession(
   session: Session | undefined,
   sessionInputItems: AgentInputItem[] | undefined,
+  runContext?: RunContext<any>,
 ): Promise<void> {
   if (!session) {
     return;
@@ -1059,15 +1106,16 @@ export async function saveStreamInputToSession(
   const compactedInput = trimToLatestCompaction(sanitizedInput);
   assertPersistableCompactionBoundary(compactedInput);
   if (compactedInput[0]?.type === 'compaction') {
-    const previousItems = await session.getItems();
+    const previousItems = await getSessionItems(session, runContext);
     await replaceSessionItemsWithRecovery(
       session,
       previousItems,
       compactedInput,
+      runContext,
     );
     return;
   }
-  await session.addItems(sanitizedInput);
+  await addSessionItems(session, sanitizedInput, runContext);
 }
 
 export async function saveStreamResultToSession(
@@ -1091,7 +1139,7 @@ export async function saveStreamResultToSession(
     options.outputBlocked === true &&
     !persistencePlan.useHistoryTransaction
   ) {
-    await saveStreamInputToSession(session, sessionInputItems);
+    await saveStreamInputToSession(session, sessionInputItems, state._context);
     return;
   }
 
@@ -1147,7 +1195,11 @@ export async function reconcileLegacyCompactionSessionBeforeResume(
     sanitizedPendingItems,
     reasoningItemIdPolicy,
   );
-  await reconcileLegacyCompactionSessionItems(session, sanitizedPendingItems);
+  await reconcileLegacyCompactionSessionItems(
+    session,
+    sanitizedPendingItems,
+    state._context,
+  );
   state._pendingLegacyCompactionSessionItems = undefined;
 }
 
@@ -1203,6 +1255,7 @@ export async function prepareInputItemsWithSession(
     preserveDroppedNewItems?: boolean;
     reasoningItemIdPolicy?: ReasoningItemIdPolicy;
   },
+  runContext?: RunContext<any>,
 ): Promise<PreparedInputWithSessionResult> {
   const newInputItems = toAgentInputList(input);
   assertValidCompactionItems(newInputItems);
@@ -1218,7 +1271,9 @@ export async function prepareInputItemsWithSession(
   const preserveDroppedNewItems = options?.preserveDroppedNewItems ?? false;
   const reasoningItemIdPolicy = options?.reasoningItemIdPolicy;
 
-  const history = trimToLatestCompaction(await session.getItems());
+  const history = trimToLatestCompaction(
+    await getSessionItems(session, runContext),
+  );
   assertPersistableCompactionBoundary(history);
   if (!sessionInputCallback) {
     const historyForModelInput = history.map((item) =>
@@ -1657,14 +1712,15 @@ async function persistRunItemsToSession(options: {
   const compactedItems = trimToLatestCompaction(sanitizedItems);
   assertPersistableCompactionBoundary(compactedItems);
   if (compactedItems[0]?.type === 'compaction') {
-    const previousItems = await session.getItems();
+    const previousItems = await getSessionItems(session, state._context);
     await replaceSessionItemsWithRecovery(
       session,
       previousItems,
       compactedItems,
+      state._context,
     );
   } else {
-    await session.addItems(sanitizedItems);
+    await addSessionItems(session, sanitizedItems, state._context);
   }
   commitPersistenceState();
   if (runCompaction) {
@@ -1711,10 +1767,15 @@ async function flushPendingSessionHistoryTransaction(
       'A pending session history transaction is missing its accepted-output replacement authority.',
     );
   }
-  await session.applyHistoryTransaction({
+  const transactionArgs = {
     operationId: pending.operationId,
     transaction: buildPendingSessionHistoryTransaction(state),
-  });
+  };
+  if (isRunContextAwareSession(session)) {
+    await session.applyHistoryTransaction(transactionArgs, state._context);
+  } else {
+    await session.applyHistoryTransaction(transactionArgs);
+  }
   state._currentTurnPersistedItemCount = pending.persistedItemCount;
   state._currentTurnDeferredSessionItemIndexes = new Set(
     pending.deferredItemIndexes,
@@ -1734,13 +1795,14 @@ async function flushPendingSessionHistoryTransaction(
 async function reconcileLegacyCompactionSessionItems(
   session: Session,
   pendingItems: AgentInputItem[],
+  runContext: RunContext<any>,
 ): Promise<void> {
   if (pendingItems.length === 0 || pendingItems[0]?.type !== 'compaction') {
     throwLegacyCompactionReconciliationError();
   }
   assertPersistableCompactionBoundary(pendingItems);
 
-  const previousItems = await session.getItems();
+  const previousItems = await getSessionItems(session, runContext);
   assertValidCompactionItems(trimToLatestCompaction(previousItems));
   const comparablePreviousItems =
     session.prepareHistoryItemsForPersistenceComparison?.(previousItems) ??
@@ -1773,7 +1835,12 @@ async function reconcileLegacyCompactionSessionItems(
     throwLegacyCompactionReconciliationError();
   }
 
-  await replaceSessionItemsWithRecovery(session, previousItems, pendingItems);
+  await replaceSessionItemsWithRecovery(
+    session,
+    previousItems,
+    pendingItems,
+    runContext,
+  );
 }
 
 function assertPersistableCompactionBoundary(items: AgentInputItem[]): void {
@@ -1823,6 +1890,7 @@ async function replaceSessionItemsWithRecovery(
   session: Session,
   previousItems: AgentInputItem[],
   replacementItems: AgentInputItem[],
+  runContext?: RunContext<any>,
 ): Promise<void> {
   assertValidCompactionItems(trimToLatestCompaction(previousItems));
   assertValidCompactionItems(trimToLatestCompaction(replacementItems));
@@ -1849,20 +1917,25 @@ async function replaceSessionItemsWithRecovery(
     ) {
       return;
     }
-    await session.replaceHistoryWithCompaction(replacementItems);
+    if (runContext && isRunContextAwareSession(session)) {
+      await session.replaceHistoryWithCompaction(replacementItems, runContext);
+    } else {
+      await session.replaceHistoryWithCompaction(replacementItems);
+    }
     return;
   }
 
   try {
-    await session.clearSession();
+    await clearSession(session, runContext);
     if (replacementItems.length > 0) {
-      await session.addItems(replacementItems);
+      await addSessionItems(session, replacementItems, runContext);
     }
   } catch (error) {
     await restoreSessionItemsAfterFailedReplacement(
       session,
       previousItems,
       error,
+      runContext,
     );
     throw error;
   }
@@ -1872,9 +1945,10 @@ async function restoreSessionItemsAfterFailedReplacement(
   session: Session,
   previousItems: AgentInputItem[],
   replacementError: unknown,
+  runContext?: RunContext<any>,
 ): Promise<void> {
   try {
-    const currentItems = await session.getItems();
+    const currentItems = await getSessionItems(session, runContext);
     if (
       currentItems.length === previousItems.length &&
       agentItemRangeMatches(currentItems, previousItems, 0)
@@ -1890,9 +1964,9 @@ async function restoreSessionItemsAfterFailedReplacement(
   }
 
   try {
-    await session.clearSession();
+    await clearSession(session, runContext);
     if (previousItems.length > 0) {
-      await session.addItems(previousItems);
+      await addSessionItems(session, previousItems, runContext);
     }
   } catch (restoreError) {
     logModelAndToolActionWarning(
@@ -1934,7 +2008,9 @@ async function runCompactionOnSession(
           ...(typeof store === 'undefined' ? {} : { store }),
           ...(typeof compactionMode === 'undefined' ? {} : { compactionMode }),
         };
-  const compactionResult = await session.runCompaction(compactionArgs);
+  const compactionResult = isRunContextAwareSession(session)
+    ? await session.runCompaction(compactionArgs, state._context)
+    : await session.runCompaction(compactionArgs);
   if (!compactionResult) {
     return;
   }

--- a/packages/agents-core/test/run.sessionRunContext.test.ts
+++ b/packages/agents-core/test/run.sessionRunContext.test.ts
@@ -1,0 +1,475 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  Agent,
+  RunContext,
+  run,
+  setTracingDisabled,
+  tool,
+  type AgentInputItem,
+  type Model,
+  type ModelRequest,
+  type ModelResponse,
+  type OpenAIResponsesCompactionArgs,
+  type RunContextAwareSession,
+  type Session,
+  type SessionHistoryTransactionArgs,
+  type StreamEvent,
+} from '../src';
+import {
+  RunCompactionItem as CompactionItem,
+  RunToolCallItem as ToolCallItem,
+  RunToolCallOutputItem as ToolCallOutputItem,
+} from '../src/items';
+import logger from '../src/logger';
+import { saveToSession } from '../src/runner/sessionPersistence';
+import { RunResult } from '../src/result';
+import { RunState } from '../src/runState';
+import type * as protocol from '../src/types/protocol';
+import { fakeModelMessage } from './stubs';
+import { Usage } from '../src/usage';
+
+type TenantContext = {
+  tenantId: string;
+};
+
+type SessionCall = {
+  name: 'getItems' | 'addItems' | 'popItem' | 'clearSession';
+  runContext: RunContext<TenantContext> | undefined;
+};
+
+class FinalResponseModel implements Model {
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    return {
+      output: [fakeModelMessage('done')],
+      usage: new Usage(),
+    };
+  }
+
+  async *getStreamedResponse(
+    _request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    yield {
+      type: 'response_done',
+      response: {
+        id: 'response-id',
+        output: [fakeModelMessage('done')],
+        usage: {
+          requests: 1,
+          inputTokens: 0,
+          outputTokens: 0,
+          totalTokens: 0,
+        },
+      },
+    } as StreamEvent;
+  }
+}
+
+class ApprovalModel implements Model {
+  private readonly responses: ModelResponse[] = [
+    {
+      output: [
+        {
+          type: 'function_call',
+          id: 'approval-item',
+          callId: 'approval-call',
+          name: 'context_tool',
+          status: 'completed',
+          arguments: '{}',
+        },
+      ],
+      usage: new Usage(),
+    },
+    {
+      output: [fakeModelMessage('done')],
+      usage: new Usage(),
+    },
+  ];
+
+  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error('No response found.');
+    }
+    return response;
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    yield* [];
+    throw new Error('Unexpected streaming request.');
+  }
+}
+
+class TenantSession implements RunContextAwareSession<TenantContext> {
+  readonly acceptsRunContext = true;
+  readonly itemsByTenant = new Map<string, AgentInputItem[]>([['default', []]]);
+  readonly calls: SessionCall[] = [];
+
+  async getSessionId(): Promise<string> {
+    return 'tenant-session';
+  }
+
+  async getItems(
+    limit?: number,
+    runContext?: RunContext<TenantContext>,
+  ): Promise<AgentInputItem[]> {
+    this.calls.push({ name: 'getItems', runContext });
+    const items = this.getTenantItems(runContext);
+    return limit === undefined ? [...items] : items.slice(-limit);
+  }
+
+  async addItems(
+    items: AgentInputItem[],
+    runContext?: RunContext<TenantContext>,
+  ): Promise<void> {
+    this.calls.push({ name: 'addItems', runContext });
+    this.getTenantItems(runContext).push(...items);
+  }
+
+  async popItem(
+    runContext?: RunContext<TenantContext>,
+  ): Promise<AgentInputItem | undefined> {
+    this.calls.push({ name: 'popItem', runContext });
+    return this.getTenantItems(runContext).pop();
+  }
+
+  async clearSession(runContext?: RunContext<TenantContext>): Promise<void> {
+    this.calls.push({ name: 'clearSession', runContext });
+    this.itemsByTenant.set(this.getTenantId(runContext), []);
+  }
+
+  protected getTenantItems(
+    runContext: RunContext<TenantContext> | undefined,
+  ): AgentInputItem[] {
+    const tenantId = this.getTenantId(runContext);
+    const items = this.itemsByTenant.get(tenantId) ?? [];
+    this.itemsByTenant.set(tenantId, items);
+    return items;
+  }
+
+  protected getTenantId(
+    runContext: RunContext<TenantContext> | undefined,
+  ): string {
+    return runContext?.context.tenantId ?? 'default';
+  }
+}
+
+class ContextAwareTransactionSession extends TenantSession {
+  readonly transactionContexts: Array<RunContext<TenantContext> | undefined> =
+    [];
+
+  async applyHistoryTransaction(
+    args: SessionHistoryTransactionArgs,
+    runContext?: RunContext<TenantContext>,
+  ): Promise<void> {
+    this.transactionContexts.push(runContext);
+    const items = this.getTenantItems(runContext);
+    if (args.transaction.type === 'append_items') {
+      items.push(...structuredClone(args.transaction.items));
+      return;
+    }
+
+    const suffixStart = items.length - args.transaction.expectedSuffix.length;
+    items.splice(
+      suffixStart,
+      args.transaction.expectedSuffix.length,
+      ...structuredClone(args.transaction.replacement),
+    );
+  }
+}
+
+class FailingTenantReplacementSession extends TenantSession {
+  readonly replacementError = new Error('replacement failed');
+  private failNextAdd = true;
+
+  override async addItems(
+    items: AgentInputItem[],
+    runContext?: RunContext<TenantContext>,
+  ): Promise<void> {
+    this.calls.push({ name: 'addItems', runContext });
+    const tenantItems = this.getTenantItems(runContext);
+    if (this.failNextAdd) {
+      this.failNextAdd = false;
+      tenantItems.push(structuredClone(items[0]));
+      throw this.replacementError;
+    }
+    tenantItems.push(...structuredClone(items));
+  }
+}
+
+class ContextAwareCompactionSession extends TenantSession {
+  readonly compactionContexts: Array<RunContext<TenantContext> | undefined> =
+    [];
+
+  async runCompaction(
+    _args?: OpenAIResponsesCompactionArgs,
+    runContext?: RunContext<TenantContext>,
+  ): Promise<null> {
+    this.compactionContexts.push(runContext);
+    return null;
+  }
+}
+
+class LegacySession implements Session {
+  readonly calls: Array<{ name: string; argumentCount: number }> = [];
+  readonly items: AgentInputItem[] = [];
+
+  async getSessionId(): Promise<string> {
+    return 'legacy-session';
+  }
+
+  async getItems(_limit?: number): Promise<AgentInputItem[]> {
+    this.calls.push({ name: 'getItems', argumentCount: arguments.length });
+    return [...this.items];
+  }
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.calls.push({ name: 'addItems', argumentCount: arguments.length });
+    this.items.push(...items);
+  }
+
+  async popItem(): Promise<AgentInputItem | undefined> {
+    this.calls.push({ name: 'popItem', argumentCount: arguments.length });
+    return this.items.pop();
+  }
+
+  async clearSession(): Promise<void> {
+    this.calls.push({ name: 'clearSession', argumentCount: arguments.length });
+    this.items.length = 0;
+  }
+}
+
+describe('run context aware sessions', () => {
+  beforeAll(() => {
+    setTracingDisabled(true);
+  });
+
+  it.each([false, true])(
+    'passes one run context through %s streaming session operations',
+    async (stream) => {
+      const context: TenantContext = { tenantId: 'tenant-a' };
+      const session = new TenantSession();
+      const agent = new Agent({
+        name: 'Context aware session',
+        model: new FinalResponseModel(),
+      });
+
+      const result = stream
+        ? await run(agent, 'hello', {
+            context,
+            session,
+            stream: true,
+          })
+        : await run(agent, 'hello', {
+            context,
+            session,
+            stream: false,
+          });
+      if ('completed' in result) {
+        await result.completed;
+      }
+
+      expect(result.finalOutput).toBe('done');
+      expect(session.itemsByTenant.get('default')).toEqual([]);
+      expect(session.itemsByTenant.get('tenant-a')).toHaveLength(2);
+      expect(session.calls.map((call) => call.name)).toEqual([
+        'getItems',
+        'addItems',
+      ]);
+      expect(
+        session.calls.every((call) => call.runContext === result.runContext),
+      ).toBe(true);
+      expect(result.runContext.context).toBe(context);
+    },
+  );
+
+  it('reuses the restored run context for resumed session operations', async () => {
+    const context: TenantContext = { tenantId: 'tenant-a' };
+    const session = new TenantSession();
+    const contextTool = tool({
+      name: 'context_tool',
+      description: 'Return a context-aware result.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const agent = new Agent({
+      name: 'Resumed context-aware session',
+      model: new ApprovalModel(),
+      tools: [contextTool],
+    });
+
+    const interrupted = await run(agent, 'hello', { context, session });
+    expect(interrupted.interruptions).toHaveLength(1);
+    interrupted.state.approve(interrupted.interruptions[0]);
+    session.calls.length = 0;
+
+    const resumed = await run(agent, interrupted.state, { session });
+
+    expect(resumed.finalOutput).toBe('done');
+    expect(resumed.runContext).toBe(interrupted.runContext);
+    expect(
+      session.calls.every((call) => call.runContext === interrupted.runContext),
+    ).toBe(true);
+    expect(session.itemsByTenant.get('default')).toEqual([]);
+    expect(session.itemsByTenant.get('tenant-a')).toHaveLength(4);
+  });
+
+  it('passes the run context to an opted-in compaction hook', async () => {
+    const session = new ContextAwareCompactionSession();
+    const result = await run(
+      new Agent({
+        name: 'Context-aware compaction',
+        model: new FinalResponseModel(),
+      }),
+      'hello',
+      {
+        context: { tenantId: 'tenant-a' },
+        session,
+      },
+    );
+
+    expect(session.compactionContexts).toEqual([result.runContext]);
+  });
+
+  it('passes the run context to session history transactions', async () => {
+    const session = new ContextAwareTransactionSession();
+    const context: TenantContext = { tenantId: 'tenant-a' };
+    const runContext = new RunContext(context);
+    const agent = new Agent<TenantContext>({
+      name: 'Context-aware transaction',
+      model: new FinalResponseModel(),
+    });
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'transaction-call',
+      name: 'context_tool',
+      arguments: '{}',
+    };
+    const callItem = new ToolCallItem(call, agent as any);
+    const resultItem = new ToolCallOutputItem(
+      {
+        type: 'function_call_result',
+        callId: call.callId,
+        name: call.name,
+        status: 'completed',
+        output: 'committed',
+      },
+      agent as any,
+      'committed',
+      undefined,
+      'executed',
+    );
+    const input = fakeModelMessage('transaction input');
+    const state = new RunState(runContext, [input], agent, 1);
+    state._generatedItems = [callItem, resultItem];
+    state._currentTurnSessionHistoryTransactionInputItems = [input];
+
+    await saveToSession(session, [input], new RunResult(state as any), {
+      outputBlocked: true,
+    });
+
+    expect(session.transactionContexts).toEqual([runContext]);
+    expect(session.itemsByTenant.get('default')).toEqual([]);
+    expect(session.itemsByTenant.get('tenant-a')).toEqual([
+      input,
+      call,
+      resultItem.rawItem,
+    ]);
+  });
+
+  it('uses the run context throughout failed replacement recovery', async () => {
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      callId: 'replacement-call',
+      name: 'context_tool',
+      arguments: '{}',
+    };
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'replacement-compaction',
+      encrypted_content: 'ciphertext',
+    };
+    const defaultItem = fakeModelMessage('default history');
+    const session = new FailingTenantReplacementSession();
+    session.itemsByTenant.set('default', [defaultItem]);
+    session.itemsByTenant.set('tenant-a', [structuredClone(call)]);
+    const runContext = new RunContext<TenantContext>({
+      tenantId: 'tenant-a',
+    });
+    const agent = new Agent<TenantContext>({
+      name: 'Context-aware replacement recovery',
+      model: new FinalResponseModel(),
+    });
+    const state = new RunState(runContext, 'input', agent, 1);
+    state._generatedItems = [
+      new CompactionItem(compaction, agent as any),
+      new ToolCallItem(call, agent as any),
+    ];
+    state._pendingLegacyCompactionSessionItems = [compaction, call];
+    state._currentTurnPersistedItemCount = 2;
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    try {
+      await expect(
+        saveToSession(session, [], new RunResult(state as any), {
+          runCompaction: false,
+        }),
+      ).rejects.toBe(session.replacementError);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(session.calls.map((call) => call.name)).toEqual([
+      'getItems',
+      'clearSession',
+      'addItems',
+      'getItems',
+      'clearSession',
+      'addItems',
+    ]);
+    expect(session.calls.every((call) => call.runContext === runContext)).toBe(
+      true,
+    );
+    expect(session.itemsByTenant.get('tenant-a')).toEqual([call]);
+    expect(session.itemsByTenant.get('default')).toEqual([defaultItem]);
+    expect(state._pendingLegacyCompactionSessionItems).toEqual([
+      compaction,
+      call,
+    ]);
+    expect(state._currentTurnPersistedItemCount).toBe(2);
+  });
+
+  it.each([false, true])(
+    'preserves legacy method call shapes for %s streaming runs',
+    async (stream) => {
+      const session = new LegacySession();
+      const agent = new Agent({
+        name: 'Legacy session',
+        model: new FinalResponseModel(),
+      });
+
+      const result = stream
+        ? await run(agent, 'hello', {
+            context: { tenantId: 'tenant-a' },
+            session,
+            stream: true,
+          })
+        : await run(agent, 'hello', {
+            context: { tenantId: 'tenant-a' },
+            session,
+            stream: false,
+          });
+      if ('completed' in result) {
+        await result.completed;
+      }
+
+      expect(result.finalOutput).toBe('done');
+      expect(session.calls).toEqual([
+        { name: 'getItems', argumentCount: 0 },
+        { name: 'addItems', argumentCount: 1 },
+      ]);
+    },
+  );
+});


### PR DESCRIPTION
This pull request adds an opt-in `RunContextAwareSession` capability so custom sessions can receive the same run context across history reads and writes, streaming, resumed runs, transactions, compaction, and replacement recovery. Existing `Session` implementations retain their legacy call shapes. It also adds tenant-scoping documentation, a typechecked example, regression coverage, and a patch changeset.

see also: https://github.com/openai/openai-agents-python/pull/4209