### PR TITLE
fix(core): publish completed guardrail results

### DIFF
--- a/.changeset/quiet-guards-report.md
+++ b/.changeset/quiet-guards-report.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: publish completed guardrail results when a sibling fails

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -158,6 +158,8 @@ The `inputGuardrailResults` and `outputGuardrailResults` properties contain agen
 
 Use these arrays when you want to log guardrail decisions, inspect extra metadata returned by guardrail functions, or debug why a run was blocked.
 
+If one guardrail fails to execute, results from sibling guardrails that completed successfully remain in the run state. For streamed runs, inspect the result arrays after `completed` rejects; for non-streamed runs, the `GuardrailExecutionError` carries the same settled `state`.
+
 ### Usage
 
 Token usage is aggregated in `result.state.usage`, which tracks request counts and token totals for the run. The same usage object is also available through `result.runContext.usage`. For streaming runs this data updates as responses arrive.

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -138,9 +138,11 @@ async function runGuardrailsWithTripwire<
     );
   });
 
+  let resultsPublished = false;
   try {
     const results = await Promise.all(guardrailPromises);
     resultsTarget.push(...results);
+    resultsPublished = true;
     for (const result of results) {
       if (result.output.tripwireTriggered) {
         if (state._currentAgentSpan) {
@@ -158,7 +160,14 @@ async function runGuardrailsWithTripwire<
     onErrorObserved?.(finalError);
     // Promise.all rejects immediately, so drain the full batch before the
     // failure is surfaced to prevent sibling guardrails from outliving the run.
-    await Promise.allSettled(guardrailPromises);
+    const settledResults = await Promise.allSettled(guardrailPromises);
+    if (!resultsPublished) {
+      for (const result of settledResults) {
+        if (result.status === 'fulfilled') {
+          resultsTarget.push(result.value);
+        }
+      }
+    }
     throw finalError;
   }
 }

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -4410,6 +4410,9 @@ describe('Runner.run (streaming)', () => {
     expect(callsBeforeSiblingFinished).toBe(0);
     expect(settledBeforeSiblingFinished).toBe(false);
     expect(model.calls).toBe(0);
+    expect(result.inputGuardrailResults.map((r) => r.guardrail.name)).toEqual([
+      'slow-parallel-guardrail',
+    ]);
   });
 
   it('persists streaming input through the blocked result save when an output guardrail trips', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -3718,6 +3718,48 @@ describe('Runner.run', () => {
       expect(result.outputGuardrailResults[0].agent).toBe(agent);
     });
 
+    it('retains completed output guardrail results on execution failure', async () => {
+      const runner = new Runner({
+        outputGuardrails: [
+          {
+            name: 'success',
+            execute: async () => ({
+              tripwireTriggered: false,
+              outputInfo: { ok: true },
+            }),
+          },
+          {
+            name: 'error',
+            execute: async () => {
+              throw new Error('boom');
+            },
+          },
+        ],
+      });
+      const agent = new Agent({
+        name: 'Out',
+        model: new FakeModel([
+          { output: [fakeModelMessage('hi')], usage: new Usage() },
+        ]),
+      });
+      let caughtError: unknown;
+
+      try {
+        await runner.run(agent, 'input');
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(GuardrailExecutionError);
+      const guardrailError = caughtError as GuardrailExecutionError;
+      expect(guardrailError.error).toEqual(new Error('boom'));
+      expect(
+        guardrailError.state
+          ?.toJSON()
+          .outputGuardrailResults.map((result) => result.guardrail.name),
+      ).toEqual(['success']);
+    });
+
     it('output guardrail tripwire throws', async () => {
       const guardrailFn = vi.fn(async () => ({
         tripwireTriggered: true,

--- a/packages/agents-core/test/runner/guardrails.test.ts
+++ b/packages/agents-core/test/runner/guardrails.test.ts
@@ -136,6 +136,13 @@ describe('runInputGuardrails', () => {
     const agent = makeAgent({ name: 'Error' });
     const state = makeState(agent);
     state._currentTurn = 2;
+    const successfulGuardrail = defineInputGuardrail({
+      name: 'success',
+      execute: async () => ({
+        tripwireTriggered: false,
+        outputInfo: { ok: true },
+      }),
+    });
     const guardrail = defineInputGuardrail({
       name: 'error',
       execute: async () => {
@@ -145,10 +152,12 @@ describe('runInputGuardrails', () => {
 
     await expect(
       withTrace('guardrails-error', () =>
-        runInputGuardrails(state, [guardrail]),
+        runInputGuardrails(state, [successfulGuardrail, guardrail]),
       ),
     ).rejects.toBeInstanceOf(GuardrailExecutionError);
-    expect(state._inputGuardrailResults).toHaveLength(0);
+    expect(state._inputGuardrailResults.map((r) => r.guardrail.name)).toEqual([
+      'success',
+    ]);
     expect(state._currentTurn).toBe(1);
   });
 
@@ -157,6 +166,7 @@ describe('runInputGuardrails', () => {
     const state = makeState(agent);
     let releaseSlowGuardrail!: () => void;
     let markSlowStarted!: () => void;
+    let markFastFinished!: () => void;
     let markErrorThrown!: () => void;
     let slowGuardrailFinished = false;
     const slowGuardrailCanFinish = new Promise<void>((resolve) => {
@@ -164,6 +174,9 @@ describe('runInputGuardrails', () => {
     });
     const slowGuardrailStarted = new Promise<void>((resolve) => {
       markSlowStarted = resolve;
+    });
+    const fastGuardrailFinished = new Promise<void>((resolve) => {
+      markFastFinished = resolve;
     });
     const errorThrown = new Promise<void>((resolve) => {
       markErrorThrown = resolve;
@@ -183,14 +196,25 @@ describe('runInputGuardrails', () => {
     const errorGuardrail = defineInputGuardrail({
       name: 'error',
       execute: async () => {
-        await slowGuardrailStarted;
+        await fastGuardrailFinished;
         markErrorThrown();
         throw new Error('boom');
       },
     });
+    const fastGuardrail = defineInputGuardrail({
+      name: 'fast',
+      execute: async () => {
+        await slowGuardrailStarted;
+        markFastFinished();
+        return {
+          tripwireTriggered: false,
+          outputInfo: { fast: true },
+        };
+      },
+    });
 
     const runPromise = withTrace('guardrails-input-error-await-sibling', () =>
-      runInputGuardrails(state, [slowGuardrail, errorGuardrail]),
+      runInputGuardrails(state, [slowGuardrail, fastGuardrail, errorGuardrail]),
     );
     let settled = false;
     void runPromise.then(
@@ -210,6 +234,10 @@ describe('runInputGuardrails', () => {
     await expect(runPromise).rejects.toBeInstanceOf(GuardrailExecutionError);
     expect(settledBeforeSiblingFinished).toBe(false);
     expect(slowGuardrailFinished).toBe(true);
+    expect(state._inputGuardrailResults.map((r) => r.guardrail.name)).toEqual([
+      'slow',
+      'fast',
+    ]);
   });
 });
 
@@ -328,9 +356,16 @@ describe('runOutputGuardrails', () => {
     ]);
   });
 
-  it('wraps errors from guardrails without recording results', async () => {
+  it('wraps errors from guardrails and records completed results', async () => {
     const agent = makeAgent({ name: 'OutError' });
     const state = makeState(agent);
+    const successfulGuardrail = defineOutputGuardrail({
+      name: 'success',
+      execute: async () => ({
+        tripwireTriggered: false,
+        outputInfo: { ok: true },
+      }),
+    });
     const runnerGuardrail = defineOutputGuardrail({
       name: 'error',
       execute: async () => {
@@ -340,10 +375,16 @@ describe('runOutputGuardrails', () => {
 
     await expect(
       withTrace('guardrails-output-error', () =>
-        runOutputGuardrails(state, [runnerGuardrail as any], 'ok'),
+        runOutputGuardrails(
+          state,
+          [successfulGuardrail as any, runnerGuardrail as any],
+          'ok',
+        ),
       ),
     ).rejects.toBeInstanceOf(GuardrailExecutionError);
-    expect(state._outputGuardrailResults).toHaveLength(0);
+    expect(state._outputGuardrailResults.map((r) => r.guardrail.name)).toEqual([
+      'success',
+    ]);
   });
 
   it('awaits sibling output guardrails before surfacing execution failures', async () => {
@@ -351,6 +392,7 @@ describe('runOutputGuardrails', () => {
     const state = makeState(agent);
     let releaseSlowGuardrail!: () => void;
     let markSlowStarted!: () => void;
+    let markFastFinished!: () => void;
     let markErrorThrown!: () => void;
     let slowGuardrailFinished = false;
     const slowGuardrailCanFinish = new Promise<void>((resolve) => {
@@ -358,6 +400,9 @@ describe('runOutputGuardrails', () => {
     });
     const slowGuardrailStarted = new Promise<void>((resolve) => {
       markSlowStarted = resolve;
+    });
+    const fastGuardrailFinished = new Promise<void>((resolve) => {
+      markFastFinished = resolve;
     });
     const errorThrown = new Promise<void>((resolve) => {
       markErrorThrown = resolve;
@@ -369,24 +414,36 @@ describe('runOutputGuardrails', () => {
         await slowGuardrailCanFinish;
         slowGuardrailFinished = true;
         return {
-          tripwireTriggered: false,
+          tripwireTriggered: true,
           outputInfo: { slow: true },
         };
       },
     });
+    const primaryError = new Error('boom');
     const errorGuardrail = defineOutputGuardrail({
       name: 'error',
       execute: async () => {
-        await slowGuardrailStarted;
+        await fastGuardrailFinished;
         markErrorThrown();
-        throw new Error('boom');
+        throw primaryError;
+      },
+    });
+    const fastGuardrail = defineOutputGuardrail({
+      name: 'fast',
+      execute: async () => {
+        await slowGuardrailStarted;
+        markFastFinished();
+        return {
+          tripwireTriggered: false,
+          outputInfo: { fast: true },
+        };
       },
     });
 
     const runPromise = withTrace('guardrails-output-error-await-sibling', () =>
       runOutputGuardrails(
         state,
-        [slowGuardrail as any, errorGuardrail as any],
+        [slowGuardrail as any, fastGuardrail as any, errorGuardrail as any],
         'ok',
       ),
     );
@@ -405,8 +462,20 @@ describe('runOutputGuardrails', () => {
     const settledBeforeSiblingFinished = settled;
     releaseSlowGuardrail();
 
-    await expect(runPromise).rejects.toBeInstanceOf(GuardrailExecutionError);
+    let caughtError: unknown;
+    try {
+      await runPromise;
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(caughtError).toBeInstanceOf(GuardrailExecutionError);
+    expect((caughtError as GuardrailExecutionError).error).toBe(primaryError);
     expect(settledBeforeSiblingFinished).toBe(false);
     expect(slowGuardrailFinished).toBe(true);
+    expect(state._outputGuardrailResults.map((r) => r.guardrail.name)).toEqual([
+      'slow',
+      'fast',
+    ]);
   });
 });


### PR DESCRIPTION
This pull request fixes agent-level guardrail diagnostics when one guardrail throws after sibling guardrails complete. The shared runner pipeline now drains the batch and publishes fulfilled input and output guardrail results exactly once in declaration order, while preserving original error and tripwire semantics across streaming and non-streaming runs.