### PR TITLE
fix: scope hosted MCP approval identity

### DIFF
--- a/.agents/references/tool-identity-and-routing.md
+++ b/.agents/references/tool-identity-and-routing.md
@@ -14,6 +14,7 @@ Provider wire-name grammar and length limits remain provider-owned validation un
 ## MCP and Handoffs
 
 - Prefixing local MCP tool names with a server name changes the model-visible collision-safe wrapper name, not the original name sent back to the MCP server.
+- Persistent hosted MCP approval identity includes both the server label and tool name, and its state uses a separate serialized namespace from legacy bare-name approvals. Legacy bare-name sticky decisions cannot authorize hosted MCP calls; an exact legacy approval request ID may be reused only when it uniquely identifies a pending request during resume.
 - Sanitize and length-limit generated MCP names deterministically, including a stable collision suffix. Cache entries must rebind wrappers to the current server instance.
 - Handoff tool names are routing identities. Keep text-runner and Realtime handoff conversion aligned and preserve explicit clone overrides.
 

--- a/.changeset/scope-hosted-mcp-approvals.md
+++ b/.changeset/scope-hosted-mcp-approvals.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-realtime': patch
+---
+
+fix: scope persistent hosted MCP approvals by server and tool identity

--- a/packages/agents-core/src/runContext.ts
+++ b/packages/agents-core/src/runContext.ts
@@ -6,6 +6,9 @@ import {
   getFunctionToolLookupKey,
   getFunctionToolLegacyStateKeyFromStateKey,
   getFunctionToolStateKeyForCall,
+  getHostedMcpApprovalRequestIdentity,
+  getHostedMcpApprovalIdentityFromStateKey,
+  getHostedMcpApprovalStateKey,
 } from './toolIdentity';
 import { UnknownContext } from './types';
 import { Usage } from './usage';
