### PR TITLE
feat(ai-sdk): support PDF file inputs

### DIFF
--- a/.changeset/ai-sdk-file-inputs.md
+++ b/.changeset/ai-sdk-file-inputs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+feat: #630 support PDF file inputs in the AI SDK adapter

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -2,6 +2,7 @@ import type {
   JSONSchema7,
   LanguageModelV2 as LanguageModelV2Base,
   LanguageModelV2CallOptions,
+  LanguageModelV2FilePart,
   LanguageModelV2FunctionTool,
   LanguageModelV2Message,
   LanguageModelV2Prompt,
@@ -238,6 +239,11 @@ type ParsedInlineImageData = {
   mediaType: string;
 };
 
+const AI_SDK_FILE_INPUT_ERROR =
+  'AI SDK file inputs require a base64 data URL, valid non-empty raw base64 data with a PDF filename or providerData.mediaType, or a public HTTP(S) URL with a PDF filename or providerData.mediaType.';
+const AI_SDK_FILE_ID_ERROR =
+  'OpenAI file IDs are not supported by the AI SDK adapter. Use an OpenAI Responses model directly, or pass file data or a public HTTP(S) URL.';
+
 function parseBase64ImageDataUrl(
   imageSource: string,
 ): ParsedInlineImageData | undefined {
@@ -265,6 +271,167 @@ function parseBase64ImageDataUrl(
     data: imageSource.slice(commaIndex + 1),
     mediaType,
   };
+}
+
+function parseBase64FileDataUrl(
+  fileSource: string,
+): ParsedInlineImageData | undefined {
+  if (!/^data:/i.test(fileSource)) {
+    return undefined;
+  }
+
+  const commaIndex = fileSource.indexOf(',');
+  if (commaIndex === -1) {
+    return undefined;
+  }
+
+  const metadata = fileSource.slice('data:'.length, commaIndex);
+  const [maybeMediaType, ...parameters] = metadata.split(';');
+  const mediaType = maybeMediaType?.trim();
+  const isBase64 = parameters.some(
+    (parameter) => parameter.trim().toLowerCase() === 'base64',
+  );
+  if (!mediaType || !isBase64) {
+    return undefined;
+  }
+
+  return {
+    data: fileSource.slice(commaIndex + 1),
+    mediaType,
+  };
+}
+
+function isValidBase64Data(value: string): boolean {
+  const normalized = value.replace(/[\t\n\f\r ]/g, '');
+  if (
+    normalized.length === 0 ||
+    normalized.length % 4 === 1 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
+  ) {
+    return false;
+  }
+
+  const paddingLength = normalized.endsWith('==')
+    ? 2
+    : normalized.endsWith('=')
+      ? 1
+      : 0;
+  if (paddingLength === 0) {
+    return true;
+  }
+
+  const dataLength = normalized.length - paddingLength;
+  return (
+    normalized.length % 4 === 0 &&
+    ((paddingLength === 1 && dataLength % 4 === 3) ||
+      (paddingLength === 2 && dataLength % 4 === 2))
+  );
+}
+
+function getProviderDataString(
+  providerData: Record<string, any> | undefined,
+  key: string,
+): string | undefined {
+  const value = providerData?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function parsePublicFileUrl(source: string): URL | undefined {
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return undefined;
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new UserError(AI_SDK_FILE_INPUT_ERROR);
+  }
+  return url;
+}
+
+function getFileMediaType(
+  providerData: Record<string, any> | undefined,
+  filename: string | undefined,
+  url?: URL,
+): string {
+  const explicitMediaType = getProviderDataString(providerData, 'mediaType');
+  if (explicitMediaType) {
+    return explicitMediaType;
+  }
+
+  if (
+    [filename, url?.pathname].some((name) =>
+      name?.toLowerCase().endsWith('.pdf'),
+    )
+  ) {
+    return 'application/pdf';
+  }
+
+  throw new UserError(AI_SDK_FILE_INPUT_ERROR);
+}
+
+function toAiSdkFilePart(
+  model: LanguageModelCompatible,
+  input: protocol.InputFile,
+): LanguageModelV2FilePart {
+  const { file, filename, providerData } = input;
+  const providerOptions = toProviderOptions(providerData, model);
+
+  if (typeof file === 'string') {
+    const inlineFile = parseBase64FileDataUrl(file);
+    if (inlineFile) {
+      if (!isValidBase64Data(inlineFile.data)) {
+        throw new UserError(AI_SDK_FILE_INPUT_ERROR);
+      }
+      return {
+        type: 'file',
+        data: toAiSdkFileData(model, inlineFile.data),
+        mediaType: inlineFile.mediaType,
+        ...(filename ? { filename } : {}),
+        providerOptions,
+      };
+    }
+
+    if (file.startsWith('data:')) {
+      throw new UserError(AI_SDK_FILE_INPUT_ERROR);
+    }
+
+    const url = parsePublicFileUrl(file);
+    if (!url && !isValidBase64Data(file)) {
+      throw new UserError(AI_SDK_FILE_INPUT_ERROR);
+    }
+    const mediaType = getFileMediaType(providerOptions, filename, url);
+    return {
+      type: 'file',
+      data: toAiSdkFileData(model, url ?? file),
+      mediaType,
+      ...(filename ? { filename } : {}),
+      providerOptions,
+    };
+  }
+
+  if (isRecord(file)) {
+    const fileRecord: Record<string, unknown> = file;
+    if (typeof fileRecord.id === 'string') {
+      throw new UserError(AI_SDK_FILE_ID_ERROR);
+    }
+    if (typeof fileRecord.url === 'string') {
+      const url = parsePublicFileUrl(fileRecord.url);
+      if (!url) {
+        throw new UserError(AI_SDK_FILE_INPUT_ERROR);
+      }
+      return {
+        type: 'file',
+        data: toAiSdkFileData(model, url),
+        mediaType: getFileMediaType(providerOptions, filename, url),
+        ...(filename ? { filename } : {}),
+        providerOptions,
+      };
+    }
+  }
+
+  throw new UserError(AI_SDK_FILE_INPUT_ERROR);
 }
 
 /**
@@ -443,7 +610,7 @@ export function itemsToLanguageV2Messages(
                     };
                   }
                   if (c.type === 'input_file') {
-                    throw new UserError('File inputs are not supported.');
+                    return toAiSdkFilePart(model, c);
                   }
                   throw new UserError(`Unknown content type: ${c.type}`);
                 }),

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -2086,21 +2086,310 @@ describe('itemsToLanguageV2Messages', () => {
     );
   });
 
-  test('rejects input_file content', () => {
+  test('converts PDF data URL input_file content and preserves ordering', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'before' },
+          {
+            type: 'input_file',
+            file: 'data:application/pdf;base64,JVBERi0xLjQ=',
+            filename: 'document.pdf',
+          },
+          { type: 'input_text', text: 'after' },
+        ],
+      } as any,
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'before', providerOptions: {} },
+          {
+            type: 'file',
+            data: 'JVBERi0xLjQ=',
+            mediaType: 'application/pdf',
+            filename: 'document.pdf',
+            providerOptions: {},
+          },
+          { type: 'text', text: 'after', providerOptions: {} },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('converts a PDF data URL with a case-variant scheme', () => {
     const items: protocol.ModelItem[] = [
       {
         role: 'user',
         content: [
           {
             type: 'input_file',
-            file: 'file_123',
+            file: 'DATA:application/pdf;base64,JVBERi0xLjQ=',
+          },
+        ],
+      } as any,
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'JVBERi0xLjQ=',
+            mediaType: 'application/pdf',
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('converts public PDF URL input_file content for AI SDK v4', () => {
+    const url = 'https://example.com/document.pdf';
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [{ type: 'input_file', file: { url }, filename: 'download' }],
+      } as any,
+    ];
+
+    expect(
+      itemsToLanguageV2Messages(
+        stubModel({}, { specificationVersion: 'v4' }),
+        items,
+      ),
+    ).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: { type: 'url', url: new URL(url) },
+            mediaType: 'application/pdf',
+            filename: 'download',
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('infers PDF media type from a string URL before its filename', () => {
+    const url = 'https://example.com/document.pdf';
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [{ type: 'input_file', file: url, filename: 'download' }],
+      } as any,
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: new URL(url),
+            mediaType: 'application/pdf',
+            filename: 'download',
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('converts raw base64 input_file content with an explicit media type', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_file',
+            file: 'JVBERi0xLjQ=',
+            filename: 'document.bin',
+            providerData: { mediaType: 'application/pdf' },
+          },
+        ],
+      } as any,
+    ];
+
+    expect(
+      itemsToLanguageV2Messages(
+        stubModel({}, { specificationVersion: 'v3' }),
+        items,
+      ),
+    ).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'JVBERi0xLjQ=',
+            mediaType: 'application/pdf',
+            filename: 'document.bin',
+            providerOptions: { mediaType: 'application/pdf' },
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('infers PDF media type for raw base64 from its filename', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_file',
+            file: 'JVBERi0xLjQ=',
+            filename: 'document.pdf',
+          },
+        ],
+      } as any,
+    ];
+
+    expect(itemsToLanguageV2Messages(stubModel({}), items)).toEqual([
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'file',
+            data: 'JVBERi0xLjQ=',
+            mediaType: 'application/pdf',
+            filename: 'document.pdf',
+            providerOptions: {},
+          },
+        ],
+        providerOptions: {},
+      },
+    ]);
+  });
+
+  test('does not use media type metadata scoped to a different model', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'input_file',
+            file: 'JVBERi0xLjQ=',
+            providerData: {
+              model: 'other:model',
+              mediaType: 'application/pdf',
+            },
           },
         ],
       } as any,
     ];
 
     expect(() => itemsToLanguageV2Messages(stubModel({}), items)).toThrow(
-      /File inputs are not supported/,
+      /providerData\.mediaType/,
+    );
+  });
+
+  test.each([
+    {
+      name: 'local path',
+      file: './document.pdf',
+      filename: 'document.pdf',
+    },
+    {
+      name: 'typoed URL',
+      file: 'https//example.com/document.pdf',
+      providerData: { mediaType: 'application/pdf' },
+    },
+    {
+      name: 'string file ID',
+      file: 'file_123',
+      filename: 'document.pdf',
+    },
+    {
+      name: 'empty data',
+      file: '',
+      providerData: { mediaType: 'application/pdf' },
+    },
+    {
+      name: 'invalid base64 length',
+      file: 'abcde',
+      filename: 'document.pdf',
+    },
+  ])(
+    'rejects invalid raw base64 input_file content: $name',
+    ({ file, filename, providerData }) => {
+      const items: protocol.ModelItem[] = [
+        {
+          role: 'user',
+          content: [{ type: 'input_file', file, filename, providerData }],
+        } as any,
+      ];
+
+      expect(() => itemsToLanguageV2Messages(stubModel({}), items)).toThrow(
+        /valid non-empty raw base64 data/,
+      );
+    },
+  );
+
+  test.each([
+    {
+      name: 'OpenAI file ID',
+      file: { id: 'file_123' },
+      error: /OpenAI file IDs are not supported/,
+    },
+    {
+      name: 'private URL scheme',
+      file: 'file:///tmp/document.pdf',
+      error: /public HTTP\(S\) URL/,
+    },
+    {
+      name: 'raw data without media type',
+      file: 'JVBERi0xLjQ=',
+      error: /providerData\.mediaType/,
+    },
+    {
+      name: 'non-base64 data URL',
+      file: 'data:application/pdf,document',
+      error: /base64 data URL/,
+    },
+    {
+      name: 'data URL with a misleading base64 parameter',
+      file: 'data:application/pdf;notbase64,document',
+      error: /base64 data URL/,
+    },
+    {
+      name: 'base64 data URL with invalid characters',
+      file: 'data:application/pdf;base64,@@@@',
+      error: /valid non-empty raw base64 data/,
+    },
+    {
+      name: 'base64 data URL with invalid length',
+      file: 'data:application/pdf;base64,abcde',
+      error: /valid non-empty raw base64 data/,
+    },
+    {
+      name: 'base64 data URL with empty data',
+      file: 'data:application/pdf;base64,',
+      error: /valid non-empty raw base64 data/,
+    },
+  ])('rejects unsupported input_file content: $name', ({ file, error }) => {
+    const items: protocol.ModelItem[] = [
+      {
+        role: 'user',
+        content: [{ type: 'input_file', file }],
+      } as any,
+    ];
+
+    expect(() => itemsToLanguageV2Messages(stubModel({}), items)).toThrow(
+      error,
     );
   });
 


### PR DESCRIPTION
This pull request resolves #630 by adding portable PDF file input support to the AI SDK adapter.

It supports base64 data URLs, raw base64 with PDF metadata, and public HTTP(S) PDF URLs across AI SDK v2, v3, and v4 models. OpenAI-specific file IDs remain unsupported and produce an actionable error directing users to the Responses model integration.

The change preserves existing image behavior, content ordering, filenames, and model-scoped provider options. It includes focused regressions, an example, and a patch changeset.
