### PR TITLE
fix(core): normalize strict referenced tool arguments

### DIFF
--- a/.changeset/calm-tools-normalize.md
+++ b/.changeset/calm-tools-normalize.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: normalize strict tool arguments without widening unsupported JSON schemas

--- a/packages/agents-core/src/utils/strictToolSchema.ts
+++ b/packages/agents-core/src/utils/strictToolSchema.ts
@@ -2,20 +2,109 @@ import type { JsonObjectSchema } from '../types';
 import { UserError } from '../errors';
 import { readZodDefinition, readZodType } from './zodCompat';
 
+type SyntheticNullableSchema = {
+  schema: unknown;
+};
+
+type JsonSchemaNullability = 'allows' | 'disallows' | 'unknown';
+
+type StrictSchemaPreparationContext = {
+  originalRoot: unknown;
+  preparedRoot: unknown;
+  preparedSchemas: WeakMap<object, object>;
+  references: Array<{
+    originalReference: string;
+    preparedSchema: Record<string, unknown>;
+  }>;
+  syntheticNullableSchemas: WeakMap<object, SyntheticNullableSchema>;
+};
+
+type PreparedOpenAIStrictToolSchema<T> = {
+  schema: T;
+  normalizeInput: (value: unknown) => unknown;
+};
+
 export function toOpenAIStrictToolSchema<T extends JsonObjectSchema<any>>(
   schema: T,
 ): T {
-  return ensureStrictSchemaEntry(structuredClone(schema), true) as T;
+  return prepareOpenAIStrictToolSchemaInternal(schema, false).schema;
 }
 
