### PR TITLE
fix(extensions): preserve AI SDK response order

### DIFF
--- a/.changeset/calm-items-keep-order.md
+++ b/.changeset/calm-items-keep-order.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: preserve AI SDK response item ordering (#1593)

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -2197,11 +2197,10 @@ export class AiSdkModel implements Model {
             continue;
           }
 
-          await flushPendingText();
-
           if (part.type === 'reasoning') {
             const reasoningText =
               typeof part.text === 'string' ? part.text : '';
+            await flushPendingText();
             output.push({
               type: 'reasoning',
               content: [{ type: 'input_text', text: reasoningText }],
@@ -2243,20 +2242,20 @@ export class AiSdkModel implements Model {
               requestedToolsByCallId.set(part.toolCallId, requestedTool);
             }
 
-            output.push(
-              createProtocolToolCallItem({
-                requestedTool,
-                toolCallId: part.toolCallId,
-                toolName: part.toolName,
-                input: part.input,
-                providerExecuted: part.providerExecuted,
-                providerData: mergeProviderData(
-                  baseProviderData,
-                  part.providerMetadata ??
-                    (hasToolCalls ? result.providerMetadata : undefined),
-                ),
-              }),
-            );
+            const toolCallItem = createProtocolToolCallItem({
+              requestedTool,
+              toolCallId: part.toolCallId,
+              toolName: part.toolName,
+              input: part.input,
+              providerExecuted: part.providerExecuted,
+              providerData: mergeProviderData(
+                baseProviderData,
+                part.providerMetadata ??
+                  (hasToolCalls ? result.providerMetadata : undefined),
+              ),
+            });
+            await flushPendingText();
+            output.push(toolCallItem);
             continue;
           }
 
@@ -2270,6 +2269,7 @@ export class AiSdkModel implements Model {
             ),
           });
           if (toolSearchOutput) {
+            await flushPendingText();
             output.push(toolSearchOutput);
           }
         }
@@ -2489,6 +2489,14 @@ export class AiSdkModel implements Model {
         );
         return reasoningBlock;
       };
