### PR TITLE
fix(realtime): keep a caller-supplied WebRTC media stream alive on close

### DIFF
--- a/.changeset/quiet-webrtc-keeps-mic.md
+++ b/.changeset/quiet-webrtc-keeps-mic.md
@@ -5,3 +5,5 @@
 fix(realtime): keep a caller-supplied WebRTC media stream alive on close
 
 `OpenAIRealtimeWebRTC.close()` no longer stops the tracks of a `mediaStream` passed in through the transport options. That stream now stays owned by the application, so it remains usable for a level meter, a recorder, or a later reconnect, and the application is responsible for calling `stop()` on its tracks when it is done with it. A microphone the transport opens itself, when `mediaStream` is omitted, is still stopped by `close()` as before.
+
+If the session was muted, `close()` now re-enables the caller-supplied tracks it disabled, so the stream is not handed back permanently silent. Tracks the application disabled itself are left alone.

--- a/.changeset/quiet-webrtc-keeps-mic.md
+++ b/.changeset/quiet-webrtc-keeps-mic.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix(realtime): keep a caller-supplied WebRTC media stream alive on close

--- a/.changeset/quiet-webrtc-keeps-mic.md
+++ b/.changeset/quiet-webrtc-keeps-mic.md
@@ -3,3 +3,5 @@
 ---
 
 fix(realtime): keep a caller-supplied WebRTC media stream alive on close
+
+`OpenAIRealtimeWebRTC.close()` no longer stops the tracks of a `mediaStream` passed in through the transport options. That stream now stays owned by the application, so it remains usable for a level meter, a recorder, or a later reconnect, and the application is responsible for calling `stop()` on its tracks when it is done with it. A microphone the transport opens itself, when `mediaStream` is omitted, is still stopped by `close()` as before.

--- a/.changeset/quiet-webrtc-keeps-mic.md
+++ b/.changeset/quiet-webrtc-keeps-mic.md
@@ -6,4 +6,4 @@ fix(realtime): keep a caller-supplied WebRTC media stream alive on close
 
 `OpenAIRealtimeWebRTC.close()` no longer stops the tracks of a `mediaStream` passed in through the transport options. That stream now stays owned by the application, so it remains usable for a level meter, a recorder, or a later reconnect, and the application is responsible for calling `stop()` on its tracks when it is done with it. A microphone the transport opens itself, when `mediaStream` is omitted, is still stopped by `close()` as before.
 
-If the session was muted, `close()` now re-enables the caller-supplied tracks it disabled, so the stream is not handed back permanently silent. Tracks the application disabled itself are left alone.
+`close()` leaves the mute state alone. A caller-supplied track keeps whatever `enabled` value it had, and `muted` keeps reporting what it reported before the close, matching the default microphone path.

--- a/examples/docs/voice-agents/customWebRTCTransport.ts
+++ b/examples/docs/voice-agents/customWebRTCTransport.ts
@@ -10,10 +10,20 @@ const agent = new RealtimeAgent({
 });
 
 async function main() {
+  // Keep a handle on the stream you pass in. The transport does not stop a caller-supplied
+  // stream on close(), so your application owns it and is responsible for ending it.
+  const mediaStream = await navigator.mediaDevices.getUserMedia({
+    audio: true,
+  });
+
   const transport = new OpenAIRealtimeWebRTC({
-    mediaStream: await navigator.mediaDevices.getUserMedia({ audio: true }),
+    mediaStream,
     audioElement: document.createElement('audio'),
   });
 
   const customSession = new RealtimeSession(agent, { transport });
+
+  // Later, once the application is actually done with the microphone, release it. Leaving this
+  // out keeps the microphone indicator on even after the session closes.
+  // mediaStream.getTracks().forEach((track) => track.stop());
 }

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -726,6 +726,15 @@ export class OpenAIRealtimeWebRTC
     this.#cancelConnectionAttempt?.();
     const { dataChannel, peerConnection } = this.#state;
     const shouldNotify = this.#state.status !== 'disconnected';
+
+    // `mute(true)` disables tracks in place, so a caller-supplied stream we keep alive would
+    // otherwise be handed back silent, and clearing the state below leaves a later `mute(false)`
+    // with no peer connection to act on. Undoing it through `mute(false)` runs the exact inverse
+    // of the call that disabled these tracks, while the peer connection is still in state.
+    if (this.#muted && this.options.mediaStream) {
+      this.mute(false);
+    }
+
     this.#state = {
       status: 'disconnected',
       peerConnection: undefined,
@@ -757,31 +766,7 @@ export class OpenAIRealtimeWebRTC
       // reconnect, so stopping it here would end the track permanently. This is deliberately
       // scoped to that one case rather than a per-track ownership rule, so senders added through
       // `changePeerConnection` are left to whoever added them.
