### PR TITLE
fix: preserve complete AI SDK final output

### DIFF
--- a/.changeset/calm-items-keep-order.md
+++ b/.changeset/calm-items-keep-order.md
@@ -1,5 +1,6 @@
 ---
+'@openai/agents-core': patch
 '@openai/agents-extensions': patch
 ---
 
-fix: preserve AI SDK response item ordering (#1593)
+fix: preserve complete AI SDK response text and item ordering (#1593)

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -12,6 +12,7 @@ import { ModelResponse } from '../model';
 import type { RunConfig, Runner, ToolErrorFormatter } from '../run';
 import { RunState } from '../runState';
 import {
+  getOutputText,
   getRefusalFromOutputMessage,
   getTextFromOutputMessage,
 } from '../utils/messages';
@@ -1239,11 +1240,17 @@ export async function resolveTurnAfterModelResponse<
     (item) => item instanceof RunMessageOutputItem,
   );
 
-  // we will use the last content output as the final output
-  const potentialFinalOutput =
+  // A model response may split assistant text across multiple messages around
+  // non-message output items such as reasoning. Preserve all of that text while
+  // retaining the last message's refusal semantics.
+  const lastMessageText =
     messageItems.length > 0
       ? getTextFromOutputMessage(messageItems[messageItems.length - 1].rawItem)
       : undefined;
+  const potentialFinalOutput =
+    typeof lastMessageText === 'undefined'
+      ? undefined
+      : getOutputText(newResponse) || lastMessageText;
 
   // Keep looping if any tool output placeholders still require an approval follow-up.
   const hasPendingToolsOrApprovals =

--- a/packages/agents-core/src/utils/messages.ts
+++ b/packages/agents-core/src/utils/messages.ts
@@ -91,7 +91,7 @@ export function getRefusalFromOutputMessage(
 }
 
 /**
- * Get the last text from the output message.
+ * Get the final text from the model response.
  * @param output
  * @returns
  */
@@ -100,7 +100,27 @@ export function getOutputText(output: ModelResponse) {
     return '';
   }
 
-  return (
-    getTextFromOutputMessage(output.output[output.output.length - 1]) || ''
-  );
+  const isSegmentedAssistantResponse =
+    output.output.some(
+      (item) =>
+        item.type === 'reasoning' ||
+        item.type === 'tool_search_call' ||
+        item.type === 'tool_search_output',
+    ) &&
+    output.output.every(
+      (item) =>
+        item.type === 'message' ||
+        item.type === 'reasoning' ||
+        item.type === 'tool_search_call' ||
+        item.type === 'tool_search_output',
+    );
+  if (!isSegmentedAssistantResponse) {
+    return (
+      getTextFromOutputMessage(output.output[output.output.length - 1]) ?? ''
+    );
+  }
+
+  return output.output
+    .map((item) => getTextFromOutputMessage(item) ?? '')
+    .join('');
 }

--- a/packages/agents-core/test/utils/messages.test.ts
+++ b/packages/agents-core/test/utils/messages.test.ts
@@ -88,6 +88,122 @@ describe('utils/messages', () => {
     expect(getOutputText(response)).toBe('first final');
   });
 
