### PR TITLE
fix: transform complete interleaved AI SDK output once

### DIFF
--- a/.changeset/soft-text-transforms.md
+++ b/.changeset/soft-text-transforms.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: transform complete interleaved AI SDK output once

--- a/.changeset/soft-text-transforms.md
+++ b/.changeset/soft-text-transforms.md
@@ -2,4 +2,4 @@
 '@openai/agents-extensions': patch
 ---
 
-fix: transform complete interleaved AI SDK output once
+fix: transform complete AI SDK text within tool boundaries

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -2073,30 +2073,49 @@ export class AiSdkModel implements Model {
     return transformed;
   }
 
-  async #transformOutputTextParts(
-    parts: protocol.OutputText[],
+  async #transformOutputTextItems(
+    items: ModelResponse['output'],
     request: ModelRequest,
     stream: boolean,
   ): Promise<void> {
-    if (parts.length === 0) {
-      return;
-    }
+    let parts: protocol.OutputText[] = [];
+    const transformParts = async () => {
+      if (parts.length === 0) {
+        return;
+      }
 
-    const originalLengths = parts.map((part) => part.text.length);
-    const transformedText = await this.#transformOutputText(
-      parts.map((part) => part.text).join(''),
-      request,
-      stream,
-    );
-    let offset = 0;
-    for (const [index, part] of parts.entries()) {
-      const end =
-        index === parts.length - 1
-          ? transformedText.length
-          : Math.min(transformedText.length, offset + originalLengths[index]);
-      part.text = transformedText.slice(offset, end);
-      offset = end;
+      const currentParts = parts;
+      parts = [];
+      const originalLengths = currentParts.map((part) => part.text.length);
+      const transformedText = await this.#transformOutputText(
+        currentParts.map((part) => part.text).join(''),
+        request,
+        stream,
+      );
+      let offset = 0;
+      for (const [index, part] of currentParts.entries()) {
+        const end =
+          index === currentParts.length - 1
+            ? transformedText.length
+            : Math.min(transformedText.length, offset + originalLengths[index]);
+        part.text = transformedText.slice(offset, end);
+        offset = end;
+      }
+    };
+
+    for (const item of items) {
+      if (item.type === 'message' && item.role === 'assistant') {
+        parts.push(
+          ...item.content.filter(
+            (content): content is protocol.OutputText =>
+              content.type === 'output_text',
+          ),
+        );
+      } else if (item.type !== 'reasoning') {
+        await transformParts();
+      }
     }