@@ -174,6 +177,7 @@ type RunContextJson = {
 };
 
 type SerializedRunContextJson = RunContextJson & {
+  hostedMcpApprovals?: Record<string, ApprovalRecord>;
   functionApprovals?: SerializedFunctionApprovals;
   legacyFunctionApprovals?: Record<string, ApprovalRecord>;
   approvalInvocations?: SerializedApprovalInvocations;
@@ -204,6 +208,11 @@ export class RunContext<TContext = UnknownContext> {
   #approvals: Map<string, ApprovalRecord>;
 
   /**
+   * Hosted MCP approvals scoped by server label and tool name.
+   */
+  #hostedMcpApprovals: Map<string, ApprovalRecord>;
+
+  /**
    * Function-tool approvals scoped to the public agent that owns the call.
    */
   #functionApprovalState: FunctionApprovalState;
@@ -222,6 +231,7 @@ export class RunContext<TContext = UnknownContext> {
     this.context = context;
     this.usage = new Usage();
     this.#approvals = new Map();
+    this.#hostedMcpApprovals = new Map();
     this.#functionApprovalState = {
       approvalsByAgent: new Map(),
       legacyApprovals: new Map(),
@@ -249,6 +259,7 @@ export class RunContext<TContext = UnknownContext> {
     target.context = this.context;
     target.usage = this.usage;
     target.#approvals = this.#approvals;
+    target.#hostedMcpApprovals = this.#hostedMcpApprovals;
     target.#functionApprovalState = this.#functionApprovalState;
     target.#approvalInvocations = this.#approvalInvocations;
     target.#toolApprovalsByAgent = this.#toolApprovalsByAgent;
@@ -265,6 +276,7 @@ export class RunContext<TContext = UnknownContext> {
     clone.usage = this.usage;
     clone.toolInput = this.toolInput;
     clone.#approvals = cloneApprovalMap(this.#approvals);
+    clone.#hostedMcpApprovals = cloneApprovalMap(this.#hostedMcpApprovals);
     clone.#functionApprovalState = {
       approvalsByAgent: cloneAgentApprovalMap(
         this.#functionApprovalState.approvalsByAgent,
@@ -293,6 +305,10 @@ export class RunContext<TContext = UnknownContext> {
     this.#approvals.clear();
     for (const [toolName, approval] of source.#approvals) {
       this.#approvals.set(toolName, cloneApprovalRecord(approval));
+    }
+    this.#hostedMcpApprovals.clear();
+    for (const [stateKey, approval] of source.#hostedMcpApprovals) {
+      this.#hostedMcpApprovals.set(stateKey, cloneApprovalRecord(approval));
     }
     this.#functionApprovalState.approvalsByAgent.clear();
     for (const [agent, approvals] of source.#functionApprovalState
@@ -503,9 +519,10 @@ export class RunContext<TContext = UnknownContext> {
         return scopedDecision;
       }
     }
-    return this.#resolveStickyApprovalEntries(
-      this.#getApprovalEntries(toolName, false),
-    );
+    const stickyEntries = getHostedMcpApprovalRequestIdentity(rawItem)
+      ? this.#getHostedMcpApprovalEntries(toolName)
+      : this.#getApprovalEntries(toolName, false);
+    return this.#resolveStickyApprovalEntries(stickyEntries);
   }
 
   /**
@@ -560,9 +577,11 @@ export class RunContext<TContext = UnknownContext> {
         return scopedMessage;
       }
     }
-    return this.#getApprovalEntries(toolName, false).find(
-      (entry) => entry.rejected === true,
-    )?.stickyRejectMessage;
+    const stickyEntries = getHostedMcpApprovalRequestIdentity(rawItem)
+      ? this.#getHostedMcpApprovalEntries(toolName)
+      : this.#getApprovalEntries(toolName, false);
+    return stickyEntries.find((entry) => entry.rejected === true)
+      ?.stickyRejectMessage;
   }
 
   /**
@@ -587,6 +606,26 @@ export class RunContext<TContext = UnknownContext> {
   _mergeApprovals(approvals: Record<string, ApprovalRecord>) {
     for (const [toolName, incoming] of Object.entries(approvals)) {
       this.#setApprovalRecord(toolName, incoming);
+    }
+  }
+
+  /** @internal */
+  _rebuildHostedMcpApprovals(approvals: Record<string, ApprovalRecord>) {
+    this.#hostedMcpApprovals = new Map();
+    this._mergeHostedMcpApprovals(approvals);
+  }
+
+  /** @internal */
+  _mergeHostedMcpApprovals(approvals: Record<string, ApprovalRecord>) {
+    for (const [stateKey, incoming] of Object.entries(approvals)) {
+      if (!getHostedMcpApprovalIdentityFromStateKey(stateKey)) {
+        continue;
+      }
+      const current = this.#hostedMcpApprovals.get(stateKey);
+      this.#hostedMcpApprovals.set(
+        stateKey,
+        current ? mergeApprovalRecords(current, incoming) : incoming,
+      );
     }
   }
 
@@ -701,6 +740,9 @@ export class RunContext<TContext = UnknownContext> {
     for (const [toolName, incoming] of source.#approvals) {
       this.#setApprovalRecord(toolName, incoming);
     }
+    for (const [stateKey, incoming] of source.#hostedMcpApprovals) {
+      this._mergeHostedMcpApprovals({ [stateKey]: incoming });
+    }
     for (const [agent, approvalsByTool] of source.#functionApprovalState
       .approvalsByAgent) {
       for (const [toolName, incoming] of approvalsByTool) {
@@ -729,6 +771,9 @@ export class RunContext<TContext = UnknownContext> {
         continue;
       }
       this.#setApprovalRecord(toolName, incoming);
+    }
+    for (const [stateKey, incoming] of source.#hostedMcpApprovals) {
+      this._mergeHostedMcpApprovals({ [stateKey]: incoming });
     }
     for (const [agent, approvalsByTool] of source.#functionApprovalState
       .approvalsByAgent) {
@@ -954,6 +999,17 @@ export class RunContext<TContext = UnknownContext> {
   ): SerializedRunContextJson {
     const approvals = new Map(this.#approvals);
     if (!agentIdentityKeys) {
+      for (const [stateKey, incoming] of this.#hostedMcpApprovals) {
+        const identity = getHostedMcpApprovalIdentityFromStateKey(stateKey);
+        if (!identity?.toolName) {
+          continue;
+        }
+        const current = approvals.get(identity.toolName);
+        approvals.set(
+          identity.toolName,
+          current ? mergeApprovalRecords(current, incoming) : incoming,
+        );
+      }
       for (const [toolName, incoming] of this.#functionApprovalState
         .legacyApprovals) {
         const current = approvals.get(toolName);
@@ -979,6 +1035,9 @@ export class RunContext<TContext = UnknownContext> {
       usage: this.usage,
       approvals: Object.fromEntries(approvals.entries()),
     };
+    if (agentIdentityKeys && this.#hostedMcpApprovals.size > 0) {
+      json.hostedMcpApprovals = Object.fromEntries(this.#hostedMcpApprovals);
+    }
     if (agentIdentityKeys) {
       const functionApprovals: SerializedFunctionApprovals = [];
       for (const [agent, approvalsByTool] of this.#functionApprovalState
@@ -1032,6 +1091,10 @@ export class RunContext<TContext = UnknownContext> {
   }
 
   #getCallId(approvalItem: RunToolApprovalItem): string {
+    const hostedIdentity = getHostedMcpApprovalRequestIdentity(approvalItem);
+    if (hostedIdentity?.requestId) {
+      return hostedIdentity.requestId;
+    }
     if ('callId' in approvalItem.rawItem) {
       return approvalItem.rawItem.callId;
     }
@@ -1089,6 +1152,40 @@ export class RunContext<TContext = UnknownContext> {
           : []),
       ],
       callId,
+    );
+  }
+
+  /** @internal */
+  _getHostedMcpApprovalStatus(
+    approvalItem: RunToolApprovalItem['rawItem'] | RunToolApprovalItem,
+  ): boolean | undefined {
+    const identity = getHostedMcpApprovalRequestIdentity(approvalItem);
+    const stateKey = identity
+      ? getHostedMcpApprovalStateKey(identity)
+      : undefined;
+    if (!identity?.requestId || !stateKey) {
+      return undefined;
+    }
+    return this.#resolveApprovalEntries(
+      this.#getHostedMcpApprovalEntries(stateKey),
+      identity.requestId,
+    );
+  }
+
+  /** @internal */
+  _getHostedMcpRejectionMessage(
+    approvalItem: RunToolApprovalItem['rawItem'] | RunToolApprovalItem,
+  ): string | undefined {
+    const identity = getHostedMcpApprovalRequestIdentity(approvalItem);
+    const stateKey = identity
+      ? getHostedMcpApprovalStateKey(identity)
+      : undefined;
+    if (!identity?.requestId || !stateKey) {
+      return undefined;
+    }
+    return this.#getRejectionMessageFromEntries(
+      this.#getHostedMcpApprovalEntries(stateKey),
+      identity.requestId,
     );
   }
 
@@ -1184,11 +1281,16 @@ export class RunContext<TContext = UnknownContext> {
     approvalItem: RunToolApprovalItem,
     { alwaysApprove = false }: { alwaysApprove?: boolean } = {},
   ) {
-    const toolName = this.#getApprovalItemToolName(approvalItem);
+    const toolName = this.#getApprovalItemStorageKey(
+      approvalItem,
+      alwaysApprove,
+    );
     const isFunctionCall = approvalItem.rawItem.type === 'function_call';
     const approvals = isFunctionCall
       ? this.#getFunctionApprovalMap(approvalItem.agent)
-      : this.#approvals;
+      : getHostedMcpApprovalRequestIdentity(approvalItem)
+        ? this.#hostedMcpApprovals
+        : this.#approvals;
     const approvalKey = this.#getApprovalStorageKey(
       toolName,
       isFunctionCall,
@@ -1228,11 +1330,16 @@ export class RunContext<TContext = UnknownContext> {
       message,
     }: { alwaysReject?: boolean; message?: string } = {},
   ) {
-    const toolName = this.#getApprovalItemToolName(approvalItem);
+    const toolName = this.#getApprovalItemStorageKey(
+      approvalItem,
+      alwaysReject,
+    );
     const isFunctionCall = approvalItem.rawItem.type === 'function_call';
     const approvals = isFunctionCall
       ? this.#getFunctionApprovalMap(approvalItem.agent)
-      : this.#approvals;
+      : getHostedMcpApprovalRequestIdentity(approvalItem)
+        ? this.#hostedMcpApprovals
+        : this.#approvals;
     const approvalKey = this.#getApprovalStorageKey(
       toolName,
       isFunctionCall,
@@ -1388,6 +1495,11 @@ export class RunContext<TContext = UnknownContext> {
       .filter((approval): approval is ApprovalRecord => approval !== undefined);
   }
 
+  #getHostedMcpApprovalEntries(stateKey: string): ApprovalRecord[] {
+    const approval = this.#hostedMcpApprovals.get(stateKey);
+    return approval ? [approval] : [];
+  }
+
   #getToolApprovalMap(agent: Agent<any, any>): Map<string, ApprovalRecord> {
     const existing = this.#toolApprovalsByAgent.get(agent);
     if (existing) {
@@ -1485,6 +1597,32 @@ export class RunContext<TContext = UnknownContext> {
       getFunctionToolStateKeyForCall(approvalItem.rawItem, fallbackName) ??
       fallbackName
     );
+  }
+
+  #getApprovalItemStorageKey(
+    approvalItem: RunToolApprovalItem,
+    persistent: boolean,
+  ): string {
+    const hostedIdentity = getHostedMcpApprovalRequestIdentity(approvalItem);
+    if (!hostedIdentity) {
+      if (approvalItem.rawItem.type === 'hosted_tool_call' && persistent) {
+        throw new UserError(
+          'Persistent hosted approval decisions require valid MCP approval request provider data.',
+        );
+      }
+      return this.#getApprovalItemToolName(approvalItem);
+    }
+    if (!hostedIdentity.requestId) {
+      throw new UserError(
+        'Hosted MCP approval decisions require a non-empty request id.',
+      );
+    }
+    if (!hostedIdentity.serverLabel || !hostedIdentity.toolName) {
+      throw new UserError(
+        'Hosted MCP approval decisions require a non-empty server label and tool name.',
+      );
+    }
+    return getHostedMcpApprovalStateKey(hostedIdentity)!;
   }
 
   #getApprovalStorageKey(

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -68,6 +68,8 @@ import {
   getFunctionToolStateKeyForCall,
   getFunctionToolStateKeyForResolvedCall,
   getFunctionToolStateKeys,
+  getHostedMcpApprovalRequestIdentity,
+  getHostedMcpApprovalRequestKey,
   getToolCallNamespace,
   getToolCallDisplayName,
   resolveFunctionToolCall,
@@ -101,6 +103,7 @@ import {
 import {
   getCanonicalToolCaller,
   getHandoffToolInvocationName,
+  getHostedMcpApprovalToolName,
   getToolInvocationCallId,
   getToolInvocationFingerprint,
   getToolInvocationNameFromFingerprint,
@@ -146,7 +149,8 @@ import {
  *   persistence bookkeeping.
  * - 1.18: Adds sandbox session-state envelope version 3 so credential-redacted
  *   mount authority cannot be consumed by older SDKs, and binds per-call approvals
- *   and committed local tool results to canonical invocation fingerprints.
+ *   and committed local tool results to canonical invocation fingerprints. It also
+ *   scopes persistent hosted MCP approvals by server label and tool name.
  */
 export const CURRENT_SCHEMA_VERSION = '1.18' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
@@ -810,12 +814,15 @@ function validateToolInvocationCompletionEvidence(
       toolCall = rawToolCall;
       const providerData = toolCall.providerData as
         { id?: unknown; name?: unknown } | undefined;
-      expectedToolName =
+      const hostedToolName =
         typeof providerData?.name === 'string'
           ? providerData.name
           : callItem instanceof RunToolApprovalItem
             ? callItem.name
             : undefined;
+      expectedToolName = hostedToolName
+        ? getHostedMcpApprovalToolName(hostedToolName, toolCall)
+        : undefined;
       evidenceCallId =
         typeof providerData?.id === 'string'
           ? providerData.id
@@ -1507,6 +1514,7 @@ export const SerializedRunState = z.object({
   context: z.object({
     usage: usageSchema,
     approvals: z.record(z.string(), approvalRecordSchema),
+    hostedMcpApprovals: z.record(z.string(), approvalRecordSchema).optional(),
     functionApprovals: functionApprovalsSchema.optional(),
     legacyFunctionApprovals: z
       .record(z.string(), approvalRecordSchema)
@@ -4884,6 +4892,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   options: RunStateContextOverrideOptions<TContext> = {},
 ): Promise<RunState<TContext, TAgent>> {
   const schemaVersion = stateJson.$schemaVersion as SupportedSchemaVersion;
+  const serializedApprovals = stateJson.context.approvals;
   if (
     schemaVersionSupportsV118State(schemaVersion) &&
     (stateJson.context.approvalInvocations === undefined ||
@@ -4927,7 +4936,12 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   if (contextOverride) {
     if (contextStrategy === 'merge') {
       if (schemaVersionSupportsV116State(schemaVersion)) {
-        context._mergeApprovals(stateJson.context.approvals);
+        context._mergeApprovals(serializedApprovals);
+        if (schemaVersionSupportsV118State(schemaVersion)) {
+          context._mergeHostedMcpApprovals(
+            stateJson.context.hostedMcpApprovals ?? {},
+          );
+        }
         context._mergeFunctionApprovals(
           stateJson.context.functionApprovals ?? [],
           agentMap,
@@ -4945,16 +4959,19 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
         deferredLegacyApprovalContext = new RunContext<TContext>(
           stateJson.context.context as TContext,
         );
-        deferredLegacyApprovalContext._rebuildApprovals(
-          stateJson.context.approvals,
-        );
+        deferredLegacyApprovalContext._rebuildApprovals(serializedApprovals);
         deferredLegacyApprovalContext._rebuildLegacyFunctionApprovals(
-          stateJson.context.approvals,
+          serializedApprovals,
         );
       }
     }
   } else {
-    context._rebuildApprovals(stateJson.context.approvals);
+    context._rebuildApprovals(serializedApprovals);
+    context._rebuildHostedMcpApprovals(
+      schemaVersionSupportsV118State(schemaVersion)
+        ? (stateJson.context.hostedMcpApprovals ?? {})
+        : {},
+    );
     context._rebuildFunctionApprovals(
       stateJson.context.functionApprovals ?? [],
       agentMap,
@@ -4962,7 +4979,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     context._rebuildLegacyFunctionApprovals(
       schemaVersionSupportsV116State(schemaVersion)
         ? (stateJson.context.legacyFunctionApprovals ?? {})
-        : stateJson.context.approvals,
+        : serializedApprovals,
     );
     context._rebuildApprovalInvocations(
       schemaVersionSupportsV118State(schemaVersion)
@@ -5185,6 +5202,17 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       state,
       schemaVersion,
     );
+    if (
+      schemaVersion !== CURRENT_SCHEMA_VERSION &&
+      shouldRestoreSerializedContext
+    ) {
+      restoreLegacyHostedMcpApprovalsForPendingRequests(
+        context,
+        stateJson.context.approvals,
+        interruptions,
+        schemaVersion === '1.17',
+      );
+    }
     state._currentStep = {
       type: 'next_step_interruption',
       data: {
@@ -5702,6 +5730,151 @@ function deserializeInterruptions(
       (item): item is RunToolApprovalItem =>
         item instanceof RunToolApprovalItem,
     );
+}
+
+function restoreLegacyHostedMcpApprovalsForPendingRequests<TContext>(
+  context: RunContext<TContext>,
+  legacyApprovals: Record<string, z.infer<typeof approvalRecordSchema>>,
+  approvalItems: readonly RunToolApprovalItem[],
+  restoreStickyDecisions: boolean,
+): void {
+  const pendingByTool = new Map<
+    string,
+    Map<string, Map<string, RunToolApprovalItem | undefined>>
+  >();
+  const stickyClaimantsByTool = new Map<
+    string,
+    Map<string, RunToolApprovalItem | undefined>
+  >();
+  for (const [index, approvalItem] of approvalItems.entries()) {
+    const identity = getHostedMcpApprovalRequestIdentity(approvalItem);
+    const requestKey = identity
+      ? getHostedMcpApprovalRequestKey(identity)
+      : undefined;
+    const rawItem = approvalItem.rawItem as Record<string, unknown>;
+    const providerData = rawItem.providerData as
+      Record<string, unknown> | undefined;
+    const toolName = identity?.toolName ?? approvalItem.name;
+    const requestId =
+      identity?.requestId ??
+      (typeof rawItem.callId === 'string'
+        ? rawItem.callId
+        : typeof rawItem.id === 'string'
+          ? rawItem.id
+          : typeof providerData?.itemId === 'string'
+            ? providerData.itemId
+            : typeof providerData?.id === 'string'
+              ? providerData.id
+              : undefined);
+    if (!toolName) {
+      continue;
+    }
+    const claimantKey =
+      requestKey ?? JSON.stringify(['legacy_pending_claim', index]);
+    const stickyClaimants = stickyClaimantsByTool.get(toolName) ?? new Map();
+    stickyClaimants.set(claimantKey, requestKey ? approvalItem : undefined);
+    stickyClaimantsByTool.set(toolName, stickyClaimants);
+    if (!requestId) {
+      continue;
+    }
+    const pendingByRequestId = pendingByTool.get(toolName) ?? new Map();
+    const claimants = pendingByRequestId.get(requestId) ?? new Map();
+    claimants.set(claimantKey, requestKey ? approvalItem : undefined);
+    pendingByRequestId.set(requestId, claimants);
+    pendingByTool.set(toolName, pendingByRequestId);
+  }
+
+  for (const [toolName, pendingByRequestId] of pendingByTool) {
+    const legacy = legacyApprovals[toolName];
+    if (!legacy) {
+      continue;
+    }
+
+    const hasStickyDecision =
+      restoreStickyDecisions &&
+      (legacy.approved === true || legacy.rejected === true);
+    if (hasStickyDecision) {
+      const claimants = stickyClaimantsByTool.get(toolName) ?? new Map();
+      if (claimants.size === 1) {
+        const approvalItem = claimants.values().next().value;
+        const requestId = approvalItem
+          ? getHostedMcpApprovalRequestIdentity(approvalItem)?.requestId
+          : undefined;
+        if (approvalItem && requestId) {
+          restoreLegacyHostedMcpApprovalDecision(
+            context,
+            approvalItem,
+            legacy,
+            requestId,
+            true,
+          );
+        }
+      }
+      continue;
+    }
+
+    for (const [requestId, claimants] of pendingByRequestId) {
+      if (claimants.size !== 1) {
+        continue;
+      }
+      const approvalItem = claimants.values().next().value;
+      if (approvalItem) {
+        restoreLegacyHostedMcpApprovalDecision(
+          context,
+          approvalItem,
+          legacy,
+          requestId,
+          false,
+        );
+      }
+    }
+  }
+}
+
+function restoreLegacyHostedMcpApprovalDecision<TContext>(
+  context: RunContext<TContext>,
+  approvalItem: RunToolApprovalItem,
+  legacy: z.infer<typeof approvalRecordSchema>,
+  requestId: string,
+  restoreStickyDecisions: boolean,
+): void {
+  const decision = resolveLegacyHostedMcpApproval(
+    legacy,
+    requestId,
+    restoreStickyDecisions,
+  );
+  if (decision === true) {
+    context.approveTool(approvalItem);
+  } else if (decision === false) {
+    context.rejectTool(approvalItem, {
+      message:
+        legacy.messages?.[requestId] ??
+        (restoreStickyDecisions && legacy.rejected === true
+          ? legacy.stickyRejectMessage
+          : undefined),
+    });
+  }
+}
+
+function resolveLegacyHostedMcpApproval(
+  legacy: z.infer<typeof approvalRecordSchema>,
+  requestId: string,
+  restoreStickyDecisions: boolean,
+): boolean | undefined {
+  const stickyApproval = restoreStickyDecisions && legacy.approved === true;
+  const stickyRejection = restoreStickyDecisions && legacy.rejected === true;
+  if (stickyApproval || stickyRejection) {
+    return stickyApproval;
+  }
+
+  const exactApproval =
+    Array.isArray(legacy.approved) && legacy.approved.includes(requestId);
+  const exactRejection =
+    Array.isArray(legacy.rejected) && legacy.rejected.includes(requestId);
+  if (exactApproval || exactRejection) {
+    return exactApproval;
+  }
+  return undefined;
 }
 
 function rebindInterruptionFunctionToolStateKeys<TContext>(

--- a/packages/agents-core/src/runner/mcpApprovals.ts
+++ b/packages/agents-core/src/runner/mcpApprovals.ts
@@ -2,9 +2,14 @@ import { Agent } from '../agent';
 import { RunItem, RunToolApprovalItem, RunToolCallItem } from '../items';
 import { RunState } from '../runState';
 import { FunctionToolResult } from '../tool';
+import {
+  getHostedMcpApprovalRequestIdentity,
+  getHostedMcpApprovalRequestKey,
+} from '../toolIdentity';
 import * as ProviderData from '../types/providerData';
 import * as protocol from '../types/protocol';
 import type { ToolRunMCPApprovalRequest } from './types';
+import { getHostedMcpApprovalToolName } from '../toolInvocation';
 
 type ResolveApproval = (
   rawItem: protocol.HostedToolCallItem,
@@ -25,7 +30,7 @@ type HandleHostedMcpApprovalsParams<TContext> = {
 
 export type HandleHostedMcpApprovalsResult = {
   pendingApprovals: Set<RunToolApprovalItem>;
-  pendingApprovalIds: Set<string>;
+  pendingApprovalKeys: Set<string>;
 };
 
 /**
@@ -42,7 +47,7 @@ export async function handleHostedMcpApprovals<TContext>({
   resolveRejectionMessage,
 }: HandleHostedMcpApprovalsParams<TContext>): Promise<HandleHostedMcpApprovalsResult> {
   const pendingApprovals = new Set<RunToolApprovalItem>();
-  const pendingApprovalIds = new Set<string>();
+  const pendingApprovalKeys = new Set<string>();
 
   for (const approvalRequest of requests) {
     const rawItem = approvalRequest.requestItem.rawItem;
@@ -58,7 +63,8 @@ export async function handleHostedMcpApprovals<TContext>({
 
     const toolData = approvalRequest.mcpTool.providerData as
       ProviderData.HostedMCPTool<TContext> | undefined;
-    const approvalRequestId = rawItem.id ?? providerData.id;
+    const approvalIdentity = getHostedMcpApprovalRequestIdentity(rawItem);
+    const approvalRequestId = approvalIdentity?.requestId;
 
     const approvalDecision =
       typeof resolveApproval === 'function'
@@ -72,7 +78,7 @@ export async function handleHostedMcpApprovals<TContext>({
             ? resolveRejectionMessage(rawItem)
             : state._context._getToolInvocationRejectionMessage(
                 agent,
-                rawItem.name,
+                getHostedMcpApprovalToolName(rawItem.name, rawItem),
                 rawItem,
               )
           : undefined;
@@ -95,7 +101,7 @@ export async function handleHostedMcpApprovals<TContext>({
       continue;
     }
 
-    if (toolData?.on_approval) {
+    if (toolData?.on_approval && approvalRequestId) {
       const approvalResult = await toolData.on_approval(
         state._context,
         approvalRequest.requestItem,
@@ -109,7 +115,7 @@ export async function handleHostedMcpApprovals<TContext>({
       }
       const approvalResponseData: ProviderData.HostedMCPApprovalResponse = {
         approve: approvalResult.approve,
-        approval_request_id: approvalRequestId ?? providerData.id,
+        approval_request_id: approvalRequestId,
         reason: approvalResult.reason,
       };
       appendIfNew(
@@ -134,10 +140,13 @@ export async function handleHostedMcpApprovals<TContext>({
     appendIfNew(approvalRequest.requestItem);
 
     pendingApprovals.add(approvalRequest.requestItem);
-    if (approvalRequestId) {
-      pendingApprovalIds.add(approvalRequestId);
+    const approvalRequestKey = approvalIdentity
+      ? getHostedMcpApprovalRequestKey(approvalIdentity)
+      : undefined;
+    if (approvalRequestKey) {
+      pendingApprovalKeys.add(approvalRequestKey);
     }
   }
 
-  return { pendingApprovals, pendingApprovalIds };
+  return { pendingApprovals, pendingApprovalKeys };
 }

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -46,7 +46,6 @@ import {
 } from './toolExecution';
 import { getRunStateTurnSpanParent } from './invocationContext';
 import { handleHostedMcpApprovals } from './mcpApprovals';
-import * as ProviderData from '../types/providerData';
 import * as protocol from '../types/protocol';
 import { AgentInputItem } from '../types';
 import type { FunctionTool, FunctionToolResult, Tool } from '../tool';
@@ -58,6 +57,8 @@ import {
   getFunctionToolStateKeys,
   getToolCallNamespace,
   resolveFunctionToolCall,
+  getHostedMcpApprovalRequestIdentity,
+  getHostedMcpApprovalRequestKey,
 } from '../toolIdentity';
 import type { RunErrorData, RunErrorHandlers } from './errorHandlers';
 import {
@@ -76,6 +77,7 @@ import {
 import { runWithSiblingCancellation } from './siblingCancellation';
 import {
   getHandoffToolInvocationName,
+  getHostedMcpApprovalToolName,
   getToolInvocationCallId,
   getToolInvocationFingerprint,
   type ApprovalCapableToolCall,
@@ -392,10 +394,7 @@ const APPROVAL_ITEM_TYPES = [
 ] as const;
 
 function isHostedMcpApprovalItem(item: RunToolApprovalItem): boolean {
-  return (
-    item.rawItem.type === 'hosted_tool_call' &&
-    item.rawItem.providerData?.type === 'mcp_approval_request'
-  );
+  return getHostedMcpApprovalRequestIdentity(item) !== undefined;
 }
 
 type ApprovalResolution = 'approved' | 'rejected' | 'pending';
@@ -1212,22 +1211,19 @@ export async function resolveInterruptedTurn<TContext>(
     functionResults,
     appendIfNew,
     resolveApproval: (rawItem) => {
-      const providerData =
-        rawItem.providerData as ProviderData.HostedMCPApprovalRequest;
-      const approvalRequestId = rawItem.id ?? providerData?.id;
-      if (!approvalRequestId) {
+      if (!getHostedMcpApprovalRequestIdentity(rawItem)?.requestId) {
         return undefined;
       }
       return state._context._resolveToolInvocationApproval(
         agent,
-        rawItem.name,
+        getHostedMcpApprovalToolName(rawItem.name, rawItem),
         rawItem,
       );
     },
     resolveRejectionMessage: (rawItem) =>
       state._context._getToolInvocationRejectionMessage(
         agent,
-        rawItem.name,
+        getHostedMcpApprovalToolName(rawItem.name, rawItem),
         rawItem,
       ),
   });
@@ -1245,16 +1241,16 @@ export async function resolveInterruptedTurn<TContext>(
       if (hostedMcpApprovals.pendingApprovals.has(item)) {
         return true;
       }
-      const approvalRequestId =
-        item.rawItem.id ??
-        (
-          item.rawItem.providerData as
-            ProviderData.HostedMCPApprovalRequest | undefined
-        )?.id;
-      if (approvalRequestId) {
-        return hostedMcpApprovals.pendingApprovalIds.has(approvalRequestId);
+      const approvalIdentity = getHostedMcpApprovalRequestIdentity(
+        item.rawItem,
+      );
+      const approvalRequestKey = approvalIdentity
+        ? getHostedMcpApprovalRequestKey(approvalIdentity)
+        : undefined;
+      if (approvalRequestKey) {
+        return hostedMcpApprovals.pendingApprovalKeys.has(approvalRequestKey);
       }
-      return false;
+      return true;
     }
 
     // Preserve all other approval items so resumptions can continue to reference the
@@ -1462,22 +1458,19 @@ export async function resolveTurnAfterModelResponse<
       functionResults,
       appendIfNew,
       resolveApproval: (rawItem) => {
-        const providerData =
-          rawItem.providerData as ProviderData.HostedMCPApprovalRequest;
-        const approvalRequestId = rawItem.id ?? providerData?.id;
-        if (!approvalRequestId) {
+        if (!getHostedMcpApprovalRequestIdentity(rawItem)?.requestId) {
           return undefined;
         }
         return state._context._resolveToolInvocationApproval(
           agent,
-          rawItem.name,
+          getHostedMcpApprovalToolName(rawItem.name, rawItem),
           rawItem,
         );
       },
       resolveRejectionMessage: (rawItem) =>
         state._context._getToolInvocationRejectionMessage(
           agent,
-          rawItem.name,
+          getHostedMcpApprovalToolName(rawItem.name, rawItem),
           rawItem,
         ),
     });

--- a/packages/agents-core/src/toolIdentity.ts
+++ b/packages/agents-core/src/toolIdentity.ts
@@ -20,6 +20,23 @@ type MaybeToolCallWithNamespace = {
   namespace?: unknown;
 };
 
+type MaybeHostedMcpApprovalRequest = {
+  type?: unknown;
+  id?: unknown;
+  itemId?: unknown;
+  name?: unknown;
+  providerData?: unknown;
+  rawItem?: unknown;
+  server_label?: unknown;
+  serverLabel?: unknown;
+};
+
+export type HostedMcpApprovalRequestIdentity = {
+  requestId?: string;
+  serverLabel?: string;
+  toolName?: string;
+};
+
 declare const FUNCTION_TOOL_LOOKUP_KEY: unique symbol;
 
 /** @internal */
@@ -29,6 +46,113 @@ export type FunctionToolLookupKey = string & {
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
+}
+
+/** @internal */
+export function getHostedMcpApprovalRequestIdentity(
+  value: unknown,
+): HostedMcpApprovalRequestIdentity | undefined {
+  const candidate = value as MaybeHostedMcpApprovalRequest;
+  const rawItem =
+    candidate?.rawItem && typeof candidate.rawItem === 'object'
+      ? (candidate.rawItem as MaybeHostedMcpApprovalRequest)
+      : candidate;
+  if (rawItem?.type !== 'hosted_tool_call') {
+    return undefined;
+  }
+
+  const providerData = rawItem.providerData as
+    MaybeHostedMcpApprovalRequest | undefined;
+  if (!providerData) {
+    return undefined;
+  }
+  if (
+    providerData.type !== undefined &&
+    providerData.type !== 'mcp_approval_request'
+  ) {
+    return undefined;
+  }
+  if (
+    providerData.type === undefined &&
+    !isNonEmptyString(providerData.server_label) &&
+    !(
+      isNonEmptyString(providerData.serverLabel) &&
+      isNonEmptyString(providerData.itemId)
+    )
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(isNonEmptyString(providerData.id)
+      ? { requestId: providerData.id }
+      : isNonEmptyString(providerData.itemId)
+        ? { requestId: providerData.itemId }
+        : isNonEmptyString(rawItem.id)
+          ? { requestId: rawItem.id }
+          : {}),
+    ...(isNonEmptyString(providerData.server_label)
+      ? { serverLabel: providerData.server_label }
+      : isNonEmptyString(providerData.serverLabel)
+        ? { serverLabel: providerData.serverLabel }
+        : {}),
+    ...(isNonEmptyString(providerData.name)
+      ? { toolName: providerData.name }
+      : isNonEmptyString(rawItem.name) &&
+          rawItem.name !== 'mcp_approval_request'
+        ? { toolName: rawItem.name }
+        : {}),
+  };
+}
+
+/** @internal */
+export function getHostedMcpApprovalStateKey(
+  identity: HostedMcpApprovalRequestIdentity,
+): string | undefined {
+  if (identity.serverLabel && identity.toolName) {
+    return JSON.stringify([
+      'hosted_mcp',
+      identity.serverLabel,
+      identity.toolName,
+    ]);
+  }
+  return undefined;
+}
+
+/** @internal */
+export function getHostedMcpApprovalRequestKey(
+  identity: HostedMcpApprovalRequestIdentity,
+): string | undefined {
+  if (identity.serverLabel && identity.toolName && identity.requestId) {
+    return JSON.stringify([
+      'hosted_mcp_request',
+      identity.serverLabel,
+      identity.toolName,
+      identity.requestId,
+    ]);
+  }
+  return undefined;
+}
+
+/** @internal */
+export function getHostedMcpApprovalIdentityFromStateKey(
+  stateKey: string,
+): HostedMcpApprovalRequestIdentity | undefined {
+  try {
+    const value = JSON.parse(stateKey);
+    if (
+      Array.isArray(value) &&
+      value.length === 3 &&
+      value[0] === 'hosted_mcp' &&
+      isNonEmptyString(value[1]) &&
+      isNonEmptyString(value[2])
+    ) {
+      return { serverLabel: value[1], toolName: value[2] };
+    }
+  } catch {
+    // Non-JSON keys are not hosted MCP approval identities.
+  }
+  return undefined;
 }
 
 function encodeFunctionToolLookupKey(parts: string[]): FunctionToolLookupKey {

--- a/packages/agents-core/src/toolInvocation.ts
+++ b/packages/agents-core/src/toolInvocation.ts
@@ -1,7 +1,11 @@
 import type { RunToolApprovalItem } from './items';
 import type { Agent } from './agent';
 import type { RunContext } from './runContext';
-import { getFunctionToolStateKey } from './toolIdentity';
+import {
+  getFunctionToolStateKey,
+  getHostedMcpApprovalRequestIdentity,
+  getHostedMcpApprovalStateKey,
+} from './toolIdentity';
 import type * as protocol from './types/protocol';
 
 export type ApprovalCapableToolCall = RunToolApprovalItem['rawItem'];
@@ -12,9 +16,23 @@ export type LocalToolCall =
   | protocol.ShellCallItem
   | protocol.ApplyPatchCallItem;
 
+export function getHostedMcpApprovalToolName(
+  toolName: string,
+  toolCall: ApprovalCapableToolCall,
+): string {
+  const identity = getHostedMcpApprovalRequestIdentity(toolCall);
+  return identity
+    ? (getHostedMcpApprovalStateKey(identity) ?? toolName)
+    : toolName;
+}
+
 export function getToolInvocationCallId(
   toolCall: ApprovalCapableToolCall,
 ): string | undefined {
+  const hostedMcpIdentity = getHostedMcpApprovalRequestIdentity(toolCall);
+  if (hostedMcpIdentity?.requestId) {
+    return hostedMcpIdentity.requestId;
+  }
   if ('callId' in toolCall && typeof toolCall.callId === 'string') {
     return toolCall.callId;
   }
@@ -134,6 +152,9 @@ function canonicalizeToolName(
   toolName: string,
   toolCall: ApprovalCapableToolCall,
 ): string {
+  if (toolCall.type === 'hosted_tool_call') {
+    return getHostedMcpApprovalToolName(toolName, toolCall);
+  }
   if (
     toolCall.type === 'computer_call' &&
     (toolName === 'computer' || toolName === 'computer_use_preview')

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -21,6 +21,7 @@ export {
 } from '../logger';
 export {
   getBoundToolInvocationRejectionMessage,
+  getHostedMcpApprovalToolName,
   getToolInvocationApproval,
   getToolInvocationRejectionMessage,
   validateHandoffToolInvocation,

--- a/packages/agents-core/test/agentScenarios.test.ts
+++ b/packages/agents-core/test/agentScenarios.test.ts
@@ -267,6 +267,27 @@ function hostedToolCall(
   };
 }
 
+function hostedMcpApprovalRequest(
+  requestId: string,
+  serverLabel: string,
+  toolName: string,
+  rawRequestId = requestId,
+): protocol.HostedToolCallItem {
+  return {
+    id: rawRequestId,
+    type: 'hosted_tool_call',
+    name: 'mcp_approval_request',
+    status: 'completed',
+    providerData: {
+      type: 'mcp_approval_request',
+      id: requestId,
+      server_label: serverLabel,
+      name: toolName,
+      arguments: '{}',
+    },
+  };
+}
+
 function textMessage(content: string): protocol.AssistantMessageItem {
   return {
     type: 'message',
@@ -2959,6 +2980,170 @@ describe('Agent scenarios (examples and docs patterns)', () => {
     });
 
     warnSpy.mockRestore();
+  });
+
+  it.each([
+    { name: 'run', stream: false },
+    { name: 'stream', stream: true },
+  ])(
+    'does not reuse a persistent hosted MCP approval across servers with $name',
+    async ({ stream }) => {
+      const model = new RecordingModel();
+      model.addMultipleTurnOutputs([
+        [hostedMcpApprovalRequest('request-a', 'server-a', 'lookup_account')],
+        [
+          hostedMcpApprovalRequest(
+            'request-b',
+            'server-b',
+            'lookup_account',
+            'conflicting-raw-request-b',
+          ),
+        ],
+      ]);
+      const agent = new Agent({
+        name: 'scoped-mcp-approval',
+        model,
+        tools: [
+          hostedMcpTool({
+            serverLabel: 'server-a',
+            serverUrl: 'https://server-a.example/mcp',
+            requireApproval: 'always',
+          }),
+          hostedMcpTool({
+            serverLabel: 'server-b',
+            serverUrl: 'https://server-b.example/mcp',
+            requireApproval: 'always',
+          }),
+        ],
+      });
+
+      const runWithMode = async (
+        input: string | RunState<unknown, Agent<unknown, 'text'>>,
+      ) => {
+        if (stream) {
+          const result = await run(agent, input, { stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input);
+      };
+
+      const first = await runWithMode('Lookup the account');
+      expect(first.interruptions).toHaveLength(1);
+      expect(
+        (first.interruptions[0].rawItem.providerData as any).server_label,
+      ).toBe('server-a');
+      first.state.approve(first.interruptions[0], { alwaysApprove: true });
+
+      const restored = await RunState.fromString(agent, first.state.toString());
+      const resumed = await runWithMode(restored);
+
+      expect(resumed.interruptions).toHaveLength(1);
+      expect(
+        (resumed.interruptions[0].rawItem.providerData as any).server_label,
+      ).toBe('server-b');
+    },
+  );
+
+  it('restores a pending schema 1.17 sticky MCP approval as exact-call approval', async () => {
+    const model = new RecordingModel();
+    model.addMultipleTurnOutputs([
+      [hostedMcpApprovalRequest('request-a', 'server-a', 'lookup_account')],
+      [hostedMcpApprovalRequest('request-b', 'server-b', 'lookup_account')],
+    ]);
+    const agent = new Agent({
+      name: 'legacy-scoped-mcp-approval',
+      model,
+      tools: [
+        hostedMcpTool({
+          serverLabel: 'server-a',
+          serverUrl: 'https://server-a.example/mcp',
+          requireApproval: 'always',
+        }),
+        hostedMcpTool({
+          serverLabel: 'server-b',
+          serverUrl: 'https://server-b.example/mcp',
+          requireApproval: 'always',
+        }),
+      ],
+    });
+
+    const first = await run(agent, 'Lookup the account');
+    expect(first.interruptions).toHaveLength(1);
+    first.state.approve(first.interruptions[0], { alwaysApprove: true });
+
+    const serialized = first.state.toJSON() as any;
+    serialized.$schemaVersion = '1.17';
+    serialized.context.approvals = {
+      lookup_account: { approved: true, rejected: [] },
+    };
+    delete serialized.context.hostedMcpApprovals;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const resumed = await run(agent, restored);
+
+    expect(resumed.interruptions).toHaveLength(1);
+    expect(
+      (resumed.interruptions[0].rawItem.providerData as any).server_label,
+    ).toBe('server-b');
+  });
+
+  it('keeps hosted MCP approvals server-scoped in nested agent resumes', async () => {
+    const nestedModel = new RecordingModel();
+    nestedModel.addMultipleTurnOutputs([
+      [hostedMcpApprovalRequest('nested-a', 'server-a', 'lookup_account')],
+      [hostedMcpApprovalRequest('nested-b', 'server-b', 'lookup_account')],
+    ]);
+    const nestedAgent = new Agent({
+      name: 'NestedMcpApprovalAgent',
+      model: nestedModel,
+      tools: [
+        hostedMcpTool({
+          serverLabel: 'server-a',
+          serverUrl: 'https://server-a.example/mcp',
+          requireApproval: 'always',
+        }),
+        hostedMcpTool({
+          serverLabel: 'server-b',
+          serverUrl: 'https://server-b.example/mcp',
+          requireApproval: 'always',
+        }),
+      ],
+    });
+    const nestedTool = nestedAgent.asTool({
+      toolName: 'nested_mcp_agent',
+      toolDescription: 'Run the nested MCP agent.',
+    });
+    const outerModel = new RecordingModel([
+      functionToolCall(
+        'nested_mcp_agent',
+        JSON.stringify({ input: 'lookup' }),
+        'outer-mcp-call',
+      ),
+    ]);
+    const outerAgent = new Agent({
+      name: 'OuterMcpApprovalAgent',
+      model: outerModel,
+      tools: [nestedTool],
+    });
+
+    const first = await run(outerAgent, 'Start');
+    expect(first.interruptions).toHaveLength(1);
+    first.state.approve(first.interruptions[0], { alwaysApprove: true });
+
+    const restored = await RunState.fromString(
+      outerAgent,
+      first.state.toString(),
+    );
+    const resumed = await run(outerAgent, restored);
+
+    expect(resumed.interruptions).toHaveLength(1);
+    expect(
+      (resumed.interruptions[0].rawItem.providerData as any).server_label,
+    ).toBe('server-b');
   });
 
   it('orchestrator calls multiple translation tools then summarizes', async () => {

--- a/packages/agents-core/test/runContext.test.ts
+++ b/packages/agents-core/test/runContext.test.ts
@@ -32,16 +32,18 @@ function createApproval(callId = '123', toolName = 'toolX') {
 function createRealtimeHostedApproval(
   itemId = 'item-1',
   toolName = 'hostedMcp',
+  serverLabel = 'server-1',
 ) {
   return new ToolApprovalItem(
     {
       type: 'hosted_tool_call',
+      id: 'hosted-output-item',
       name: toolName,
       arguments: '{}',
       status: 'in_progress',
       providerData: {
         itemId,
-        serverLabel: 'server-1',
+        serverLabel,
         type: 'mcp_approval_request',
       },
     } as any,
@@ -294,16 +296,202 @@ describe('RunContext', () => {
 
     ctx.rejectTool(item, { message: 'Denied by policy.' });
 
-    expect(
-      ctx.isToolApproved({ toolName: 'hostedMcp', callId: 'item-1' }),
-    ).toBe(false);
-    expect(ctx.getRejectionMessage('hostedMcp', 'item-1')).toBe(
-      'Denied by policy.',
-    );
-    expect(ctx.toJSON().approvals.hostedMcp.messages).toEqual({
-      'item-1': 'Denied by policy.',
-    });
+    expect(ctx._getHostedMcpApprovalStatus(item)).toBe(false);
+    expect(ctx._getHostedMcpRejectionMessage(item)).toBe('Denied by policy.');
+    expect(ctx.toJSON()).not.toHaveProperty('hostedMcpApprovals');
   });
+
+  it('fails closed for legacy sticky hosted MCP decisions', () => {
+    const ctx = new RunContext();
+    const item = createRealtimeHostedApproval();
+    ctx._rebuildApprovals({
+      hostedMcp: {
+        approved: true,
+        rejected: [],
+      },
+    });
+
+    expect(ctx._getHostedMcpApprovalStatus(item)).toBeUndefined();
+  });
+
+  it('does not treat a colliding aggregate key as hosted MCP state', () => {
+    const ctx = new RunContext();
+    const item = createRealtimeHostedApproval();
+    const collidingLegacyKey = JSON.stringify([
+      'hosted_mcp',
+      'server-1',
+      'hostedMcp',
+    ]);
+    ctx._rebuildApprovals({
+      [collidingLegacyKey]: {
+        approved: true,
+        rejected: [],
+      },
+    });
+
+    expect(ctx._getHostedMcpApprovalStatus(item)).toBeUndefined();
+  });
+
+  it('isolates hosted MCP state from colliding local tool names', () => {
+    const stateKey = JSON.stringify(['hosted_mcp', 'server-1', 'hostedMcp']);
+    const hosted = createRealtimeHostedApproval();
+    const local = new ToolApprovalItem(
+      {
+        type: 'shell_call',
+        callId: 'local-call',
+        name: stateKey,
+        status: 'completed',
+        action: { commands: ['echo ok'] },
+      } as any,
+      agent,
+      stateKey,
+    );
+
+    const hostedContext = new RunContext();
+    hostedContext.approveTool(hosted, { alwaysApprove: true });
+    expect(
+      hostedContext.isToolApproved({
+        toolName: stateKey,
+        callId: 'future-local-call',
+        functionTool: false,
+      }),
+    ).toBeUndefined();
+    expect(
+      hostedContext._resolveToolInvocationApproval(
+        agent,
+        stateKey,
+        local.rawItem,
+      ),
+    ).toBeUndefined();
+
+    const localContext = new RunContext();
+    localContext.approveTool(local, { alwaysApprove: true });
+    expect(localContext._getHostedMcpApprovalStatus(hosted)).toBeUndefined();
+  });
+
+  it('does not consult legacy exact-call hosted MCP decisions at runtime', () => {
+    const ctx = new RunContext();
+    const item = createRealtimeHostedApproval();
+    ctx._rebuildApprovals({
+      hostedMcp: {
+        approved: [],
+        rejected: ['item-1'],
+        messages: { 'item-1': 'Legacy denial.' },
+      },
+    });
+
+    expect(ctx._getHostedMcpApprovalStatus(item)).toBeUndefined();
+    expect(ctx._getHostedMcpRejectionMessage(item)).toBeUndefined();
+  });
+
+  it('keeps generic hosted one-shot approvals with opaque provider data', () => {
+    const ctx = new RunContext();
+    const item = new ToolApprovalItem(
+      {
+        type: 'hosted_tool_call',
+        id: 'opaque-hosted-call',
+        name: 'opaque_hosted_tool',
+        status: 'completed',
+        providerData: { vendor: 'example' },
+      } as any,
+      agent,
+    );
+
+    ctx.approveTool(item);
+
+    expect(
+      ctx.isToolApproved({
+        toolName: 'opaque_hosted_tool',
+        callId: 'opaque-hosted-call',
+        functionTool: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not expose hosted MCP rejection messages to local tools', () => {
+    const ctx = new RunContext();
+    const hosted = createRealtimeHostedApproval('item-a', 'shell');
+    const shell = new ToolApprovalItem(
+      {
+        type: 'shell_call',
+        callId: 'shell-call',
+        name: 'shell',
+        status: 'completed',
+        action: { commands: ['echo ok'] },
+      } as any,
+      agent,
+      'shell',
+    );
+
+    ctx.rejectTool(hosted, {
+      alwaysReject: true,
+      message: 'Hosted-only policy.',
+    });
+    ctx.rejectTool(shell);
+
+    expect(
+      ctx.getRejectionMessage('shell', 'shell-call', { functionTool: false }),
+    ).toBeUndefined();
+  });
+
+  it('does not expose ambiguous hosted MCP rejection messages publicly', () => {
+    const ctx = new RunContext();
+    ctx._rebuildApprovals({
+      [JSON.stringify(['hosted_mcp', 'server-a', 'lookup_account'])]: {
+        approved: [],
+        rejected: ['shared-call'],
+        messages: { 'shared-call': 'Denied by server A.' },
+      },
+      [JSON.stringify(['hosted_mcp', 'server-b', 'lookup_account'])]: {
+        approved: [],
+        rejected: ['shared-call'],
+        messages: { 'shared-call': 'Denied by server B.' },
+      },
+    });
+
+    expect(
+      ctx.getRejectionMessage('lookup_account', 'shared-call', {
+        functionTool: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('rejects hosted MCP decisions without a server identity', () => {
+    const ctx = new RunContext();
+    const item = createRealtimeHostedApproval();
+    delete (item.rawItem.providerData as any).serverLabel;
+
+    expect(() => ctx.approveTool(item)).toThrow(
+      'Hosted MCP approval decisions require a non-empty server label and tool name.',
+    );
+    expect(() => ctx.rejectTool(item)).toThrow(
+      'Hosted MCP approval decisions require a non-empty server label and tool name.',
+    );
+  });
+
+  it.each([
+    { label: 'missing', providerData: undefined },
+    {
+      label: 'wrong-type',
+      providerData: { type: 'web_search_call', id: 'item-1' },
+    },
+  ])(
+    'rejects hosted MCP decisions with $label provider data',
+    ({ providerData }) => {
+      const ctx = new RunContext();
+      const item = createRealtimeHostedApproval();
+      (item.rawItem as any).providerData = providerData;
+
+      expect(() => ctx.approveTool(item, { alwaysApprove: true })).toThrow(
+        'Persistent hosted approval decisions require valid MCP approval request provider data.',
+      );
+      expect(() => ctx.rejectTool(item, { alwaysReject: true })).toThrow(
+        'Persistent hosted approval decisions require valid MCP approval request provider data.',
+      );
+      expect(ctx.toJSON().approvals).toEqual({});
+      expect(ctx.toJSON()).not.toHaveProperty('hostedMcpApprovals');
+    },
+  );
 
   it('rebuilds approvals map', () => {
     const ctx = new RunContext();

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -10128,6 +10128,674 @@ export function registerRunStateApprovalTests(): void {
       ).toBe('Blocked everywhere');
     });
 
+    it('round-trips server-scoped hosted MCP approvals', async () => {
+      const context = new RunContext();
+      const agent = new Agent({ name: 'HostedMcpApprovalStateAgent' });
+      const state = new RunState(context, 'input', agent, 1);
+      const approval = new ToolApprovalItem(
+        {
+          type: 'hosted_tool_call',
+          id: 'request-a',
+          name: 'lookup_account',
+          status: 'in_progress',
+          providerData: {
+            type: 'mcp_approval_request',
+            id: 'request-a',
+            server_label: 'server-a',
+            name: 'lookup_account',
+            arguments: '{}',
+          },
+        },
+        agent,
+      );
+      state.approve(approval, { alwaysApprove: true });
+
+      const serialized = state.toJSON() as any;
+      const approvalKey = JSON.stringify([
+        'hosted_mcp',
+        'server-a',
+        'lookup_account',
+      ]);
+      expect(serialized.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+      expect(serialized.context.hostedMcpApprovals).toEqual({
+        [approvalKey]: { approved: true, rejected: [] },
+      });
+      expect(serialized.context.approvals).toEqual({});
+
+      const restored = await RunState.fromString(agent, state.toString());
+      const sameServer = new ToolApprovalItem(
+        {
+          ...approval.rawItem,
+          id: 'request-a-next',
+          providerData: {
+            ...(approval.rawItem.providerData as Record<string, unknown>),
+            id: 'request-a-next',
+          },
+        },
+        agent,
+      );
+      const otherServer = new ToolApprovalItem(
+        {
+          ...sameServer.rawItem,
+          id: 'request-b',
+          providerData: {
+            ...(sameServer.rawItem.providerData as Record<string, unknown>),
+            id: 'request-b',
+            server_label: 'server-b',
+          },
+        },
+        agent,
+      );
+
+      expect(restored._context._getHostedMcpApprovalStatus(sameServer)).toBe(
+        true,
+      );
+      expect(
+        restored._context._getHostedMcpApprovalStatus(otherServer),
+      ).toBeUndefined();
+    });
+
+    it('preserves legacy local approvals whose names resemble hosted keys', async () => {
+      const agent = new Agent({ name: 'LegacyCollidingLocalApprovalAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const collidingName = JSON.stringify([
+        'hosted_mcp',
+        'server-a',
+        'lookup_account',
+      ]);
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.17';
+      serialized.context.approvals = {
+        [collidingName]: { approved: true, rejected: [] },
+      };
+      delete serialized.context.hostedMcpApprovals;
+      delete serialized.context.approvalInvocations;
+      delete serialized.completedToolInvocations;
+      delete serialized.completedToolInvocationEvidence;
+      delete serialized.ambiguousToolInvocationCallIds;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      expect(
+        restored._context.isToolApproved({
+          toolName: collidingName,
+          callId: 'future-local-call',
+          functionTool: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('rejects request-only hosted MCP approvals before serialization', () => {
+      const context = new RunContext();
+      const agent = new Agent({ name: 'HostedMcpRequestApprovalStateAgent' });
+      const state = new RunState(context, 'input', agent, 1);
+      const approval = new ToolApprovalItem(
+        {
+          type: 'hosted_tool_call',
+          id: 'request-only',
+          name: 'lookup_account',
+          status: 'in_progress',
+          providerData: {
+            type: 'mcp_approval_request',
+            id: 'request-only',
+            name: 'lookup_account',
+            arguments: '{}',
+          },
+        },
+        agent,
+      );
+      expect(() => state.approve(approval)).toThrow(
+        'Hosted MCP approval decisions require a non-empty server label and tool name.',
+      );
+      expect(state.toJSON().context.approvals).toEqual({});
+    });
+
+    it('reads schema 1.17 hosted MCP decisions without trusting sticky names', async () => {
+      const agent = new Agent({ name: 'LegacyHostedMcpApprovalStateAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const pendingStickyApproval = new ToolApprovalItem(
+        {
+          type: 'hosted_tool_call',
+          id: 'pending-sticky-request',
+          name: 'lookup_account',
+          status: 'in_progress',
+          providerData: {
+            type: 'mcp_approval_request',
+            id: 'pending-sticky-request',
+            server_label: 'server-a',
+            name: 'lookup_account',
+            arguments: '{}',
+          },
+        },
+        agent,
+      );
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [pendingStickyApproval] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.17';
+      serialized.context.approvals = {
+        lookup_account: {
+          approved: true,
+          rejected: ['legacy-request'],
+          messages: { 'legacy-request': 'Legacy exact denial.' },
+        },
+      };
+      serialized.context.hostedMcpApprovals = {
+        [JSON.stringify(['hosted_mcp', 'server-a', 'lookup_account'])]: {
+          approved: true,
+          rejected: [],
+        },
+      };
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      const merged = await RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        new RunContext(),
+        { contextStrategy: 'merge' },
+      );
+      const replaced = await RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        new RunContext(),
+        { contextStrategy: 'replace' },
+      );
+      const buildApproval = (requestId: string) =>
+        new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            id: requestId,
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              id: requestId,
+              server_label: 'server-a',
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+
+      expect(
+        restored._context._getHostedMcpApprovalStatus(
+          buildApproval('future-request'),
+        ),
+      ).toBeUndefined();
+      expect(
+        restored._context._getHostedMcpApprovalStatus(
+          buildApproval('pending-sticky-request'),
+        ),
+      ).toBe(true);
+      expect(
+        merged._context._getHostedMcpApprovalStatus(
+          buildApproval('pending-sticky-request'),
+        ),
+      ).toBe(true);
+      expect(
+        replaced._context._getHostedMcpApprovalStatus(
+          buildApproval('pending-sticky-request'),
+        ),
+      ).toBeUndefined();
+      const exactLegacyApproval = buildApproval('legacy-request');
+      expect(
+        restored._context._getHostedMcpApprovalStatus(exactLegacyApproval),
+      ).toBeUndefined();
+      expect(
+        restored._context._getHostedMcpRejectionMessage(exactLegacyApproval),
+      ).toBeUndefined();
+      expect(
+        restored.toJSON().context.hostedMcpApprovals?.[
+          JSON.stringify(['hosted_mcp', 'server-a', 'lookup_account'])
+        ],
+      ).toEqual({ approved: ['pending-sticky-request'], rejected: [] });
+    });
+
+    it('restores schema 1.17 sticky rejection only for the pending MCP request', async () => {
+      const agent = new Agent({ name: 'LegacyHostedMcpRejectionStateAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const buildApproval = (requestId: string) =>
+        new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            id: requestId,
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              id: requestId,
+              server_label: 'server-a',
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: {
+          interruptions: [buildApproval('pending-sticky-rejection')],
+        },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.17';
+      serialized.context.approvals = {
+        lookup_account: {
+          approved: [],
+          rejected: true,
+          stickyRejectMessage: 'Denied before serialization.',
+        },
+      };
+      delete serialized.context.hostedMcpApprovals;
+      const serializedState = JSON.stringify(serialized);
+
+      const restored = await RunState.fromString(agent, serializedState);
+      const merged = await RunState.fromStringWithContext(
+        agent,
+        serializedState,
+        new RunContext(),
+        { contextStrategy: 'merge' },
+      );
+      const replaced = await RunState.fromStringWithContext(
+        agent,
+        serializedState,
+        new RunContext(),
+        { contextStrategy: 'replace' },
+      );
+      const pendingApproval = buildApproval('pending-sticky-rejection');
+
+      expect(
+        restored._context._getHostedMcpApprovalStatus(pendingApproval),
+      ).toBe(false);
+      expect(
+        restored._context._getHostedMcpRejectionMessage(pendingApproval),
+      ).toBe('Denied before serialization.');
+      expect(
+        restored._context._getHostedMcpApprovalStatus(
+          buildApproval('future-request'),
+        ),
+      ).toBeUndefined();
+      expect(merged._context._getHostedMcpApprovalStatus(pendingApproval)).toBe(
+        false,
+      );
+      expect(
+        replaced._context._getHostedMcpApprovalStatus(pendingApproval),
+      ).toBeUndefined();
+      expect(
+        restored.toJSON().context.hostedMcpApprovals?.[
+          JSON.stringify(['hosted_mcp', 'server-a', 'lookup_account'])
+        ],
+      ).toEqual({
+        approved: [],
+        rejected: ['pending-sticky-rejection'],
+        messages: {
+          'pending-sticky-rejection': 'Denied before serialization.',
+        },
+      });
+    });
+
+    it('preserves schema 1.17 sticky rejection precedence over an exact approval', async () => {
+      const agent = new Agent({ name: 'LegacyHostedMcpPrecedenceAgent' });
+      const pendingApproval = new ToolApprovalItem(
+        {
+          type: 'hosted_tool_call',
+          id: 'pending-mixed-decision',
+          name: 'lookup_account',
+          status: 'in_progress',
+          providerData: {
+            type: 'mcp_approval_request',
+            id: 'pending-mixed-decision',
+            server_label: 'server-a',
+            name: 'lookup_account',
+            arguments: '{}',
+          },
+        },
+        agent,
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [pendingApproval] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.17';
+      serialized.context.approvals = {
+        lookup_account: {
+          approved: ['pending-mixed-decision'],
+          rejected: true,
+          stickyRejectMessage: 'Rejected before serialization.',
+        },
+      };
+      delete serialized.context.hostedMcpApprovals;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(
+        restored._context._getHostedMcpApprovalStatus(pendingApproval),
+      ).toBe(false);
+      expect(
+        restored._context._getHostedMcpRejectionMessage(pendingApproval),
+      ).toBe('Rejected before serialization.');
+    });
+
+    it('fails closed when a legacy exact approval matches multiple MCP servers', async () => {
+      const agent = new Agent({ name: 'LegacyHostedMcpAmbiguousAgent' });
+      const buildApproval = (serverLabel: string) =>
+        new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            id: 'shared-legacy-request',
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              id: 'shared-legacy-request',
+              server_label: serverLabel,
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+      const serverA = buildApproval('server-a');
+      const serverB = buildApproval('server-b');
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [serverA, serverB] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.17';
+      serialized.context.approvals = {
+        lookup_account: {
+          approved: ['shared-legacy-request'],
+          rejected: [],
+        },
+      };
+      delete serialized.context.hostedMcpApprovals;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(
+        restored._context._getHostedMcpApprovalStatus(serverA),
+      ).toBeUndefined();
+      expect(
+        restored._context._getHostedMcpApprovalStatus(serverB),
+      ).toBeUndefined();
+      expect(
+        restored.toJSON().context.hostedMcpApprovals?.[
+          JSON.stringify(['hosted_mcp', 'server-a', 'lookup_account'])
+        ],
+      ).toBeUndefined();
+    });
+
+    it('fails closed when a legacy sticky approval matches multiple pending requests', async () => {
+      const agent = new Agent({ name: 'LegacyHostedMcpStickyAmbiguousAgent' });
+      const buildApproval = (requestId: string, serverLabel: string) =>
+        new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            id: requestId,
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              id: requestId,
+              server_label: serverLabel,
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+      const serverA = buildApproval('request-a', 'server-a');
+      const serverB = buildApproval('request-b', 'server-b');
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [serverA, serverB] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.17';
+      serialized.context.approvals = {
+        lookup_account: { approved: true, rejected: [] },
+      };
+      delete serialized.context.hostedMcpApprovals;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(
+        restored._context._getHostedMcpApprovalStatus(serverA),
+      ).toBeUndefined();
+      expect(
+        restored._context._getHostedMcpApprovalStatus(serverB),
+      ).toBeUndefined();
+    });
+
+    it.each([
+      { approved: true, rejected: [] as string[] },
+      { approved: [] as string[], rejected: true },
+    ])(
+      'fails closed when a legacy sticky decision has a same-tool claimant without an id',
+      async (legacyDecision) => {
+        const agent = new Agent({
+          name: 'LegacyHostedMcpIncompleteStickyAgent',
+        });
+        const complete = new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            id: 'complete-request',
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              id: 'complete-request',
+              server_label: 'server-a',
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+        const incomplete = new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              server_label: 'server-b',
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+        const state = new RunState(new RunContext(), 'input', agent, 1);
+        state._currentStep = {
+          type: 'next_step_interruption',
+          data: { interruptions: [complete, incomplete] },
+        };
+        const serialized = state.toJSON() as any;
+        serialized.$schemaVersion = '1.17';
+        serialized.context.approvals = {
+          lookup_account: legacyDecision,
+        };
+        delete serialized.context.hostedMcpApprovals;
+
+        const restored = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+
+        expect(
+          restored._context._getHostedMcpApprovalStatus(complete),
+        ).toBeUndefined();
+      },
+    );
+
+    it.each(['incomplete hosted MCP', 'same-named shell'] as const)(
+      'fails closed when a legacy exact approval also matches a %s claimant',
+      async (claimantKind) => {
+        const agent = new Agent({ name: 'LegacyHostedMcpClaimantAgent' });
+        const hosted = new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            id: 'shared-claim',
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              id: 'shared-claim',
+              server_label: 'server-a',
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+        const otherClaimant =
+          claimantKind === 'incomplete hosted MCP'
+            ? new ToolApprovalItem(
+                {
+                  type: 'hosted_tool_call',
+                  id: 'shared-claim',
+                  name: 'lookup_account',
+                  status: 'in_progress',
+                  providerData: {
+                    type: 'mcp_approval_request',
+                    id: 'shared-claim',
+                    name: 'lookup_account',
+                    arguments: '{}',
+                  },
+                },
+                agent,
+              )
+            : new ToolApprovalItem(
+                {
+                  type: 'shell_call',
+                  callId: 'shared-claim',
+                  name: 'lookup_account',
+                  status: 'in_progress',
+                  action: { commands: ['echo test'] },
+                } as any,
+                agent,
+              );
+        const state = new RunState(new RunContext(), 'input', agent, 1);
+        state._currentStep = {
+          type: 'next_step_interruption',
+          data: { interruptions: [hosted, otherClaimant] },
+        };
+        const serialized = state.toJSON() as any;
+        serialized.$schemaVersion = '1.17';
+        serialized.context.approvals = {
+          lookup_account: {
+            approved: ['shared-claim'],
+            rejected: [],
+          },
+        };
+        delete serialized.context.hostedMcpApprovals;
+
+        const restored = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+
+        expect(
+          restored._context._getHostedMcpApprovalStatus(hosted),
+        ).toBeUndefined();
+      },
+    );
+
+    it('preserves a schema 1.15 exact MCP approval across a function-name collision', async () => {
+      const sameNamedFunction = tool({
+        name: 'lookup_account',
+        description: 'Look up a local account.',
+        parameters: z.object({}),
+        execute: async () => 'local',
+      });
+      const agent = new Agent({
+        name: 'LegacyHostedMcpExactApprovalAgent',
+        tools: [sameNamedFunction],
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const buildApproval = (requestId: string, serverLabel = 'server-a') =>
+        new ToolApprovalItem(
+          {
+            type: 'hosted_tool_call',
+            id: requestId,
+            name: 'lookup_account',
+            status: 'in_progress',
+            providerData: {
+              type: 'mcp_approval_request',
+              id: requestId,
+              server_label: serverLabel,
+              name: 'lookup_account',
+              arguments: '{}',
+            },
+          },
+          agent,
+        );
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [buildApproval('legacy-exact-request')] },
+      };
+      const serialized = state.toJSON() as any;
+      serialized.$schemaVersion = '1.15';
+      serialized.context.approvals = {
+        lookup_account: {
+          approved: ['legacy-exact-request'],
+          rejected: [],
+        },
+      };
+      delete serialized.context.hostedMcpApprovals;
+      delete serialized.context.functionApprovals;
+      delete serialized.context.legacyFunctionApprovals;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(
+        restored._context._getHostedMcpApprovalStatus(
+          buildApproval('legacy-exact-request'),
+        ),
+      ).toBe(true);
+      expect(
+        restored._context._getHostedMcpApprovalStatus(
+          buildApproval('future-request'),
+        ),
+      ).toBeUndefined();
+      expect(
+        restored._context._getHostedMcpApprovalStatus(
+          buildApproval('legacy-exact-request', 'server-b'),
+        ),
+      ).toBeUndefined();
+      expect(
+        restored.toJSON().context.hostedMcpApprovals?.[
+          JSON.stringify(['hosted_mcp', 'server-a', 'lookup_account'])
+        ],
+      ).toEqual({ approved: ['legacy-exact-request'], rejected: [] });
+    });
+
     it('tracks qualified tool names for namespaced approvals', () => {
       const context = new RunContext();
       const agent = new Agent({ name: 'AgentNamespaceApproval' });

--- a/packages/agents-core/test/runner/mcpApprovals.test.ts
+++ b/packages/agents-core/test/runner/mcpApprovals.test.ts
@@ -7,6 +7,7 @@ import { RunState } from '../../src/runState';
 import { handleHostedMcpApprovals } from '../../src/runner/mcpApprovals';
 import type { ToolRunMCPApprovalRequest } from '../../src/runner/types';
 import { hostedMcpTool } from '../../src/tool';
+import { getHostedMcpApprovalToolName } from '../../src/toolInvocation';
 import type {
   HostedMCPApprovalRequest,
   HostedMCPApprovalResponse,
@@ -17,12 +18,15 @@ const TEST_AGENT = new Agent({ name: 'TestAgent', outputType: 'text' });
 
 const buildApprovalRequest = (
   id = 'mcpr_1',
-  args = '{}',
+  argsOrServerLabel = '{}',
+  toolName?: string,
 ): ToolRunMCPApprovalRequest => {
+  const serverLabel = toolName ? argsOrServerLabel : 'stub';
+  const args = toolName ? '{}' : argsOrServerLabel;
   const providerData: HostedMCPApprovalRequest = {
     id,
-    name: 'list_files',
-    server_label: 'stub',
+    name: toolName ?? 'list_files',
+    server_label: serverLabel,
     arguments: args,
   };
 
@@ -41,7 +45,7 @@ const buildApprovalRequest = (
   return {
     requestItem,
     mcpTool: hostedMcpTool({
-      serverLabel: 'stub',
+      serverLabel,
       requireApproval: 'always',
     }),
   };
@@ -63,6 +67,7 @@ describe('handleHostedMcpApprovals', () => {
       .fn()
       .mockResolvedValue({ approve: true, reason: 'ok' });
     const approvalRequest = buildApprovalRequest();
+    approvalRequest.requestItem.rawItem.id = 'raw-request';
     approvalRequest.mcpTool = hostedMcpTool({
       serverLabel: 'stub',
       requireApproval: 'always',
@@ -83,12 +88,16 @@ describe('handleHostedMcpApprovals', () => {
     const response = newItems[0] as RunToolCallItem;
     const raw = response.rawItem as protocol.HostedToolCallItem;
     expect(raw.name).toBe('mcp_approval_response');
+    expect(raw.providerData).toMatchObject({
+      approval_request_id: 'mcpr_1',
+      approve: true,
+    });
     expect(raw.caller).toEqual({
       type: 'program',
       callerId: 'call_prog_1',
     });
     expect(result.pendingApprovals.size).toBe(0);
-    expect(result.pendingApprovalIds.size).toBe(0);
+    expect(result.pendingApprovalKeys.size).toBe(0);
   });
 
   it('binds callback approval to the exact hosted MCP invocation', async () => {
@@ -105,7 +114,7 @@ describe('handleHostedMcpApprovals', () => {
     const resolveApproval = (rawItem: protocol.HostedToolCallItem) =>
       state._context._resolveToolInvocationApproval(
         TEST_AGENT,
-        rawItem.name,
+        getHostedMcpApprovalToolName(rawItem.name, rawItem),
         rawItem,
       );
 
@@ -183,7 +192,7 @@ describe('handleHostedMcpApprovals', () => {
         resolveApproval: (item) =>
           state._context._resolveToolInvocationApproval(
             TEST_AGENT,
-            item.name,
+            getHostedMcpApprovalToolName(item.name, item),
             item,
           ),
       });
@@ -234,14 +243,11 @@ describe('handleHostedMcpApprovals', () => {
       functionResults,
       appendIfNew: (item) => newItems.push(item),
       resolveApproval: (rawItem) =>
-        state._context.isToolApproved({
-          toolName: rawItem.name,
-          callId:
-            rawItem.id ??
-            (rawItem.providerData as HostedMCPApprovalRequest | undefined)
-              ?.id ??
-            '',
-        }),
+        state._context._resolveToolInvocationApproval(
+          TEST_AGENT,
+          getHostedMcpApprovalToolName(rawItem.name, rawItem),
+          rawItem,
+        ),
     });
 
     expect(functionResults).toHaveLength(0);
@@ -258,7 +264,7 @@ describe('handleHostedMcpApprovals', () => {
       callerId: 'call_prog_1',
     });
     expect(result.pendingApprovals.size).toBe(0);
-    expect(result.pendingApprovalIds.size).toBe(0);
+    expect(result.pendingApprovalKeys.size).toBe(0);
   });
 
   it('forwards explicit reject messages into hosted MCP approval responses', async () => {
@@ -274,14 +280,7 @@ describe('handleHostedMcpApprovals', () => {
       functionResults,
       appendIfNew: (item) => newItems.push(item),
       resolveApproval: (rawItem) =>
-        state._context.isToolApproved({
-          toolName: rawItem.name,
-          callId:
-            rawItem.id ??
-            (rawItem.providerData as HostedMCPApprovalRequest | undefined)
-              ?.id ??
-            '',
-        }),
+        state._context._getHostedMcpApprovalStatus(rawItem),
     });
 
     expect(functionResults).toHaveLength(0);
@@ -299,7 +298,7 @@ describe('handleHostedMcpApprovals', () => {
       callerId: 'call_prog_1',
     });
     expect(result.pendingApprovals.size).toBe(0);
-    expect(result.pendingApprovalIds.size).toBe(0);
+    expect(result.pendingApprovalKeys.size).toBe(0);
   });
 
   it('omits hosted MCP rejection reasons by default', async () => {
@@ -313,14 +312,7 @@ describe('handleHostedMcpApprovals', () => {
       functionResults,
       appendIfNew: (item) => newItems.push(item),
       resolveApproval: (rawItem) =>
-        state._context.isToolApproved({
-          toolName: rawItem.name,
-          callId:
-            rawItem.id ??
-            (rawItem.providerData as HostedMCPApprovalRequest | undefined)
-              ?.id ??
-            '',
-        }),
+        state._context._getHostedMcpApprovalStatus(rawItem),
     });
 
     expect(functionResults).toHaveLength(0);
@@ -334,7 +326,7 @@ describe('handleHostedMcpApprovals', () => {
     });
     expect(providerData.reason).toBeUndefined();
     expect(result.pendingApprovals.size).toBe(0);
-    expect(result.pendingApprovalIds.size).toBe(0);
+    expect(result.pendingApprovalKeys.size).toBe(0);
   });
 
   it('surfaces pending approvals when no decision exists', async () => {
@@ -347,21 +339,73 @@ describe('handleHostedMcpApprovals', () => {
       functionResults,
       appendIfNew: (item) => newItems.push(item),
       resolveApproval: (rawItem) =>
-        state._context.isToolApproved({
-          toolName: rawItem.name,
-          callId:
-            rawItem.id ??
-            (rawItem.providerData as HostedMCPApprovalRequest | undefined)
-              ?.id ??
-            '',
-        }),
+        state._context._getHostedMcpApprovalStatus(rawItem),
     });
 
     expect(functionResults).toHaveLength(1);
     expect(functionResults[0].type).toBe('hosted_mcp_tool_approval');
     expect(newItems).toContain(approvalRequest.requestItem);
     expect(result.pendingApprovals.has(approvalRequest.requestItem)).toBe(true);
-    expect(result.pendingApprovalIds.has('mcpr_pending')).toBe(true);
+    expect(
+      result.pendingApprovalKeys.has(
+        JSON.stringify([
+          'hosted_mcp_request',
+          'stub',
+          'list_files',
+          'mcpr_pending',
+        ]),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not reuse persistent decisions across hosted MCP servers', () => {
+    const serverA = buildApprovalRequest(
+      'mcpr_server_a',
+      'server-a',
+      'lookup_account',
+    );
+    const sameServer = buildApprovalRequest(
+      'mcpr_server_a_next',
+      'server-a',
+      'lookup_account',
+    );
+    const serverB = buildApprovalRequest(
+      'mcpr_server_b',
+      'server-b',
+      'lookup_account',
+    );
+
+    state.approve(serverA.requestItem, { alwaysApprove: true });
+
+    expect(
+      state._context._getHostedMcpApprovalStatus(sameServer.requestItem),
+    ).toBe(true);
+    expect(
+      state._context._getHostedMcpApprovalStatus(serverB.requestItem),
+    ).toBeUndefined();
+  });
+
+  it('uses one canonical request ID for approval lookup and response', async () => {
+    const approvalRequest = buildApprovalRequest('provider-request');
+    approvalRequest.requestItem.rawItem.id = 'raw-request';
+    state.approve(approvalRequest.requestItem);
+
+    const result = await handleHostedMcpApprovals({
+      requests: [approvalRequest],
+      agent: TEST_AGENT,
+      state,
+      functionResults,
+      appendIfNew: (item) => newItems.push(item),
+      resolveApproval: (rawItem) =>
+        state._context._getHostedMcpApprovalStatus(rawItem),
+    });
+
+    expect(result.pendingApprovals.size).toBe(0);
+    expect(newItems).toHaveLength(1);
+    expect(newItems[0].rawItem.providerData).toMatchObject({
+      approval_request_id: 'provider-request',
+      approve: true,
+    });
   });
 
   it('ignores non-hosted raw items', async () => {
@@ -389,7 +433,7 @@ describe('handleHostedMcpApprovals', () => {
     expect(functionResults).toHaveLength(0);
     expect(newItems).toHaveLength(0);
     expect(result.pendingApprovals.size).toBe(0);
-    expect(result.pendingApprovalIds.size).toBe(0);
+    expect(result.pendingApprovalKeys.size).toBe(0);
   });
 
   it('ignores hosted approval items that are missing provider data', async () => {
@@ -409,7 +453,7 @@ describe('handleHostedMcpApprovals', () => {
     expect(functionResults).toHaveLength(0);
     expect(newItems).toHaveLength(0);
     expect(result.pendingApprovals.size).toBe(0);
-    expect(result.pendingApprovalIds.size).toBe(0);
+    expect(result.pendingApprovalKeys.size).toBe(0);
   });
 
   it('treats approval requests without ids as pending without tracking an id', async () => {
@@ -432,7 +476,7 @@ describe('handleHostedMcpApprovals', () => {
     expect(functionResults).toHaveLength(1);
     expect(newItems).toContain(approvalRequest.requestItem);
     expect(result.pendingApprovals.has(approvalRequest.requestItem)).toBe(true);
-    expect(result.pendingApprovalIds.size).toBe(0);
+    expect(result.pendingApprovalKeys.size).toBe(0);
   });
 
   it('surfaces pending approvals when no resolver is provided', async () => {
@@ -449,6 +493,15 @@ describe('handleHostedMcpApprovals', () => {
     expect(functionResults).toHaveLength(1);
     expect(newItems).toContain(approvalRequest.requestItem);
     expect(result.pendingApprovals.has(approvalRequest.requestItem)).toBe(true);
-    expect(result.pendingApprovalIds.has('mcpr_no_resolver')).toBe(true);
+    expect(
+      result.pendingApprovalKeys.has(
+        JSON.stringify([
+          'hosted_mcp_request',
+          'stub',
+          'list_files',
+          'mcpr_no_resolver',
+        ]),
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/agents-core/test/runner/turnResolution.test.ts
+++ b/packages/agents-core/test/runner/turnResolution.test.ts
@@ -2304,7 +2304,7 @@ describe('resolveInterruptedTurn', () => {
     expect(result.preStepItems).not.toContain(rootApproval);
   });
 
-  it('removes resolved hosted MCP approvals but keeps unresolved ones', async () => {
+  it('filters pending hosted MCP approvals by server, tool, and request id', async () => {
     const agent = new Agent({ name: 'MCPAgent' });
     const approvalCall: protocol.HostedToolCallItem = {
       type: 'hosted_tool_call',
@@ -2312,8 +2312,7 @@ describe('resolveInterruptedTurn', () => {
       id: 'mcpr_123',
       status: 'in_progress',
       providerData: {
-        type: 'mcp_approval_request',
-        server_label: 'server',
+        server_label: 'server-a',
         name: 'approve_me',
         id: 'mcpr_123',
         arguments: '{}',
@@ -2321,10 +2320,25 @@ describe('resolveInterruptedTurn', () => {
       },
     };
     const approvalItem = new ToolApprovalItem(approvalCall, agent);
-    const originalPreStepItems = [approvalItem];
+    const pendingCall: protocol.HostedToolCallItem = {
+      ...approvalCall,
+      id: 'mcpr_456',
+      providerData: {
+        ...approvalCall.providerData,
+        id: 'mcpr_456',
+        server_label: 'server-b',
+      },
+    };
+    const pendingItem = new ToolApprovalItem(pendingCall, agent);
+    const originalPreStepItems = [approvalItem, pendingItem];
 
     const processedResponse: ProcessedResponse = {
-      newItems: [new ToolCallItem(approvalCall, agent), approvalItem],
+      newItems: [
+        new ToolCallItem(approvalCall, agent),
+        new ToolCallItem(pendingCall, agent),
+        approvalItem,
+        pendingItem,
+      ],
       handoffs: [],
       functions: [],
       computerActions: [],
@@ -2336,7 +2350,15 @@ describe('resolveInterruptedTurn', () => {
           mcpTool: {
             type: 'hosted_tool',
             name: 'hosted_mcp',
-            providerData: { server_label: 'server', type: 'mcp' },
+            providerData: { server_label: 'server-a', type: 'mcp' },
+          } as any,
+        },
+        {
+          requestItem: pendingItem,
+          mcpTool: {
+            type: 'hosted_tool',
+            name: 'hosted_mcp',
+            providerData: { server_label: 'server-b', type: 'mcp' },
           } as any,
         },
       ],
@@ -2366,6 +2388,7 @@ describe('resolveInterruptedTurn', () => {
     );
 
     expect(result.preStepItems).not.toContain(approvalItem);
+    expect(result.preStepItems).toContain(pendingItem);
     expect(result.newStepItems).toContainEqual(
       expect.objectContaining({
         rawItem: expect.objectContaining({

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -19,6 +19,7 @@ import { isZodObject, toSmartString } from '@openai/agents-core/utils';
 import {
   getSafeErrorType,
   getBoundToolInvocationRejectionMessage,
+  getHostedMcpApprovalToolName,
   hasDynamicFunctionToolApprovalPolicy,
   hasInspectableFunctionToolArguments,
   getToolInvocationApproval,
@@ -2338,7 +2339,10 @@ export class RealtimeSession<
       const rejectionReason = getBoundToolInvocationRejectionMessage(
         this.#context,
         effectiveApprovalItem.agent,
-        effectiveApprovalItem.toolName ?? effectiveApprovalItem.rawItem.name,
+        getHostedMcpApprovalToolName(
+          effectiveApprovalItem.toolName ?? effectiveApprovalItem.rawItem.name,
+          effectiveApprovalItem.rawItem,
+        ),
         effectiveApprovalItem.rawItem,
       );
       if (issued) {

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -3882,9 +3882,9 @@ describe('RealtimeSession', () => {
       arguments: { foo: 'bar' },
       approved: null,
     });
-    expect(s.context.getRejectionMessage('hosted_mcp', 'item-msg-1')).toBe(
-      'Denied by policy',
-    );
+    expect(
+      s.context.getRejectionMessage('hosted_mcp', 'item-msg-1'),
+    ).toBeUndefined();
   });
 
   it('reuses stored reject messages for hosted tool calls', async () => {


### PR DESCRIPTION
Scopes persistent hosted MCP approval decisions by server and tool identity, preventing approvals from authorizing same-named tools on another server.

The change preserves legacy exact-request decisions while treating unscoped sticky state as unauthorized, adds backward-compatible RunState schema handling, and covers streaming, non-streaming, Realtime, serialization, resume, and nested-agent paths.