+  it('getOutputText joins messages segmented by reasoning', () => {
+    const response: ModelResponse = {
+      usage: new Usage(),
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'first' }],
+        } as any,
+        {
+          type: 'reasoning',
+          content: [{ type: 'input_text', text: 'thinking' }],
+        } as any,
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'second' }],
+        } as any,
+      ],
+    };
+
+    expect(getOutputText(response)).toBe('firstsecond');
+  });
+
+  it('getOutputText joins messages around provider-executed tool search', () => {
+    const response: ModelResponse = {
+      usage: new Usage(),
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'first' }],
+        } as any,
+        {
+          type: 'reasoning',
+          content: [{ type: 'input_text', text: 'thinking' }],
+        } as any,
+        {
+          type: 'tool_search_call',
+          callId: 'search_1',
+          execution: 'server',
+          arguments: { query: 'weather' },
+        },
+        {
+          type: 'tool_search_output',
+          callId: 'search_1',
+          execution: 'server',
+          tools: [{ type: 'tool_reference', functionName: 'get_weather' }],
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'second' }],
+        } as any,
+      ],
+    };
+
+    expect(getOutputText(response)).toBe('firstsecond');
+  });
+
+  it('getOutputText keeps the last message without reasoning', () => {
+    const response: ModelResponse = {
+      usage: new Usage(),
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'first' }],
+        } as any,
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'second' }],
+        } as any,
+      ],
+    };
+
+    expect(getOutputText(response)).toBe('second');
+  });
+
+  it('getOutputText joins messages when reasoning is the final item', () => {
+    const response: ModelResponse = {
+      usage: new Usage(),
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'first' }],
+        } as any,
+        {
+          type: 'reasoning',
+          content: [{ type: 'input_text', text: 'thinking' }],
+        } as any,
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'second' }],
+        } as any,
+        {
+          type: 'reasoning',
+          content: [{ type: 'input_text', text: 'checking' }],
+        } as any,
+      ],
+    };
+
+    expect(getOutputText(response)).toBe('firstsecond');
+  });
+
   it('getOutputText returns empty string when output is empty', () => {
     const response: ModelResponse = {
       usage: new Usage(),

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -14,6 +14,7 @@ import {
   handoff,
   protocol,
   run,
+  RunContext,
   tool,
   toolNamespace,
   withTrace,
@@ -2867,6 +2868,139 @@ describe('AiSdkModel.getResponse', () => {
     expect(result.finalOutput).toBe('Hello world');
   });
 
+  test('keeps complete final output across interleaved reasoning', async () => {
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              { type: 'text', text: 'first' },
+              { type: 'reasoning', text: 'thinking' },
+              { type: 'text', text: 'second' },
+              { type: 'reasoning', text: 'checking' },
+            ],
+            usage: { inputTokens: 1, outputTokens: 3, totalTokens: 4 },
+            providerMetadata: {},
+            response: { id: 'id' },
+            finishReason: 'stop',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+
+    const result = await run(
+      new Agent({ name: 'Assistant', model }),
+      'Respond in two parts.',
+    );
+
+    expect(result.newItems.map((item) => item.rawItem?.type)).toEqual([
+      'message',
+      'reasoning',
+      'message',
+      'reasoning',
+    ]);
+    expect(result.finalOutput).toBe('firstsecond');
+  });
+
+  test('keeps complete final output when used as an agent tool', async () => {
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              { type: 'text', text: 'first' },
+              { type: 'reasoning', text: 'thinking' },
+              { type: 'text', text: 'second' },
+              { type: 'reasoning', text: 'checking' },
+            ],
+            usage: { inputTokens: 1, outputTokens: 3, totalTokens: 4 },
+            providerMetadata: {},
+            response: { id: 'id' },
+            finishReason: 'stop',
+            warnings: [],
+          } as any;
+        },
+      }),
+    );
+    const agentTool = new Agent({ name: 'Assistant', model }).asTool({
+      toolDescription: 'Respond in two parts.',
+    });
+
+    const output = await agentTool.invoke(
+      new RunContext(),
+      JSON.stringify({ input: 'Respond in two parts.' }),
+    );
+
+    expect(output).toBe('firstsecond');
+  });
+
+  test('keeps complete final output around provider-executed tool search', async () => {
+    const model = new AiSdkModel(
+      stubModel(
+        {
+          async doGenerate() {
+            return {
+              content: [
+                { type: 'text', text: 'first' },
+                {
+                  type: 'reasoning',
+                  text: 'searching',
+                  providerMetadata: {
+                    anthropic: { signature: 'sig-search' },
+                  },
+                },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  input: { query: 'weather' },
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'search_1',
+                  toolName: 'tool_search',
+                  result: [{ type: 'tool_reference', toolName: 'get_weather' }],
+                },
+                { type: 'text', text: 'second' },
+              ],
+              usage: { inputTokens: 1, outputTokens: 5, totalTokens: 6 },
+              providerMetadata: {},
+              response: { id: 'id' },
+              finishReason: 'stop',
+              warnings: [],
+            } as any;
+          },
+        },
+        { provider: 'anthropic.messages', specificationVersion: 'v3' },
+      ),
+    );
+
+    const result = await run(
+      new Agent({
+        name: 'Assistant',
+        model,
+        tools: [
+          aiSdkToolSearchTool({
+            type: 'provider',
+            id: 'anthropic.tool_search_regex_20251119',
+          }),
+        ],
+      }),
+      'Search and answer.',
+    );
+
+    expect(result.newItems.map((item) => item.rawItem?.type)).toEqual([
+      'message',
+      'reasoning',
+      'tool_search_call',
+      'tool_search_output',
+      'message',
+    ]);
+    expect(result.finalOutput).toBe('firstsecond');
+  });
+
   test('applies transformOutputText to finalized assistant text', async () => {
     const transformOutputText = vi.fn((text: string, context: any) => {
       expect(context.stream).toBe(false);
@@ -4640,6 +4774,55 @@ describe('AiSdkModel.getStreamedResponse', () => {
         },
       },
     ]);
+  });
+
+  test('keeps complete streamed final output across interleaved reasoning', async () => {
+    const parts = [
+      { type: 'text-delta', id: 'text-1', delta: 'first' },
+      { type: 'reasoning-start', id: 'reasoning-1' },
+      {
+        type: 'reasoning-delta',
+        id: 'reasoning-1',
+        delta: 'thinking',
+      },
+      { type: 'reasoning-end', id: 'reasoning-1' },
+      { type: 'text-delta', id: 'text-2', delta: 'second' },
+      { type: 'reasoning-start', id: 'reasoning-2' },
+      {
+        type: 'reasoning-delta',
+        id: 'reasoning-2',
+        delta: 'checking',
+      },
+      { type: 'reasoning-end', id: 'reasoning-2' },
+      { type: 'response-metadata', id: 'id1' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 3 },
+      },
+    ];
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream() {
+          return { stream: partsStream(parts) } as any;
+        },
+      }),
+    );
+
+    const result = await run(
+      new Agent({ name: 'Assistant', model }),
+      'Respond in two parts.',
+      { stream: true },
+    );
+    await result.completed;
+
+    expect(result.newItems.map((item) => item.rawItem?.type)).toEqual([
+      'message',
+      'reasoning',
+      'message',
+      'reasoning',
+    ]);
+    expect(result.finalOutput).toBe('firstsecond');
   });
 
   test('keeps streamed text contiguous across replacement tool calls', async () => {


### PR DESCRIPTION
This pull request fixes a follow-up regression from #1594 where preserving the source order of text and reasoning parts could cause the Agents runner to expose only the final text segment.

It preserves ordered response items while concatenating the complete assistant text for direct, streamed, and `Agent.asTool()` runs. Ordinary multiple-message responses retain their existing last-message behavior, and refusal, tool, approval, and structured-output handling remain unchanged.