+    await transformParts();
   }
 
   async getResponse(request: ModelRequest) {
@@ -2198,7 +2217,6 @@ export class AiSdkModel implements Model {
           string,
           SerializedTool | SerializedHandoff
         >();
-        const textOutputs: protocol.OutputText[] = [];
         let pendingTextParts: string[] = [];
         const flushPendingText = () => {
           if (pendingTextParts.length === 0) {
@@ -2208,7 +2226,6 @@ export class AiSdkModel implements Model {
             type: 'output_text',
             text: pendingTextParts.join(''),
           };
-          textOutputs.push(textOutput);
           output.push({
             type: 'message',
             content: [textOutput],
@@ -2317,7 +2334,7 @@ export class AiSdkModel implements Model {
           }
         }
         flushPendingText();
-        await this.#transformOutputTextParts(textOutputs, request, false);
+        await this.#transformOutputTextItems(output, request, false);
 
         if (span && request.tracing === true) {
           span.spanData.output = output;
@@ -2703,10 +2720,6 @@ export class AiSdkModel implements Model {
       }
 
       const outputs: protocol.OutputModelItem[] = [];
-      const textOutputs = orderedOutputEntries.flatMap((entry) =>
-        entry.kind === 'text' ? [entry.output] : [],
-      );
-      await this.#transformOutputTextParts(textOutputs, request, true);
 
       for (const entry of orderedOutputEntries) {
         if (entry.kind === 'reasoning') {
@@ -2761,6 +2774,7 @@ export class AiSdkModel implements Model {
           ),
         });
       }
+      await this.#transformOutputTextItems(outputs, request, true);
 
       const finalEvent: protocol.StreamEventResponseCompleted = {
         type: 'response_done',

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -2073,6 +2073,32 @@ export class AiSdkModel implements Model {
     return transformed;
   }
 
+  async #transformOutputTextParts(
+    parts: protocol.OutputText[],
+    request: ModelRequest,
+    stream: boolean,
+  ): Promise<void> {
+    if (parts.length === 0) {
+      return;
+    }
+
+    const originalLengths = parts.map((part) => part.text.length);
+    const transformedText = await this.#transformOutputText(
+      parts.map((part) => part.text).join(''),
+      request,
+      stream,
+    );
+    let offset = 0;
+    for (const [index, part] of parts.entries()) {
+      const end =
+        index === parts.length - 1
+          ? transformedText.length
+          : Math.min(transformedText.length, offset + originalLengths[index]);
+      part.text = transformedText.slice(offset, end);
+      offset = end;
+    }
+  }
+
   async getResponse(request: ModelRequest) {
     return withGenerationSpan(async (span) => {
       try {
@@ -2172,19 +2198,20 @@ export class AiSdkModel implements Model {
           string,
           SerializedTool | SerializedHandoff
         >();
+        const textOutputs: protocol.OutputText[] = [];
         let pendingTextParts: string[] = [];
-        const flushPendingText = async () => {
+        const flushPendingText = () => {
           if (pendingTextParts.length === 0) {
             return;
           }
-          const transformedText = await this.#transformOutputText(
-            pendingTextParts.join(''),
-            request,
-            false,
-          );
+          const textOutput: protocol.OutputText = {
+            type: 'output_text',
+            text: pendingTextParts.join(''),
+          };
+          textOutputs.push(textOutput);
           output.push({
             type: 'message',
-            content: [{ type: 'output_text', text: transformedText }],
+            content: [textOutput],
             role: 'assistant',
             status: 'completed',
             providerData: mergeProviderData(
@@ -2216,7 +2243,7 @@ export class AiSdkModel implements Model {
             ) {
               continue;
             }
-            await flushPendingText();
+            flushPendingText();
             output.push({
               type: 'reasoning',
               content: [{ type: 'input_text', text: reasoningText }],
@@ -2270,7 +2297,7 @@ export class AiSdkModel implements Model {
                   (hasToolCalls ? result.providerMetadata : undefined),
               ),
             });
-            await flushPendingText();
+            flushPendingText();
             output.push(toolCallItem);
             continue;
           }
@@ -2285,11 +2312,12 @@ export class AiSdkModel implements Model {
             ),
           });
           if (toolSearchOutput) {
-            await flushPendingText();
+            flushPendingText();
             output.push(toolSearchOutput);
           }
         }
-        await flushPendingText();
+        flushPendingText();
+        await this.#transformOutputTextParts(textOutputs, request, false);
 
         if (span && request.tracing === true) {
           span.spanData.output = output;
@@ -2675,6 +2703,10 @@ export class AiSdkModel implements Model {
       }
 
       const outputs: protocol.OutputModelItem[] = [];
+      const textOutputs = orderedOutputEntries.flatMap((entry) =>
+        entry.kind === 'text' ? [entry.output] : [],
+      );
+      await this.#transformOutputTextParts(textOutputs, request, true);
 
       for (const entry of orderedOutputEntries) {
         if (entry.kind === 'reasoning') {
@@ -2706,16 +2738,11 @@ export class AiSdkModel implements Model {
         }
 
         if (entry.kind === 'text') {
-          const transformedText = await this.#transformOutputText(
-            entry.output.text,
-            request,
-            true,
-          );
           outputs.push({
             type: 'message',
             ...(entry.itemId ? { id: entry.itemId } : {}),
             role: 'assistant',
-            content: [{ ...entry.output, text: transformedText }],
+            content: [entry.output],
             status: 'completed',
             providerData: mergeProviderData(
               baseProviderData,

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -2903,6 +2903,52 @@ describe('AiSdkModel.getResponse', () => {
     expect(result.finalOutput).toBe('firstsecond');
   });
 
+  test('transforms complete structured output once across interleaved reasoning', async () => {
+    const transformOutputText = vi.fn((text: string) => {
+      return text.match(/\{[\s\S]*\}/)?.[0] ?? text;
+    });
+    const model = new AiSdkModel(
+      stubModel({
+        async doGenerate() {
+          return {
+            content: [
+              { type: 'text', text: 'Result: {"content":' },
+              { type: 'reasoning', text: 'thinking' },
+              { type: 'text', text: '"structured"}' },
+            ],
+            usage: { inputTokens: 1, outputTokens: 3, totalTokens: 4 },
+            providerMetadata: {},
+            response: { id: 'id' },
+            finishReason: 'stop',
+            warnings: [],
+          } as any;
+        },
+      }),
+      { transformOutputText },
+    );
+
+    const result = await run(
+      new Agent({
+        name: 'Structured Assistant',
+        model,
+        outputType: z.object({ content: z.string() }),
+      }),
+      'Respond with structured output.',
+    );
+
+    expect(transformOutputText).toHaveBeenCalledOnce();
+    expect(transformOutputText).toHaveBeenCalledWith(
+      'Result: {"content":"structured"}',
+      expect.objectContaining({ stream: false }),
+    );
+    expect(result.newItems.map((item) => item.rawItem?.type)).toEqual([
+      'message',
+      'reasoning',
+      'message',
+    ]);
+    expect(result.finalOutput).toEqual({ content: 'structured' });
+  });
+
   test('keeps complete final output when used as an agent tool', async () => {
     const model = new AiSdkModel(
       stubModel({
@@ -4823,6 +4869,64 @@ describe('AiSdkModel.getStreamedResponse', () => {
       'reasoning',
     ]);
     expect(result.finalOutput).toBe('firstsecond');
+  });
+
+  test('transforms complete streamed structured output once across interleaved reasoning', async () => {
+    const transformOutputText = vi.fn((text: string) => {
+      return text.match(/\{[\s\S]*\}/)?.[0] ?? text;
+    });
+    const parts = [
+      {
+        type: 'text-delta',
+        id: 'text-1',
+        delta: 'Result: {"content":',
+      },
+      { type: 'reasoning-start', id: 'reasoning-1' },
+      {
+        type: 'reasoning-delta',
+        id: 'reasoning-1',
+        delta: 'thinking',
+      },
+      { type: 'reasoning-end', id: 'reasoning-1' },
+      { type: 'text-delta', id: 'text-2', delta: '"structured"}' },
+      { type: 'response-metadata', id: 'id1' },
+      {
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 3 },
+      },
+    ];
+    const model = new AiSdkModel(
+      stubModel({
+        async doStream() {
+          return { stream: partsStream(parts) } as any;
+        },
+      }),
+      { transformOutputText },
+    );
+
+    const result = await run(
+      new Agent({
+        name: 'Structured Assistant',
+        model,
+        outputType: z.object({ content: z.string() }),
+      }),
+      'Respond with structured output.',
+      { stream: true },
+    );
+    await result.completed;
+
+    expect(transformOutputText).toHaveBeenCalledOnce();
+    expect(transformOutputText).toHaveBeenCalledWith(
+      'Result: {"content":"structured"}',
+      expect.objectContaining({ stream: true }),
+    );
+    expect(result.newItems.map((item) => item.rawItem?.type)).toEqual([
+      'message',
+      'reasoning',
+      'message',
+    ]);
+    expect(result.finalOutput).toEqual({ content: 'structured' });
   });
 
   test('keeps streamed text contiguous across replacement tool calls', async () => {

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -2981,14 +2981,17 @@ describe('AiSdkModel.getResponse', () => {
     expect(output).toBe('firstsecond');
   });
 
-  test('keeps complete final output around provider-executed tool search', async () => {
+  test('transforms text separately around provider-executed tool search', async () => {
+    const transformOutputText = vi.fn((text: string) =>
+      text.replace('wrapped:', ''),
+    );
     const model = new AiSdkModel(
       stubModel(
         {
           async doGenerate() {
             return {
               content: [
-                { type: 'text', text: 'first' },
+                { type: 'text', text: 'wrapped:first' },
                 {
                   type: 'reasoning',
                   text: 'searching',
@@ -3003,13 +3006,14 @@ describe('AiSdkModel.getResponse', () => {
                   input: { query: 'weather' },
                   providerExecuted: true,
                 },
+                { type: 'text', text: 'wrapped:between-call-and-result' },
                 {
                   type: 'tool-result',
                   toolCallId: 'search_1',
                   toolName: 'tool_search',
                   result: [{ type: 'tool_reference', toolName: 'get_weather' }],
                 },
-                { type: 'text', text: 'second' },
+                { type: 'text', text: 'wrapped:after-result' },
               ],
               usage: { inputTokens: 1, outputTokens: 5, totalTokens: 6 },
               providerMetadata: {},
@@ -3021,6 +3025,7 @@ describe('AiSdkModel.getResponse', () => {
         },
         { provider: 'anthropic.messages', specificationVersion: 'v3' },
       ),
+      { transformOutputText },
     );
 
     const result = await run(
@@ -3041,10 +3046,21 @@ describe('AiSdkModel.getResponse', () => {
       'message',
       'reasoning',
       'tool_search_call',
+      'message',
       'tool_search_output',
       'message',
     ]);
-    expect(result.finalOutput).toBe('firstsecond');
+    expect(transformOutputText.mock.calls.map(([text]) => text)).toEqual([
+      'wrapped:first',
+      'wrapped:between-call-and-result',
+      'wrapped:after-result',
+    ]);
+    expect(
+      result.newItems
+        .filter((item) => item.rawItem?.type === 'message')
+        .map((item) => (item.rawItem as any).content[0].text),
+    ).toEqual(['first', 'between-call-and-result', 'after-result']);
+    expect(result.finalOutput).toBe('firstbetween-call-and-resultafter-result');
   });
 
   test('applies transformOutputText to finalized assistant text', async () => {
@@ -5209,8 +5225,12 @@ describe('AiSdkModel.getStreamedResponse', () => {
     warnSpy.mockRestore();
   });
 
-  test('preserves provider-executed tool search call and result order in streaming mode', async () => {
+  test('preserves text transform boundaries and provider-executed tool search order in streaming mode', async () => {
+    const transformOutputText = vi.fn((text: string) =>
+      text.replace('wrapped:', ''),
+    );
     const parts = [
+      { type: 'text-delta', id: 'text-1', delta: 'wrapped:first' },
       {
         type: 'tool-call',
         toolCallId: 'search_1',
@@ -5219,16 +5239,31 @@ describe('AiSdkModel.getStreamedResponse', () => {
         providerExecuted: true,
       },
       {
+        type: 'text-delta',
+        id: 'text-2',
+        delta: 'wrapped:after-search-call',
+      },
+      {
         type: 'tool-result',
         toolCallId: 'search_1',
         toolName: 'tool_search',
         result: [{ type: 'tool_reference', toolName: 'get_weather' }],
       },
       {
+        type: 'text-delta',
+        id: 'text-3',
+        delta: 'wrapped:after-search-result',
+      },
+      {
         type: 'tool-call',
         toolCallId: 'weather_1',
         toolName: 'get_weather',
         input: { city: 'Tokyo' },
+      },
+      {
+        type: 'text-delta',
+        id: 'text-4',
+        delta: 'wrapped:after-function-call',
       },
       { type: 'response-metadata', id: 'response_stream_1' },
       {
@@ -5246,6 +5281,7 @@ describe('AiSdkModel.getStreamedResponse', () => {
         },
         { provider: 'anthropic.messages', specificationVersion: 'v3' },
       ),
+      { transformOutputText },
     );
 
     const events: any[] = [];
@@ -5275,23 +5311,43 @@ describe('AiSdkModel.getStreamedResponse', () => {
 
     const final = events.at(-1);
     expect(final.response.output.map((item: any) => item.type)).toEqual([
+      'message',
       'tool_search_call',
+      'message',
       'tool_search_output',
+      'message',
       'function_call',
+      'message',
     ]);
-    expect(final.response.output[0]).toMatchObject({
+    expect(final.response.output[1]).toMatchObject({
       id: 'search_1',
       execution: 'server',
     });
-    expect(final.response.output[1]).toMatchObject({
+    expect(final.response.output[3]).toMatchObject({
       callId: 'search_1',
       execution: 'server',
       tools: [{ type: 'tool_reference', toolName: 'get_weather' }],
     });
-    expect(final.response.output[2]).toMatchObject({
+    expect(final.response.output[5]).toMatchObject({
       callId: 'weather_1',
       name: 'get_weather',
     });
+    expect(transformOutputText.mock.calls.map(([text]) => text)).toEqual([
+      'wrapped:first',
+      'wrapped:after-search-call',
+      'wrapped:after-search-result',
+      'wrapped:after-function-call',
+    ]);
+    expect(
+      final.response.output
+        .filter((item: any) => item.type === 'message')
+        .map((item: any) => item.content[0].text),
+    ).toEqual([
+      'first',
+      'after-search-call',
+      'after-search-result',
+      'after-function-call',
+    ]);
   });
 
   test('preserves interleaved reasoning and tool order in streaming mode', async () => {


### PR DESCRIPTION
This pull request fixes AI SDK structured-output failures when reasoning items split assistant text into multiple segments. It preserves the ordered message and reasoning items while applying transformOutputText exactly once to the complete assistant text in both generated and streamed responses.