+      const closeActiveTextForReasoning = (reasoningBlock: {
+        text: string;
+        providerMetadata?: Record<string, any>;
+      }) => {
+        if (reasoningBlock.text || reasoningBlock.providerMetadata) {
+          activeTextEntry = undefined;
+        }
+      };
 
       const appendToolItem = (
         item:
@@ -2501,6 +2509,7 @@ export class AiSdkModel implements Model {
           ? toolCallEntryIndexById.get(toolCallId)
           : undefined;
         if (existingIndex === undefined) {
+          activeTextEntry = undefined;
           const entryIndex = orderedOutputEntries.length;
           orderedOutputEntries.push({ kind: 'tool', item });
           if (toolCallId) {
@@ -2543,14 +2552,16 @@ export class AiSdkModel implements Model {
             break;
           }
           case 'reasoning-start': {
-            activeTextEntry = undefined;
             // Start tracking a new reasoning block
             const reasoningId = (part as any).id ?? 'default';
-            getReasoningBlock(reasoningId, (part as any).providerMetadata);
+            const reasoningBlock = getReasoningBlock(
+              reasoningId,
+              (part as any).providerMetadata,
+            );
+            closeActiveTextForReasoning(reasoningBlock);
             break;
           }
           case 'reasoning-delta': {
-            activeTextEntry = undefined;
             // Accumulate reasoning text
             const reasoningId = (part as any).id ?? 'default';
             const reasoningBlock = getReasoningBlock(
@@ -2558,17 +2569,20 @@ export class AiSdkModel implements Model {
               (part as any).providerMetadata,
             );
             reasoningBlock.text += (part as any).delta ?? '';
+            closeActiveTextForReasoning(reasoningBlock);
             break;
           }
           case 'reasoning-end': {
-            activeTextEntry = undefined;
             // Capture final provider metadata (may contain signature)
             const reasoningId = (part as any).id ?? 'default';
-            getReasoningBlock(reasoningId, (part as any).providerMetadata);
+            const reasoningBlock = getReasoningBlock(
+              reasoningId,
+              (part as any).providerMetadata,
+            );
+            closeActiveTextForReasoning(reasoningBlock);
             break;
           }
           case 'tool-call': {
-            activeTextEntry = undefined;
             const toolCallId = (part as any).toolCallId;
             if (toolCallId) {
               const requestedTool =
@@ -2594,7 +2608,6 @@ export class AiSdkModel implements Model {
             break;
           }
           case 'tool-result': {
-            activeTextEntry = undefined;
             const toolCallId = (part as any).toolCallId;
             if (!toolCallId) {
               break;

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -1814,6 +1814,13 @@ function mergeProviderMetadata(
   return merged;
 }
 
+function shouldEmitReasoning(
+  text: string,
+  providerMetadata: Record<string, any> | undefined,
+): boolean {
+  return text.length > 0 || providerMetadata !== undefined;
+}
+
 function getHostedToolArgs(providerData: unknown): Record<string, any> {
   if (!isRecord(providerData)) {
     return {};
@@ -2200,6 +2207,15 @@ export class AiSdkModel implements Model {
           if (part.type === 'reasoning') {
             const reasoningText =
               typeof part.text === 'string' ? part.text : '';
+            const reasoningProviderMetadata = mergeProviderData(
+              undefined,
+              part.providerMetadata,
+            );
+            if (
+              !shouldEmitReasoning(reasoningText, reasoningProviderMetadata)
+            ) {
+              continue;
+            }
             await flushPendingText();
             output.push({
               type: 'reasoning',
@@ -2207,7 +2223,7 @@ export class AiSdkModel implements Model {
               rawContent: [{ type: 'reasoning_text', text: reasoningText }],
               providerData: mergeProviderData(
                 baseProviderData,
-                part.providerMetadata,
+                reasoningProviderMetadata,
               ),
             });
             continue;
@@ -2493,7 +2509,12 @@ export class AiSdkModel implements Model {
         text: string;
         providerMetadata?: Record<string, any>;
       }) => {
-        if (reasoningBlock.text || reasoningBlock.providerMetadata) {
+        if (
+          shouldEmitReasoning(
+            reasoningBlock.text,
+            reasoningBlock.providerMetadata,
+          )
+        ) {
           activeTextEntry = undefined;
         }
       };
@@ -2661,7 +2682,12 @@ export class AiSdkModel implements Model {
           if (!reasoningBlock) {
             continue;
           }
-          if (!reasoningBlock.text && !reasoningBlock.providerMetadata) {
+          if (
+            !shouldEmitReasoning(
+              reasoningBlock.text,
+              reasoningBlock.providerMetadata,
+            )
+          ) {
             continue;
           }
           outputs.push({

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -2165,11 +2165,39 @@ export class AiSdkModel implements Model {
           string,
           SerializedTool | SerializedHandoff
         >();
-        let emittedText = false;
+        let pendingTextParts: string[] = [];
+        const flushPendingText = async () => {
+          if (pendingTextParts.length === 0) {
+            return;
+          }
+          const transformedText = await this.#transformOutputText(
+            pendingTextParts.join(''),
+            request,
+            false,
+          );
+          output.push({
+            type: 'message',
+            content: [{ type: 'output_text', text: transformedText }],
+            role: 'assistant',
+            status: 'completed',
+            providerData: mergeProviderData(
+              baseProviderData,
+              (result as any).providerMetadata,
+            ),
+          });
+          pendingTextParts = [];
+        };
         for (const part of resultContent) {
           if (!part) {
             continue;
           }
+
+          if (part.type === 'text' && typeof part.text === 'string') {
+            pendingTextParts.push(part.text);
+            continue;
+          }
+
+          await flushPendingText();
 
           if (part.type === 'reasoning') {
             const reasoningText =
@@ -2183,36 +2211,6 @@ export class AiSdkModel implements Model {
                 part.providerMetadata,
               ),
             });
-            continue;
-          }
-
-          if (part.type === 'text' && typeof part.text === 'string') {
-            if (!emittedText) {
-              const combinedText = resultContent
-                .filter(
-                  (content: any) =>
-                    content?.type === 'text' &&
-                    typeof content.text === 'string',
-                )
-                .map((content: any) => content.text)
-                .join('');
-              const transformedText = await this.#transformOutputText(
-                combinedText,
-                request,
-                false,
-              );
-              output.push({
-                type: 'message',
-                content: [{ type: 'output_text', text: transformedText }],
-                role: 'assistant',
-                status: 'completed',
-                providerData: mergeProviderData(
-                  baseProviderData,
-                  (result as any).providerMetadata,
-                ),
-              });
-              emittedText = true;
-            }
             continue;
           }
 
@@ -2275,6 +2273,7 @@ export class AiSdkModel implements Model {
             output.push(toolSearchOutput);
           }
         }
+        await flushPendingText();
 
         if (span && request.tracing === true) {
           span.spanData.output = output;
@@ -2446,7 +2445,11 @@ export class AiSdkModel implements Model {
       let usageOutputTokensDetails: Record<string, number> | undefined;
       type StreamOutputEntry =
         | { kind: 'reasoning'; reasoningId: string }
-        | { kind: 'text' }
+        | {
+            kind: 'text';
+            output: protocol.OutputText;
+            itemId?: string;
+          }
         | {
             kind: 'tool';
             item:
@@ -2460,8 +2463,8 @@ export class AiSdkModel implements Model {
         string,
         SerializedTool | SerializedHandoff
       >();
-      let textOutput: protocol.OutputText | undefined;
-      let textItemId: string | undefined;
+      let activeTextEntry:
+        Extract<StreamOutputEntry, { kind: 'text' }> | undefined;
 
       const reasoningBlocks = new Map<
         string,
@@ -2518,31 +2521,36 @@ export class AiSdkModel implements Model {
 
         switch (part.type) {
           case 'text-delta': {
-            if (!textOutput) {
-              textOutput = { type: 'output_text', text: '' };
-              orderedOutputEntries.push({ kind: 'text' });
-              // The adapter combines all AI SDK text blocks into one output
-              // message, so every normalized delta must use that message ID.
-              textItemId =
-                typeof (part as any).id === 'string'
-                  ? (part as any).id
-                  : undefined;
+            if (!activeTextEntry) {
+              activeTextEntry = {
+                kind: 'text',
+                output: { type: 'output_text', text: '' },
+                itemId:
+                  typeof (part as any).id === 'string'
+                    ? (part as any).id
+                    : undefined,
+              };
+              orderedOutputEntries.push(activeTextEntry);
             }
-            textOutput.text += (part as any).delta;
+            activeTextEntry.output.text += (part as any).delta;
             yield {
               type: 'output_text_delta',
               delta: (part as any).delta,
-              ...(textItemId ? { itemId: textItemId } : {}),
+              ...(activeTextEntry.itemId
+                ? { itemId: activeTextEntry.itemId }
+                : {}),
             };
             break;
           }
           case 'reasoning-start': {
+            activeTextEntry = undefined;
             // Start tracking a new reasoning block
             const reasoningId = (part as any).id ?? 'default';
             getReasoningBlock(reasoningId, (part as any).providerMetadata);
             break;
           }
           case 'reasoning-delta': {
+            activeTextEntry = undefined;
             // Accumulate reasoning text
             const reasoningId = (part as any).id ?? 'default';
             const reasoningBlock = getReasoningBlock(
@@ -2553,12 +2561,14 @@ export class AiSdkModel implements Model {
             break;
           }
           case 'reasoning-end': {
+            activeTextEntry = undefined;
             // Capture final provider metadata (may contain signature)
             const reasoningId = (part as any).id ?? 'default';
             getReasoningBlock(reasoningId, (part as any).providerMetadata);
             break;
           }
           case 'tool-call': {
+            activeTextEntry = undefined;
             const toolCallId = (part as any).toolCallId;
             if (toolCallId) {
               const requestedTool =
@@ -2584,6 +2594,7 @@ export class AiSdkModel implements Model {
             break;
           }
           case 'tool-result': {
+            activeTextEntry = undefined;
             const toolCallId = (part as any).toolCallId;
             if (!toolCallId) {
               break;
@@ -2656,19 +2667,16 @@ export class AiSdkModel implements Model {
         }
 
         if (entry.kind === 'text') {
-          if (!textOutput) {
-            continue;
-          }
           const transformedText = await this.#transformOutputText(
-            textOutput.text,
+            entry.output.text,
             request,
             true,
           );
           outputs.push({
             type: 'message',
-            ...(textItemId ? { id: textItemId } : {}),
+            ...(entry.itemId ? { id: entry.itemId } : {}),
             role: 'assistant',
-            content: [{ ...textOutput, text: transformedText }],
+            content: [{ ...entry.output, text: transformedText }],
             status: 'completed',
             providerData: mergeProviderData(
               baseProviderData,

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -899,6 +899,7 @@ export function itemsToLanguageV2Messages(
         };
         continue;
       }
+      flushCurrentAssistantMessage();
       messages.push({
         role: 'assistant',
         content: [
@@ -2157,26 +2158,6 @@ export class AiSdkModel implements Model {
 
         const resultContent = (result as any).content ?? [];
 
-        // Emit reasoning before tool calls so Anthropic thinking signatures propagate into the next turn.
-        // Extract and add reasoning items FIRST (required by Anthropic: thinking blocks must precede tool_use blocks)
-        const reasoningParts = resultContent.filter(
-          (c: any) => c && c.type === 'reasoning',
-        );
-        for (const reasoningPart of reasoningParts) {
-          const reasoningText =
-            typeof reasoningPart.text === 'string' ? reasoningPart.text : '';
-          output.push({
-            type: 'reasoning',
-            content: [{ type: 'input_text', text: reasoningText }],
-            rawContent: [{ type: 'reasoning_text', text: reasoningText }],
-            // Preserve provider-specific metadata (including signature for Anthropic extended thinking)
-            providerData: mergeProviderData(
-              baseProviderData,
-              reasoningPart.providerMetadata,
-            ),
-          });
-        }
-
         const hasToolCalls = resultContent.some(
           (c: any) => c && c.type === 'tool-call',
         );
@@ -2184,11 +2165,58 @@ export class AiSdkModel implements Model {
           string,
           SerializedTool | SerializedHandoff
         >();
+        let emittedText = false;
         for (const part of resultContent) {
-          if (
-            !part ||
-            (part.type !== 'tool-call' && part.type !== 'tool-result')
-          ) {
+          if (!part) {
+            continue;
+          }
+
+          if (part.type === 'reasoning') {
+            const reasoningText =
+              typeof part.text === 'string' ? part.text : '';
+            output.push({
+              type: 'reasoning',
+              content: [{ type: 'input_text', text: reasoningText }],
+              rawContent: [{ type: 'reasoning_text', text: reasoningText }],
+              providerData: mergeProviderData(
+                baseProviderData,
+                part.providerMetadata,
+              ),
+            });
+            continue;
+          }
+
+          if (part.type === 'text' && typeof part.text === 'string') {
+            if (!emittedText) {
+              const combinedText = resultContent
+                .filter(
+                  (content: any) =>
+                    content?.type === 'text' &&
+                    typeof content.text === 'string',
+                )
+                .map((content: any) => content.text)
+                .join('');
+              const transformedText = await this.#transformOutputText(
+                combinedText,
+                request,
+                false,
+              );
+              output.push({
+                type: 'message',
+                content: [{ type: 'output_text', text: transformedText }],
+                role: 'assistant',
+                status: 'completed',
+                providerData: mergeProviderData(
+                  baseProviderData,
+                  (result as any).providerMetadata,
+                ),
+              });
+              emittedText = true;
+            }
+            continue;
+          }
+
+          if (part.type !== 'tool-call' && part.type !== 'tool-result') {
             continue;
           }
 
@@ -2245,37 +2273,6 @@ export class AiSdkModel implements Model {
           });
           if (toolSearchOutput) {
             output.push(toolSearchOutput);
-          }
-        }
-
-        // Some of other platforms may return both tool calls and text.
-        // Putting a text message here will let the agent loop to complete,
-        // so adding this item only when the tool calls are empty.
-        // Note that the same support is not available for streaming mode.
-        if (!hasToolCalls) {
-          const textParts = resultContent.filter(
-            (c: any) => c && c.type === 'text' && typeof c.text === 'string',
-          );
-          if (textParts.length > 0) {
-            // A model response may contain multiple text parts. Concatenate them
-            // to mirror the streaming path (which accumulates every text-delta
-            // into a single output_text) instead of dropping all but the first.
-            const combinedText = textParts.map((c: any) => c.text).join('');
-            const transformedText = await this.#transformOutputText(
-              combinedText,
-              request,
-              false,
-            );
-            output.push({
-              type: 'message',
-              content: [{ type: 'output_text', text: transformedText }],
-              role: 'assistant',
-              status: 'completed',
-              providerData: mergeProviderData(
-                baseProviderData,
-                (result as any).providerMetadata,
-              ),
-            });
           }
         }
 
@@ -2447,12 +2444,18 @@ export class AiSdkModel implements Model {
       let usageCompletionTokens = 0;
       let usageInputTokensDetails: Record<string, number> | undefined;
       let usageOutputTokensDetails: Record<string, number> | undefined;
-      const toolItems: Array<
-        | protocol.FunctionCallItem
-        | protocol.ToolSearchCallItem
-        | protocol.ToolSearchOutputItem
-      > = [];
-      const toolCallItemIndexById = new Map<string, number>();
+      type StreamOutputEntry =
+        | { kind: 'reasoning'; reasoningId: string }
+        | { kind: 'text' }
+        | {
+            kind: 'tool';
+            item:
+              | protocol.FunctionCallItem
+              | protocol.ToolSearchCallItem
+              | protocol.ToolSearchOutputItem;
+          };
+      const orderedOutputEntries: StreamOutputEntry[] = [];
+      const toolCallEntryIndexById = new Map<string, number>();
       const requestedToolsByCallId = new Map<
         string,
         SerializedTool | SerializedHandoff
@@ -2460,8 +2463,6 @@ export class AiSdkModel implements Model {
       let textOutput: protocol.OutputText | undefined;
       let textItemId: string | undefined;
 
-      // State for tracking reasoning blocks (for Anthropic extended thinking):
-      // Track reasoning deltas so we can preserve Anthropic signatures even when text is redacted.
       const reasoningBlocks = new Map<
         string,
         {
@@ -2473,15 +2474,38 @@ export class AiSdkModel implements Model {
         reasoningId: string,
         providerMetadata: Record<string, any> | undefined,
       ) => {
-        const reasoningBlock = reasoningBlocks.get(reasoningId) ?? {
-          text: '',
-        };
+        let reasoningBlock = reasoningBlocks.get(reasoningId);
+        if (!reasoningBlock) {
+          reasoningBlock = { text: '' };
+          reasoningBlocks.set(reasoningId, reasoningBlock);
+          orderedOutputEntries.push({ kind: 'reasoning', reasoningId });
+        }
         reasoningBlock.providerMetadata = mergeProviderMetadata(
           reasoningBlock.providerMetadata,
           providerMetadata,
         );
-        reasoningBlocks.set(reasoningId, reasoningBlock);
         return reasoningBlock;
+      };
+
+      const appendToolItem = (
+        item:
+          | protocol.FunctionCallItem
+          | protocol.ToolSearchCallItem
+          | protocol.ToolSearchOutputItem,
+        toolCallId?: string,
+      ) => {
+        const existingIndex = toolCallId
+          ? toolCallEntryIndexById.get(toolCallId)
+          : undefined;
+        if (existingIndex === undefined) {
+          const entryIndex = orderedOutputEntries.length;
+          orderedOutputEntries.push({ kind: 'tool', item });
+          if (toolCallId) {
+            toolCallEntryIndexById.set(toolCallId, entryIndex);
+          }
+        } else {
+          orderedOutputEntries[existingIndex] = { kind: 'tool', item };
+        }
       };
 
       for await (const part of stream) {
@@ -2496,6 +2520,7 @@ export class AiSdkModel implements Model {
           case 'text-delta': {
             if (!textOutput) {
               textOutput = { type: 'output_text', text: '' };
+              orderedOutputEntries.push({ kind: 'text' });
               // The adapter combines all AI SDK text blocks into one output
               // message, so every normalized delta must use that message ID.
               textItemId =
@@ -2554,13 +2579,7 @@ export class AiSdkModel implements Model {
                   (part as any).providerMetadata,
                 ),
               });
-              const existingIndex = toolCallItemIndexById.get(toolCallId);
-              if (existingIndex === undefined) {
-                toolCallItemIndexById.set(toolCallId, toolItems.length);
-                toolItems.push(toolCallItem);
-              } else {
-                toolItems[existingIndex] = toolCallItem;
-              }
+              appendToolItem(toolCallItem, toolCallId);
             }
             break;
           }
@@ -2584,7 +2603,7 @@ export class AiSdkModel implements Model {
               ),
             });
             if (toolSearchOutput) {
-              toolItems.push(toolSearchOutput);
+              appendToolItem(toolSearchOutput);
             }
             break;
           }
@@ -2612,13 +2631,18 @@ export class AiSdkModel implements Model {
 
       const outputs: protocol.OutputModelItem[] = [];
 
-      // Add reasoning items FIRST (required by Anthropic: thinking blocks must precede tool_use blocks)
-      // Emit reasoning item even when text is empty to preserve signature in providerData for redacted thinking streams
-      for (const [reasoningId, reasoningBlock] of reasoningBlocks) {
-        if (reasoningBlock.text || reasoningBlock.providerMetadata) {
+      for (const entry of orderedOutputEntries) {
+        if (entry.kind === 'reasoning') {
+          const reasoningBlock = reasoningBlocks.get(entry.reasoningId);
+          if (!reasoningBlock) {
+            continue;
+          }
+          if (!reasoningBlock.text && !reasoningBlock.providerMetadata) {
+            continue;
+          }
           outputs.push({
             type: 'reasoning',
-            id: reasoningId !== 'default' ? reasoningId : undefined,
+            id: entry.reasoningId !== 'default' ? entry.reasoningId : undefined,
             content: [{ type: 'input_text', text: reasoningBlock.text }],
             rawContent: [{ type: 'reasoning_text', text: reasoningBlock.text }],
             // Preserve provider-specific metadata (including signature for Anthropic extended thinking)
@@ -2628,33 +2652,37 @@ export class AiSdkModel implements Model {
               responseId ? { responseId } : undefined,
             ),
           });
+          continue;
         }
-      }
 
-      if (textOutput) {
-        const transformedText = await this.#transformOutputText(
-          textOutput.text,
-          request,
-          true,
-        );
+        if (entry.kind === 'text') {
+          if (!textOutput) {
+            continue;
+          }
+          const transformedText = await this.#transformOutputText(
+            textOutput.text,
+            request,
+            true,
+          );
+          outputs.push({
+            type: 'message',
+            ...(textItemId ? { id: textItemId } : {}),
+            role: 'assistant',
+            content: [{ ...textOutput, text: transformedText }],
+            status: 'completed',
+            providerData: mergeProviderData(
+              baseProviderData,
+              responseId ? { responseId } : undefined,
+            ),
+          });
+          continue;
+        }
+
         outputs.push({
-          type: 'message',
-          ...(textItemId ? { id: textItemId } : {}),
-          role: 'assistant',
-          content: [{ ...textOutput, text: transformedText }],
-          status: 'completed',
+          ...entry.item,
           providerData: mergeProviderData(
             baseProviderData,
-            responseId ? { responseId } : undefined,
-          ),
-        });
-      }
-      for (const toolItem of toolItems) {
-        outputs.push({
-          ...toolItem,
-          providerData: mergeProviderData(
-            baseProviderData,
-            toolItem.providerData,
+            entry.item.providerData,
             responseId ? { responseId } : undefined,
           ),
         });

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -2839,6 +2839,34 @@ describe('AiSdkModel.getResponse', () => {
     expect(result.finalOutput).toBe('Hello world');
   });
 
+  test('keeps text contiguous across empty reasoning content', async () => {
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              { type: 'text', text: 'Hello ' },
+              { type: 'reasoning', text: '' },
+              { type: 'text', text: 'world' },
+            ],
+            usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+            providerMetadata: {},
+            response: { id: 'id' },
+            finishReason: 'stop',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+
+    const result = await run(
+      new Agent({ name: 'Assistant', model }),
+      'Say hello.',
+    );
+
+    expect(result.finalOutput).toBe('Hello world');
+  });
+
   test('applies transformOutputText to finalized assistant text', async () => {
     const transformOutputText = vi.fn((text: string, context: any) => {
       expect(context.stream).toBe(false);

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -1240,6 +1240,63 @@ describe('itemsToLanguageV2Messages', () => {
     ]);
   });
 
+  test('preserves reasoning order around provider-executed tool search', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'reasoning',
+        content: [{ type: 'input_text', text: 'Find a weather tool.' }],
+        providerData: { anthropic: { signature: 'sig-before-search' } },
+      } as any,
+      {
+        type: 'tool_search_call',
+        callId: 'search_1',
+        execution: 'server',
+        arguments: { query: 'weather' },
+        status: 'completed',
+      },
+      {
+        type: 'tool_search_output',
+        callId: 'search_1',
+        execution: 'server',
+        status: 'completed',
+        tools: [{ type: 'tool_reference', toolName: 'get_weather' }],
+      },
+      {
+        type: 'reasoning',
+        content: [{ type: 'input_text', text: 'Call the weather tool.' }],
+        providerData: { anthropic: { signature: 'sig-after-search' } },
+      } as any,
+      {
+        type: 'function_call',
+        callId: 'weather_1',
+        name: 'get_weather',
+        arguments: '{"city":"Tokyo"}',
+        status: 'completed',
+      },
+    ];
+
+    const messages = itemsToLanguageV2Messages(stubModel({}), items);
+    const assistantContent = messages.flatMap((message) =>
+      message.role === 'assistant' && Array.isArray(message.content)
+        ? message.content
+        : [],
+    );
+
+    expect(assistantContent.map((part) => part.type)).toEqual([
+      'reasoning',
+      'tool-call',
+      'tool-result',
+      'reasoning',
+      'tool-call',
+    ]);
+    expect(assistantContent[0]).toMatchObject({
+      providerOptions: { anthropic: { signature: 'sig-before-search' } },
+    });
+    expect(assistantContent[3]).toMatchObject({
+      providerOptions: { anthropic: { signature: 'sig-after-search' } },
+    });
+  });
+
   test('orders provider-executed tool searches before pending client calls', () => {
     const items: protocol.ModelItem[] = [
       {
@@ -3094,6 +3151,110 @@ describe('AiSdkModel.getResponse', () => {
     });
   });
 
+  test('preserves interleaved reasoning and tool order in doGenerate', async () => {
+    const model = new AiSdkModel(
+      stubModel(
+        {
+          async doGenerate() {
+            return {
+              content: [
+                {
+                  type: 'reasoning',
+                  text: 'Find a weather tool.',
+                  providerMetadata: {
+                    anthropic: { signature: 'sig-before-search' },
+                  },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  input: { query: 'weather' },
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  result: [{ type: 'tool_reference', toolName: 'get_weather' }],
+                },
+                {
+                  type: 'text',
+                  text: 'I found the weather tool.',
+                },
+                {
+                  type: 'reasoning',
+                  text: 'Call the weather tool.',
+                  providerMetadata: {
+                    anthropic: { signature: 'sig-after-search' },
+                  },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'weather_1',
+                  toolName: 'get_weather',
+                  input: { city: 'Tokyo' },
+                },
+              ],
+              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+              providerMetadata: {},
+              response: { id: 'response_1' },
+              finishReason: 'tool-calls',
+              warnings: [],
+            } as any;
+          },
+        },
+        { provider: 'anthropic.messages', specificationVersion: 'v3' },
+      ),
+    );
+
+    const result = await withTrace('t', () =>
+      model.getResponse({
+        input: 'Find the weather tool and use it.',
+        tools: [
+          aiSdkToolSearchTool({
+            type: 'provider',
+            id: 'anthropic.tool_search_regex_20251119',
+          }),
+          {
+            type: 'function',
+            name: 'get_weather',
+            description: 'Get the weather.',
+            parameters: { type: 'object', properties: {} },
+            strict: true,
+            providerData: { anthropic: { deferLoading: true } },
+          } as any,
+        ],
+        handoffs: [],
+        modelSettings: {},
+        outputType: 'text',
+        tracing: false,
+      } as any),
+    );
+
+    expect(result.output.map((item) => item.type)).toEqual([
+      'reasoning',
+      'tool_search_call',
+      'tool_search_output',
+      'message',
+      'reasoning',
+      'function_call',
+    ]);
+    expect(result.output[0]).toMatchObject({
+      providerData: {
+        anthropic: { signature: 'sig-before-search' },
+      },
+    });
+    expect(result.output[3]).toMatchObject({
+      content: [{ type: 'output_text', text: 'I found the weather tool.' }],
+    });
+    expect(result.output[4]).toMatchObject({
+      providerData: {
+        anthropic: { signature: 'sig-after-search' },
+      },
+    });
+  });
+
   test('preserves provider-executed tool search errors and continues the run', async () => {
     const prompts: any[] = [];
     const errorResult = {
@@ -4572,6 +4733,122 @@ describe('AiSdkModel.getStreamedResponse', () => {
     expect(final.response.output[2]).toMatchObject({
       callId: 'weather_1',
       name: 'get_weather',
+    });
+  });
+
+  test('preserves interleaved reasoning and tool order in streaming mode', async () => {
+    const parts = [
+      {
+        type: 'reasoning-start',
+        id: 'reasoning_1',
+      },
+      {
+        type: 'reasoning-delta',
+        id: 'reasoning_1',
+        delta: 'Find a weather tool.',
+      },
+      {
+        type: 'reasoning-end',
+        id: 'reasoning_1',
+        providerMetadata: {
+          anthropic: { signature: 'sig-before-search' },
+        },
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'search_1',
+        toolName: 'tool_search',
+        input: { query: 'weather' },
+        providerExecuted: true,
+      },
+      {
+        type: 'tool-result',
+        toolCallId: 'search_1',
+        toolName: 'tool_search',
+        result: [{ type: 'tool_reference', toolName: 'get_weather' }],
+      },
+      {
+        type: 'reasoning-start',
+        id: 'reasoning_2',
+      },
+      {
+        type: 'reasoning-delta',
+        id: 'reasoning_2',
+        delta: 'Call the weather tool.',
+      },
+      {
+        type: 'reasoning-end',
+        id: 'reasoning_2',
+        providerMetadata: {
+          anthropic: { signature: 'sig-after-search' },
+        },
+      },
+      {
+        type: 'tool-call',
+        toolCallId: 'weather_1',
+        toolName: 'get_weather',
+        input: { city: 'Tokyo' },
+      },
+      { type: 'response-metadata', id: 'response_stream_1' },
+      {
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 3, outputTokens: 4 },
+      },
+    ];
+    const model = new AiSdkModel(
+      stubModel(
+        {
+          async doStream() {
+            return { stream: partsStream(parts) } as any;
+          },
+        },
+        { provider: 'anthropic.messages', specificationVersion: 'v3' },
+      ),
+    );
+
+    const events: any[] = [];
+    for await (const event of model.getStreamedResponse({
+      input: 'Find the weather tool and use it.',
+      tools: [
+        aiSdkToolSearchTool({
+          type: 'provider',
+          id: 'anthropic.tool_search_regex_20251119',
+        }),
+        {
+          type: 'function',
+          name: 'get_weather',
+          description: 'Get the weather.',
+          parameters: { type: 'object', properties: {} },
+          strict: true,
+          providerData: { anthropic: { deferLoading: true } },
+        } as any,
+      ],
+      handoffs: [],
+      modelSettings: {},
+      outputType: 'text',
+      tracing: false,
+    } as any)) {
+      events.push(event);
+    }
+
+    const final = events.at(-1);
+    expect(final.response.output.map((item: any) => item.type)).toEqual([
+      'reasoning',
+      'tool_search_call',
+      'tool_search_output',
+      'reasoning',
+      'function_call',
+    ]);
+    expect(final.response.output[0]).toMatchObject({
+      providerData: {
+        anthropic: { signature: 'sig-before-search' },
+      },
+    });
+    expect(final.response.output[3]).toMatchObject({
+      providerData: {
+        anthropic: { signature: 'sig-after-search' },
+      },
     });
   });
 

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -2801,6 +2801,44 @@ describe('AiSdkModel.getResponse', () => {
     ]);
   });
 
+  test('keeps text contiguous across skipped response content', async () => {
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              { type: 'text', text: 'Hello ' },
+              {
+                type: 'source',
+                sourceType: 'url',
+                id: 'source-1',
+                url: 'https://example.com/source',
+              },
+              {
+                type: 'file',
+                mediaType: 'image/png',
+                data: 'iVBORw0KGgo=',
+              },
+              { type: 'text', text: 'world' },
+            ],
+            usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+            providerMetadata: {},
+            response: { id: 'id' },
+            finishReason: 'stop',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+
+    const result = await run(
+      new Agent({ name: 'Assistant', model }),
+      'Say hello.',
+    );
+
+    expect(result.finalOutput).toBe('Hello world');
+  });
+
   test('applies transformOutputText to finalized assistant text', async () => {
     const transformOutputText = vi.fn((text: string, context: any) => {
       expect(context.stream).toBe(false);
@@ -4454,6 +4492,195 @@ describe('AiSdkModel.getStreamedResponse', () => {
         callId: 'c1',
         name: 'foo',
         arguments: '{"k":"v"}',
+        status: 'completed',
+        providerData: {
+          model: 'stub:m',
+          responseId: 'id1',
+        },
+      },
+    ]);
+  });
+
+  test('keeps streamed text contiguous across skipped response content', async () => {
+    const parts = [
+      { type: 'text-delta', id: 'text-1', delta: 'Hello ' },
+      {
+        type: 'source',
+        sourceType: 'url',
+        id: 'source-1',
+        url: 'https://example.com/source',
+      },
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        data: 'iVBORw0KGgo=',
+      },
+      { type: 'text-delta', id: 'text-2', delta: 'world' },
+      { type: 'response-metadata', id: 'id1' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 2 },
+      },
+    ];
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream() {
+          return { stream: partsStream(parts) } as any;
+        },
+      }),
+    );
+
+    const events: any[] = [];
+    for await (const event of model.getStreamedResponse({
+      input: 'Say hello.',
+      tools: [],
+      handoffs: [],
+      modelSettings: {},
+      outputType: 'text',
+      tracing: false,
+    } as any)) {
+      events.push(event);
+    }
+
+    const final = events.at(-1);
+    expect(final.response.output).toEqual([
+      {
+        type: 'message',
+        id: 'text-1',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello world' }],
+        status: 'completed',
+        providerData: {
+          model: 'stub:m',
+          responseId: 'id1',
+        },
+      },
+    ]);
+  });
+
+  test('keeps streamed text contiguous across empty reasoning frames', async () => {
+    const parts = [
+      { type: 'text-delta', id: 'text-1', delta: 'Hello ' },
+      { type: 'reasoning-start', id: 'reasoning-1' },
+      { type: 'reasoning-end', id: 'reasoning-1' },
+      { type: 'text-delta', id: 'text-2', delta: 'world' },
+      { type: 'response-metadata', id: 'id1' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 2 },
+      },
+    ];
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream() {
+          return { stream: partsStream(parts) } as any;
+        },
+      }),
+    );
+
+    const events: any[] = [];
+    for await (const event of model.getStreamedResponse({
+      input: 'Say hello.',
+      tools: [],
+      handoffs: [],
+      modelSettings: {},
+      outputType: 'text',
+      tracing: false,
+    } as any)) {
+      events.push(event);
+    }
+
+    expect(
+      events.filter((event) => event.type === 'output_text_delta'),
+    ).toEqual([
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'Hello ' },
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'world' },
+    ]);
+    const final = events.at(-1);
+    expect(final.response.output).toEqual([
+      {
+        type: 'message',
+        id: 'text-1',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello world' }],
+        status: 'completed',
+        providerData: {
+          model: 'stub:m',
+          responseId: 'id1',
+        },
+      },
+    ]);
+  });
+
+  test('keeps streamed text contiguous across replacement tool calls', async () => {
+    const parts = [
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'lookup',
+        input: '{"version":1}',
+      },
+      { type: 'text-delta', id: 'text-1', delta: 'Hello ' },
+      {
+        type: 'tool-call',
+        toolCallId: 'call-1',
+        toolName: 'lookup',
+        input: '{"version":2}',
+      },
+      { type: 'text-delta', id: 'text-2', delta: 'world' },
+      { type: 'response-metadata', id: 'id1' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 2 },
+      },
+    ];
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream() {
+          return { stream: partsStream(parts) } as any;
+        },
+      }),
+    );
+
+    const events: any[] = [];
+    for await (const event of model.getStreamedResponse({
+      input: 'Say hello.',
+      tools: [],
+      handoffs: [],
+      modelSettings: {},
+      outputType: 'text',
+      tracing: false,
+    } as any)) {
+      events.push(event);
+    }
+
+    expect(
+      events.filter((event) => event.type === 'output_text_delta'),
+    ).toEqual([
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'Hello ' },
+      { type: 'output_text_delta', itemId: 'text-1', delta: 'world' },
+    ]);
+    const final = events.at(-1);
+    expect(final.response.output).toEqual([
+      {
+        type: 'function_call',
+        callId: 'call-1',
+        name: 'lookup',
+        arguments: '{"version":2}',
+        status: 'completed',
+        providerData: {
+          model: 'stub:m',
+          responseId: 'id1',
+        },
+      },
+      {
+        type: 'message',
+        id: 'text-1',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'Hello world' }],
         status: 'completed',
         providerData: {
           model: 'stub:m',

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -342,7 +342,7 @@ describe('AiSdkModel end-to-end scenarios', () => {
     },
   );
 
-  test('streams text blocks and tool calls with a stable message ID', async () => {
+  test('preserves separate text message IDs around tool calls', async () => {
     const parts = [
       { type: 'text-delta', id: 'text-1', delta: 'Hello ' },
       {
@@ -396,7 +396,7 @@ describe('AiSdkModel end-to-end scenarios', () => {
       events.filter((event) => event.type === 'output_text_delta'),
     ).toEqual([
       { type: 'output_text_delta', itemId: 'text-1', delta: 'Hello ' },
-      { type: 'output_text_delta', itemId: 'text-1', delta: 'world' },
+      { type: 'output_text_delta', itemId: 'text-2', delta: 'world' },
     ]);
     expect(final.type).toBe('response_done');
     expect(final.response.output).toEqual([
@@ -404,7 +404,7 @@ describe('AiSdkModel end-to-end scenarios', () => {
         type: 'message',
         id: 'text-1',
         role: 'assistant',
-        content: [{ type: 'output_text', text: 'Hello world' }],
+        content: [{ type: 'output_text', text: 'Hello ' }],
         status: 'completed',
         providerData: { model: 'stub:m', responseId: 'resp-stream' },
       },
@@ -415,6 +415,14 @@ describe('AiSdkModel end-to-end scenarios', () => {
         arguments: '{"q":"a"}',
         status: 'completed',
         providerData: { model: 'stub:m', meta: 1, responseId: 'resp-stream' },
+      },
+      {
+        type: 'message',
+        id: 'text-2',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'world' }],
+        status: 'completed',
+        providerData: { model: 'stub:m', responseId: 'resp-stream' },
       },
       {
         type: 'function_call',
@@ -3190,6 +3198,10 @@ describe('AiSdkModel.getResponse', () => {
                   },
                 },
                 {
+                  type: 'text',
+                  text: 'I will call it now.',
+                },
+                {
                   type: 'tool-call',
                   toolCallId: 'weather_1',
                   toolName: 'get_weather',
@@ -3238,6 +3250,7 @@ describe('AiSdkModel.getResponse', () => {
       'tool_search_output',
       'message',
       'reasoning',
+      'message',
       'function_call',
     ]);
     expect(result.output[0]).toMatchObject({
@@ -3252,6 +3265,9 @@ describe('AiSdkModel.getResponse', () => {
       providerData: {
         anthropic: { signature: 'sig-after-search' },
       },
+    });
+    expect(result.output[5]).toMatchObject({
+      content: [{ type: 'output_text', text: 'I will call it now.' }],
     });
   });
 
@@ -4768,6 +4784,11 @@ describe('AiSdkModel.getStreamedResponse', () => {
         result: [{ type: 'tool_reference', toolName: 'get_weather' }],
       },
       {
+        type: 'text-delta',
+        id: 'text_1',
+        delta: 'I found the weather tool.',
+      },
+      {
         type: 'reasoning-start',
         id: 'reasoning_2',
       },
@@ -4782,6 +4803,11 @@ describe('AiSdkModel.getStreamedResponse', () => {
         providerMetadata: {
           anthropic: { signature: 'sig-after-search' },
         },
+      },
+      {
+        type: 'text-delta',
+        id: 'text_2',
+        delta: 'I will call it now.',
       },
       {
         type: 'tool-call',
@@ -4837,7 +4863,9 @@ describe('AiSdkModel.getStreamedResponse', () => {
       'reasoning',
       'tool_search_call',
       'tool_search_output',
+      'message',
       'reasoning',
+      'message',
       'function_call',
     ]);
     expect(final.response.output[0]).toMatchObject({
@@ -4846,9 +4874,17 @@ describe('AiSdkModel.getStreamedResponse', () => {
       },
     });
     expect(final.response.output[3]).toMatchObject({
+      id: 'text_1',
+      content: [{ type: 'output_text', text: 'I found the weather tool.' }],
+    });
+    expect(final.response.output[4]).toMatchObject({
       providerData: {
         anthropic: { signature: 'sig-after-search' },
       },
+    });
+    expect(final.response.output[5]).toMatchObject({
+      id: 'text_2',
+      content: [{ type: 'output_text', text: 'I will call it now.' }],
     });
   });
 


### PR DESCRIPTION
This pull request resolves #1593.

It preserves source-relative AI SDK response ordering across non-streaming generation, streaming output, and replay conversion. Interleaved reasoning, provider-executed tool-search calls and results, aggregated text, and subsequent client tool calls now retain their original positions while preserving provider metadata, reasoning signatures, text message IDs, and tool-call replacement behavior.

It also adds focused regressions for all three conversion paths and a patch changeset for `@openai/agents-extensions`.