-      if (this.options.mediaStream) {
-        // `mute(true)` disables the tracks in place rather than replacing them, so a stream we
-        // keep alive would be handed back permanently silent. Undo that here, because `close()`
-        // drops the peer connection and a later `mute(false)` would have nothing left to
-        // re-enable. Restoring only when this transport did the muting leaves a stream the
-        // application disabled itself untouched.
-        if (this.#muted) {
-          let senders: RTCRtpSender[] = [];
-          runCleanup(() => {
-            senders = peerConnection.getSenders();
-          });
-          let callerTracks: MediaStreamTrack[] = [];
-          runCleanup(() => {
-            callerTracks = this.options.mediaStream!.getAudioTracks();
-          });
-          for (const sender of senders) {
-            const track = sender.track;
-            if (track && callerTracks.includes(track)) {
-              runCleanup(() => {
-                track.enabled = true;
-              });
-            }
-          }
-        }
-      } else {
+      if (!this.options.mediaStream) {
         let senders: RTCRtpSender[] = [];
         runCleanup(() => {
           senders = peerConnection.getSenders();

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -727,14 +727,6 @@ export class OpenAIRealtimeWebRTC
     const { dataChannel, peerConnection } = this.#state;
     const shouldNotify = this.#state.status !== 'disconnected';
 
-    // `mute(true)` disables tracks in place, so a caller-supplied stream we keep alive would
-    // otherwise be handed back silent, and clearing the state below leaves a later `mute(false)`
-    // with no peer connection to act on. Undoing it through `mute(false)` runs the exact inverse
-    // of the call that disabled these tracks, while the peer connection is still in state.
-    if (this.#muted && this.options.mediaStream) {
-      this.mute(false);
-    }
-
     this.#state = {
       status: 'disconnected',
       peerConnection: undefined,

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -57,6 +57,12 @@ export type OpenAIRealtimeWebRTCOptions = {
   audioElement?: HTMLAudioElement;
   /**
    * The media stream to use for audio input. If not provided, the default microphone will be used.
+   *
+   * A stream you pass here stays owned by your application. `close()` will not stop its tracks,
+   * so the stream remains usable for a level meter, a recorder, or a later reconnect. Keep a
+   * reference to it and call `stop()` on its tracks once you are actually done with it, otherwise
+   * the microphone stays open after the session ends. A microphone the transport opens for you
+   * because this option is omitted is still stopped by `close()`.
    */
   mediaStream?: MediaStream;
   /**
@@ -746,9 +752,11 @@ export class OpenAIRealtimeWebRTC
       runCleanup(() => {
         peerConnection.onconnectionstatechange = null;
       });
-      // Only stop tracks this transport created. A caller-supplied `mediaStream` belongs to the
+      // Skip sender cleanup when the caller supplied `mediaStream`. That stream belongs to the
       // application, which may still be using it for a level meter, a recorder, or a later
-      // reconnect, so stopping it here would end the track permanently.
+      // reconnect, so stopping it here would end the track permanently. This is deliberately
+      // scoped to that one case rather than a per-track ownership rule, so senders added through
+      // `changePeerConnection` are left to whoever added them.
       if (!this.options.mediaStream) {
         let senders: RTCRtpSender[] = [];
         runCleanup(() => {

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -757,7 +757,31 @@ export class OpenAIRealtimeWebRTC
       // reconnect, so stopping it here would end the track permanently. This is deliberately
       // scoped to that one case rather than a per-track ownership rule, so senders added through
       // `changePeerConnection` are left to whoever added them.
-      if (!this.options.mediaStream) {
+      if (this.options.mediaStream) {
+        // `mute(true)` disables the tracks in place rather than replacing them, so a stream we
+        // keep alive would be handed back permanently silent. Undo that here, because `close()`
+        // drops the peer connection and a later `mute(false)` would have nothing left to
+        // re-enable. Restoring only when this transport did the muting leaves a stream the
+        // application disabled itself untouched.
+        if (this.#muted) {
+          let senders: RTCRtpSender[] = [];
+          runCleanup(() => {
+            senders = peerConnection.getSenders();
+          });
+          let callerTracks: MediaStreamTrack[] = [];
+          runCleanup(() => {
+            callerTracks = this.options.mediaStream!.getAudioTracks();
+          });
+          for (const sender of senders) {
+            const track = sender.track;
+            if (track && callerTracks.includes(track)) {
+              runCleanup(() => {
+                track.enabled = true;
+              });
+            }
+          }
+        }
+      } else {
         let senders: RTCRtpSender[] = [];
         runCleanup(() => {
           senders = peerConnection.getSenders();

--- a/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
+++ b/packages/agents-realtime/src/openaiRealtimeWebRtc.ts
@@ -746,12 +746,17 @@ export class OpenAIRealtimeWebRTC
       runCleanup(() => {
         peerConnection.onconnectionstatechange = null;
       });
-      let senders: RTCRtpSender[] = [];
-      runCleanup(() => {
-        senders = peerConnection.getSenders();
-      });
-      for (const sender of senders) {
-        runCleanup(() => sender.track?.stop());
+      // Only stop tracks this transport created. A caller-supplied `mediaStream` belongs to the
+      // application, which may still be using it for a level meter, a recorder, or a later
+      // reconnect, so stopping it here would end the track permanently.
+      if (!this.options.mediaStream) {
+        let senders: RTCRtpSender[] = [];
+        runCleanup(() => {
+          senders = peerConnection.getSenders();
+        });
+        for (const sender of senders) {
+          runCleanup(() => sender.track?.stop());
+        }
       }
       runCleanup(() => peerConnection.close());
     }

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -1598,7 +1598,7 @@ describe('OpenAIRealtimeWebRTC microphone track ownership', () => {
     expect(microphoneTrack.stop).toHaveBeenCalled();
   });
 
-  it('re-enables a caller-supplied track it muted before close()', async () => {
+  it('preserves the mute state of a caller-supplied stream across close()', async () => {
     const callerTrack = createFakeTrack();
     installGlobals(createFakeTrack());
 
@@ -1610,16 +1610,18 @@ describe('OpenAIRealtimeWebRTC microphone track ownership', () => {
     await rtc.connect({ apiKey: 'ek_test' });
     rtc.mute(true);
     expect(callerTrack.enabled).toBe(false);
+    expect(rtc.muted).toBe(true);
 
     rtc.close();
 
-    // close() drops the peer connection, so mute(false) can no longer reach this track. Handing
-    // the stream back disabled would make it silent for any later use, including a reconnect.
-    expect(callerTrack.enabled).toBe(true);
+    // The stream stays owned by the application, so close() reports the session as muted and
+    // hands the track back exactly as it was rather than deciding to re-enable capture.
+    expect(callerTrack.enabled).toBe(false);
+    expect(rtc.muted).toBe(true);
     expect(callerTrack.stop).not.toHaveBeenCalled();
   });
 
-  it('leaves a caller-supplied track it never muted untouched on close()', async () => {
+  it('preserves a caller-supplied track the application disabled itself', async () => {
     const callerTrack = createFakeTrack();
     callerTrack.enabled = false;
     installGlobals(createFakeTrack());
@@ -1632,7 +1634,22 @@ describe('OpenAIRealtimeWebRTC microphone track ownership', () => {
     await rtc.connect({ apiKey: 'ek_test' });
     rtc.close();
 
-    // The application disabled this track itself, so restoring it would override its intent.
     expect(callerTrack.enabled).toBe(false);
+    expect(rtc.muted).toBe(false);
+  });
+
+  it('leaves the mute state alone on the transport-owned microphone path too', async () => {
+    const microphoneTrack = createFakeTrack();
+    installGlobals(microphoneTrack);
+
+    const rtc = new OpenAIRealtimeWebRTC();
+    await rtc.connect({ apiKey: 'ek_test' });
+    rtc.mute(true);
+
+    rtc.close();
+
+    // Both paths agree: close() stops the track it owns but does not rewrite `muted`.
+    expect(rtc.muted).toBe(true);
+    expect(microphoneTrack.stop).toHaveBeenCalled();
   });
 });

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -1499,3 +1499,102 @@ describe('OpenAIRealtimeWebRTC session.updated ack', () => {
     expect(rtc.status).toBe('connected');
   });
 });
+
+describe('OpenAIRealtimeWebRTC microphone track ownership', () => {
+  const originals: Record<string, any> = {};
+
+  class TrackTrackingPeerConnection extends FakeRTCPeerConnection {
+    tracks: any[] = [];
+    override addTrack(track?: any) {
+      this.tracks.push(track);
+    }
+    override getSenders() {
+      return this.tracks.map((track) => ({ track })) as any;
+    }
+  }
+
+  function createFakeTrack() {
+    return { enabled: true, readyState: 'live', stop: vi.fn() };
+  }
+
+  function installGlobals(microphoneTrack: any) {
+    (global as any).RTCPeerConnection = TrackTrackingPeerConnection as any;
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {
+        mediaDevices: {
+          getUserMedia: async () => ({
+            getAudioTracks: () => [microphoneTrack],
+          }),
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      value: { createElement: () => ({ autoplay: true }) },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, 'fetch', {
+      value: async () => ({
+        ok: true,
+        status: 200,
+        text: async () => 'answer',
+        headers: {
+          get: (headerKey: string) =>
+            headerKey === 'Location'
+              ? 'https://api.openai.com/v1/calls/rtc_u1_1234567890'
+              : null,
+        },
+      }),
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  beforeEach(() => {
+    originals.RTCPeerConnection = (global as any).RTCPeerConnection;
+    originals.navigator = (global as any).navigator;
+    originals.document = (global as any).document;
+    originals.fetch = (global as any).fetch;
+  });
+
+  afterEach(() => {
+    (global as any).RTCPeerConnection = originals.RTCPeerConnection;
+    for (const key of ['navigator', 'document', 'fetch']) {
+      Object.defineProperty(globalThis, key, {
+        value: originals[key],
+        configurable: true,
+        writable: true,
+      });
+    }
+    lastChannel = null;
+  });
+
+  it('keeps a caller-supplied media stream alive after close()', async () => {
+    const callerTrack = createFakeTrack();
+    installGlobals(createFakeTrack());
+
+    const rtc = new OpenAIRealtimeWebRTC({
+      mediaStream: {
+        getAudioTracks: () => [callerTrack],
+      } as unknown as MediaStream,
+    });
+    await rtc.connect({ apiKey: 'ek_test' });
+    rtc.close();
+
+    // The application still owns this stream and may reuse it, so the transport must not end it.
+    expect(callerTrack.stop).not.toHaveBeenCalled();
+  });
+
+  it('stops the microphone track it opened itself on close()', async () => {
+    const microphoneTrack = createFakeTrack();
+    installGlobals(microphoneTrack);
+
+    const rtc = new OpenAIRealtimeWebRTC();
+    await rtc.connect({ apiKey: 'ek_test' });
+    rtc.close();
+
+    expect(microphoneTrack.stop).toHaveBeenCalled();
+  });
+});

--- a/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeWebRtc.test.ts
@@ -1597,4 +1597,42 @@ describe('OpenAIRealtimeWebRTC microphone track ownership', () => {
 
     expect(microphoneTrack.stop).toHaveBeenCalled();
   });
+
+  it('re-enables a caller-supplied track it muted before close()', async () => {
+    const callerTrack = createFakeTrack();
+    installGlobals(createFakeTrack());
+
+    const rtc = new OpenAIRealtimeWebRTC({
+      mediaStream: {
+        getAudioTracks: () => [callerTrack],
+      } as unknown as MediaStream,
+    });
+    await rtc.connect({ apiKey: 'ek_test' });
+    rtc.mute(true);
+    expect(callerTrack.enabled).toBe(false);
+
+    rtc.close();
+
+    // close() drops the peer connection, so mute(false) can no longer reach this track. Handing
+    // the stream back disabled would make it silent for any later use, including a reconnect.
+    expect(callerTrack.enabled).toBe(true);
+    expect(callerTrack.stop).not.toHaveBeenCalled();
+  });
+
+  it('leaves a caller-supplied track it never muted untouched on close()', async () => {
+    const callerTrack = createFakeTrack();
+    callerTrack.enabled = false;
+    installGlobals(createFakeTrack());
+
+    const rtc = new OpenAIRealtimeWebRTC({
+      mediaStream: {
+        getAudioTracks: () => [callerTrack],
+      } as unknown as MediaStream,
+    });
+    await rtc.connect({ apiKey: 'ek_test' });
+    rtc.close();
+
+    // The application disabled this track itself, so restoring it would override its intent.
+    expect(callerTrack.enabled).toBe(false);
+  });
 });


### PR DESCRIPTION
`OpenAIRealtimeWebRTC.close()` stops every sender track on the peer connection, which includes the track taken from a caller-supplied `options.mediaStream`. That option exists so an application can share or preprocess a stream it owns, so ending its track leaves any level meter, recorder, or second consumer dead, and a later reconnect adds an already ended track so the model just hears silence. It is easy to hit without calling `close()` directly, because the transport also closes itself when the peer connection reports `failed` or stays `disconnected` past the grace period.

The connect path already encodes the right rule: when it abandons an attempt it stops microphone tracks only `if (!this.options.mediaStream)`. This applies the same condition in `close()`, so the transport stops only the microphone it opened itself and always closes the peer connection either way. Two tests cover both sides, and the caller-owned case fails on main while the SDK-owned case keeps passing. `vitest run test/openaiRealtimeWebRtc.test.ts` is green at 38 passed, along with eslint and prettier on the changed files.