-function ensureStrictSchemaEntry(entry: unknown, isRoot = false): unknown {
+export function prepareOpenAIStrictToolSchema<T extends JsonObjectSchema<any>>(
+  schema: T,
+): PreparedOpenAIStrictToolSchema<T> {
+  return prepareOpenAIStrictToolSchemaInternal(schema, true);
+}
+
+function prepareOpenAIStrictToolSchemaInternal<T extends JsonObjectSchema<any>>(
+  schema: T,
+  requireUnambiguousNormalization: boolean,
+): PreparedOpenAIStrictToolSchema<T> {
+  validateOpenAIStrictProviderSchema(schema, schema);
+  validateOpenAIStrictJsonSchema(
+    schema,
+    schema,
+    new WeakSet(),
+    requireUnambiguousNormalization,
+  );
+  const preparedSchemas = new WeakMap<object, object>();
+  const syntheticNullableSchemas = new WeakMap<
+    object,
+    SyntheticNullableSchema
+  >();
+  const context: StrictSchemaPreparationContext = {
+    originalRoot: schema,
+    preparedRoot: undefined,
+    preparedSchemas,
+    references: [],
+    syntheticNullableSchemas,
+  };
+  const strictSchema = ensureStrictSchemaEntry(
+    structuredClone(schema),
+    schema,
+    context,
+    true,
+  ) as T;
+  stabilizeLocalJsonSchemaReferences(strictSchema, context);
+  context.preparedRoot = strictSchema;
+
+  return {
+    schema: strictSchema,
+    normalizeInput: (value: unknown) =>
+      normalizeStrictJsonSchemaValue(strictSchema, value, context),
+  };
+}
+
+function ensureStrictSchemaEntry(
+  entry: unknown,
+  originalEntry: unknown,
+  context: StrictSchemaPreparationContext,
+  isRoot = false,
+): unknown {
   if (typeof entry !== 'object' || entry === null) {
     return entry;
   }
 
   const record = entry as Record<string, unknown>;
+  const originalRecord = isRecord(originalEntry) ? originalEntry : undefined;
+  if (originalRecord) {
+    const preparedRecord = context.preparedSchemas.get(originalRecord);
+    if (preparedRecord) {
+      return preparedRecord;
+    }
+    context.preparedSchemas.set(originalRecord, record);
+  }
+  if (typeof originalRecord?.$ref === 'string') {
+    context.references.push({
+      originalReference: originalRecord.$ref,
+      preparedSchema: record,
+    });
+  }
   const properties = isRecord(record.properties)
     ? record.properties
+    : undefined;
+  const originalProperties = isRecord(originalRecord?.properties)
+    ? originalRecord.properties
     : undefined;
   const hasObjectKeywords =
     properties !== undefined || 'additionalProperties' in record;
@@ -34,24 +123,37 @@ function ensureStrictSchemaEntry(entry: unknown, isRoot = false): unknown {
     record.type = 'object';
   }
 
-  if (record.type === 'object' && properties !== undefined) {
+  if (schemaConvertsObjectProperties(record) && properties !== undefined) {
+    const preparedProperties = { ...properties };
+    record.properties = preparedProperties;
     const originalRequired = new Set(
-      Array.isArray(record.required) ? record.required.map(String) : [],
+      Array.isArray(originalRecord?.required)
+        ? originalRecord.required.map(String)
+        : [],
     );
 
-    for (const [key, value] of Object.entries(properties)) {
-      const normalized = ensureStrictSchemaEntry(value);
-      properties[key] = originalRequired.has(key)
-        ? normalized
-        : wrapNullableSchema(normalized);
+    for (const [key, value] of Object.entries(preparedProperties)) {
+      const originalValue = originalProperties?.[key] ?? value;
+      const optional = !originalRequired.has(key);
+      const nullability = optional
+        ? getKnownJsonSchemaNullability(originalValue, context.originalRoot)
+        : undefined;
+      const normalized = ensureStrictSchemaEntry(value, originalValue, context);
+      preparedProperties[key] =
+        nullability === 'disallows'
+          ? wrapNullableSchema(normalized, context.syntheticNullableSchemas)
+          : normalized;
     }
 
-    record.required = Object.keys(properties);
+    record.required = Object.keys(preparedProperties);
     record.additionalProperties = false;
   }
 
   for (const key of ['$defs', 'definitions']) {
     const nested = record[key];
+    const originalNested = isRecord(originalRecord?.[key])
+      ? originalRecord[key]
+      : undefined;
     if (
       typeof nested === 'object' &&
       nested !== null &&
@@ -61,23 +163,46 @@ function ensureStrictSchemaEntry(entry: unknown, isRoot = false): unknown {
         nested as Record<string, unknown>,
       )) {
         (nested as Record<string, unknown>)[nestedKey] =
-          ensureStrictSchemaEntry(nestedValue);
+          ensureStrictSchemaEntry(
+            nestedValue,
+            originalNested?.[nestedKey] ?? nestedValue,
+            context,
+          );
       }
     }
   }
 
-  for (const key of ['anyOf', 'allOf', 'oneOf']) {
+  for (const key of ['anyOf']) {
     const nested = record[key];
+    const originalNested = Array.isArray(originalRecord?.[key])
+      ? originalRecord[key]
+      : [];
     if (Array.isArray(nested)) {
-      record[key] = nested.map((value) => ensureStrictSchemaEntry(value));
+      record[key] = nested.map((value, index) =>
+        ensureStrictSchemaEntry(value, originalNested[index] ?? value, context),
+      );
     }
   }
 
   const items = record.items;
+  const originalItems = originalRecord?.items;
   if (Array.isArray(items)) {
-    record.items = items.map((value) => ensureStrictSchemaEntry(value));
+    const originalItemEntries = Array.isArray(originalItems)
+      ? originalItems
+      : [];
+    record.items = items.map((value, index) =>
+      ensureStrictSchemaEntry(
+        value,
+        originalItemEntries[index] ?? value,
+        context,
+      ),
+    );
   } else if (typeof items === 'object' && items !== null) {
-    record.items = ensureStrictSchemaEntry(items);
+    record.items = ensureStrictSchemaEntry(
+      items,
+      originalItems ?? items,
+      context,
+    );
   }
 
   if (record.default === null) {
@@ -87,12 +212,104 @@ function ensureStrictSchemaEntry(entry: unknown, isRoot = false): unknown {
   return record;
 }
 
-function wrapNullableSchema(schema: unknown): unknown {
-  if (
-    typeof schema !== 'object' ||
-    schema === null ||
-    isSchemaNullable(schema as Record<string, unknown>)
-  ) {
+function schemaConvertsObjectProperties(
+  schema: Record<string, unknown>,
+): boolean {
+  return (
+    isRecord(schema.properties) &&
+    (schema.type === 'object' ||
+      (Array.isArray(schema.type) && schema.type.includes('object')) ||
+      typeof schema.type === 'undefined')
+  );
+}
+
+function stabilizeLocalJsonSchemaReferences(
+  preparedRoot: unknown,
+  context: StrictSchemaPreparationContext,
+): void {
+  if (!isRecord(preparedRoot)) {
+    return;
+  }
+
+  // Strict conversion can wrap an optional property, replace
+  // `additionalProperties`, or leave an inapplicable subschema untouched. A
+  // local pointer into one of those locations would no longer identify the
+  // target that was classified and normalized. Hoist only those unstable
+  // targets so the provider schema and invocation normalizer share one
+  // context-independent prepared node.
+  const hoistedReferences = new WeakMap<object, string>();
+  let nextDefinitionIndex = 0;
+
+  for (let index = 0; index < context.references.length; index += 1) {
+    const { originalReference, preparedSchema } = context.references[index];
+    const originalTarget = resolveLocalJsonSchemaReference(
+      originalReference,
+      context.originalRoot,
+    );
+    if (typeof originalTarget === 'undefined') {
+      continue;
+    }
+
+    const preparedTarget = isRecord(originalTarget)
+      ? (context.preparedSchemas.get(originalTarget) ??
+        ensureStrictSchemaEntry(
+          structuredClone(originalTarget),
+          originalTarget,
+          context,
+        ))
+      : originalTarget;
+    const pointerTarget = resolveLocalJsonSchemaReference(
+      originalReference,
+      preparedRoot,
+    );
+    if (pointerTarget === preparedTarget) {
+      continue;
+    }
+
+    let definitionName = isRecord(originalTarget)
+      ? hoistedReferences.get(originalTarget)
+      : undefined;
+    if (!definitionName) {
+      const existingDefinitions = preparedRoot.$defs;
+      if (
+        typeof existingDefinitions !== 'undefined' &&
+        !isRecord(existingDefinitions)
+      ) {
+        throw new UserError(
+          'Cannot stabilize local JSON schema references because the root `$defs` value is not an object. Use an object-valued `$defs` or disable strict mode.',
+        );
+      }
+      const definitions = isRecord(existingDefinitions)
+        ? existingDefinitions
+        : {};
+      preparedRoot.$defs = definitions;
+      do {
+        definitionName = `__openai_strict_ref_${nextDefinitionIndex}`;
+        nextDefinitionIndex += 1;
+      } while (
+        Object.prototype.hasOwnProperty.call(definitions, definitionName)
+      );
+      definitions[definitionName] = preparedTarget;
+      if (isRecord(originalTarget)) {
+        hoistedReferences.set(originalTarget, definitionName);
+      }
+    }
+    preparedSchema.$ref = `#/$defs/${definitionName}`;
+  }
+}
+
+function wrapNullableSchema(
+  schema: unknown,
+  syntheticNullableSchemas: WeakMap<object, SyntheticNullableSchema>,
+): unknown {
+  if (schema === false) {
+    const nullableSchema = {
+      anyOf: [false, { type: 'null' }],
+    };
+    syntheticNullableSchemas.set(nullableSchema, { schema });
+    return nullableSchema;
+  }
+  if (typeof schema !== 'object' || schema === null) {
     return schema;
   }
 
@@ -101,83 +318,92 @@ function wrapNullableSchema(schema: unknown): unknown {
       ? { description: (schema as { description: string }).description }
       : {};
 
-  return {
+  const nullableSchema = {
     ...description,
     anyOf: [schema, { type: 'null' }],
   };
-}
-
-function isSchemaNullable(schema: Record<string, unknown>): boolean {
-  const type = schema.type;
-  if (type === 'null') {
-    return true;
-  }
-  if (Array.isArray(type) && type.includes('null')) {
-    return true;
-  }
-
-  for (const key of ['anyOf', 'oneOf', 'allOf']) {
-    const entries = schema[key];
-    if (
-      Array.isArray(entries) &&
-      entries.some(
-        (entry) =>
-          typeof entry === 'object' &&
-          entry !== null &&
-          isSchemaNullable(entry as Record<string, unknown>),
-      )
-    ) {
-      return true;
-    }
-  }
-
-  return false;
+  syntheticNullableSchemas.set(nullableSchema, {
+    schema,
+  });
+  return nullableSchema;
 }
 
 export function stripStrictNullsForJsonSchema(
   schema: unknown,
   value: unknown,
-  optionalProperty: boolean = false,
+): unknown {
+  if (!isRecord(schema)) {
+    return value;
+  }
+
+  return prepareOpenAIStrictToolSchema(
+    schema as JsonObjectSchema<any>,
+  ).normalizeInput(value);
+}
+
+function normalizeStrictJsonSchemaValue(
+  schema: unknown,
+  value: unknown,
+  context: StrictSchemaPreparationContext,
 ): unknown {
   if (value === undefined) {
     return undefined;
   }
-  if (value === null) {
-    if (optionalProperty && !jsonSchemaAllowsNull(schema)) {
-      return undefined;
+
+  let currentSchema = schema;
+  if (isRecord(currentSchema)) {
+    const syntheticNullableSchema =
+      context.syntheticNullableSchemas.get(currentSchema);
+    if (syntheticNullableSchema) {
+      if (value === null) {
+        return undefined;
+      }
+      currentSchema = syntheticNullableSchema.schema;
     }
+  }
+  const resolvedSchema = resolveLocalJsonSchema(currentSchema, context);
+  if (resolvedSchema !== currentSchema) {
+    return normalizeStrictJsonSchemaValue(resolvedSchema, value, context);
+  }
+
+  if (value === null) {
     return value;
   }
 
   if (Array.isArray(value)) {
-    const schemaRecord = isRecord(schema) ? schema : undefined;
+    const schemaRecord = isRecord(currentSchema) ? currentSchema : undefined;
     const items = schemaRecord?.items;
     if (Array.isArray(items)) {
       return value.map((entry, index) =>
-        stripStrictNullsForJsonSchema(items[index], entry),
+        normalizeStrictJsonSchemaValue(items[index], entry, context),
       );
     }
     if (items && typeof items === 'object') {
-      return value.map((entry) => stripStrictNullsForJsonSchema(items, entry));
+      return value.map((entry) =>
+        normalizeStrictJsonSchemaValue(items, entry, context),
+      );
     }
     return value;
   }
 
-  if (!isRecord(value) || !isJsonSchemaObject(schema)) {
+  if (
+    !isRecord(value) ||
+    !isRecord(currentSchema) ||
+    !schemaConvertsObjectProperties(currentSchema)
+  ) {
     return value;
   }
 
-  const properties = isRecord(schema.properties) ? schema.properties : {};
-  const required = new Set(
-    Array.isArray(schema.required) ? schema.required.map(String) : [],
-  );
+  const properties = isRecord(currentSchema.properties)
+    ? currentSchema.properties
+    : {};
   const normalized: Record<string, unknown> = { ...value };
 
   for (const [key, propertySchema] of Object.entries(properties)) {
-    const nextValue = stripStrictNullsForJsonSchema(
+    const nextValue = normalizeStrictJsonSchemaValue(
       propertySchema,
       normalized[key],
-      !required.has(key),
+      context,
     );
     if (typeof nextValue === 'undefined') {
       delete normalized[key];
@@ -189,25 +415,543 @@ export function stripStrictNullsForJsonSchema(
   return normalized;
 }
 
-function isJsonSchemaObject(schema: unknown): schema is Record<
-  string,
-  unknown
-> & {
-  properties?: Record<string, unknown>;
-  required?: unknown[];
-} {
+// This guard defines the local argument normalizer's supported boundary; it is
+// not a complete validator for every provider-specific JSON Schema keyword.
+// Reject composition and reference forms whose nullability cannot be mapped
+// without widening the caller's schema. Local `$ref` values must resolve within
+// the root document and cannot carry assertion siblings. Plain `anyOf` branches
+// that contain optional object fields are also rejected below, even when they
+// have a discriminator, because this path has no runtime schema validator to
+// select a branch. Nested `$id` resources are rejected because local pointers
+// are resolved only within the root resource. Use Zod for branch-aware
+// validation, make the affected fields required, move sibling constraints into
+// the branch or target, or disable strict mode.
+// Provider compatibility is checked across every retained schema location,
+// including properties that the local null normalizer does not traverse.
+// Schema applicators outside the traversal below are rejected rather than
+// partially interpreted, even when a provider model may accept a subset.
+const unsupportedStrictNormalizationKeywords = [
+  '$dynamicRef',
+  '$recursiveRef',
+  'additionalItems',
+  'allOf',
+  'contains',
+  'contentSchema',
+  'dependencies',
+  'dependentRequired',
+  'dependentSchemas',
+  'else',
+  'if',
+  'maxContains',
+  'minContains',
+  'not',
+  'oneOf',
+  'patternProperties',
+  'prefixItems',
+  'propertyNames',
+  'then',
+  'unevaluatedItems',
+  'unevaluatedProperties',
+] as const;
+
+const referenceMetadataKeywords = new Set([
+  '$anchor',
+  '$comment',
+  '$defs',
+  '$id',
+  '$ref',
+  '$schema',
+  'default',
+  'deprecated',
+  'description',
+  'definitions',
+  'examples',
+  'readOnly',
+  'title',
+  'writeOnly',
+]);
+
+const anyOfMetadataKeywords = new Set([...referenceMetadataKeywords, 'anyOf']);
+
+function validateOpenAIStrictProviderSchema(
+  schema: unknown,
+  rootSchema: unknown,
+  visitedSchemas: WeakSet<object> = new WeakSet(),
+): void {
+  if (typeof schema === 'boolean') {
+    return;
+  }
   if (!isRecord(schema)) {
-    return false;
+    throw new UserError(
+      'Cannot convert a JSON schema containing a non-boolean, non-object schema node to strict mode. Replace the invalid node with a JSON schema object or boolean, or disable strict mode.',
+    );
+  }
+  if (visitedSchemas.has(schema)) {
+    return;
+  }
+  visitedSchemas.add(schema);
+
+  if (schema !== rootSchema && '$id' in schema) {
+    throw new UserError(
+      'Cannot convert a JSON schema with a nested `$id` resource to strict mode because local references are resolved only within the root resource. Remove the nested `$id` or disable strict mode.',
+    );
   }
 
-  return (
-    schema.type === 'object' ||
-    (isRecord(schema.properties) && !Array.isArray(schema.properties))
+  for (const keyword of unsupportedStrictNormalizationKeywords) {
+    if (keyword in schema) {
+      throw new UserError(
+        `Cannot convert a JSON schema using unsupported keyword \`${keyword}\` to strict mode. Remove the keyword or disable strict mode.`,
+      );
+    }
+  }
+
+  if ('$ref' in schema) {
+    if (typeof schema.$ref !== 'string') {
+      throw new UserError(
+        'Cannot convert a JSON schema with a non-string `$ref` to strict mode.',
+      );
+    }
+    const resolved = resolveLocalJsonSchemaReference(schema.$ref, rootSchema);
+    if (typeof resolved === 'undefined') {
+      throw new UserError(
+        `Cannot convert unresolved or external JSON schema reference \`${schema.$ref}\` to strict mode. Use a local reference or disable strict mode.`,
+      );
+    }
+    validateOpenAIStrictProviderSchema(resolved, rootSchema, visitedSchemas);
+  }
+
+  if ('anyOf' in schema) {
+    if (!Array.isArray(schema.anyOf) || schema.anyOf.length === 0) {
+      throw new UserError(
+        'Cannot convert a JSON schema with an invalid `anyOf` to strict mode.',
+      );
+    }
+    for (const branch of schema.anyOf) {
+      validateOpenAIStrictProviderSchema(branch, rootSchema, visitedSchemas);
+    }
+  }
+
+  const properties = isRecord(schema.properties)
+    ? schema.properties
+    : undefined;
+  if (properties) {
+    for (const propertySchema of Object.values(properties)) {
+      validateOpenAIStrictProviderSchema(
+        propertySchema,
+        rootSchema,
+        visitedSchemas,
+      );
+    }
+  }
+
+  const items = schema.items;
+  if (Array.isArray(items)) {
+    for (const item of items) {
+      validateOpenAIStrictProviderSchema(item, rootSchema, visitedSchemas);
+    }
+  } else if (typeof items !== 'undefined') {
+    validateOpenAIStrictProviderSchema(items, rootSchema, visitedSchemas);
+  }
+
+  if ('additionalProperties' in schema) {
+    validateOpenAIStrictProviderSchema(
+      schema.additionalProperties,
+      rootSchema,
+      visitedSchemas,
+    );
+  }
+
+  for (const key of ['$defs', 'definitions']) {
+    const definitions = schema[key];
+    if (!isRecord(definitions)) {
+      continue;
+    }
+    for (const definition of Object.values(definitions)) {
+      validateOpenAIStrictProviderSchema(
+        definition,
+        rootSchema,
+        visitedSchemas,
+      );
+    }
+  }
+}
+
+function validateOpenAIStrictJsonSchema(
+  schema: unknown,
+  rootSchema: unknown,
+  visitedSchemas: WeakSet<object> = new WeakSet(),
+  requireUnambiguousNormalization = true,
+): void {
+  if (typeof schema === 'boolean') {
+    return;
+  }
+  if (!isRecord(schema) || visitedSchemas.has(schema)) {
+    return;
+  }
+  visitedSchemas.add(schema);
+
+  if ('$ref' in schema) {
+    if (typeof schema.$ref !== 'string') {
+      throw new UserError(
+        'Cannot convert a JSON schema with a non-string `$ref` to strict mode.',
+      );
+    }
+    const unsupportedSibling = Object.keys(schema).find(
+      (key) => !referenceMetadataKeywords.has(key),
+    );
+    if (unsupportedSibling) {
+      throw new UserError(
+        `Cannot convert a JSON schema combining \`$ref\` with sibling keyword \`${unsupportedSibling}\` to strict mode. Move the constraint into the referenced schema or disable strict mode.`,
+      );
+    }
+    const resolved = resolveLocalJsonSchemaReference(schema.$ref, rootSchema);
+    if (typeof resolved === 'undefined') {
+      throw new UserError(
+        `Cannot convert unresolved or external JSON schema reference \`${schema.$ref}\` to strict mode. Use a local reference or disable strict mode.`,
+      );
+    }
+    validateOpenAIStrictJsonSchema(
+      resolved,
+      rootSchema,
+      visitedSchemas,
+      requireUnambiguousNormalization,
+    );
+  }
+
+  if ('anyOf' in schema) {
+    if (!Array.isArray(schema.anyOf) || schema.anyOf.length === 0) {
+      throw new UserError(
+        'Cannot convert a JSON schema with an invalid `anyOf` to strict mode.',
+      );
+    }
+    const unsupportedSibling = Object.keys(schema).find(
+      (key) => !anyOfMetadataKeywords.has(key),
+    );
+    if (unsupportedSibling) {
+      throw new UserError(
+        `Cannot convert a JSON schema combining \`anyOf\` with sibling keyword \`${unsupportedSibling}\` to strict mode. Move the constraint into each branch or disable strict mode.`,
+      );
+    }
+    for (const branch of schema.anyOf) {
+      validateOpenAIStrictJsonSchema(
+        branch,
+        rootSchema,
+        visitedSchemas,
+        requireUnambiguousNormalization,
+      );
+    }
+    // Plain JSON Schema tools do not have a runtime validator that selects the
+    // matching branch. Supporting even discriminated branches here would add a
+    // second partial schema interpreter alongside the Zod validation path.
+    if (
+      requireUnambiguousNormalization &&
+      schema.anyOf.some((branch) =>
+        jsonSchemaRequiresSyntheticNullStripping(branch, rootSchema),
+      )
+    ) {
+      throw new UserError(
+        'Cannot convert an `anyOf` branch containing optional object properties to strict mode because plain JSON Schema tools do not select a branch during input normalization. Use a Zod schema, make the branch properties required, or disable strict mode.',
+      );
+    }
+  }
+
+  const properties = isRecord(schema.properties)
+    ? schema.properties
+    : undefined;
+  if (schemaConvertsObjectProperties(schema) && properties) {
+    const required = new Set(
+      Array.isArray(schema.required) ? schema.required.map(String) : [],
+    );
+    for (const [key, propertySchema] of Object.entries(properties)) {
+      validateOpenAIStrictJsonSchema(
+        propertySchema,
+        rootSchema,
+        visitedSchemas,
+        requireUnambiguousNormalization,
+      );
+      if (!required.has(key)) {
+        getKnownJsonSchemaNullability(propertySchema, rootSchema);
+      }
+    }
+  }
+
+  const items = schema.items;
+  if (Array.isArray(items)) {
+    for (const item of items) {
+      validateOpenAIStrictJsonSchema(
+        item,
+        rootSchema,
+        visitedSchemas,
+        requireUnambiguousNormalization,
+      );
+    }
+  } else if (typeof items !== 'undefined') {
+    validateOpenAIStrictJsonSchema(
+      items,
+      rootSchema,
+      visitedSchemas,
+      requireUnambiguousNormalization,
+    );
+  }
+
+  for (const key of ['$defs', 'definitions']) {
+    const definitions = schema[key];
+    if (!isRecord(definitions)) {
+      continue;
+    }
+    for (const definition of Object.values(definitions)) {
+      validateOpenAIStrictJsonSchema(
+        definition,
+        rootSchema,
+        visitedSchemas,
+        requireUnambiguousNormalization,
+      );
+    }
+  }
+}
+
+function getKnownJsonSchemaNullability(
+  schema: unknown,
+  rootSchema: unknown,
+): Exclude<JsonSchemaNullability, 'unknown'> {
+  const nullability = getJsonSchemaNullability(schema, rootSchema);
+  if (nullability === 'unknown') {
+    throw new UserError(
+      'Cannot determine whether an optional JSON schema property accepts `null`. Make its nullability explicit with a supported schema form, make the property required, or disable strict mode.',
+    );
+  }
+  return nullability;
+}
+
+function getJsonSchemaNullability(
+  schema: unknown,
+  rootSchema: unknown,
+  visitedReferences: ReadonlySet<string> = new Set(),
+): JsonSchemaNullability {
+  if (schema === true) {
+    return 'allows';
+  }
+  if (schema === false) {
+    return 'disallows';
+  }
+  if (!isRecord(schema)) {
+    return 'unknown';
+  }
+
+  const type = schema.type;
+  if ('type' in schema) {
+    if (typeof type !== 'string' && !Array.isArray(type)) {
+      return 'unknown';
+    }
+    if (type !== 'null' && !(Array.isArray(type) && type.includes('null'))) {
+      return 'disallows';
+    }
+  }
+
+  if ('enum' in schema) {
+    if (!Array.isArray(schema.enum)) {
+      return 'unknown';
+    }
+    if (!schema.enum.includes(null)) {
+      return 'disallows';
+    }
+  }
+
+  if ('const' in schema && schema.const !== null) {
+    return 'disallows';
+  }
+
+  if ('$ref' in schema) {
+    const referencedNullability = getReferencedJsonSchemaNullability(
+      schema.$ref,
+      rootSchema,
+      visitedReferences,
+    );
+    if (referencedNullability !== 'allows') {
+      return referencedNullability;
+    }
+  }
+
+  if ('anyOf' in schema) {
+    if (!Array.isArray(schema.anyOf)) {
+      return 'unknown';
+    }
+    const entries = schema.anyOf.map((entry) =>
+      getJsonSchemaNullability(entry, rootSchema, visitedReferences),
+    );
+    if (entries.includes('allows')) {
+      return 'allows';
+    }
+    return entries.every((entry) => entry === 'disallows')
+      ? 'disallows'
+      : 'unknown';
+  }
+
+  // Strict conversion infers an object type for nested schemas that declare
+  // properties. Preserve that released interpretation when deciding whether an
+  // optional property needs a synthetic nullable wrapper.
+  if (!('type' in schema) && isRecord(schema.properties)) {
+    return 'disallows';
+  }
+
+  return 'allows';
+}
+
+function jsonSchemaRequiresSyntheticNullStripping(
+  schema: unknown,
+  rootSchema: unknown,
+  visitedSchemas: WeakSet<object> = new WeakSet(),
+): boolean {
+  if (!isRecord(schema) || visitedSchemas.has(schema)) {
+    return false;
+  }
+  visitedSchemas.add(schema);
+
+  if (typeof schema.$ref === 'string') {
+    const resolved = resolveLocalJsonSchemaReference(schema.$ref, rootSchema);
+    return jsonSchemaRequiresSyntheticNullStripping(
+      resolved,
+      rootSchema,
+      visitedSchemas,
+    );
+  }
+
+  if (Array.isArray(schema.anyOf)) {
+    return schema.anyOf.some((branch) =>
+      jsonSchemaRequiresSyntheticNullStripping(
+        branch,
+        rootSchema,
+        visitedSchemas,
+      ),
+    );
+  }
+
+  const properties =
+    schemaConvertsObjectProperties(schema) && isRecord(schema.properties)
+      ? schema.properties
+      : {};
+  const required = new Set(
+    Array.isArray(schema.required) ? schema.required.map(String) : [],
+  );
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    if (
+      (!required.has(key) &&
+        getKnownJsonSchemaNullability(propertySchema, rootSchema) ===
+          'disallows') ||
+      jsonSchemaRequiresSyntheticNullStripping(
+        propertySchema,
+        rootSchema,
+        visitedSchemas,
+      )
+    ) {
+      return true;
+    }
+  }
+
+  const items = schema.items;
+  return Array.isArray(items)
+    ? items.some((item) =>
+        jsonSchemaRequiresSyntheticNullStripping(
+          item,
+          rootSchema,
+          visitedSchemas,
+        ),
+      )
+    : jsonSchemaRequiresSyntheticNullStripping(
+        items,
+        rootSchema,
+        visitedSchemas,
+      );
+}
+
+function getReferencedJsonSchemaNullability(
+  reference: unknown,
+  rootSchema: unknown,
+  visitedReferences: ReadonlySet<string>,
+): JsonSchemaNullability {
+  if (typeof reference !== 'string' || visitedReferences.has(reference)) {
+    return 'unknown';
+  }
+
+  const resolved = resolveLocalJsonSchemaReference(reference, rootSchema);
+  if (typeof resolved === 'undefined') {
+    return 'unknown';
+  }
+  return getJsonSchemaNullability(
+    resolved,
+    rootSchema,
+    new Set([...visitedReferences, reference]),
   );
 }
 
-function jsonSchemaAllowsNull(schema: unknown): boolean {
-  return isRecord(schema) ? isSchemaNullable(schema) : false;
+function resolveLocalJsonSchema(
+  schema: unknown,
+  context: StrictSchemaPreparationContext,
+): unknown {
+  let current = schema;
+  const visitedReferences = new Set<string>();
+
+  while (isRecord(current) && typeof current.$ref === 'string') {
+    const reference = current.$ref;
+    if (visitedReferences.has(reference)) {
+      return schema;
+    }
+    visitedReferences.add(reference);
+
+    const resolved = resolveLocalJsonSchemaReference(
+      reference,
+      context.preparedRoot,
+    );
+    if (typeof resolved === 'undefined') {
+      return schema;
+    }
+    current = resolved;
+  }
+
+  return current;
+}
+
+function resolveLocalJsonSchemaReference(
+  reference: string,
+  rootSchema: unknown,
+): unknown {
+  if (!reference.startsWith('#')) {
+    return undefined;
+  }
+  return reference === '#'
+    ? rootSchema
+    : resolveJsonPointer(rootSchema, reference);
+}
+
+function resolveJsonPointer(root: unknown, reference: string): unknown {
+  let current = root;
+  let pointer: string;
+
+  try {
+    pointer = decodeURIComponent(reference.slice(1));
+  } catch {
+    return undefined;
+  }
+  if (!pointer.startsWith('/')) {
+    return undefined;
+  }
+
+  for (const rawToken of pointer.slice(1).split('/')) {
+    if (/~(?:[^01]|$)/.test(rawToken)) {
+      return undefined;
+    }
+    const token = rawToken.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (
+      typeof current !== 'object' ||
+      current === null ||
+      !Object.prototype.hasOwnProperty.call(current, token)
+    ) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[token];
+  }
+
+  return current;
 }
 
 export function stripStrictNullsForZodSchema(
@@ -236,6 +980,11 @@ export function stripStrictNullsForZodSchema(
         return normalized;
       }
     }
+  }
+
+  if (type === 'intersection') {
+    const left = stripStrictNullsForZodSchema(def?.left, value);
+    return stripStrictNullsForZodSchema(def?.right, left);
   }
 
   if (type === 'object' && isRecord(value)) {

--- a/packages/agents-core/src/utils/tools.ts
+++ b/packages/agents-core/src/utils/tools.ts
@@ -6,13 +6,15 @@ import { isZodObject } from './typeGuards';
 import type { AgentOutputType } from '../agent';
 import {
   zodJsonSchemaCompat,
+  zodJsonSchemaCompatForOpenAIStrict,
+  assertLosslessOpenAIStrictZodSchemaConversion,
   hasJsonSchemaObjectShape,
   mergeJsonSchemaDescriptions,
 } from './zodJsonSchemaCompat';
 import type { ZodObjectLike } from './zodCompat';
 import { asZodType } from './zodCompat';
 import {
-  stripStrictNullsForJsonSchema,
+  prepareOpenAIStrictToolSchema,
   stripStrictNullsForZodSchema,
   toOpenAIStrictToolSchema,
 } from './strictToolSchema';
@@ -111,18 +113,29 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
 
   if (isZodObject(inputType)) {
     const useFallback = (originalError?: unknown) => {
-      const fallbackSchema = buildJsonSchemaFromZod(inputType);
+      const strictFallback = options.strict
+        ? zodJsonSchemaCompatForOpenAIStrict(inputType)
+        : undefined;
+      if (
+        strictFallback?.loweredObjectIntersection ||
+        strictFallback?.loweredPrimitiveIntersection
+      ) {
+        assertLosslessOpenAIStrictZodSchemaConversion(strictFallback);
+      }
+      const fallbackSchema = options.strict
+        ? strictFallback?.schema
+        : buildJsonSchemaFromZod(inputType);
       if (fallbackSchema) {
         return {
           schema: options.strict
             ? toOpenAIStrictToolSchema(fallbackSchema)
             : fallbackSchema,
           parser: (rawInput: string) =>
-            inputType.parse(
-              options.strict
-                ? stripStrictNullsForZodSchema(inputType, JSON.parse(rawInput))
-                : JSON.parse(rawInput),
-            ),
+            options.strict
+              ? inputType.parse(
+                  stripStrictNullsForZodSchema(inputType, JSON.parse(rawInput)),
+                )
+              : inputType.parse(JSON.parse(rawInput)),
         };
       }
 
@@ -149,18 +162,28 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
     }
 
     if (hasJsonSchemaObjectShape(formattedFunction.parameters)) {
-      const fallbackSchema = buildJsonSchemaFromZod(inputType);
+      const strictFallback = options.strict
+        ? zodJsonSchemaCompatForOpenAIStrict(inputType)
+        : undefined;
+      const fallbackSchema =
+        strictFallback?.schema ?? buildJsonSchemaFromZod(inputType);
       if (fallbackSchema) {
         mergeJsonSchemaDescriptions(
           formattedFunction.parameters as JsonObjectSchema<any>,
           fallbackSchema,
         );
       }
+      const upstreamSchema =
+        formattedFunction.parameters as JsonObjectSchema<any>;
+      const strictSchemaSource =
+        strictFallback?.loweredObjectIntersection ||
+        (strictFallback?.loweredPrimitiveIntersection &&
+          containsJsonSchemaAllOf(upstreamSchema))
+          ? useLosslessStrictFallback(strictFallback)
+          : upstreamSchema;
       return {
         schema: options.strict
-          ? toOpenAIStrictToolSchema(
-              formattedFunction.parameters as JsonObjectSchema<any>,
-            )
+          ? toOpenAIStrictToolSchema(strictSchemaSource)
           : (formattedFunction.parameters as JsonObjectSchema<any>),
         parser: options.strict
           ? (rawInput: string) =>
@@ -173,16 +196,104 @@ export function getSchemaAndParserFromInputType<T extends ToolInputParameters>(
 
     return useFallback();
   } else if (typeof inputType === 'object' && inputType !== null) {
+    const preparedSchema = options.strict
+      ? prepareOpenAIStrictToolSchema(inputType)
+      : undefined;
     return {
-      schema: options.strict ? toOpenAIStrictToolSchema(inputType) : inputType,
-      parser: options.strict
+      schema: preparedSchema?.schema ?? inputType,
+      parser: preparedSchema
         ? (rawInput: string) =>
-            stripStrictNullsForJsonSchema(inputType, JSON.parse(rawInput))
+            preparedSchema.normalizeInput(JSON.parse(rawInput))
         : parser,
     };
   }
 
   throw new UserError('Input type is not a ZodObject or a valid JSON schema');
+}
+
+function useLosslessStrictFallback(
+  conversion: NonNullable<
+    ReturnType<typeof zodJsonSchemaCompatForOpenAIStrict>
+  >,
+): JsonObjectSchema<any> {
+  assertLosslessOpenAIStrictZodSchemaConversion(conversion);
+  return conversion.schema;
+}
+
+function containsJsonSchemaAllOf(
+  value: unknown,
+  visited: WeakSet<object> = new WeakSet(),
+): boolean {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    visited.has(value)
+  ) {
+    return false;
+  }
+  visited.add(value);
+  const schema = value as Record<string, unknown>;
+  if (Array.isArray(schema.allOf)) {
+    return true;
+  }
+
+  for (const key of [
+    'additionalItems',
+    'additionalProperties',
+    'contains',
+    'contentSchema',
+    'else',
+    'if',
+    'items',
+    'not',
+    'propertyNames',
+    'then',
+    'unevaluatedItems',
+    'unevaluatedProperties',
+  ]) {
+    const nested = schema[key];
+    if (Array.isArray(nested)) {
+      if (nested.some((entry) => containsJsonSchemaAllOf(entry, visited))) {
+        return true;
+      }
+    } else if (containsJsonSchemaAllOf(nested, visited)) {
+      return true;
+    }
+  }
+
+  for (const key of ['anyOf', 'oneOf', 'prefixItems']) {
+    const nested = schema[key];
+    if (
+      Array.isArray(nested) &&
+      nested.some((entry) => containsJsonSchemaAllOf(entry, visited))
+    ) {
+      return true;
+    }
+  }
+
+  for (const key of [
+    '$defs',
+    'definitions',
+    'dependencies',
+    'dependentSchemas',
+    'patternProperties',
+    'properties',
+  ]) {
+    const nested = schema[key];
+    if (
+      typeof nested === 'object' &&
+      nested !== null &&
+      !Array.isArray(nested) &&
+      Object.values(nested).some((entry) =>
+        containsJsonSchemaAllOf(entry, visited),
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/packages/agents-core/src/utils/zodJsonSchemaCompat.ts
+++ b/packages/agents-core/src/utils/zodJsonSchemaCompat.ts
@@ -1,4 +1,5 @@
 import type { JsonObjectSchema, JsonSchemaDefinitionEntry } from '../types';
+import { UserError } from '../errors';
 import type { ZodObjectLike } from './zodCompat';
 import { readZodDefinition, readZodType } from './zodCompat';
 
@@ -33,6 +34,20 @@ type ShapeCandidate = {
   shape?: Record<string, unknown> | (() => Record<string, unknown>);
 };
 
+type ConversionContext = {
+  lowerObjectIntersections: boolean;
+  loweredObjectIntersection: boolean;
+  loweredPrimitiveIntersection: boolean;
+  losslessForWholeSchemaFallback: boolean;
+};
+
+export type OpenAIStrictZodSchemaConversion = {
+  schema: JsonObjectSchema<any>;
+  loweredObjectIntersection: boolean;
+  loweredPrimitiveIntersection: boolean;
+  losslessForWholeSchemaFallback: boolean;
+};
+
 const JSON_SCHEMA_DRAFT_07 = 'http://json-schema.org/draft-07/schema#';
 const OPTIONAL_WRAPPERS = new Set(['optional']);
 const DECORATOR_WRAPPERS = new Set([
@@ -47,6 +62,14 @@ const DECORATOR_WRAPPERS = new Set([
   'readonly',
   'refinement',
   'transform',
+]);
+const LOSSLESS_STRICT_FALLBACK_DECORATORS = new Set([
+  'brand',
+  'branded',
+  'catch',
+  'default',
+  'prefault',
+  'readonly',
 ]);
 
 // Primitive leaf nodes map 1:1 to JSON Schema types; everything else is handled
@@ -72,12 +95,48 @@ export function hasJsonSchemaObjectShape(
 export function zodJsonSchemaCompat(
   input: ZodObjectLike,
 ): JsonObjectSchema<any> | undefined {
+  return convertZodObjectSchema(input, {
+    lowerObjectIntersections: false,
+    loweredObjectIntersection: false,
+    loweredPrimitiveIntersection: false,
+    losslessForWholeSchemaFallback: true,
+  })?.schema;
+}
+
+export function zodJsonSchemaCompatForOpenAIStrict(
+  input: ZodObjectLike,
+): OpenAIStrictZodSchemaConversion | undefined {
+  return convertZodObjectSchema(input, {
+    lowerObjectIntersections: true,
+    loweredObjectIntersection: false,
+    loweredPrimitiveIntersection: false,
+    losslessForWholeSchemaFallback: true,
+  });
+}
+
+function convertZodObjectSchema(
+  input: ZodObjectLike,
+  context: ConversionContext,
+): OpenAIStrictZodSchemaConversion | undefined {
+  const rootDefinition = readZodDefinition(input);
+  if (
+    context.lowerObjectIntersections &&
+    !isLosslessStrictFallbackNode('object', rootDefinition)
+  ) {
+    context.losslessForWholeSchemaFallback = false;
+  }
   // Attempt to build an object schema from Zod's internal shape. If we cannot
   // understand the structure we return undefined, letting callers raise a
   // descriptive error instead of emitting an invalid schema.
-  const schema = buildObjectSchema(input);
+  const schema = buildObjectSchema(input, context);
   if (!schema) {
     return undefined;
+  }
+  if (
+    context.loweredObjectIntersection &&
+    !context.losslessForWholeSchemaFallback
+  ) {
+    throwLossyZodIntersectionFallback();
   }
 
   if (!Array.isArray(schema.required)) {
@@ -92,7 +151,28 @@ export function zodJsonSchemaCompat(
     schema.$schema = JSON_SCHEMA_DRAFT_07;
   }
 
-  return schema as JsonObjectSchema<Record<string, JsonSchemaDefinitionEntry>>;
+  return {
+    schema: schema as JsonObjectSchema<
+      Record<string, JsonSchemaDefinitionEntry>
+    >,
+    loweredObjectIntersection: context.loweredObjectIntersection,
+    loweredPrimitiveIntersection: context.loweredPrimitiveIntersection,
+    losslessForWholeSchemaFallback: context.losslessForWholeSchemaFallback,
+  };
+}
+
+export function assertLosslessOpenAIStrictZodSchemaConversion(
+  conversion: OpenAIStrictZodSchemaConversion,
+): void {
+  if (!conversion.losslessForWholeSchemaFallback) {
+    throwLossyZodIntersectionFallback();
+  }
+}
+
+function throwLossyZodIntersectionFallback(): never {
+  throw new UserError(
+    'Cannot convert this Zod schema with an intersection to OpenAI strict mode without losing constraints. Use unconstrained compatible intersections, combine the fields into one Zod object, or disable strict mode.',
+  );
 }
 
 export function mergeJsonSchemaDescriptions(
@@ -182,7 +262,10 @@ export function mergeJsonSchemaDescriptions(
   }
 }
 
-function buildObjectSchema(value: unknown): LooseJsonObjectSchema | undefined {
+function buildObjectSchema(
+  value: unknown,
+  context: ConversionContext,
+): LooseJsonObjectSchema | undefined {
   const shape = readShape(value);
   if (!shape) {
     return undefined;
@@ -192,7 +275,7 @@ function buildObjectSchema(value: unknown): LooseJsonObjectSchema | undefined {
   const required: string[] = [];
 
   for (const [key, field] of Object.entries(shape)) {
-    const { schema, optional } = convertProperty(field);
+    const { schema, optional } = convertProperty(field, context);
     if (!schema) {
       return undefined;
     }
@@ -225,10 +308,19 @@ function buildObjectSchema(value: unknown): LooseJsonObjectSchema | undefined {
   return schema;
 }
 
-function convertProperty(value: unknown): {
+function convertProperty(
+  value: unknown,
+  context: ConversionContext,
+): {
   schema?: JsonSchemaDefinitionEntry;
   optional: boolean;
 } {
+  if (
+    context.lowerObjectIntersections &&
+    hasUnsupportedStrictFallbackDecorator(value)
+  ) {
+    context.losslessForWholeSchemaFallback = false;
+  }
   // Remove wrapper decorators (brand, transform, etc.) before attempting to
   // classify the node, tracking whether we crossed an `optional` boundary so we
   // can populate the `required` array later.
@@ -245,12 +337,22 @@ function convertProperty(value: unknown): {
     current = next;
   }
 
-  return { schema: convertSchema(current), optional };
+  return { schema: convertSchema(current, context), optional };
 }
 
-function convertSchema(value: unknown): JsonSchemaDefinitionEntry | undefined {
+function convertSchema(
+  value: unknown,
+  context: ConversionContext,
+): JsonSchemaDefinitionEntry | undefined {
   if (value === undefined) {
     return undefined;
+  }
+
+  if (
+    context.lowerObjectIntersections &&
+    hasUnsupportedStrictFallbackDecorator(value)
+  ) {
+    context.losslessForWholeSchemaFallback = false;
   }
 
   const unwrapped = unwrapDecorators(value);
@@ -260,50 +362,77 @@ function convertSchema(value: unknown): JsonSchemaDefinitionEntry | undefined {
   if (!type) {
     return undefined;
   }
+  if (
+    context.lowerObjectIntersections &&
+    !isLosslessStrictFallbackNode(type, def)
+  ) {
+    context.losslessForWholeSchemaFallback = false;
+  }
 
+  let schema: JsonSchemaDefinitionEntry | undefined;
   if (type in SIMPLE_TYPE_MAPPING) {
-    return { ...SIMPLE_TYPE_MAPPING[type] };
+    schema = { ...SIMPLE_TYPE_MAPPING[type] };
+  } else {
+    switch (type) {
+      case 'object':
+        schema = buildObjectSchema(unwrapped, context);
+        break;
+      case 'array':
+        schema = buildArraySchema(def, context);
+        break;
+      case 'tuple':
+        schema = buildTupleSchema(def, context);
+        break;
+      case 'union':
+      case 'discriminatedunion':
+        schema = buildUnionSchema(def, context);
+        break;
+      case 'intersection':
+        schema = buildIntersectionSchema(def, context);
+        break;
+      case 'literal':
+        schema = buildLiteral(def);
+        break;
+      case 'enum':
+      case 'nativeenum':
+        schema = buildEnum(def);
+        break;
+      case 'record':
+        schema = buildRecordSchema(def, context);
+        break;
+      case 'nullable':
+        schema = buildNullableSchema(def, context);
+        break;
+      default:
+        return undefined;
+    }
   }
 
-  switch (type) {
-    case 'object':
-      return buildObjectSchema(unwrapped);
-    case 'array':
-      return buildArraySchema(def);
-    case 'tuple':
-      return buildTupleSchema(def);
-    case 'union':
-    case 'discriminatedunion':
-      return buildUnionSchema(def);
-    case 'intersection':
-      return buildIntersectionSchema(def);
-    case 'literal':
-      return buildLiteral(def);
-    case 'enum':
-    case 'nativeenum':
-      return buildEnum(def);
-    case 'record':
-      return buildRecordSchema(def);
-    case 'nullable':
-      return buildNullableSchema(def);
-    default:
-      return undefined;
+  const description = readZodDescription(value);
+  if (schema && description) {
+    schema.description = description;
   }
+  return schema;
 }
 
 // --- JSON Schema builders -------------------------------------------------
 
 function buildArraySchema(
   def: Record<string, unknown> | undefined,
+  context: ConversionContext,
 ): JsonSchemaDefinitionEntry | undefined {
-  const items = convertSchema(extractFirst(def, 'element', 'items', 'type'));
+  const items = convertSchema(
+    extractFirst(def, 'element', 'items', 'type'),
+    context,
+  );
   return items ? { type: 'array', items } : undefined;
 }
 
 function buildTupleSchema(
   def: Record<string, unknown> | undefined,
+  context: ConversionContext,
 ): JsonSchemaDefinitionEntry | undefined {
-  const items = convertAllOrFail(coerceArray(def?.items));
+  const items = convertAllOrFail(coerceArray(def?.items), context);
   if (!items || !items.length) {
     return undefined;
   }
@@ -320,8 +449,12 @@ function buildTupleSchema(
 
 function buildUnionSchema(
   def: Record<string, unknown> | undefined,
+  context: ConversionContext,
 ): JsonSchemaDefinitionEntry | undefined {
-  const options = convertAllOrFail(coerceArray(def?.options ?? def?.schemas));
+  const options = convertAllOrFail(
+    coerceArray(def?.options ?? def?.schemas),
+    context,
+  );
   return options && options.length ? { anyOf: options } : undefined;
 }
 
@@ -335,10 +468,11 @@ function buildUnionSchema(
  */
 function convertAllOrFail(
   members: unknown[],
+  context: ConversionContext,
 ): JsonSchemaDefinitionEntry[] | undefined {
   const converted: JsonSchemaDefinitionEntry[] = [];
   for (const member of members) {
-    const schema = convertSchema(member);
+    const schema = convertSchema(member, context);
     if (!schema) {
       return undefined;
     }
@@ -349,16 +483,47 @@ function convertAllOrFail(
 
 function buildIntersectionSchema(
   def: Record<string, unknown> | undefined,
+  context: ConversionContext,
 ): JsonSchemaDefinitionEntry | undefined {
-  const left = convertSchema(def?.left);
-  const right = convertSchema(def?.right);
-  return left && right ? { allOf: [left, right] } : undefined;
+  const leftSource = def?.left;
+  const rightSource = def?.right;
+  const left = convertSchema(leftSource, context);
+  const right = convertSchema(rightSource, context);
+  if (!left || !right) {
+    return undefined;
+  }
+  if (!context.lowerObjectIntersections) {
+    return { allOf: [left, right] };
+  }
+
+  // OpenAI Structured Outputs does not support `allOf`. The strict tool path
+  // therefore lowers only closed object intersections that can be represented
+  // without changing what the authoritative Zod parser forwards to the tool.
+  if (
+    !isClosedZodObjectIntersectionOperand(leftSource) ||
+    !isClosedZodObjectIntersectionOperand(rightSource)
+  ) {
+    const mergedPrimitive = mergePrimitiveIntersectionSchemas(left, right);
+    if (mergedPrimitive) {
+      context.loweredPrimitiveIntersection = true;
+      return mergedPrimitive;
+    }
+    context.losslessForWholeSchemaFallback = false;
+    return { allOf: [left, right] };
+  }
+  const merged = mergeObjectIntersectionSchemas(left, right);
+  if (!merged) {
+    throwUnsupportedZodIntersection();
+  }
+  context.loweredObjectIntersection = true;
+  return merged;
 }
 
 function buildRecordSchema(
   def: Record<string, unknown> | undefined,
+  context: ConversionContext,
 ): JsonSchemaDefinitionEntry | undefined {
-  const valueSchema = convertSchema(def?.valueType ?? def?.values);
+  const valueSchema = convertSchema(def?.valueType ?? def?.values, context);
   return valueSchema
     ? { type: 'object', additionalProperties: valueSchema }
     : undefined;
@@ -366,9 +531,201 @@ function buildRecordSchema(
 
 function buildNullableSchema(
   def: Record<string, unknown> | undefined,
+  context: ConversionContext,
 ): JsonSchemaDefinitionEntry | undefined {
-  const inner = convertSchema(def?.innerType ?? def?.type);
+  const inner = convertSchema(def?.innerType ?? def?.type, context);
   return inner ? { anyOf: [inner, { type: 'null' }] } : undefined;
+}
+
+function isClosedZodObjectIntersectionOperand(value: unknown): boolean {
+  const unwrapped = unwrapDecorators(value);
+  const type = readZodType(unwrapped);
+  if (type === 'intersection') {
+    return true;
+  }
+  if (type !== 'object') {
+    return false;
+  }
+
+  const def = readZodDefinition(unwrapped);
+  const catchall = def?.catchall;
+  // Zod v3 strict object intersections reject the other branch's distinct
+  // properties during parsing, so flattening them would widen the provider
+  // schema beyond what the authoritative parser accepts.
+  if (
+    !def ||
+    def.unknownKeys === 'strict' ||
+    def.unknownKeys === 'passthrough' ||
+    (typeof catchall !== 'undefined' && readZodType(catchall) !== 'never')
+  ) {
+    throwUnsupportedZodIntersection();
+  }
+  return true;
+}
+
+function mergeObjectIntersectionSchemas(
+  left: JsonSchemaDefinitionEntry,
+  right: JsonSchemaDefinitionEntry,
+): JsonSchemaDefinitionEntry | undefined {
+  if (!isClosedJsonObjectSchema(left) || !isClosedJsonObjectSchema(right)) {
+    return undefined;
+  }
+
+  const properties = { ...left.properties };
+  for (const [key, value] of Object.entries(right.properties)) {
+    if (Object.prototype.hasOwnProperty.call(properties, key)) {
+      return undefined;
+    }
+    properties[key] = value;
+  }
+
+  const required = new Set<string>();
+  for (const schema of [left, right]) {
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        required.add(String(key));
+      }
+    }
+  }
+  const descriptions = [left.description, right.description].filter(
+    (description): description is string => typeof description === 'string',
+  );
+  return {
+    type: 'object',
+    properties,
+    required: [...required],
+    additionalProperties: false,
+    ...(descriptions.length > 0
+      ? { description: descriptions.join('\n\n') }
+      : {}),
+  };
+}
+
+function mergePrimitiveIntersectionSchemas(
+  left: JsonSchemaDefinitionEntry,
+  right: JsonSchemaDefinitionEntry,
+): JsonSchemaDefinitionEntry | undefined {
+  if (
+    typeof left !== 'object' ||
+    left === null ||
+    typeof right !== 'object' ||
+    right === null ||
+    typeof left.type !== 'string' ||
+    left.type !== right.type ||
+    !['string', 'number', 'boolean'].includes(left.type) ||
+    Object.keys(left).some((key) => !['type', 'description'].includes(key)) ||
+    Object.keys(right).some((key) => !['type', 'description'].includes(key))
+  ) {
+    return undefined;
+  }
+
+  const descriptions = [left.description, right.description].filter(
+    (description): description is string => typeof description === 'string',
+  );
+  return {
+    type: left.type,
+    ...(descriptions.length > 0
+      ? { description: descriptions.join('\n\n') }
+      : {}),
+  };
+}
+
+function isClosedJsonObjectSchema(
+  value: JsonSchemaDefinitionEntry,
+): value is JsonSchemaDefinitionEntry & {
+  type: 'object';
+  properties: Record<string, JsonSchemaDefinitionEntry>;
+  required?: unknown[];
+  additionalProperties: false;
+  description?: string;
+} {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    value.type === 'object' &&
+    typeof value.properties === 'object' &&
+    value.properties !== null &&
+    value.additionalProperties === false
+  );
+}
+
+function throwUnsupportedZodIntersection(): never {
+  throw new UserError(
+    'Cannot convert this Zod intersection to an OpenAI strict schema. Use compatible Zod object intersections with distinct properties and closed object branches, combine the fields into one Zod object, or disable strict mode.',
+  );
+}
+
+function hasUnsupportedStrictFallbackDecorator(value: unknown): boolean {
+  let current = value;
+  while (true) {
+    const type = readZodType(current);
+    if (!type) {
+      return false;
+    }
+    if (OPTIONAL_WRAPPERS.has(type)) {
+      const inner = readZodDefinition(current)?.innerType;
+      if (!inner || inner === current) {
+        return false;
+      }
+      current = inner;
+      continue;
+    }
+    if (!DECORATOR_WRAPPERS.has(type)) {
+      return false;
+    }
+    if (!LOSSLESS_STRICT_FALLBACK_DECORATORS.has(type)) {
+      return true;
+    }
+    const def = readZodDefinition(current);
+    const next =
+      def?.innerType ??
+      def?.schema ??
+      def?.base ??
+      def?.type ??
+      def?.wrapped ??
+      def?.underlying;
+    if (!next || next === current) {
+      return true;
+    }
+    current = next;
+  }
+}
+
+function isLosslessStrictFallbackNode(
+  type: string,
+  def: Record<string, unknown> | undefined,
+): boolean {
+  if (!def) {
+    return false;
+  }
+  if (Array.isArray(def.checks) && def.checks.length > 0) {
+    return false;
+  }
+  if (typeof def.check === 'string') {
+    return false;
+  }
+  if (
+    type === 'array' &&
+    [def.minLength, def.maxLength, def.exactLength].some(
+      (constraint) => constraint !== null && constraint !== undefined,
+    )
+  ) {
+    return false;
+  }
+  if (type === 'tuple' && typeof def.rest !== 'undefined') {
+    return false;
+  }
+  if (type === 'record') {
+    return false;
+  }
+  if (type === 'object') {
+    const catchall = def.catchall;
+    return (
+      def.unknownKeys !== 'passthrough' &&
+      (typeof catchall === 'undefined' || readZodType(catchall) === 'never')
+    );
+  }
+  return true;
 }
 
 function unwrapDecorators(value: unknown): unknown {

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../src/tool';
 import type { ShellTool } from '../src/tool';
 import { z } from 'zod';
+import { z as zod3 } from 'zod/v3';
 import { Computer } from '../src';
 import { Agent } from '../src/agent';
 import { RunContext } from '../src/runContext';
@@ -45,6 +46,669 @@ describe('Tool', () => {
     });
     expect(Object.keys(t.parameters.properties).length).toEqual(1);
     expect(t.parameters.required.length).toEqual(1);
+  });
+
+  it('supports strict Zod object intersections', async () => {
+    const execute = vi.fn(() => 'ok');
+    const t = tool({
+      name: 'zod_intersection',
+      description: 'Use a strict Zod object intersection.',
+      parameters: z.object({
+        combined: z.intersection(
+          z.object({ optional: z.string().optional() }),
+          z.object({ required: z.number() }),
+        ),
+      }),
+      execute,
+    });
+
+    expect(serializeTool(t)).toMatchObject({
+      strict: true,
+      parameters: {
+        properties: {
+          combined: {
+            type: 'object',
+            properties: {
+              optional: {
+                anyOf: [{ type: 'string' }, { type: 'null' }],
+              },
+              required: { type: 'number' },
+            },
+            required: ['optional', 'required'],
+            additionalProperties: false,
+          },
+        },
+      },
+    });
+
+    await t.invoke(
+      new RunContext(),
+      JSON.stringify({ combined: { optional: null, required: 1 } }),
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      { combined: { required: 1 } },
+      expect.any(RunContext),
+      undefined,
+    );
+  });
+
+  it('supports strict Zod v3 object intersections', async () => {
+    const execute = vi.fn(() => 'ok');
+    const parameters = zod3.object({
+      combined: zod3.intersection(
+        zod3.object({ optional: zod3.string().optional() }),
+        zod3.object({ required: zod3.number() }),
+      ),
+    });
+    const t = tool({
+      name: 'zod_v3_intersection',
+      description: 'Use a strict Zod v3 object intersection.',
+      parameters: parameters as any,
+      execute,
+    });
+
+    await t.invoke(
+      new RunContext(),
+      JSON.stringify({ combined: { optional: null, required: 1 } }),
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      { combined: { required: 1 } },
+      expect.any(RunContext),
+      undefined,
+    );
+  });
+
+  it('rejects strict Zod v3 strict-object intersections', () => {
+    expect(() =>
+      tool({
+        name: 'strict_zod_v3_intersection',
+        description: 'Reject an incompatible strict Zod v3 intersection.',
+        parameters: zod3.object({
+          combined: zod3.intersection(
+            zod3.object({ left: zod3.string() }).strict(),
+            zod3.object({ right: zod3.number() }).strict(),
+          ),
+        }) as any,
+        execute: async () => 'ok',
+      }),
+    ).toThrow('closed object branches');
+  });
+
+  it.each([
+    [
+      'map-valued patternProperties',
+      {
+        type: 'object',
+        patternProperties: { '^value$': { type: 'string' } },
+        additionalProperties: false,
+      },
+    ],
+    [
+      'singleton contains',
+      {
+        type: 'array',
+        items: { type: 'string' },
+        contains: { type: 'string' },
+      },
+    ],
+    [
+      'array-valued prefixItems',
+      {
+        type: 'array',
+        prefixItems: [{ type: 'string' }],
+      },
+    ],
+  ])('rejects unsupported strict JSON Schema %s', (_, valueSchema) => {
+    expect(() =>
+      tool({
+        name: 'unsupported_strict_schema_container',
+        description: 'Reject an unsupported strict schema container.',
+        parameters: {
+          type: 'object',
+          properties: { value: valueSchema },
+          required: ['value'],
+          additionalProperties: false,
+        } as any,
+        execute: async () => 'ok',
+      }),
+    ).toThrow('unsupported keyword');
+  });
+
+  it.each([
+    [
+      'property schema',
+      {
+        type: 'object',
+        properties: { value: 1 },
+        required: ['value'],
+        additionalProperties: false,
+      },
+    ],
+    [
+      'anyOf branch',
+      {
+        type: 'object',
+        properties: { value: { anyOf: [{ type: 'string' }, 1] } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+    ],
+    [
+      'additionalProperties schema',
+      {
+        type: 'object',
+        properties: { value: { type: 'string', additionalProperties: 1 } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+    ],
+    [
+      '$ref target',
+      {
+        type: 'object',
+        properties: { value: { $ref: '#/required' } },
+        required: ['value'],
+        additionalProperties: false,
+      },
+    ],
+  ])('rejects an invalid strict JSON Schema %s', (_, parameters) => {
+    expect(() =>
+      tool({
+        name: 'invalid_strict_schema_node',
+        description: 'Reject an invalid strict schema node.',
+        parameters: parameters as any,
+        execute: async () => 'ok',
+      }),
+    ).toThrow('non-boolean, non-object schema node');
+  });
+
+  it('preserves upstream support for strict typed Zod intersections', () => {
+    const t = tool({
+      name: 'typed_zod_intersection',
+      description: 'Use a strict typed Zod intersection.',
+      parameters: z.object({
+        value: z.intersection(z.string(), z.string()),
+      }),
+      execute: async () => 'ok',
+    });
+
+    expect((serializeTool(t) as any).parameters.properties.value).toMatchObject(
+      { type: 'string' },
+    );
+  });
+
+  it('supports strict Zod v3 typed intersections without allOf', () => {
+    const t = tool({
+      name: 'typed_zod_v3_intersection',
+      description: 'Use a strict typed Zod v3 intersection.',
+      parameters: zod3.object({
+        value: zod3.intersection(zod3.string(), zod3.string()),
+      }) as any,
+      execute: async () => 'ok',
+    });
+
+    expect((serializeTool(t) as any).parameters.properties.value).toEqual({
+      type: 'string',
+    });
+  });
+
+  it('preserves upstream Zod v4 constraints beside typed intersections', () => {
+    const t = tool({
+      name: 'constrained_typed_zod_v4_intersection',
+      description: 'Preserve upstream strict Zod v4 constraints.',
+      parameters: z.object({
+        value: z.intersection(z.string(), z.string()),
+        constrained: z.string().min(3),
+      }),
+      execute: async () => 'ok',
+    });
+
+    expect(
+      (serializeTool(t) as any).parameters.properties.constrained,
+    ).toMatchObject({ type: 'string', minLength: 3 });
+  });
+
+  it('does not treat a property named allOf as an applicator', () => {
+    const t = tool({
+      name: 'all_of_property',
+      description: 'Keep a regular property named allOf.',
+      parameters: z.object({
+        value: z.intersection(z.string(), z.string()),
+        allOf: z.string().min(3),
+      }),
+      execute: async () => 'ok',
+    });
+
+    expect((serializeTool(t) as any).parameters.properties).toMatchObject({
+      value: { type: 'string' },
+      allOf: { type: 'string', minLength: 3 },
+    });
+  });
+
+  it('does not inspect default values for allOf applicators', () => {
+    const t = tool({
+      name: 'all_of_default_value',
+      description: 'Keep allOf instance data in a default value.',
+      parameters: z.object({
+        value: z.intersection(z.string(), z.string()),
+        config: z
+          .object({ allOf: z.array(z.string()).min(1) })
+          .default({ allOf: ['x'] }),
+      }),
+      execute: async () => 'ok',
+    });
+
+    expect(
+      (serializeTool(t) as any).parameters.properties.config,
+    ).toMatchObject({
+      default: { allOf: ['x'] },
+      properties: {
+        allOf: { type: 'array', minItems: 1 },
+      },
+    });
+  });
+
+  it('preserves constrained strict Zod fallbacks without intersections', () => {
+    const t = tool({
+      name: 'constrained_zod_fallback',
+      description: 'Preserve an existing constrained strict Zod fallback.',
+      parameters: z.object({
+        command: z.string().min(1),
+        retries: z.number().int().min(0).default(0),
+      }),
+      execute: async () => 'ok',
+    });
+
+    expect(serializeTool(t)).toMatchObject({
+      parameters: {
+        properties: {
+          command: { type: 'string' },
+          retries: { type: 'integer' },
+        },
+      },
+    });
+  });
+
+  it('runs Zod callbacks once while stripping a synthetic null', async () => {
+    let transforms = 0;
+    let refinements = 0;
+    let defaults = 0;
+    const execute = vi.fn(() => 'ok');
+    const t = tool({
+      name: 'effectful_zod_fields',
+      description: 'Normalize without repeating Zod callbacks.',
+      parameters: zod3.object({
+        optional: zod3.string().optional(),
+        transformed: zod3.string().transform((value) => {
+          transforms += 1;
+          return value.toUpperCase();
+        }),
+        refined: zod3.string().superRefine(() => {
+          refinements += 1;
+        }),
+        defaulted: zod3.string().default(() => {
+          defaults += 1;
+          return 'default';
+        }),
+      }) as any,
+      execute,
+    });
+
+    await t.invoke(
+      new RunContext(),
+      JSON.stringify({ optional: null, transformed: 'x', refined: 'y' }),
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      { transformed: 'X', refined: 'y', defaulted: 'default' },
+      expect.any(RunContext),
+      undefined,
+    );
+    expect(transforms).toBe(1);
+    expect(refinements).toBe(1);
+    expect(defaults).toBe(1);
+  });
+
+  it.each([
+    [
+      'Zod v4',
+      z.object({
+        combined: z.intersection(
+          z.object({ left: z.string() }),
+          z.object({ right: z.number() }),
+        ),
+        constrained: z.string().min(3),
+      }),
+    ],
+    [
+      'Zod v3',
+      zod3.object({
+        combined: zod3.intersection(
+          zod3.object({ left: zod3.string() }),
+          zod3.object({ right: zod3.number() }),
+        ),
+        constrained: zod3.string().min(3),
+      }),
+    ],
+    [
+      'direct Zod v4 format',
+      z.object({
+        combined: z.intersection(
+          z.object({ left: z.string() }),
+          z.object({ right: z.number() }),
+        ),
+        constrained: z.email(),
+      }),
+    ],
+  ])(
+    'rejects lossy whole-schema %s intersection fallbacks',
+    (_, parameters) => {
+      expect(() =>
+        tool({
+          name: 'constrained_zod_intersection',
+          description: 'Reject a lossy strict Zod intersection fallback.',
+          parameters: parameters as any,
+          execute: async () => 'ok',
+        }),
+      ).toThrow('without losing constraints');
+    },
+  );
+
+  it('supports compatible typed and object intersections together', () => {
+    const t = tool({
+      name: 'mixed_zod_intersections',
+      description: 'Use compatible strict Zod intersections.',
+      parameters: z.object({
+        objectValue: z.intersection(
+          z.object({ left: z.string() }),
+          z.object({ right: z.number() }),
+        ),
+        typedValue: z.intersection(z.string(), z.string()),
+      }),
+      execute: async () => 'ok',
+    });
+
+    expect(serializeTool(t)).toMatchObject({
+      parameters: {
+        properties: {
+          objectValue: {
+            type: 'object',
+            properties: {
+              left: { type: 'string' },
+              right: { type: 'number' },
+            },
+          },
+          typedValue: { type: 'string' },
+        },
+      },
+    });
+  });
+
+  it.each([
+    [
+      'Zod v4 root passthrough',
+      z
+        .object({
+          combined: z.intersection(
+            z.object({ left: z.string() }),
+            z.object({ right: z.number() }),
+          ),
+        })
+        .passthrough(),
+    ],
+    [
+      'Zod v4 root refinement',
+      z
+        .object({
+          combined: z.intersection(
+            z.object({ left: z.string() }),
+            z.object({ right: z.number() }),
+          ),
+        })
+        .refine(() => false),
+    ],
+    [
+      'Zod v3 root catchall',
+      zod3
+        .object({
+          combined: zod3.intersection(
+            zod3.object({ left: zod3.string() }),
+            zod3.object({ right: zod3.number() }),
+          ),
+        })
+        .catchall(zod3.string()),
+    ],
+  ])('rejects lossy %s whole-schema fallbacks', (_, parameters) => {
+    expect(() =>
+      tool({
+        name: 'lossy_root_zod_intersection',
+        description: 'Reject a lossy root strict Zod intersection fallback.',
+        parameters: parameters as any,
+        execute: async () => 'ok',
+      }),
+    ).toThrow('without losing constraints');
+  });
+
+  it('supports nested strict Zod v4 object intersections', async () => {
+    const execute = vi.fn(() => 'ok');
+    const nestedIntersection = z.intersection(
+      z.object({ optional: z.string().optional() }),
+      z.object({ required: z.number() }),
+    );
+    const t = tool({
+      name: 'nested_zod_intersection',
+      description: 'Use nested strict Zod object intersections.',
+      parameters: z.object({
+        nested: z.object({ combined: nestedIntersection }),
+        list: z.array(nestedIntersection),
+      }),
+      execute,
+    });
+
+    expect(serializeTool(t)).toMatchObject({
+      parameters: {
+        properties: {
+          nested: {
+            properties: {
+              combined: {
+                properties: {
+                  optional: {
+                    anyOf: [{ type: 'string' }, { type: 'null' }],
+                  },
+                  required: { type: 'number' },
+                },
+              },
+            },
+          },
+          list: {
+            items: {
+              properties: {
+                optional: {
+                  anyOf: [{ type: 'string' }, { type: 'null' }],
+                },
+                required: { type: 'number' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await t.invoke(
+      new RunContext(),
+      JSON.stringify({
+        nested: { combined: { optional: null, required: 1 } },
+        list: [{ optional: null, required: 2 }],
+      }),
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      {
+        nested: { combined: { required: 1 } },
+        list: [{ required: 2 }],
+      },
+      expect.any(RunContext),
+      undefined,
+    );
+  });
+
+  it('preserves strict Zod intersection branch descriptions', () => {
+    const t = tool({
+      name: 'described_zod_intersection',
+      description: 'Preserve Zod intersection descriptions.',
+      parameters: z.object({
+        combined: z.intersection(
+          z.object({ left: z.string() }).describe('Left-side semantics.'),
+          z.object({ right: z.number() }).describe('Right-side semantics.'),
+        ),
+      }),
+      execute: async () => 'ok',
+    });
+
+    expect(
+      ((serializeTool(t) as any).parameters.properties.combined as any)
+        .description,
+    ).toBe('Left-side semantics.\n\nRight-side semantics.');
+  });
+
+  it.each([
+    [
+      'Zod v4',
+      z.object({
+        list: z.array(
+          z
+            .intersection(
+              z.object({ left: z.string() }).describe('Left.'),
+              z.object({ right: z.string() }).describe('Right.'),
+            )
+            .describe('Wrapper.'),
+        ),
+      }),
+    ],
+    [
+      'Zod v3',
+      zod3.object({
+        list: zod3.array(
+          zod3
+            .intersection(
+              zod3.object({ left: zod3.string() }).describe('Left.'),
+              zod3.object({ right: zod3.string() }).describe('Right.'),
+            )
+            .describe('Wrapper.'),
+        ),
+      }),
+    ],
+  ])(
+    'preserves nested %s intersection wrapper descriptions',
+    (_, parameters) => {
+      const t = tool({
+        name: 'nested_described_zod_intersection',
+        description: 'Preserve a nested Zod intersection description.',
+        parameters: parameters as any,
+        execute: async () => 'ok',
+      });
+
+      expect(
+        ((serializeTool(t) as any).parameters.properties.list.items as any)
+          .description,
+      ).toBe('Wrapper.');
+    },
+  );
+
+  it('rejects incompatible strict Zod intersections', () => {
+    expect(() =>
+      tool({
+        name: 'incompatible_zod_intersection',
+        description: 'Reject an incompatible strict Zod intersection.',
+        parameters: z.object({
+          value: z.intersection(
+            z.object({ shared: z.string() }),
+            z.object({ shared: z.number() }),
+          ),
+        }),
+        execute: async () => 'ok',
+      }),
+    ).toThrow('compatible Zod object intersections with distinct properties');
+  });
+
+  it.each([
+    [
+      'Zod v4 passthrough',
+      z.object({
+        value: z.intersection(
+          z.object({ left: z.string() }).passthrough(),
+          z.object({ right: z.string() }),
+        ),
+      }),
+    ],
+    [
+      'Zod v4 catchall',
+      z.object({
+        value: z.intersection(
+          z.object({ left: z.string() }).catchall(z.string()),
+          z.object({ right: z.string() }),
+        ),
+      }),
+    ],
+    [
+      'Zod v3 passthrough',
+      zod3.object({
+        value: zod3.intersection(
+          zod3.object({ left: zod3.string() }).passthrough(),
+          zod3.object({ right: zod3.string() }),
+        ),
+      }),
+    ],
+    [
+      'Zod v3 catchall',
+      zod3.object({
+        value: zod3.intersection(
+          zod3.object({ left: zod3.string() }).catchall(zod3.string()),
+          zod3.object({ right: zod3.string() }),
+        ),
+      }),
+    ],
+    [
+      'decorated Zod v4 passthrough',
+      z.object({
+        value: z.intersection(
+          z.object({ left: z.string() }).passthrough().readonly(),
+          z.object({ right: z.string() }),
+        ),
+      }),
+    ],
+    [
+      'decorated Zod v4 catchall',
+      z.object({
+        value: z.intersection(
+          z
+            .object({ left: z.string() })
+            .catchall(z.string())
+            .default({ left: 'default' }),
+          z.object({ right: z.string() }),
+        ),
+      }),
+    ],
+    [
+      'decorated Zod v3 passthrough',
+      zod3.object({
+        value: zod3.intersection(
+          zod3.object({ left: zod3.string() }).passthrough().readonly(),
+          zod3.object({ right: zod3.string() }),
+        ),
+      }),
+    ],
+  ])('rejects strict intersections with an open %s branch', (_, parameters) => {
+    expect(() =>
+      tool({
+        name: 'open_zod_intersection',
+        description: 'Reject an open strict Zod intersection.',
+        parameters: parameters as any,
+        execute: async () => 'ok',
+      }),
+    ).toThrow('closed object branches');
   });
 
   it('normalizes typeless nested objects in strict JSON schemas', () => {
@@ -140,6 +804,36 @@ describe('Tool', () => {
       strict: false,
       parameters,
     });
+  });
+
+  it('rejects unsupported schemas only for strict tools', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        value: { not: { type: 'null' } },
+      },
+      required: [],
+      additionalProperties: false,
+    } as any;
+
+    expect(() =>
+      tool({
+        name: 'strict_unsupported_schema',
+        description: 'Reject an unsupported strict schema.',
+        parameters,
+        execute: async () => 'ok',
+      }),
+    ).toThrow('unsupported keyword `not`');
+
+    expect(
+      tool({
+        name: 'non_strict_unsupported_schema',
+        description: 'Allow an unsupported non-strict schema.',
+        parameters,
+        strict: false,
+        execute: async () => 'ok',
+      }).strict,
+    ).toBe(false);
   });
 
   it('records deferLoading when requested', () => {
@@ -1125,6 +1819,63 @@ describe('tool.invoke', () => {
     });
     const res = await t.invoke(new RunContext(), '{"msg": "there"}');
     expect(res).toBe('hi there');
+  });
+
+  it('normalizes strict input through local JSON Schema references', async () => {
+    const execute = vi.fn(() => 'ok');
+    const t = tool({
+      name: 'local_ref',
+      description: 'Uses a local JSON Schema reference.',
+      parameters: {
+        type: 'object',
+        properties: {
+          payload: { $ref: '#/$defs/payload' },
+          requiredAlias: { $ref: '#/$defs/payload/properties/note' },
+          optionalAlias: { $ref: '#/$defs/payload/properties/note' },
+        },
+        required: ['payload', 'requiredAlias'],
+        $defs: {
+          payload: {
+            type: 'object',
+            properties: {
+              note: { type: 'string' },
+              enumValue: { enum: ['value'] },
+              typedEnumValue: { type: 'string', enum: ['value'] },
+              constValue: { $ref: '#/$defs/constValue' },
+              explicitNull: { $ref: '#/$defs/maybeValue' },
+            },
+            required: [],
+          },
+          constValue: { const: 'value' },
+          maybeValue: {
+            anyOf: [{ type: 'string' }, { $ref: '#/$defs/nullValue' }],
+          },
+          nullValue: { type: 'null' },
+        },
+      } as any,
+      execute,
+    });
+
+    await t.invoke(
+      new RunContext(),
+      JSON.stringify({
+        payload: {
+          note: null,
+          enumValue: null,
+          typedEnumValue: null,
+          constValue: null,
+          explicitNull: null,
+        },
+        requiredAlias: null,
+        optionalAlias: null,
+      }),
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      { payload: { explicitNull: null }, requiredAlias: null },
+      expect.any(RunContext),
+      undefined,
+    );
   });
 
   it('uses errorFunction on parse error', async () => {

--- a/packages/agents-core/test/utils/strictToolSchema.test.ts
+++ b/packages/agents-core/test/utils/strictToolSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
 import {
+  prepareOpenAIStrictToolSchema,
   stripStrictNullsForJsonSchema,
   stripStrictNullsForZodSchema,
   toOpenAIStrictToolSchema,
@@ -233,6 +234,42 @@ describe('utils/strictToolSchema', () => {
     expect(input.properties.nested.required).toEqual([]);
   });
 
+  it('preserves optionality for inferred closed objects', () => {
+    const input = {
+      type: 'object',
+      properties: {
+        nested: {
+          properties: {
+            value: { type: 'string' },
+          },
+          required: [],
+          additionalProperties: false,
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    };
+
+    const prepared = prepareOpenAIStrictToolSchema(input as any);
+
+    expect(prepared.schema.properties.nested).toEqual({
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            value: {
+              anyOf: [{ type: 'string' }, { type: 'null' }],
+            },
+          },
+          required: ['value'],
+          additionalProperties: false,
+        },
+        { type: 'null' },
+      ],
+    });
+    expect(prepared.normalizeInput({ nested: null })).toEqual({});
+  });
+
   it('rejects typeless open object schemas instead of narrowing them', () => {
     const input = {
       type: 'object',
@@ -259,7 +296,7 @@ describe('utils/strictToolSchema', () => {
         required: { type: 'string' },
         optional: { type: 'number' },
         nullableOptional: {
-          oneOf: [{ type: 'string' }, { type: 'null' }],
+          anyOf: [{ type: 'string' }, { type: 'null' }],
         },
         tuple: {
           type: 'array',
@@ -275,8 +312,15 @@ describe('utils/strictToolSchema', () => {
             required: [],
           },
         },
+        nullableObject: {
+          type: ['object', 'null'],
+          properties: {
+            optionalChild: { type: 'boolean' },
+          },
+          required: [],
+        },
       },
-      required: ['required', 'tuple', 'list'],
+      required: ['required', 'tuple', 'list', 'nullableObject'],
     };
 
     expect(
@@ -286,13 +330,639 @@ describe('utils/strictToolSchema', () => {
         nullableOptional: null,
         tuple: ['x', null],
         list: [{ optionalChild: null }],
+        nullableObject: { optionalChild: null },
       }),
     ).toEqual({
       required: 'ok',
       nullableOptional: null,
       tuple: ['x', null],
       list: [{}],
+      nullableObject: {},
     });
+  });
+
+  it.each([
+    ['$defs', '$defs', '#/$defs/payload'],
+    ['legacy definitions', 'definitions', '#/definitions/payload'],
+  ])('strips strict nulls through %s references', (_name, key, $ref) => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref },
+      },
+      required: ['payload'],
+      [key]: {
+        payload: {
+          type: 'object',
+          properties: {
+            note: { type: 'string' },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        payload: { note: null },
+      }),
+    ).toEqual({ payload: {} });
+  });
+
+  it('decodes URI and JSON Pointer reference tokens', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/$defs/path%20with~1slash~0tilde' },
+      },
+      required: ['payload'],
+      $defs: {
+        'path with/slash~tilde': {
+          type: 'object',
+          properties: {
+            note: { type: 'string' },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        payload: { note: null },
+      }),
+    ).toEqual({ payload: {} });
+  });
+
+  it('decodes URI fragments before splitting JSON Pointer tokens', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#%2F$defs%2Fgroup%2F$defs%2Fpayload' },
+      },
+      required: ['payload'],
+      $defs: {
+        group: {
+          $defs: {
+            payload: {
+              type: 'object',
+              properties: {
+                note: { type: 'string' },
+              },
+              required: [],
+            },
+          },
+        },
+        'group/$defs/payload': {
+          type: 'object',
+          properties: {
+            note: { type: ['string', 'null'] },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        payload: { note: null },
+      }),
+    ).toEqual({ payload: {} });
+  });
+
+  it('resolves references against original schema pointer paths', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        alias: {
+          $ref: '#/$defs/payload/properties/optionalContainer/properties/target',
+        },
+      },
+      required: ['alias'],
+      $defs: {
+        payload: {
+          type: 'object',
+          properties: {
+            optionalContainer: {
+              type: 'object',
+              properties: {
+                target: {
+                  type: 'object',
+                  properties: { child: { type: 'string' } },
+                  required: [],
+                },
+              },
+              required: [],
+            },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        alias: { child: null },
+      }),
+    ).toEqual({ alias: {} });
+  });
+
+  it('stabilizes references to schemas outside the ordinary conversion walk', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/$defs/scalar/properties/target' },
+      },
+      required: ['payload'],
+      $defs: {
+        scalar: {
+          type: 'string',
+          properties: {
+            target: {
+              type: 'object',
+              properties: { note: { type: 'string' } },
+              required: [],
+            },
+          },
+        },
+      },
+    };
+
+    const prepared = prepareOpenAIStrictToolSchema(schema as any);
+    const reference = (prepared.schema.properties.payload as any).$ref;
+
+    expect(reference).toMatch(/^#\/\$defs\/__openai_strict_ref_/);
+    expect(prepared.normalizeInput({ payload: { note: null } })).toEqual({
+      payload: {},
+    });
+  });
+
+  it('stabilizes references to schemas replaced during strict conversion', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/$defs/container/additionalProperties' },
+      },
+      required: ['payload'],
+      $defs: {
+        container: {
+          type: 'object',
+          properties: {},
+          required: [],
+          additionalProperties: {
+            type: 'object',
+            properties: { note: { type: 'string' } },
+            required: [],
+          },
+        },
+      },
+    };
+
+    const prepared = prepareOpenAIStrictToolSchema(schema as any);
+
+    expect((prepared.schema.properties.payload as any).$ref).toMatch(
+      /^#\/\$defs\/__openai_strict_ref_/,
+    );
+    expect(prepared.normalizeInput({ payload: { note: null } })).toEqual({
+      payload: {},
+    });
+  });
+
+  it('rejects references created only by strict conversion', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        alias: {
+          $ref: '#/$defs/payload/properties/note/anyOf/0',
+        },
+      },
+      required: ['alias'],
+      $defs: {
+        payload: {
+          type: 'object',
+          properties: {
+            note: {
+              type: 'object',
+              properties: { child: { type: 'string' } },
+              required: [],
+            },
+          },
+          required: [],
+        },
+      },
+    };
+
+    expect(() => toOpenAIStrictToolSchema(schema as any)).toThrow(
+      'Cannot convert unresolved or external JSON schema reference',
+    );
+  });
+
+  it('preserves canonical prepared nodes for reused schema objects', () => {
+    const shared = {
+      type: 'object',
+      properties: { note: { type: 'string' } },
+      required: [],
+    };
+    const schema = {
+      type: 'object',
+      properties: {
+        requiredAlias: { $ref: '#/$defs/a/properties/note' },
+        optionalAlias: { $ref: '#/$defs/a/properties/note' },
+        a: { $ref: '#/$defs/a' },
+        b: { $ref: '#/$defs/b' },
+      },
+      required: ['requiredAlias', 'a', 'b'],
+      $defs: { a: shared, b: shared },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        requiredAlias: null,
+        optionalAlias: null,
+        a: { note: null },
+        b: { note: null },
+      }),
+    ).toEqual({ requiredAlias: null, a: {}, b: {} });
+  });
+
+  it.each([
+    ['required first', ['requiredOwner', 'optionalOwner']],
+    ['optional first', ['optionalOwner', 'requiredOwner']],
+  ])(
+    'keeps shared property containers contextual with %s',
+    (_name, propertyOrder) => {
+      const sharedProperties = { value: { type: 'string' } };
+      const owners = {
+        requiredOwner: {
+          type: 'object',
+          properties: sharedProperties,
+          required: ['value'],
+        },
+        optionalOwner: {
+          type: 'object',
+          properties: sharedProperties,
+          required: [],
+        },
+      };
+      const properties = Object.fromEntries(
+        propertyOrder.map((key) => [key, owners[key as keyof typeof owners]]),
+      );
+      const schema = {
+        type: 'object',
+        properties,
+        required: propertyOrder,
+      };
+
+      const prepared = prepareOpenAIStrictToolSchema(schema as any);
+
+      expect(
+        prepared.normalizeInput({
+          requiredOwner: { value: null },
+          optionalOwner: { value: null },
+        }),
+      ).toEqual({
+        requiredOwner: { value: null },
+        optionalOwner: {},
+      });
+    },
+  );
+
+  it('strips strict nulls through recursive root references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        note: { type: 'string' },
+        child: { $ref: '#' },
+      },
+      required: [],
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        note: null,
+        child: { note: null },
+      }),
+    ).toEqual({ child: {} });
+  });
+
+  it('preserves null allowed by a referenced schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: { $ref: '#/$defs/value' },
+      },
+      required: [],
+      $defs: {
+        value: { type: ['string', 'null'] },
+      },
+    };
+
+    expect(stripStrictNullsForJsonSchema(schema, { value: null })).toEqual({
+      value: null,
+    });
+  });
+
+  it('preserves null allowed through a referenced union branch', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: { $ref: '#/$defs/maybeValue' },
+      },
+      required: [],
+      $defs: {
+        maybeValue: {
+          anyOf: [{ type: 'string' }, { $ref: '#/$defs/nullValue' }],
+        },
+        nullValue: { type: 'null' },
+      },
+    };
+
+    expect(stripStrictNullsForJsonSchema(schema, { value: null })).toEqual({
+      value: null,
+    });
+  });
+
+  it('preserves null allowed by enum-only and const-only schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        enumValue: { enum: ['value', null] },
+        constValue: { $ref: '#/$defs/nullValue' },
+      },
+      required: [],
+      $defs: {
+        nullValue: { const: null },
+      },
+    };
+
+    expect(
+      stripStrictNullsForJsonSchema(schema, {
+        enumValue: null,
+        constValue: null,
+      }),
+    ).toEqual({ enumValue: null, constValue: null });
+  });
+
+  it('normalizes optional boolean JSON Schema nodes', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        directTrue: true,
+        directFalse: false,
+        referencedTrue: { $ref: '#/$defs/trueSchema' },
+        referencedFalse: { $ref: '#/$defs/falseSchema' },
+        unionTrue: { anyOf: [false, true] },
+        unionFalse: { anyOf: [false, { const: 'value' }] },
+      },
+      required: [],
+      $defs: {
+        trueSchema: true,
+        falseSchema: false,
+      },
+      additionalProperties: false,
+    };
+
+    const prepared = prepareOpenAIStrictToolSchema(schema as any);
+    expect(
+      prepared.normalizeInput({
+        directTrue: null,
+        directFalse: null,
+        referencedTrue: null,
+        referencedFalse: null,
+        unionTrue: null,
+        unionFalse: null,
+      }),
+    ).toEqual({
+      directTrue: null,
+      referencedTrue: null,
+      unionTrue: null,
+    });
+  });
+
+  it.each([
+    ['not', { not: { type: 'null' } }],
+    ['oneOf', { oneOf: [{ type: 'string' }, { type: 'null' }] }],
+    ['allOf', { allOf: [{ type: 'string' }] }],
+    ['if', { if: { type: 'string' }, then: { const: 'value' } }],
+    [
+      'patternProperties',
+      { patternProperties: { '^value$': { type: 'string' } } },
+    ],
+    ['contains', { type: 'array', contains: { type: 'string' } }],
+    ['prefixItems', { prefixItems: [{ type: 'string' }] }],
+  ])('rejects unsupported strict `%s` schemas', (keyword, propertySchema) => {
+    const schema = {
+      type: 'object',
+      properties: { value: propertySchema },
+      required: [],
+    };
+
+    expect(() => toOpenAIStrictToolSchema(schema as any)).toThrow(
+      `unsupported keyword \`${keyword}\``,
+    );
+  });
+
+  it('rejects unsupported keywords in retained schema locations', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          type: 'string',
+          properties: {
+            ignored: { allOf: [{ type: 'string' }] },
+          },
+        },
+      },
+      required: ['value'],
+      additionalProperties: false,
+    };
+
+    expect(() => toOpenAIStrictToolSchema(schema as any)).toThrow(
+      'unsupported keyword `allOf`',
+    );
+  });
+
+  it.each([
+    [
+      '$ref',
+      {
+        type: 'object',
+        $ref: '#/$defs/value',
+        properties: { local: { type: 'string' } },
+        required: [],
+      },
+    ],
+    [
+      'anyOf',
+      {
+        anyOf: [{ type: 'object' }],
+        properties: { local: { type: 'string' } },
+        required: [],
+      },
+    ],
+  ])(
+    'rejects ambiguous `%s` sibling constraints',
+    (keyword, propertySchema) => {
+      const schema = {
+        type: 'object',
+        properties: { value: propertySchema },
+        required: [],
+        $defs: { value: { type: 'object' } },
+      };
+
+      expect(() => toOpenAIStrictToolSchema(schema as any)).toThrow(
+        `combining \`${keyword}\` with sibling keyword`,
+      );
+    },
+  );
+
+  it('rejects branch-aware normalization for plain anyOf schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            {
+              type: 'object',
+              properties: {
+                kind: { const: 'text' },
+                note: { type: 'string' },
+              },
+              required: ['kind'],
+            },
+            {
+              type: 'object',
+              properties: {
+                kind: { const: 'count' },
+                count: { type: 'number' },
+              },
+              required: ['kind'],
+            },
+          ],
+        },
+      },
+      required: ['value'],
+    };
+
+    expect(() => prepareOpenAIStrictToolSchema(schema as any)).toThrow(
+      '`anyOf` branch containing optional object properties',
+    );
+  });
+
+  it('ignores inapplicable properties when checking plain anyOf branches', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        value: {
+          anyOf: [
+            {
+              type: 'string',
+              properties: { ignored: { type: 'string' } },
+            },
+            { type: 'number' },
+          ],
+        },
+      },
+      required: ['value'],
+    };
+
+    expect(() => prepareOpenAIStrictToolSchema(schema as any)).not.toThrow();
+  });
+
+  it('leaves schemas outside the local normalization traversal unchanged', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        booleanSchema: true,
+        stringWithInapplicableProperties: {
+          type: 'string',
+          properties: {
+            ignored: { type: 'null' },
+          },
+        },
+      },
+      required: ['booleanSchema', 'stringWithInapplicableProperties'],
+    };
+
+    expect(toOpenAIStrictToolSchema(schema as any)).toEqual({
+      ...schema,
+      additionalProperties: false,
+    });
+  });
+
+  it('does not normalize values through inapplicable properties', () => {
+    const sharedTarget = {
+      type: 'object',
+      properties: { note: { type: 'string' } },
+      required: [],
+    };
+    const schema = {
+      type: 'object',
+      properties: {
+        scalar: {
+          type: 'string',
+          properties: { ignored: sharedTarget },
+        },
+      },
+      required: ['scalar'],
+      $defs: { sharedTarget },
+    };
+
+    const prepared = prepareOpenAIStrictToolSchema(schema as any);
+
+    expect(
+      prepared.normalizeInput({ scalar: { ignored: { note: null } } }),
+    ).toEqual({ scalar: { ignored: { note: null } } });
+  });
+
+  it('rejects nested JSON Schema resource scopes', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: { $ref: '#/$defs/container' },
+      },
+      required: ['payload'],
+      $defs: {
+        target: { type: ['string', 'null'] },
+        container: {
+          $id: 'https://example.com/container',
+          type: 'object',
+          properties: {
+            value: { $ref: '#/$defs/target' },
+          },
+          required: ['value'],
+          $defs: {
+            target: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    expect(() => toOpenAIStrictToolSchema(schema as any)).toThrow(
+      'nested `$id` resource',
+    );
+  });
+
+  it.each([
+    [
+      'cyclic',
+      '#/$defs/first',
+      {
+        first: { $ref: '#/$defs/second' },
+        second: { $ref: '#/$defs/first' },
+      },
+    ],
+    ['unresolved', '#/$defs/missing', {}],
+    ['external', 'https://example.com/schema.json#/$defs/payload', {}],
+  ])('rejects indeterminate %s references', (_name, $ref, $defs) => {
+    const schema = {
+      type: 'object',
+      properties: { payload: { $ref } },
+      required: [],
+      $defs,
+    };
+
+    expect(() => toOpenAIStrictToolSchema(schema as any)).toThrow();
   });
 
   it('strips strict nulls from optional Zod object, union, array, tuple, and record fields', () => {

--- a/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
+++ b/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { z } from 'zod';
 import { z as zod3 } from 'zod/v3';
-import { zodJsonSchemaCompat } from '../../src/utils/zodJsonSchemaCompat';
+import {
+  zodJsonSchemaCompat,
+  zodJsonSchemaCompatForOpenAIStrict,
+} from '../../src/utils/zodJsonSchemaCompat';
 
 describe('utils/zodJsonSchemaCompat', () => {
   it('builds schema for basic object with optional property', () => {
@@ -131,6 +134,49 @@ describe('utils/zodJsonSchemaCompat', () => {
       type: 'string',
       enum: ['one', 'two'],
     });
+  });
+
+  it('lowers closed object intersections for OpenAI strict schemas', () => {
+    const schema = z.object({
+      list: z.array(
+        z
+          .intersection(
+            z.object({ left: z.string() }).describe('Left.'),
+            z.object({ right: z.number() }).describe('Right.'),
+          )
+          .describe('Wrapper.'),
+      ),
+    });
+
+    const converted = zodJsonSchemaCompatForOpenAIStrict(schema);
+    expect(converted?.loweredObjectIntersection).toBe(true);
+    expect(converted?.schema.properties.list).toMatchObject({
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          left: { type: 'string' },
+          right: { type: 'number' },
+        },
+        required: ['left', 'right'],
+        additionalProperties: false,
+        description: 'Wrapper.',
+      },
+    });
+  });
+
+  it('rejects strict whole-schema fallbacks that would lose constraints', () => {
+    const schema = z.object({
+      combined: z.intersection(
+        z.object({ left: z.string().min(3) }),
+        z.object({ right: z.number() }),
+      ),
+      sibling: z.string().email(),
+    });
+
+    expect(() => zodJsonSchemaCompatForOpenAIStrict(schema)).toThrow(
+      'without losing constraints',
+    );
   });
 
   it('converts nested record and array structures', () => {


### PR DESCRIPTION
This pull request fixes strict plain JSON Schema argument normalization when nested schemas are reached through local references. It prepares the provider-visible strict schema and invocation normalizer together, removes only SDK-introduced nulls, and preserves explicit or indeterminate null values. It also adds coverage for local definitions, recursive references, JSON Pointer decoding, composed nullability, and unresolved reference fallback.