### PR TITLE
fix: bind tool approvals and completed replays to canonical invocations

### DIFF
--- a/.changeset/fair-tools-remember.md
+++ b/.changeset/fair-tools-remember.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-realtime': patch
+---
+
+fix: bind tool approvals and completed replays to canonical invocations

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -85,7 +85,12 @@ import {
   saveToSession,
   type SessionPersistenceOptions,
 } from './runner/sessionPersistence';
-import { resolveTurnAfterModelResponse } from './runner/turnResolution';
+import {
+  filterSuppressedToolCallItems,
+  preflightModelResponseToolInvocations,
+  preflightToolInvocations,
+  resolveTurnAfterModelResponse,
+} from './runner/turnResolution';
 import { hasBlockedOutputExecutionEffect } from './runner/blockedOutputPersistence';
 import { prepareTurn } from './runner/turnPreparation';
 import { prepareAgentArtifacts } from './runner/modelPreparation';
@@ -1516,10 +1521,23 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               options.toolNotFoundBehavior,
               {
                 allowPromptSuppliedTools: preparedCall.allowPromptSuppliedTools,
+                beforeClientToolSearch: () =>
+                  preflightModelResponseToolInvocations(
+                    state._currentAgent,
+                    state,
+                    state._lastTurnResponse!,
+                    preparedCall.tools,
+                    preparedCall.handoffs,
+                  ),
               },
             );
 
             state._lastProcessedResponse = processedResponse;
+            const suppressedToolCalls = preflightToolInvocations(
+              state._currentAgent,
+              state,
+              processedResponse,
+            );
 
             await guardrailTracker.awaitCompletion();
 
@@ -1535,6 +1553,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               agentToolParentRunConfig,
               options.errorHandlers,
               options.signal,
+              suppressedToolCalls,
             );
 
             applyTurnResult({
@@ -2307,16 +2326,33 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             options.toolNotFoundBehavior,
             {
               allowPromptSuppliedTools: preparedCall.allowPromptSuppliedTools,
+              beforeClientToolSearch: () =>
+                preflightModelResponseToolInvocations(
+                  currentAgent,
+                  result.state,
+                  result.state._lastTurnResponse!,
+                  preparedCall.tools,
+                  preparedCall.handoffs,
+                ),
             },
           );
 
           result.state._lastProcessedResponse = processedResponse;
+          const suppressedToolCalls = preflightToolInvocations(
+            currentAgent,
+            result.state,
+            processedResponse,
+          );
+          const streamableItems = filterSuppressedToolCallItems(
+            processedResponse.newItems,
+            suppressedToolCalls,
+          );
 
           // Record the items emitted directly from the model response so we do not
           // stream them again after tools and other side effects finish.
-          const preToolItems = new Set<RunItem>(processedResponse.newItems);
+          const preToolItems = new Set<RunItem>(streamableItems);
           if (preToolItems.size > 0) {
-            streamStepItemsToRunResult(result, processedResponse.newItems);
+            streamStepItemsToRunResult(result, streamableItems);
           }
 
           const turnResult = await resolveTurnAfterModelResponse(
@@ -2331,6 +2367,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             agentToolParentRunConfig,
             options.errorHandlers,
             options.signal,
+            suppressedToolCalls,
           );
 
           applyTurnResult({

--- a/packages/agents-core/src/runContext.ts
+++ b/packages/agents-core/src/runContext.ts
@@ -1,5 +1,5 @@
 import type { Agent } from './agent';
-import { UserError } from './errors';
+import { ModelBehaviorError, UserError } from './errors';
 import { RunToolApprovalItem } from './items';
 import logger from './logger';
 import {
@@ -9,6 +9,11 @@ import {
 } from './toolIdentity';
 import { UnknownContext } from './types';
 import { Usage } from './usage';
+import {
+  getToolInvocationCallId,
+  getToolInvocationFingerprint,
+  type ApprovalCapableToolCall,
+} from './toolInvocation';
 
 type ApprovalRecord = {
   approved: boolean | string[];
@@ -17,8 +22,51 @@ type ApprovalRecord = {
   stickyRejectMessage?: string;
 };
 
+function cloneApprovalRecord(record: ApprovalRecord): ApprovalRecord {
+  return {
+    approved: Array.isArray(record.approved)
+      ? [...record.approved]
+      : record.approved,
+    rejected: Array.isArray(record.rejected)
+      ? [...record.rejected]
+      : record.rejected,
+    ...(record.messages ? { messages: { ...record.messages } } : {}),
+    ...(record.stickyRejectMessage !== undefined
+      ? { stickyRejectMessage: record.stickyRejectMessage }
+      : {}),
+  };
+}
+
+function cloneApprovalMap(
+  records: ReadonlyMap<string, ApprovalRecord>,
+): Map<string, ApprovalRecord> {
+  return new Map(
+    [...records].map(([toolName, record]) => [
+      toolName,
+      cloneApprovalRecord(record),
+    ]),
+  );
+}
+
+function cloneAgentApprovalMap(
+  records: ReadonlyMap<Agent<any, any>, ReadonlyMap<string, ApprovalRecord>>,
+): Map<Agent<any, any>, Map<string, ApprovalRecord>> {
+  return new Map(
+    [...records].map(([agent, approvals]) => [
+      agent,
+      cloneApprovalMap(approvals),
+    ]),
+  );
+}
+
 type SerializedFunctionApprovals = Array<{
   agentIdentity: string;
+  approvals: Record<string, ApprovalRecord>;
+}>;
+
+type SerializedApprovalInvocations = Array<{
+  agentIdentity: string;
+  invocations: Record<string, string>;
   approvals: Record<string, ApprovalRecord>;
 }>;
 
@@ -128,6 +176,7 @@ type RunContextJson = {
 type SerializedRunContextJson = RunContextJson & {
   functionApprovals?: SerializedFunctionApprovals;
   legacyFunctionApprovals?: Record<string, ApprovalRecord>;
+  approvalInvocations?: SerializedApprovalInvocations;
 };
 
 /**
@@ -159,6 +208,16 @@ export class RunContext<TContext = UnknownContext> {
    */
   #functionApprovalState: FunctionApprovalState;
 
+  /**
+   * Canonical invocation fingerprints for per-call approval decisions.
+   */
+  #approvalInvocations: Map<Agent<any, any>, Map<string, string>>;
+
+  /**
+   * Non-function per-call decisions scoped to the public agent that owns them.
+   */
+  #toolApprovalsByAgent: Map<Agent<any, any>, Map<string, ApprovalRecord>>;
+
   constructor(context: TContext = {} as TContext) {
     this.context = context;
     this.usage = new Usage();
@@ -167,6 +226,8 @@ export class RunContext<TContext = UnknownContext> {
       approvalsByAgent: new Map(),
       legacyApprovals: new Map(),
     };
+    this.#approvalInvocations = new Map();
+    this.#toolApprovalsByAgent = new Map();
   }
 
   /**
@@ -189,7 +250,319 @@ export class RunContext<TContext = UnknownContext> {
     target.usage = this.usage;
     target.#approvals = this.#approvals;
     target.#functionApprovalState = this.#functionApprovalState;
+    target.#approvalInvocations = this.#approvalInvocations;
+    target.#toolApprovalsByAgent = this.#toolApprovalsByAgent;
     return target;
+  }
+
+  /**
+   * Creates an isolated context copy for transactional RunState restoration.
+   * @internal
+   */
+  _cloneForRunStateDeserialization(): RunContext<TContext> {
+    const clone = this._createFork();
+    clone.context = this.context;
+    clone.usage = this.usage;
+    clone.toolInput = this.toolInput;
+    clone.#approvals = cloneApprovalMap(this.#approvals);
+    clone.#functionApprovalState = {
+      approvalsByAgent: cloneAgentApprovalMap(
+        this.#functionApprovalState.approvalsByAgent,
+      ),
+      legacyApprovals: cloneApprovalMap(
+        this.#functionApprovalState.legacyApprovals,
+      ),
+    };
+    clone.#approvalInvocations = new Map(
+      [...this.#approvalInvocations].map(([agent, invocations]) => [
+        agent,
+        new Map(invocations),
+      ]),
+    );
+    clone.#toolApprovalsByAgent = cloneAgentApprovalMap(
+      this.#toolApprovalsByAgent,
+    );
+    return clone;
+  }
+
+  /**
+   * Replaces approval state after a transactional RunState restoration passes.
+   * @internal
+   */
+  _replaceApprovalState(source: RunContext<TContext>): void {
+    this.#approvals.clear();
+    for (const [toolName, approval] of source.#approvals) {
+      this.#approvals.set(toolName, cloneApprovalRecord(approval));
+    }
+    this.#functionApprovalState.approvalsByAgent.clear();
+    for (const [agent, approvals] of source.#functionApprovalState
+      .approvalsByAgent) {
+      this.#functionApprovalState.approvalsByAgent.set(
+        agent,
+        cloneApprovalMap(approvals),
+      );
+    }
+    this.#functionApprovalState.legacyApprovals.clear();
+    for (const [toolName, approval] of source.#functionApprovalState
+      .legacyApprovals) {
+      this.#functionApprovalState.legacyApprovals.set(
+        toolName,
+        cloneApprovalRecord(approval),
+      );
+    }
+    this.#approvalInvocations.clear();
+    for (const [agent, invocations] of source.#approvalInvocations) {
+      this.#approvalInvocations.set(agent, new Map(invocations));
+    }
+    this.#toolApprovalsByAgent.clear();
+    for (const [agent, approvals] of source.#toolApprovalsByAgent) {
+      this.#toolApprovalsByAgent.set(agent, cloneApprovalMap(approvals));
+    }
+  }
+
+  /**
+   * Rebuild per-call approval bindings from serialized RunState data.
+   * @internal
+   */
+  _rebuildApprovalInvocations(
+    invocations: SerializedApprovalInvocations,
+    agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+  ): void {
+    this.#approvalInvocations = new Map();
+    this.#toolApprovalsByAgent = new Map();
+    this._mergeApprovalInvocations(invocations, agentsByIdentity);
+  }
+
+  /**
+   * Merge serialized per-call approval bindings into a live context.
+   * @internal
+   */
+  _mergeApprovalInvocations(
+    invocations: SerializedApprovalInvocations,
+    agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+  ): void {
+    this._validateApprovalInvocations(invocations, agentsByIdentity);
+    for (const {
+      agentIdentity,
+      invocations: byCallId,
+      approvals,
+    } of invocations) {
+      const agent = agentsByIdentity.get(agentIdentity)!;
+      this.#mergeAgentApprovalInvocations(
+        agent,
+        new Map(Object.entries(byCallId)),
+      );
+      for (const [toolName, incoming] of Object.entries(approvals)) {
+        this.#setToolApprovalRecord(agent, toolName, incoming);
+      }
+    }
+  }
+
+  /**
+   * Validate serialized approval-invocation ownership and conflicts without
+   * mutating this context.
+   * @internal
+   */
+  _validateApprovalInvocations(
+    invocations: SerializedApprovalInvocations,
+    agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+  ): void {
+    const seenAgentIdentities = new Set<string>();
+    for (const { agentIdentity, invocations: byCallId } of invocations) {
+      if (
+        !agentsByIdentity.has(agentIdentity) ||
+        seenAgentIdentities.has(agentIdentity)
+      ) {
+        throw new UserError(
+          'RunState contains invalid approval invocation ownership for the current agent graph.',
+        );
+      }
+      seenAgentIdentities.add(agentIdentity);
+      const agent = agentsByIdentity.get(agentIdentity)!;
+      for (const [callId, fingerprint] of Object.entries(byCallId)) {
+        this._validateAgentApprovalInvocation(agent, callId, fingerprint);
+      }
+    }
+  }
+
+  /**
+   * Bind a legacy per-call decision to its serialized approval item.
+   * @internal
+   */
+  _bindLegacyApprovalInvocation(approvalItem: RunToolApprovalItem): void {
+    const callId = getToolInvocationCallId(approvalItem.rawItem);
+    const agentInvocations = this.#getApprovalInvocations(approvalItem.agent);
+    if (!callId || agentInvocations.has(callId)) {
+      return;
+    }
+    const toolName = this.#getApprovalItemToolName(approvalItem);
+    const decision = this.isToolApproved({
+      toolName,
+      callId,
+      functionTool: false,
+      ...(approvalItem.rawItem.type === 'function_call'
+        ? { agent: approvalItem.agent }
+        : {}),
+    });
+    if (decision !== undefined) {
+      agentInvocations.set(
+        callId,
+        getToolInvocationFingerprint(toolName, approvalItem.rawItem),
+      );
+      if (approvalItem.rawItem.type !== 'function_call') {
+        this.#copyPerCallToolApproval(approvalItem.agent, toolName, callId);
+      }
+    }
+  }
+
+  /**
+   * Fail closed when an agent-local call ID with a per-call decision is reused.
+   * @internal
+   */
+  _validateAgentApprovalInvocation(
+    agent: Agent<any, any>,
+    callId: string,
+    fingerprint: string,
+  ): void {
+    const approvedFingerprint = this.#approvalInvocations
+      .get(agent)
+      ?.get(callId);
+    if (
+      approvedFingerprint !== undefined &&
+      approvedFingerprint !== fingerprint
+    ) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${callId} was reused for a different invocation after an approval decision.`,
+      );
+    }
+  }
+
+  /**
+   * Validate a canonical tool invocation before approval lookup or execution.
+   * @internal
+   */
+  _validateToolInvocation(
+    agent: Agent<any, any>,
+    toolName: string,
+    rawItem: ApprovalCapableToolCall,
+  ): { callId: string; fingerprint: string } {
+    const callId = getToolInvocationCallId(rawItem);
+    if (!callId) {
+      throw new ModelBehaviorError(
+        'Tool invocation is missing a non-empty call ID.',
+      );
+    }
+    const fingerprint = getToolInvocationFingerprint(toolName, rawItem);
+    this._validateAgentApprovalInvocation(agent, callId, fingerprint);
+    return { callId, fingerprint };
+  }
+
+  /**
+   * Resolve a decision only when its per-call binding belongs to this agent.
+   * Sticky tool-wide decisions remain shared.
+   * @internal
+   */
+  _resolveToolInvocationApproval(
+    agent: Agent<any, any>,
+    toolName: string,
+    rawItem: ApprovalCapableToolCall,
+  ): boolean | undefined {
+    const { callId, fingerprint } = this._validateToolInvocation(
+      agent,
+      toolName,
+      rawItem,
+    );
+    if (rawItem.type === 'function_call') {
+      const scopedEntries = this.#getFunctionApprovalEntries(
+        toolName,
+        false,
+        agent,
+      );
+      const stickyDecision = this.#resolveStickyApprovalEntries(scopedEntries);
+      if (stickyDecision !== undefined) {
+        return stickyDecision;
+      }
+      const legacyEntries = this.#getLegacyFunctionApprovalEntries(toolName);
+      const legacyStickyDecision =
+        this.#resolveStickyApprovalEntries(legacyEntries);
+      if (legacyStickyDecision !== undefined) {
+        return legacyStickyDecision;
+      }
+      if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
+        return (
+          this.#resolveApprovalEntries(scopedEntries, callId) ??
+          this.#resolveApprovalEntries(legacyEntries, callId)
+        );
+      }
+      return undefined;
+    }
+    const entries = this.#getToolApprovalEntries(toolName, agent);
+    if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
+      const scopedDecision = this.#resolveApprovalEntries(entries, callId);
+      if (scopedDecision !== undefined) {
+        return scopedDecision;
+      }
+    }
+    return this.#resolveStickyApprovalEntries(
+      this.#getApprovalEntries(toolName, false),
+    );
+  }
+
+  /**
+   * Resolve a rejection message only from the owning per-call binding or a
+   * sticky tool-wide rejection.
+   * @internal
+   */
+  _getToolInvocationRejectionMessage(
+    agent: Agent<any, any>,
+    toolName: string,
+    rawItem: ApprovalCapableToolCall,
+  ): string | undefined {
+    const { callId, fingerprint } = this._validateToolInvocation(
+      agent,
+      toolName,
+      rawItem,
+    );
+    if (rawItem.type === 'function_call') {
+      const scopedEntries = this.#getFunctionApprovalEntries(
+        toolName,
+        false,
+        agent,
+      );
+      const stickyMessage = scopedEntries.find(
+        (entry) => entry.rejected === true,
+      )?.stickyRejectMessage;
+      if (stickyMessage !== undefined) {
+        return stickyMessage;
+      }
+      const legacyEntries = this.#getLegacyFunctionApprovalEntries(toolName);
+      const legacyStickyMessage = legacyEntries.find(
+        (entry) => entry.rejected === true,
+      )?.stickyRejectMessage;
+      if (legacyStickyMessage !== undefined) {
+        return legacyStickyMessage;
+      }
+      if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
+        return (
+          this.#getRejectionMessageFromEntries(scopedEntries, callId) ??
+          this.#getRejectionMessageFromEntries(legacyEntries, callId)
+        );
+      }
+      return undefined;
+    }
+    const entries = this.#getToolApprovalEntries(toolName, agent);
+    if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
+      const scopedMessage = this.#getRejectionMessageFromEntries(
+        entries,
+        callId,
+      );
+      if (scopedMessage !== undefined) {
+        return scopedMessage;
+      }
+    }
+    return this.#getApprovalEntries(toolName, false).find(
+      (entry) => entry.rejected === true,
+    )?.stickyRejectMessage;
   }
 
   /**
@@ -323,6 +696,8 @@ export class RunContext<TContext = UnknownContext> {
    * @internal
    */
   _mergeApprovalState(source: RunContext<TContext>): void {
+    this.#mergeLiveApprovalInvocations(source.#approvalInvocations);
+    this.#mergeLiveToolApprovals(source.#toolApprovalsByAgent);
     for (const [toolName, incoming] of source.#approvals) {
       this.#setApprovalRecord(toolName, incoming);
     }
@@ -347,6 +722,8 @@ export class RunContext<TContext = UnknownContext> {
     source: RunContext<TContext>,
     exactToolNames: ReadonlySet<string>,
   ): void {
+    this.#mergeLiveApprovalInvocations(source.#approvalInvocations);
+    this.#mergeLiveToolApprovals(source.#toolApprovalsByAgent);
     for (const [toolName, incoming] of source.#approvals) {
       if (exactToolNames.has(toolName) && this.#approvals.has(toolName)) {
         continue;
@@ -625,6 +1002,28 @@ export class RunContext<TContext = UnknownContext> {
           this.#functionApprovalState.legacyApprovals,
         );
       }
+      const approvalInvocations: SerializedApprovalInvocations = [];
+      const approvalAgents = new Set([
+        ...this.#approvalInvocations.keys(),
+        ...this.#toolApprovalsByAgent.keys(),
+      ]);
+      for (const agent of approvalAgents) {
+        const invocations = this.#approvalInvocations.get(agent) ?? new Map();
+        const approvalsByTool =
+          this.#toolApprovalsByAgent.get(agent) ?? new Map();
+        const agentIdentity = agentIdentityKeys.get(agent);
+        if (
+          agentIdentity &&
+          (invocations.size > 0 || approvalsByTool.size > 0)
+        ) {
+          approvalInvocations.push({
+            agentIdentity,
+            invocations: Object.fromEntries(invocations),
+            approvals: Object.fromEntries(approvalsByTool),
+          });
+        }
+      }
+      json.approvalInvocations = approvalInvocations;
     }
     if (typeof this.toolInput !== 'undefined') {
       json.toolInput = this.toolInput;
@@ -697,26 +1096,9 @@ export class RunContext<TContext = UnknownContext> {
     approvalEntries: readonly ApprovalRecord[],
     callId: string,
   ): boolean | undefined {
-    const hasPermanentApproval = approvalEntries.some(
-      (approvalEntry) => approvalEntry.approved === true,
-    );
-    const hasPermanentRejection = approvalEntries.some(
-      (approvalEntry) => approvalEntry.rejected === true,
-    );
-
-    if (hasPermanentApproval && hasPermanentRejection) {
-      logger.warn(
-        'Tool is permanently approved and rejected at the same time. Approval takes precedence',
-      );
-      return true;
-    }
-
-    if (hasPermanentApproval) {
-      return true;
-    }
-
-    if (hasPermanentRejection) {
-      return false;
+    const stickyDecision = this.#resolveStickyApprovalEntries(approvalEntries);
+    if (stickyDecision !== undefined) {
+      return stickyDecision;
     }
 
     const individualCallApproval = approvalEntries.some((approvalEntry) =>
@@ -748,6 +1130,33 @@ export class RunContext<TContext = UnknownContext> {
     return undefined;
   }
 
+  #resolveStickyApprovalEntries(
+    approvalEntries: readonly ApprovalRecord[],
+  ): boolean | undefined {
+    const hasPermanentApproval = approvalEntries.some(
+      (approvalEntry) => approvalEntry.approved === true,
+    );
+    const hasPermanentRejection = approvalEntries.some(
+      (approvalEntry) => approvalEntry.rejected === true,
+    );
+
+    if (hasPermanentApproval && hasPermanentRejection) {
+      logger.warn(
+        'Tool is permanently approved and rejected at the same time. Approval takes precedence',
+      );
+      return true;
+    }
+
+    if (hasPermanentApproval) {
+      return true;
+    }
+
+    if (hasPermanentRejection) {
+      return false;
+    }
+    return undefined;
+  }
+
   #getRejectionMessageFromEntries(
     approvalEntries: readonly ApprovalRecord[],
     callId: string,
@@ -776,15 +1185,17 @@ export class RunContext<TContext = UnknownContext> {
     { alwaysApprove = false }: { alwaysApprove?: boolean } = {},
   ) {
     const toolName = this.#getApprovalItemToolName(approvalItem);
-    const approvals =
-      approvalItem.rawItem.type === 'function_call'
-        ? this.#getFunctionApprovalMap(approvalItem.agent)
-        : this.#approvals;
+    const isFunctionCall = approvalItem.rawItem.type === 'function_call';
+    const approvals = isFunctionCall
+      ? this.#getFunctionApprovalMap(approvalItem.agent)
+      : this.#approvals;
     const approvalKey = this.#getApprovalStorageKey(
       toolName,
-      approvalItem.rawItem.type === 'function_call',
+      isFunctionCall,
       approvals,
     );
+    const callId = this.#getCallId(approvalItem);
+    this.#bindApprovalInvocation(toolName, approvalItem);
     if (alwaysApprove) {
       approvals.set(approvalKey, {
         approved: true,
@@ -793,14 +1204,16 @@ export class RunContext<TContext = UnknownContext> {
       return;
     }
 
-    const approvalEntry = approvals.get(approvalKey) ?? {
-      approved: [],
-      rejected: [],
-    };
-    if (Array.isArray(approvalEntry.approved)) {
-      approvalEntry.approved.push(this.#getCallId(approvalItem));
+    this.#recordPerCallApproval(approvals, approvalKey, callId, true);
+    if (!isFunctionCall) {
+      const scopedApprovals = this.#getToolApprovalMap(approvalItem.agent);
+      const scopedKey = this.#getApprovalStorageKey(
+        toolName,
+        false,
+        scopedApprovals,
+      );
+      this.#recordPerCallApproval(scopedApprovals, scopedKey, callId, true);
     }
-    approvals.set(approvalKey, approvalEntry);
   }
 
   /**
@@ -816,17 +1229,18 @@ export class RunContext<TContext = UnknownContext> {
     }: { alwaysReject?: boolean; message?: string } = {},
   ) {
     const toolName = this.#getApprovalItemToolName(approvalItem);
-    const approvals =
-      approvalItem.rawItem.type === 'function_call'
-        ? this.#getFunctionApprovalMap(approvalItem.agent)
-        : this.#approvals;
+    const isFunctionCall = approvalItem.rawItem.type === 'function_call';
+    const approvals = isFunctionCall
+      ? this.#getFunctionApprovalMap(approvalItem.agent)
+      : this.#approvals;
     const approvalKey = this.#getApprovalStorageKey(
       toolName,
-      approvalItem.rawItem.type === 'function_call',
+      isFunctionCall,
       approvals,
     );
+    const callId = this.#getCallId(approvalItem);
+    this.#bindApprovalInvocation(toolName, approvalItem);
     if (alwaysReject) {
-      const callId = this.#getCallId(approvalItem);
       approvals.set(approvalKey, {
         approved: false,
         rejected: true,
@@ -840,20 +1254,96 @@ export class RunContext<TContext = UnknownContext> {
       return;
     }
 
+    this.#recordPerCallApproval(approvals, approvalKey, callId, false, message);
+    if (!isFunctionCall) {
+      const scopedApprovals = this.#getToolApprovalMap(approvalItem.agent);
+      const scopedKey = this.#getApprovalStorageKey(
+        toolName,
+        false,
+        scopedApprovals,
+      );
+      this.#recordPerCallApproval(
+        scopedApprovals,
+        scopedKey,
+        callId,
+        false,
+        message,
+      );
+    }
+  }
+
+  #recordPerCallApproval(
+    approvals: Map<string, ApprovalRecord>,
+    approvalKey: string,
+    callId: string,
+    approved: boolean,
+    message?: string,
+  ): void {
     const approvalEntry = approvals.get(approvalKey) ?? {
       approved: [] as string[],
       rejected: [] as string[],
     };
-
-    if (Array.isArray(approvalEntry.rejected)) {
-      const callId = this.#getCallId(approvalItem);
-      approvalEntry.rejected.push(callId);
-      if (message !== undefined) {
-        approvalEntry.messages = approvalEntry.messages ?? {};
-        approvalEntry.messages[callId] = message;
-      }
+    const decisions = approved
+      ? approvalEntry.approved
+      : approvalEntry.rejected;
+    if (Array.isArray(decisions) && !decisions.includes(callId)) {
+      decisions.push(callId);
+    }
+    if (!approved && message !== undefined) {
+      approvalEntry.messages = approvalEntry.messages ?? {};
+      approvalEntry.messages[callId] = message;
     }
     approvals.set(approvalKey, approvalEntry);
+  }
+
+  #bindApprovalInvocation(
+    toolName: string,
+    approvalItem: RunToolApprovalItem,
+  ): void {
+    const { callId, fingerprint } = this._validateToolInvocation(
+      approvalItem.agent,
+      toolName,
+      approvalItem.rawItem,
+    );
+    this.#getApprovalInvocations(approvalItem.agent).set(callId, fingerprint);
+  }
+
+  #getApprovalInvocations(agent: Agent<any, any>): Map<string, string> {
+    const existing = this.#approvalInvocations.get(agent);
+    if (existing) {
+      return existing;
+    }
+    const invocations = new Map<string, string>();
+    this.#approvalInvocations.set(agent, invocations);
+    return invocations;
+  }
+
+  #mergeAgentApprovalInvocations(
+    agent: Agent<any, any>,
+    incoming: ReadonlyMap<string, string>,
+  ): void {
+    for (const [callId, fingerprint] of incoming) {
+      this._validateAgentApprovalInvocation(agent, callId, fingerprint);
+      this.#getApprovalInvocations(agent).set(callId, fingerprint);
+    }
+  }
+
+  #mergeLiveApprovalInvocations(
+    incoming: ReadonlyMap<Agent<any, any>, ReadonlyMap<string, string>>,
+  ): void {
+    for (const [agent, invocations] of incoming) {
+      this.#mergeAgentApprovalInvocations(agent, invocations);
+    }
+  }
+
+  #mergeLiveToolApprovals(
+    incoming: ReadonlyMap<Agent<any, any>, ReadonlyMap<string, ApprovalRecord>>,
+  ): void {
+    for (const [agent, approvalsByTool] of incoming) {
+      for (const [toolName, approval] of approvalsByTool) {
+        this.#setToolApprovalRecord(agent, toolName, approval);
+      }
+    }
   }
 
   /**
@@ -883,6 +1373,62 @@ export class RunContext<TContext = UnknownContext> {
     return getApprovalToolNameCandidates(toolName, includeFunctionAliases)
       .map((candidate) => this.#approvals.get(candidate))
       .filter((approval): approval is ApprovalRecord => approval !== undefined);
+  }
+
+  #getToolApprovalEntries(
+    toolName: string,
+    agent: Agent<any, any>,
+  ): ApprovalRecord[] {
+    const approvalsByTool = this.#toolApprovalsByAgent.get(agent);
+    if (!approvalsByTool) {
+      return [];
+    }
+    return getApprovalToolNameCandidates(toolName, false)
+      .map((candidate) => approvalsByTool.get(candidate))
+      .filter((approval): approval is ApprovalRecord => approval !== undefined);
+  }
+
+  #getToolApprovalMap(agent: Agent<any, any>): Map<string, ApprovalRecord> {
+    const existing = this.#toolApprovalsByAgent.get(agent);
+    if (existing) {
+      return existing;
+    }
+    const approvals = new Map<string, ApprovalRecord>();
+    this.#toolApprovalsByAgent.set(agent, approvals);
+    return approvals;
+  }
+
+  #copyPerCallToolApproval(
+    agent: Agent<any, any>,
+    toolName: string,
+    callId: string,
+  ): void {
+    const sourceEntries = this.#getApprovalEntries(toolName, false);
+    const approved = sourceEntries.some(
+      (entry) =>
+        Array.isArray(entry.approved) && entry.approved.includes(callId),
+    );
+    const rejected = sourceEntries.some(
+      (entry) =>
+        Array.isArray(entry.rejected) && entry.rejected.includes(callId),
+    );
+    if (!approved && !rejected) {
+      return;
+    }
+    const approvals = this.#getToolApprovalMap(agent);
+    const approvalKey = this.#getApprovalStorageKey(toolName, false, approvals);
+    if (approved) {
+      this.#recordPerCallApproval(approvals, approvalKey, callId, true);
+    }
+    if (rejected) {
+      this.#recordPerCallApproval(
+        approvals,
+        approvalKey,
+        callId,
+        false,
+        this.#getRejectionMessageFromEntries(sourceEntries, callId),
+      );
+    }
   }
 
   #getFunctionApprovalEntries(
@@ -959,6 +1505,19 @@ export class RunContext<TContext = UnknownContext> {
     incoming: ApprovalRecord,
   ): void {
     const approvalsByTool = this.#getFunctionApprovalMap(agent);
+    const current = approvalsByTool.get(toolName);
+    approvalsByTool.set(
+      toolName,
+      current ? mergeApprovalRecords(current, incoming) : incoming,
+    );
+  }
+
+  #setToolApprovalRecord(
+    agent: Agent<any, any>,
+    toolName: string,
+    incoming: ApprovalRecord,
+  ): void {
+    const approvalsByTool = this.#getToolApprovalMap(agent);
     const current = approvalsByTool.get(toolName);
     approvalsByTool.set(
       toolName,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -30,7 +30,7 @@ import { nextStepSchema, NextStep } from './runner/steps';
 import { createToolRunFunction, type ProcessedResponse } from './runner/types';
 import { hasBlockedOutputExecutionEffect } from './runner/blockedOutputPersistence';
 import type { AgentSpanData, Span } from './tracing/spans';
-import { SystemError, UserError } from './errors';
+import { ModelBehaviorError, SystemError, UserError } from './errors';
 import { getGlobalTraceProvider } from './tracing/provider';
 import { Usage } from './usage';
 import { Trace } from './tracing/traces';
@@ -94,6 +94,19 @@ import {
   getSerializedShellToolPlaceholder,
 } from './sandbox/runtime/toolRehydration';
 import {
+  getToolResultCorrelationForCall,
+  getToolResultCorrelationForResult,
+  getToolResultCorrelationKey,
+} from './runner/toolResultCorrelation';
+import {
+  getCanonicalToolCaller,
+  getHandoffToolInvocationName,
+  getToolInvocationCallId,
+  getToolInvocationFingerprint,
+  getToolInvocationNameFromFingerprint,
+  type LocalToolCall,
+} from './toolInvocation';
+import {
   sanitizeSerializedSandboxState,
   type SerializedSandboxState,
 } from './sandbox/runtime/sessionState';
@@ -132,7 +145,8 @@ import {
  * - 1.17: Adds durable local tool execution provenance and blocked-output session
  *   persistence bookkeeping.
  * - 1.18: Adds sandbox session-state envelope version 3 so credential-redacted
- *   mount authority cannot be consumed by older SDKs.
+ *   mount authority cannot be consumed by older SDKs, and binds per-call approvals
+ *   and committed local tool results to canonical invocation fingerprints.
  */
 export const CURRENT_SCHEMA_VERSION = '1.18' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
@@ -159,20 +173,28 @@ const SUPPORTED_SCHEMA_VERSIONS = [
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
 const $schemaVersion = z.enum(SUPPORTED_SCHEMA_VERSIONS);
 
+function schemaVersionSupportsV118State(
+  schemaVersion: SupportedSchemaVersion,
+): boolean {
+  return schemaVersion === CURRENT_SCHEMA_VERSION;
+}
+
 function schemaVersionSupportsV116State(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
   return (
     schemaVersion === '1.16' ||
     schemaVersion === '1.17' ||
-    schemaVersion === CURRENT_SCHEMA_VERSION
+    schemaVersionSupportsV118State(schemaVersion)
   );
 }
 
 function schemaVersionSupportsV117State(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
-  return schemaVersion === '1.17' || schemaVersion === CURRENT_SCHEMA_VERSION;
+  return (
+    schemaVersion === '1.17' || schemaVersionSupportsV118State(schemaVersion)
+  );
 }
 
 type ContextOverrideStrategy = 'merge' | 'replace';
@@ -197,6 +219,823 @@ type RunStateContextOverrideOptions<TContext> = {
   contextOverride?: RunContext<TContext>;
   contextStrategy?: ContextOverrideStrategy;
 };
+
+function getLocalToolResultCallId(
+  rawItem: RunToolCallOutputItem['rawItem'],
+): string | undefined {
+  switch (rawItem.type) {
+    case 'function_call_result':
+    case 'computer_call_result':
+    case 'shell_call_output':
+    case 'apply_patch_call_output':
+      return rawItem.callId;
+    default:
+      return undefined;
+  }
+}
+
+function isTrackedLocalToolResult(
+  rawItem: RunToolCallOutputItem['rawItem'],
+): boolean {
+  return (
+    rawItem.type === 'function_call_result' ||
+    rawItem.type === 'computer_call_result' ||
+    rawItem.type === 'shell_call_output' ||
+    rawItem.type === 'apply_patch_call_output'
+  );
+}
+
+function getSerializedLocalToolIdentity(
+  toolCall: LocalToolCall,
+  approvalNames: ReadonlyMap<string, string>,
+  agent: Agent<any, any>,
+): string | undefined {
+  if (toolCall.type === 'function_call') {
+    return getFunctionToolStateKeyForCall(toolCall, toolCall.name);
+  }
+  const callId = getToolInvocationCallId(toolCall);
+  if (callId) {
+    const approvalName = approvalNames.get(callId);
+    if (approvalName) {
+      return approvalName;
+    }
+  }
+  const expectedType =
+    toolCall.type === 'computer_call'
+      ? 'computer'
+      : toolCall.type === 'shell_call'
+        ? 'shell'
+        : 'apply_patch';
+  return agent.tools.find((tool) => tool.type === expectedType)?.name;
+}
+
+function toolResultMatchesCall(
+  toolCall: LocalToolCall,
+  result: RunToolCallOutputItem['rawItem'],
+): boolean {
+  const callCorrelation = getToolResultCorrelationForCall(toolCall);
+  const resultCorrelation = getToolResultCorrelationForResult(result);
+  if (
+    !callCorrelation ||
+    !resultCorrelation ||
+    getToolResultCorrelationKey(callCorrelation) !==
+      getToolResultCorrelationKey(resultCorrelation)
+  ) {
+    return false;
+  }
+  const callCaller = getCanonicalToolCaller(toolCall);
+  const resultCaller = getCanonicalToolCaller(result);
+  if (
+    callCaller.type !== resultCaller.type ||
+    (callCaller.type === 'program' &&
+      (resultCaller.type !== 'program' ||
+        callCaller.callerId !== resultCaller.callerId))
+  ) {
+    return false;
+  }
+  if (toolCall.type !== 'function_call') {
+    return true;
+  }
+  return (
+    result.type === 'function_call_result' &&
+    result.name === toolCall.name &&
+    result.namespace === toolCall.namespace
+  );
+}
+
+function toolItemsHaveSameCaller(left: unknown, right: unknown): boolean {
+  const leftCaller = getCanonicalToolCaller(left);
+  const rightCaller = getCanonicalToolCaller(right);
+  return (
+    leftCaller.type === rightCaller.type &&
+    (leftCaller.type !== 'program' ||
+      (rightCaller.type === 'program' &&
+        leftCaller.callerId === rightCaller.callerId))
+  );
+}
+
+function getAgentInvocationMap<T>(
+  records: Map<Agent<any, any>, Map<string, T>>,
+  agent: Agent<any, any>,
+): Map<string, T> {
+  const existing = records.get(agent);
+  if (existing) {
+    return existing;
+  }
+  const byCallId = new Map<string, T>();
+  records.set(agent, byCallId);
+  return byCallId;
+}
+
+type ToolInvocationCompletionEvidence = {
+  fingerprint: string;
+  items: [RunItem, RunItem];
+};
+
+function getAgentAmbiguousCallIds(
+  records: Map<Agent<any, any>, Set<string>>,
+  agent: Agent<any, any>,
+): Set<string> {
+  const existing = records.get(agent);
+  if (existing) {
+    return existing;
+  }
+  const callIds = new Set<string>();
+  records.set(agent, callIds);
+  return callIds;
+}
+
+function recordObservedToolInvocation(
+  observed: Map<Agent<any, any>, Map<string, string>>,
+  ambiguous: Map<Agent<any, any>, Set<string>>,
+  agent: Agent<any, any>,
+  callId: string,
+  fingerprint: string,
+): void {
+  const agentObserved = getAgentInvocationMap(observed, agent);
+  const previous = agentObserved.get(callId);
+  if (previous !== undefined && previous !== fingerprint) {
+    getAgentAmbiguousCallIds(ambiguous, agent).add(callId);
+    agentObserved.delete(callId);
+  } else if (!ambiguous.get(agent)?.has(callId)) {
+    agentObserved.set(callId, fingerprint);
+  }
+}
+
+function serializeAgentInvocationRecords(
+  records: ReadonlyMap<Agent<any, any>, ReadonlyMap<string, string>>,
+  agentIdentityKeys: ReadonlyMap<Agent<any, any>, string>,
+): Array<{ agentIdentity: string; invocations: Record<string, string> }> {
+  const serialized: Array<{
+    agentIdentity: string;
+    invocations: Record<string, string>;
+  }> = [];
+  for (const [agent, invocations] of records) {
+    const agentIdentity = agentIdentityKeys.get(agent);
+    if (agentIdentity && invocations.size > 0) {
+      serialized.push({
+        agentIdentity,
+        invocations: Object.fromEntries(invocations),
+      });
+    }
+  }
+  return serialized;
+}
+
+function serializeAgentCallIdSets(
+  records: ReadonlyMap<Agent<any, any>, ReadonlySet<string>>,
+  agentIdentityKeys: ReadonlyMap<Agent<any, any>, string>,
+): Array<{ agentIdentity: string; callIds: string[] }> {
+  const serialized: Array<{ agentIdentity: string; callIds: string[] }> = [];
+  for (const [agent, callIds] of records) {
+    const agentIdentity = agentIdentityKeys.get(agent);
+    if (agentIdentity && callIds.size > 0) {
+      serialized.push({ agentIdentity, callIds: [...callIds].sort() });
+    }
+  }
+  return serialized;
+}
+
+function deserializeAgentInvocationRecords(
+  records: ReadonlyArray<{
+    agentIdentity: string;
+    invocations: Record<string, string>;
+  }>,
+  agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+): Map<Agent<any, any>, Map<string, string>> {
+  const deserialized = new Map<Agent<any, any>, Map<string, string>>();
+  const seenAgentIdentities = new Set<string>();
+  for (const { agentIdentity, invocations } of records) {
+    const agent = agentsByIdentity.get(agentIdentity);
+    if (!agent || seenAgentIdentities.has(agentIdentity)) {
+      throw new UserError(
+        'RunState contains invalid completed tool invocation ownership for the current agent graph.',
+      );
+    }
+    seenAgentIdentities.add(agentIdentity);
+    deserialized.set(agent, new Map(Object.entries(invocations)));
+  }
+  return deserialized;
+}
+
+function deserializeAgentCallIdSets(
+  records: ReadonlyArray<{ agentIdentity: string; callIds: string[] }>,
+  agentsByIdentity: ReadonlyMap<string, Agent<any, any>>,
+): Map<Agent<any, any>, Set<string>> {
+  const deserialized = new Map<Agent<any, any>, Set<string>>();
+  const seenAgentIdentities = new Set<string>();
+  for (const { agentIdentity, callIds } of records) {
+    const agent = agentsByIdentity.get(agentIdentity);
+    if (!agent || seenAgentIdentities.has(agentIdentity)) {
+      throw new UserError(
+        'RunState contains invalid ambiguous tool invocation ownership for the current agent graph.',
+      );
+    }
+    seenAgentIdentities.add(agentIdentity);
+    deserialized.set(agent, new Set(callIds));
+  }
+  return deserialized;
+}
+
+function inferCompletedToolInvocations(generatedItems: readonly RunItem[]): {
+  completed: Map<Agent<any, any>, Map<string, string>>;
+  ambiguous: Map<Agent<any, any>, Set<string>>;
+  evidence: Map<Agent<any, any>, Map<string, RunItem[]>>;
+} {
+  const approvalNames = new Map<Agent<any, any>, Map<string, string>>();
+  const pendingLocalCalls = new Map<
+    Agent<any, any>,
+    Map<
+      string,
+      {
+        toolCall: LocalToolCall;
+        identityResolved: boolean;
+        evidence: RunItem[];
+      }
+    >
+  >();
+  const pendingHostedMcpCalls = new Map<
+    Agent<any, any>,
+    Map<string, { toolCall: protocol.HostedToolCallItem; evidence: RunItem[] }>
+  >();
+  const observed = new Map<Agent<any, any>, Map<string, string>>();
+  const completed = new Map<Agent<any, any>, Map<string, string>>();
+  const ambiguous = new Map<Agent<any, any>, Set<string>>();
+  const evidence = new Map<Agent<any, any>, Map<string, RunItem[]>>();
+
+  for (const item of generatedItems) {
+    if (item instanceof RunToolApprovalItem) {
+      const callId = getToolInvocationCallId(item.rawItem);
+      if (!callId || !item.name) {
+        throw new UserError(
+          'RunState contains a tool approval request without a canonical invocation identity.',
+        );
+      }
+      const toolName = item.functionToolStateKey ?? item.name;
+      getAgentInvocationMap(approvalNames, item.agent).set(callId, toolName);
+      const pending = pendingLocalCalls.get(item.agent)?.get(callId);
+      if (pending) {
+        if (
+          getToolInvocationFingerprint('', pending.toolCall) !==
+          getToolInvocationFingerprint('', item.rawItem)
+        ) {
+          getAgentAmbiguousCallIds(ambiguous, item.agent).add(callId);
+          observed.get(item.agent)?.delete(callId);
+        } else if (!completed.get(item.agent)?.has(callId)) {
+          observed.get(item.agent)?.delete(callId);
+          recordObservedToolInvocation(
+            observed,
+            ambiguous,
+            item.agent,
+            callId,
+            getToolInvocationFingerprint(toolName, pending.toolCall),
+          );
+        }
+      }
+      recordObservedToolInvocation(
+        observed,
+        ambiguous,
+        item.agent,
+        callId,
+        getToolInvocationFingerprint(toolName, item.rawItem),
+      );
+      if (
+        item.rawItem.type === 'function_call' ||
+        item.rawItem.type === 'computer_call' ||
+        item.rawItem.type === 'shell_call' ||
+        item.rawItem.type === 'apply_patch_call'
+      ) {
+        getAgentInvocationMap(pendingLocalCalls, item.agent).set(callId, {
+          toolCall: item.rawItem,
+          identityResolved: true,
+          evidence: pending ? [...pending.evidence, item] : [item],
+        });
+      }
+      continue;
+    }
+    if (item instanceof RunHandoffCallItem) {
+      const rawItem = item.rawItem;
+      const callId = getToolInvocationCallId(rawItem);
+      if (!callId) {
+        throw new UserError(
+          'RunState contains a handoff call without a non-empty call ID.',
+        );
+      }
+      const fingerprint = getToolInvocationFingerprint(
+        getHandoffToolInvocationName(rawItem.name),
+        rawItem,
+      );
+      recordObservedToolInvocation(
+        observed,
+        ambiguous,
+        item.agent,
+        callId,
+        fingerprint,
+      );
+      getAgentInvocationMap(pendingLocalCalls, item.agent).set(callId, {
+        toolCall: rawItem,
+        identityResolved: true,
+        evidence: [item],
+      });
+      continue;
+    }
+    if (item instanceof RunToolCallItem) {
+      const rawItem = item.rawItem;
+      if (
+        rawItem.type === 'hosted_tool_call' &&
+        (rawItem.providerData?.type === 'mcp_approval_request' ||
+          rawItem.name === 'mcp_approval_request')
+      ) {
+        const providerData = rawItem.providerData as
+          { id?: unknown; name?: unknown } | undefined;
+        if (
+          typeof providerData?.id !== 'string' ||
+          providerData.id.length === 0 ||
+          typeof providerData.name !== 'string' ||
+          providerData.name.length === 0
+        ) {
+          throw new UserError(
+            'RunState contains a hosted MCP approval request without a canonical invocation identity.',
+          );
+        }
+        recordObservedToolInvocation(
+          observed,
+          ambiguous,
+          item.agent,
+          providerData.id,
+          getToolInvocationFingerprint(providerData.name, rawItem),
+        );
+        getAgentInvocationMap(pendingHostedMcpCalls, item.agent).set(
+          providerData.id,
+          { toolCall: rawItem, evidence: [item] },
+        );
+        continue;
+      }
+      if (
+        rawItem.type === 'hosted_tool_call' &&
+        rawItem.name === 'mcp_approval_response'
+      ) {
+        const providerData = rawItem.providerData as
+          { approval_request_id?: unknown } | undefined;
+        const callId = providerData?.approval_request_id;
+        if (typeof callId !== 'string' || callId.length === 0) {
+          throw new UserError(
+            'RunState contains a hosted MCP approval response without a non-empty approval request ID.',
+          );
+        }
+        const pending = pendingHostedMcpCalls.get(item.agent)?.get(callId);
+        if (!pending || !toolItemsHaveSameCaller(pending.toolCall, rawItem)) {
+          getAgentAmbiguousCallIds(ambiguous, item.agent).add(callId);
+          observed.get(item.agent)?.delete(callId);
+        }
+        pendingHostedMcpCalls.get(item.agent)?.delete(callId);
+        const fingerprint = observed.get(item.agent)?.get(callId);
+        if (
+          fingerprint !== undefined &&
+          !ambiguous.get(item.agent)?.has(callId)
+        ) {
+          getAgentInvocationMap(completed, item.agent).set(callId, fingerprint);
+          getAgentInvocationMap(evidence, item.agent).set(callId, [
+            ...(pending?.evidence ?? []),
+            item,
+          ]);
+        }
+        continue;
+      }
+      if (
+        rawItem.type !== 'function_call' &&
+        rawItem.type !== 'computer_call' &&
+        rawItem.type !== 'shell_call' &&
+        rawItem.type !== 'apply_patch_call'
+      ) {
+        continue;
+      }
+      const callId = getToolInvocationCallId(rawItem);
+      if (!callId) {
+        throw new UserError(
+          'RunState contains a local tool call without a non-empty call ID.',
+        );
+      }
+      const toolName = getSerializedLocalToolIdentity(
+        rawItem,
+        approvalNames.get(item.agent) ?? new Map(),
+        item.agent,
+      );
+      const agentPending = getAgentInvocationMap(pendingLocalCalls, item.agent);
+      const previousPending = agentPending.get(callId);
+      if (
+        previousPending &&
+        getToolInvocationFingerprint('', previousPending.toolCall) !==
+          getToolInvocationFingerprint('', rawItem)
+      ) {
+        getAgentAmbiguousCallIds(ambiguous, item.agent).add(callId);
+        agentPending.delete(callId);
+        observed.get(item.agent)?.delete(callId);
+        continue;
+      }
+      if (!ambiguous.get(item.agent)?.has(callId)) {
+        agentPending.set(callId, {
+          toolCall: rawItem,
+          identityResolved: toolName !== undefined,
+          evidence: [item],
+        });
+      }
+      if (!toolName) {
+        continue;
+      }
+      const fingerprint = getToolInvocationFingerprint(toolName, rawItem);
+      recordObservedToolInvocation(
+        observed,
+        ambiguous,
+        item.agent,
+        callId,
+        fingerprint,
+      );
+      continue;
+    }
+    if (
+      item instanceof RunToolCallOutputItem ||
+      item instanceof RunHandoffOutputItem
+    ) {
+      if (item instanceof RunHandoffOutputItem) {
+        const callId = item.rawItem.callId;
+        if (!callId) {
+          throw new UserError(
+            'RunState contains a handoff output without a non-empty call ID.',
+          );
+        }
+        const pending = pendingLocalCalls.get(item.sourceAgent)?.get(callId);
+        if (
+          !pending ||
+          !toolResultMatchesCall(pending.toolCall, item.rawItem)
+        ) {
+          getAgentAmbiguousCallIds(ambiguous, item.sourceAgent).add(callId);
+          observed.get(item.sourceAgent)?.delete(callId);
+        }
+        pendingLocalCalls.get(item.sourceAgent)?.delete(callId);
+        const fingerprint = observed.get(item.sourceAgent)?.get(callId);
+        if (
+          fingerprint !== undefined &&
+          !ambiguous.get(item.sourceAgent)?.has(callId)
+        ) {
+          getAgentInvocationMap(completed, item.sourceAgent).set(
+            callId,
+            fingerprint,
+          );
+          getAgentInvocationMap(evidence, item.sourceAgent).set(callId, [
+            ...(pending?.evidence ?? []),
+            item,
+          ]);
+        }
+        continue;
+      }
+      if (!isTrackedLocalToolResult(item.rawItem)) {
+        continue;
+      }
+      const callId = getLocalToolResultCallId(item.rawItem);
+      if (!callId) {
+        throw new UserError(
+          'RunState contains a local tool output without a non-empty call ID.',
+        );
+      }
+      const pending = pendingLocalCalls.get(item.agent)?.get(callId);
+      if (
+        !pending ||
+        !pending.identityResolved ||
+        !toolResultMatchesCall(pending.toolCall, item.rawItem)
+      ) {
+        getAgentAmbiguousCallIds(ambiguous, item.agent).add(callId);
+        observed.get(item.agent)?.delete(callId);
+      }
+      pendingLocalCalls.get(item.agent)?.delete(callId);
+      const fingerprint = callId
+        ? observed.get(item.agent)?.get(callId)
+        : undefined;
+      if (
+        callId &&
+        fingerprint !== undefined &&
+        !ambiguous.get(item.agent)?.has(callId)
+      ) {
+        getAgentInvocationMap(completed, item.agent).set(callId, fingerprint);
+        getAgentInvocationMap(evidence, item.agent).set(callId, [
+          ...(pending?.evidence ?? []),
+          item,
+        ]);
+      }
+    }
+  }
+  return { completed, ambiguous, evidence };
+}
+
+function rebuildLegacyCompletedToolInvocations(
+  state: RunState<any, Agent<any, any>>,
+  generatedItems: readonly RunItem[],
+): void {
+  const inferred = inferCompletedToolInvocations(generatedItems);
+  state._completedToolInvocations = inferred.completed;
+  state._ambiguousToolInvocationCallIds = inferred.ambiguous;
+}
+
+function getPerCallApprovalIds(record: {
+  approved: boolean | string[];
+  rejected: boolean | string[];
+}): Set<string> {
+  return new Set([
+    ...(Array.isArray(record.approved) ? record.approved : []),
+    ...(Array.isArray(record.rejected) ? record.rejected : []),
+  ]);
+}
+
+function validateCurrentApprovalInvocationRecords(
+  context: z.infer<typeof SerializedRunState>['context'],
+): void {
+  const invocationRecords = new Map(
+    (context.approvalInvocations ?? []).map((record) => [
+      record.agentIdentity,
+      record.invocations,
+    ]),
+  );
+  for (const record of context.functionApprovals ?? []) {
+    const invocations = invocationRecords.get(record.agentIdentity);
+    for (const approval of Object.values(record.approvals)) {
+      for (const callId of getPerCallApprovalIds(approval)) {
+        if (invocations?.[callId] === undefined) {
+          throw new UserError(
+            'RunState contains a per-call function approval without its canonical invocation binding.',
+          );
+        }
+      }
+    }
+  }
+  for (const record of context.approvalInvocations ?? []) {
+    for (const approval of Object.values(record.approvals)) {
+      for (const callId of getPerCallApprovalIds(approval)) {
+        if (record.invocations[callId] === undefined) {
+          throw new UserError(
+            'RunState contains a per-call tool approval without its canonical invocation binding.',
+          );
+        }
+      }
+    }
+  }
+}
+
+function validateToolInvocationCompletionEvidence(
+  agent: Agent<any, any>,
+  callId: string,
+  evidence: ToolInvocationCompletionEvidence,
+): string {
+  const [callItem, outputItem] = evidence.items;
+  const toolName = getToolInvocationNameFromFingerprint(evidence.fingerprint);
+  let toolCall: LocalToolCall | protocol.HostedToolCallItem;
+  let expectedToolName: string | undefined;
+  let evidenceCallId: string | undefined;
+  let correlated = false;
+
+  if (callItem instanceof RunHandoffCallItem) {
+    toolCall = callItem.rawItem;
+    expectedToolName = getHandoffToolInvocationName(toolCall.name);
+    evidenceCallId = toolCall.callId;
+    correlated =
+      callItem.agent === agent &&
+      outputItem instanceof RunHandoffOutputItem &&
+      outputItem.sourceAgent === agent &&
+      toolResultMatchesCall(toolCall, outputItem.rawItem);
+  } else if (
+    callItem instanceof RunToolCallItem ||
+    callItem instanceof RunToolApprovalItem
+  ) {
+    const rawToolCall = callItem.rawItem;
+    if (rawToolCall.type === 'hosted_tool_call') {
+      toolCall = rawToolCall;
+      const providerData = toolCall.providerData as
+        { id?: unknown; name?: unknown } | undefined;
+      expectedToolName =
+        typeof providerData?.name === 'string'
+          ? providerData.name
+          : callItem instanceof RunToolApprovalItem
+            ? callItem.name
+            : undefined;
+      evidenceCallId =
+        typeof providerData?.id === 'string'
+          ? providerData.id
+          : getToolInvocationCallId(toolCall);
+      const outputProviderData =
+        outputItem instanceof RunToolCallItem &&
+        outputItem.rawItem.type === 'hosted_tool_call'
+          ? (outputItem.rawItem.providerData as
+              { approval_request_id?: unknown } | undefined)
+          : undefined;
+      correlated =
+        callItem.agent === agent &&
+        outputItem instanceof RunToolCallItem &&
+        outputItem.agent === agent &&
+        outputItem.rawItem.type === 'hosted_tool_call' &&
+        outputItem.rawItem.name === 'mcp_approval_response' &&
+        outputProviderData?.approval_request_id === callId &&
+        toolItemsHaveSameCaller(toolCall, outputItem.rawItem);
+    } else if (
+      rawToolCall.type === 'function_call' ||
+      rawToolCall.type === 'computer_call' ||
+      rawToolCall.type === 'shell_call' ||
+      rawToolCall.type === 'apply_patch_call'
+    ) {
+      toolCall = rawToolCall;
+      expectedToolName =
+        toolCall.type === 'function_call'
+          ? callItem instanceof RunToolApprovalItem
+            ? (callItem.functionToolStateKey ?? callItem.name)
+            : getFunctionToolLegacyStateKeyFromStateKey(toolName ?? '') ===
+                getFunctionToolLegacyStateKeyFromStateKey(
+                  getFunctionToolStateKeyForCall(toolCall, toolCall.name) ?? '',
+                )
+              ? toolName
+              : undefined
+          : callItem instanceof RunToolApprovalItem
+            ? callItem.name
+            : toolName;
+      evidenceCallId = getToolInvocationCallId(toolCall);
+      correlated =
+        callItem.agent === agent &&
+        outputItem instanceof RunToolCallOutputItem &&
+        outputItem.agent === agent &&
+        isTrackedLocalToolResult(outputItem.rawItem) &&
+        toolResultMatchesCall(toolCall, outputItem.rawItem);
+    } else {
+      throw new UserError(
+        'RunState completed tool invocation evidence contains an unsupported call item.',
+      );
+    }
+  } else {
+    throw new UserError(
+      'RunState completed tool invocation evidence is missing its canonical call item.',
+    );
+  }
+
+  if (
+    !toolName ||
+    !expectedToolName ||
+    expectedToolName !== toolName ||
+    evidenceCallId !== callId ||
+    getToolInvocationFingerprint(toolName, toolCall) !== evidence.fingerprint ||
+    !correlated
+  ) {
+    throw new UserError(
+      'RunState completed tool invocation evidence is not a correlated canonical completion.',
+    );
+  }
+  return evidence.fingerprint;
+}
+
+function findToolInvocationCompletionEvidence(
+  agent: Agent<any, any>,
+  callId: string,
+  fingerprint: string,
+  outputItem: RunItem,
+  candidates: readonly RunItem[],
+): ToolInvocationCompletionEvidence | undefined {
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const candidate = candidates[index];
+    if (candidate === outputItem) {
+      continue;
+    }
+    const evidence: ToolInvocationCompletionEvidence = {
+      fingerprint,
+      items: [candidate, outputItem],
+    };
+    try {
+      validateToolInvocationCompletionEvidence(agent, callId, evidence);
+      return evidence;
+    } catch (error) {
+      if (!(error instanceof UserError)) {
+        throw error;
+      }
+    }
+  }
+  return undefined;
+}
+
+function getCompletionOutputCallId(
+  item: RunItem,
+  agent: Agent<any, any>,
+): string | undefined {
+  if (item instanceof RunHandoffOutputItem) {
+    return item.sourceAgent === agent ? item.rawItem.callId : undefined;
+  }
+  if (item instanceof RunToolCallOutputItem) {
+    return item.agent === agent && isTrackedLocalToolResult(item.rawItem)
+      ? getLocalToolResultCallId(item.rawItem)
+      : undefined;
+  }
+  if (
+    item instanceof RunToolCallItem &&
+    item.agent === agent &&
+    item.rawItem.type === 'hosted_tool_call' &&
+    item.rawItem.name === 'mcp_approval_response'
+  ) {
+    const providerData = item.rawItem.providerData as
+      { approval_request_id?: unknown } | undefined;
+    return typeof providerData?.approval_request_id === 'string'
+      ? providerData.approval_request_id
+      : undefined;
+  }
+  return undefined;
+}
+
+function validateGeneratedHistoryForCompletionEvidence(
+  generatedItems: readonly RunItem[],
+  agent: Agent<any, any>,
+  callId: string,
+  evidence: ToolInvocationCompletionEvidence,
+): void {
+  const outputItems = generatedItems.filter(
+    (item) => getCompletionOutputCallId(item, agent) === callId,
+  );
+  for (const outputItem of outputItems) {
+    if (
+      !findToolInvocationCompletionEvidence(
+        agent,
+        callId,
+        evidence.fingerprint,
+        outputItem,
+        [evidence.items[0], ...generatedItems],
+      )
+    ) {
+      throw new UserError(
+        'RunState generated item history conflicts with completed tool invocation evidence.',
+      );
+    }
+  }
+}
+
+function validateCurrentCompletedToolInvocations(
+  state: RunState<any, Agent<any, any>>,
+  generatedItems: readonly RunItem[],
+): void {
+  const serializedCompleted = state._completedToolInvocations;
+  const inferred = inferCompletedToolInvocations(generatedItems);
+  const inferredCompleted = inferred.completed;
+  const evidenceCompleted = new Map<Agent<any, any>, Map<string, string>>();
+  for (const [agent, invocations] of state._completedToolInvocationEvidence) {
+    for (const [callId, evidence] of invocations) {
+      validateGeneratedHistoryForCompletionEvidence(
+        generatedItems,
+        agent,
+        callId,
+        evidence,
+      );
+      getAgentInvocationMap(evidenceCompleted, agent).set(
+        callId,
+        validateToolInvocationCompletionEvidence(agent, callId, evidence),
+      );
+    }
+  }
+
+  for (const [agent, invocations] of inferredCompleted) {
+    const serializedInvocations = serializedCompleted.get(agent);
+    for (const [callId, fingerprint] of invocations) {
+      if (serializedInvocations?.get(callId) !== fingerprint) {
+        throw new UserError(
+          'RunState completed tool invocation records do not match the generated item history.',
+        );
+      }
+    }
+  }
+  for (const [agent, invocations] of serializedCompleted) {
+    const evidenceInvocations = evidenceCompleted.get(agent);
+    for (const [callId, fingerprint] of invocations) {
+      if (evidenceInvocations?.get(callId) !== fingerprint) {
+        throw new UserError(
+          'RunState completed tool invocation records do not match correlated completion evidence.',
+        );
+      }
+    }
+  }
+  for (const [agent, invocations] of evidenceCompleted) {
+    const serializedInvocations = serializedCompleted.get(agent);
+    for (const [callId, fingerprint] of invocations) {
+      if (serializedInvocations?.get(callId) !== fingerprint) {
+        throw new UserError(
+          'RunState completed tool invocation evidence does not match completed invocation authority.',
+        );
+      }
+    }
+  }
+  const inferredAmbiguous = inferred.ambiguous;
+  for (const [agent, callIds] of inferredAmbiguous) {
+    const serializedCallIds = state._ambiguousToolInvocationCallIds.get(agent);
+    for (const callId of callIds) {
+      if (evidenceCompleted.get(agent)?.has(callId)) {
+        continue;
+      }
+      if (!serializedCallIds?.has(callId)) {
+        throw new UserError(
+          'RunState ambiguous tool invocation records do not match the generated item history.',
+        );
+      }
+    }
+  }
+}
 
 const serializedAgentSchema = z.object({
   name: z.string(),
@@ -321,6 +1160,126 @@ const itemSchema = z.discriminatedUnion('type', [
     functionToolStateKey: z.string().optional(),
   }),
 ]);
+
+const serializedToolInvocationCompletionEvidenceItemSchema = z.union([
+  z
+    .object({
+      generatedItemIndex: z.number().int().min(0),
+    })
+    .strict(),
+  z
+    .object({
+      item: itemSchema,
+    })
+    .strict(),
+]);
+
+const serializedToolInvocationCompletionEvidenceSchema = z
+  .object({
+    fingerprint: z.string(),
+    items: z.tuple([
+      serializedToolInvocationCompletionEvidenceItemSchema,
+      serializedToolInvocationCompletionEvidenceItemSchema,
+    ]),
+  })
+  .strict();
+
+type SerializedToolInvocationCompletionEvidence = z.infer<
+  typeof serializedToolInvocationCompletionEvidenceSchema
+>;
+
+function serializeAgentInvocationEvidence(
+  records: ReadonlyMap<
+    Agent<any, any>,
+    ReadonlyMap<string, ToolInvocationCompletionEvidence>
+  >,
+  agentIdentityKeys: ReadonlyMap<Agent<any, any>, string>,
+  generatedItems: readonly RunItem[],
+): Array<{
+  agentIdentity: string;
+  invocations: Record<string, SerializedToolInvocationCompletionEvidence>;
+}> {
+  const serialized: Array<{
+    agentIdentity: string;
+    invocations: Record<string, SerializedToolInvocationCompletionEvidence>;
+  }> = [];
+  const generatedItemIndexes = new Map(
+    generatedItems.map((item, index) => [item, index]),
+  );
+  for (const [agent, invocations] of records) {
+    const agentIdentity = agentIdentityKeys.get(agent);
+    if (!agentIdentity || invocations.size === 0) {
+      continue;
+    }
+    serialized.push({
+      agentIdentity,
+      invocations: Object.fromEntries(
+        [...invocations].map(([callId, evidence]) => [
+          callId,
+          {
+            fingerprint: evidence.fingerprint,
+            items: evidence.items.map((item) => {
+              const generatedItemIndex = generatedItemIndexes.get(item);
+              return generatedItemIndex === undefined
+                ? { item: serializeRunItem(item, agentIdentityKeys) }
+                : { generatedItemIndex };
+            }) as SerializedToolInvocationCompletionEvidence['items'],
+          },
+        ]),
+      ),
+    });
+  }
+  return serialized;
+}
+
+function deserializeAgentInvocationEvidence(
+  records: ReadonlyArray<{
+    agentIdentity: string;
+    invocations: Record<string, SerializedToolInvocationCompletionEvidence>;
+  }>,
+  agentsByIdentity: Map<string, Agent<any, any>>,
+  generatedItems: readonly RunItem[],
+): Map<Agent<any, any>, Map<string, ToolInvocationCompletionEvidence>> {
+  const deserialized = new Map<
+    Agent<any, any>,
+    Map<string, ToolInvocationCompletionEvidence>
+  >();
+  const seenAgentIdentities = new Set<string>();
+  for (const { agentIdentity, invocations } of records) {
+    const agent = agentsByIdentity.get(agentIdentity);
+    if (!agent || seenAgentIdentities.has(agentIdentity)) {
+      throw new UserError(
+        'RunState contains invalid completed tool invocation evidence ownership for the current agent graph.',
+      );
+    }
+    seenAgentIdentities.add(agentIdentity);
+    deserialized.set(
+      agent,
+      new Map(
+        Object.entries(invocations).map(([callId, evidence]) => [
+          callId,
+          {
+            fingerprint: evidence.fingerprint,
+            items: evidence.items.map((reference) => {
+              if ('generatedItemIndex' in reference) {
+                const generatedItem =
+                  generatedItems[reference.generatedItemIndex];
+                if (!generatedItem) {
+                  throw new UserError(
+                    'RunState completed tool invocation evidence references a missing generated item.',
+                  );
+                }
+                return generatedItem;
+              }
+              return deserializeItem(reference.item, agentsByIdentity);
+            }) as [RunItem, RunItem],
+          },
+        ]),
+      ),
+    );
+  }
+  return deserialized;
+}
 
 const serializedTraceSchema = z.object({
   object: z.literal('trace'),
@@ -528,6 +1487,15 @@ const functionApprovalContextSchema = z.object({
   legacyFunctionApprovals: z
     .record(z.string(), approvalRecordSchema)
     .optional(),
+  approvalInvocations: z
+    .array(
+      z.object({
+        agentIdentity: z.string(),
+        invocations: z.record(z.string(), z.string()),
+        approvals: z.record(z.string(), approvalRecordSchema),
+      }),
+    )
+    .optional(),
 });
 
 export const SerializedRunState = z.object({
@@ -542,6 +1510,15 @@ export const SerializedRunState = z.object({
     functionApprovals: functionApprovalsSchema.optional(),
     legacyFunctionApprovals: z
       .record(z.string(), approvalRecordSchema)
+      .optional(),
+    approvalInvocations: z
+      .array(
+        z.object({
+          agentIdentity: z.string(),
+          invocations: z.record(z.string(), z.string()),
+          approvals: z.record(z.string(), approvalRecordSchema),
+        }),
+      )
       .optional(),
     context: z.record(z.string(), z.any()),
     toolInput: z.any().optional(),
@@ -579,6 +1556,33 @@ export const SerializedRunState = z.object({
   currentTurnSessionInputItems: z.array(protocol.ModelItem).optional(),
   pendingSessionHistoryTransaction:
     pendingSessionHistoryTransactionSchema.optional(),
+  completedToolInvocations: z
+    .array(
+      z.object({
+        agentIdentity: z.string(),
+        invocations: z.record(z.string(), z.string()),
+      }),
+    )
+    .optional(),
+  completedToolInvocationEvidence: z
+    .array(
+      z.object({
+        agentIdentity: z.string(),
+        invocations: z.record(
+          z.string(),
+          serializedToolInvocationCompletionEvidenceSchema,
+        ),
+      }),
+    )
+    .optional(),
+  ambiguousToolInvocationCallIds: z
+    .array(
+      z.object({
+        agentIdentity: z.string(),
+        callIds: z.array(z.string()),
+      }),
+    )
+    .optional(),
   pendingLegacyCompactionSessionItems: z.array(protocol.ModelItem).optional(),
   conversationId: z.string().optional(),
   previousResponseId: z.string().optional(),
@@ -688,6 +1692,26 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Legacy pending-run keys mapped to their canonical category-aware keys.
    */
   public _pendingAgentToolRunAliases: Map<string, string>;
+  /**
+   * Canonical invocation fingerprints whose local tool outputs are committed to run history.
+   */
+  public _completedToolInvocations: Map<Agent<any, any>, Map<string, string>>;
+  /**
+   * Completed invocations whose supporting run items were removed by a
+   * supported history replacement.
+   */
+  public _completedToolInvocationEvidence: Map<
+    Agent<any, any>,
+    Map<string, ToolInvocationCompletionEvidence>
+  >;
+  /**
+   * Canonical invocations observed in the active run before their outputs are committed.
+   */
+  public _observedToolInvocations: Map<Agent<any, any>, Map<string, string>>;
+  /**
+   * Legacy call IDs whose serialized history cannot identify one canonical invocation.
+   */
+  public _ambiguousToolInvocationCallIds: Map<Agent<any, any>, Set<string>>;
   /**
    * Items generated by the agent during the run.
    */
@@ -828,6 +1852,10 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._toolUseTracker = new AgentToolUseTracker();
     this._pendingAgentToolRuns = new Map();
     this._pendingAgentToolRunAliases = new Map();
+    this._completedToolInvocations = new Map();
+    this._completedToolInvocationEvidence = new Map();
+    this._observedToolInvocations = new Map();
+    this._ambiguousToolInvocationCallIds = new Map();
     this._generatedItems = [];
     this._currentTurnPersistedItemCount = 0;
     this._currentTurnDeferredSessionItemIndexes = new Set();
@@ -883,6 +1911,152 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
   public clearTrace(): void {
     this._trace = null;
     this._currentAgentSpan = undefined;
+  }
+
+  /**
+   * Validate and observe a canonical local tool invocation before side effects.
+   * @internal
+   * @returns Whether the exact invocation already has a committed output.
+   */
+  _observeToolInvocation(
+    agent: Agent<any, any>,
+    callId: string,
+    fingerprint: string,
+  ): boolean {
+    const completed = this._preflightToolInvocation(agent, callId, fingerprint);
+    if (!completed) {
+      getAgentInvocationMap(this._observedToolInvocations, agent).set(
+        callId,
+        fingerprint,
+      );
+    }
+    return completed;
+  }
+
+  /**
+   * Validate a canonical local tool invocation without recording it.
+   * @internal
+   */
+  _preflightToolInvocation(
+    agent: Agent<any, any>,
+    callId: string,
+    fingerprint: string,
+  ): boolean {
+    this._context._validateAgentApprovalInvocation(agent, callId, fingerprint);
+    const ambiguous = this._ambiguousToolInvocationCallIds.get(agent);
+    if (ambiguous?.has(callId)) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${callId} has ambiguous invocation history and cannot be executed safely.`,
+        this,
+      );
+    }
+    const completed = this._completedToolInvocations.get(agent)?.get(callId);
+    if (completed !== undefined) {
+      if (completed !== fingerprint) {
+        throw new ModelBehaviorError(
+          `Tool call ID ${callId} was reused for a different invocation after its output was committed.`,
+          this,
+        );
+      }
+      return true;
+    }
+    const observed = this._observedToolInvocations.get(agent)?.get(callId);
+    if (observed !== undefined && observed !== fingerprint) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${callId} was reused for different tool invocations in the same run.`,
+        this,
+      );
+    }
+    return false;
+  }
+
+  /**
+   * Commit fingerprints for local tool output items added to run history.
+   * @internal
+   */
+  _commitToolInvocations(items: readonly RunItem[]): void {
+    const evidenceCandidates = [...this._generatedItems, ...items];
+    const commit = (
+      agent: Agent<any, any>,
+      callId: string,
+      outputItem: RunItem,
+    ): void => {
+      const fingerprint = this._observedToolInvocations.get(agent)?.get(callId);
+      if (fingerprint === undefined) {
+        return;
+      }
+      const evidence = findToolInvocationCompletionEvidence(
+        agent,
+        callId,
+        fingerprint,
+        outputItem,
+        evidenceCandidates,
+      );
+      if (!evidence) {
+        return;
+      }
+      getAgentInvocationMap(this._completedToolInvocations, agent).set(
+        callId,
+        fingerprint,
+      );
+      getAgentInvocationMap(this._completedToolInvocationEvidence, agent).set(
+        callId,
+        evidence,
+      );
+    };
+
+    for (const item of items) {
+      if (
+        item instanceof RunToolCallItem &&
+        item.rawItem.type === 'hosted_tool_call' &&
+        item.rawItem.name === 'mcp_approval_response'
+      ) {
+        const providerData = item.rawItem.providerData as
+          { approval_request_id?: unknown } | undefined;
+        const callId = providerData?.approval_request_id;
+        if (typeof callId !== 'string' || callId.length === 0) {
+          throw new ModelBehaviorError(
+            'Hosted MCP approval response is missing a non-empty approval request ID.',
+            this,
+          );
+        }
+        commit(item.agent, callId, item);
+        continue;
+      }
+      if (item instanceof RunHandoffOutputItem) {
+        const callId = item.rawItem.callId;
+        if (!callId) {
+          throw new ModelBehaviorError(
+            'Handoff output is missing a non-empty call ID.',
+            this,
+          );
+        }
+        commit(item.sourceAgent, callId, item);
+        continue;
+      }
+      if (!(item instanceof RunToolCallOutputItem)) {
+        continue;
+      }
+      if (!isTrackedLocalToolResult(item.rawItem)) {
+        continue;
+      }
+      const callId = getLocalToolResultCallId(item.rawItem);
+      if (!callId) {
+        throw new ModelBehaviorError(
+          'Tool output is missing a non-empty call ID.',
+          this,
+        );
+      }
+      commit(item.agent, callId, item);
+    }
+  }
+
+  /**
+   * Replaces generated history after completion evidence has been committed.
+   * @internal
+   */
+  _replaceGeneratedItems(generatedItems: RunItem[]): void {
+    this._generatedItems = generatedItems;
   }
 
   private getOrCreateToolSearchRuntimeToolState(
@@ -1157,6 +2331,112 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
   ): z.infer<typeof SerializedRunState> {
     assertSandboxStateUsesCurrentSessionEnvelope(this._sandbox);
     const agentIdentity = buildAgentIdentityMap(this.#startingAgent);
+    const completedToolInvocations = new Map(
+      [...this._completedToolInvocations].map(([agent, invocations]) => [
+        agent,
+        new Map(invocations),
+      ]),
+    );
+    const inferredInvocations = inferCompletedToolInvocations(
+      this._generatedItems,
+    );
+    for (const [agent, invocations] of inferredInvocations.completed) {
+      const completedByAgent = getAgentInvocationMap(
+        completedToolInvocations,
+        agent,
+      );
+      for (const [callId, fingerprint] of invocations) {
+        const existing = completedByAgent.get(callId);
+        if (existing !== undefined && existing !== fingerprint) {
+          throw new UserError(
+            'RunState completed tool invocation records conflict with the generated item history.',
+          );
+        }
+        completedByAgent.set(callId, fingerprint);
+      }
+    }
+    const completedToolInvocationEvidence = new Map(
+      [...this._completedToolInvocationEvidence].map(([agent, invocations]) => [
+        agent,
+        new Map(invocations),
+      ]),
+    );
+    for (const [agent, invocations] of inferredInvocations.completed) {
+      for (const [callId, fingerprint] of invocations) {
+        const evidenceByAgent = getAgentInvocationMap(
+          completedToolInvocationEvidence,
+          agent,
+        );
+        if (!evidenceByAgent.has(callId)) {
+          const inferredEvidence = inferredInvocations.evidence
+            .get(agent)
+            ?.get(callId);
+          const outputItem = inferredEvidence?.at(-1);
+          const evidence =
+            outputItem && inferredEvidence
+              ? findToolInvocationCompletionEvidence(
+                  agent,
+                  callId,
+                  fingerprint,
+                  outputItem,
+                  inferredEvidence,
+                )
+              : undefined;
+          if (evidence) {
+            evidenceByAgent.set(callId, evidence);
+          }
+        }
+      }
+    }
+    for (const [agent, invocations] of completedToolInvocationEvidence) {
+      const completedByAgent = completedToolInvocations.get(agent);
+      for (const [callId, evidence] of invocations) {
+        validateGeneratedHistoryForCompletionEvidence(
+          this._generatedItems,
+          agent,
+          callId,
+          evidence,
+        );
+        const fingerprint = validateToolInvocationCompletionEvidence(
+          agent,
+          callId,
+          evidence,
+        );
+        if (completedByAgent?.get(callId) !== fingerprint) {
+          throw new UserError(
+            'RunState completed tool invocation evidence lacks completed invocation authority.',
+          );
+        }
+      }
+    }
+    for (const [agent, invocations] of completedToolInvocations) {
+      const evidenceByAgent = completedToolInvocationEvidence.get(agent);
+      for (const [callId, fingerprint] of invocations) {
+        if (evidenceByAgent?.get(callId)?.fingerprint !== fingerprint) {
+          throw new UserError(
+            'RunState completed tool invocation records lack correlated completion evidence.',
+          );
+        }
+      }
+    }
+    const ambiguousToolInvocationCallIds = new Map(
+      [...this._ambiguousToolInvocationCallIds].map(([agent, callIds]) => [
+        agent,
+        new Set(callIds),
+      ]),
+    );
+    for (const [agent, callIds] of inferredInvocations.ambiguous) {
+      const ambiguousByAgent = getAgentAmbiguousCallIds(
+        ambiguousToolInvocationCallIds,
+        agent,
+      );
+      for (const callId of callIds) {
+        if (completedToolInvocationEvidence.get(agent)?.has(callId)) {
+          continue;
+        }
+        ambiguousByAgent.add(callId);
+      }
+    }
 
     const includeTracingApiKey = options.includeTracingApiKey === true;
     const contextJson = this._context._toJSONForRunState(agentIdentity.byAgent);
@@ -1227,6 +2507,19 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       ),
       pendingAgentToolRunAliases: Object.fromEntries(
         this._pendingAgentToolRunAliases.entries(),
+      ),
+      completedToolInvocations: serializeAgentInvocationRecords(
+        completedToolInvocations,
+        agentIdentity.byAgent,
+      ),
+      completedToolInvocationEvidence: serializeAgentInvocationEvidence(
+        completedToolInvocationEvidence,
+        agentIdentity.byAgent,
+        this._generatedItems,
+      ),
+      ambiguousToolInvocationCallIds: serializeAgentCallIdSets(
+        ambiguousToolInvocationCallIds,
+        agentIdentity.byAgent,
       ),
       currentTurnPersistedItemCount: this._currentTurnPersistedItemCount,
       currentTurnDeferredSessionItemIndexes:
@@ -1451,7 +2744,7 @@ function assertSchemaVersionSupportsToolSearch(
     schemaVersion === '1.15' ||
     schemaVersion === '1.16' ||
     schemaVersion === '1.17' ||
-    schemaVersion === CURRENT_SCHEMA_VERSION
+    schemaVersionSupportsV118State(schemaVersion)
   ) {
     return;
   }
@@ -1475,7 +2768,7 @@ function assertSchemaVersionSupportsCustomData(
     schemaVersion === '1.15' ||
     schemaVersion === '1.16' ||
     schemaVersion === '1.17' ||
-    schemaVersion === CURRENT_SCHEMA_VERSION
+    schemaVersionSupportsV118State(schemaVersion)
   ) {
     return;
   }
@@ -1501,7 +2794,7 @@ function schemaVersionSupportsAgentIdentity(
     schemaVersion === '1.15' ||
     schemaVersion === '1.16' ||
     schemaVersion === '1.17' ||
-    schemaVersion === CURRENT_SCHEMA_VERSION
+    schemaVersionSupportsV118State(schemaVersion)
   );
 }
 
@@ -1514,7 +2807,7 @@ function assertSchemaVersionSupportsProgrammaticToolCalling(
     schemaVersion === '1.15' ||
     schemaVersion === '1.16' ||
     schemaVersion === '1.17' ||
-    schemaVersion === CURRENT_SCHEMA_VERSION
+    schemaVersionSupportsV118State(schemaVersion)
   ) {
     return;
   }
@@ -1546,14 +2839,14 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
     schemaVersion === '1.15' ||
     schemaVersion === '1.16' ||
     schemaVersion === '1.17' ||
-    schemaVersion === CURRENT_SCHEMA_VERSION;
+    schemaVersionSupportsV118State(schemaVersion);
   if (
     envelopes.every(
       (envelope) =>
         envelope.version === 1 ||
         (envelope.version === 2 && supportsVersion2) ||
         (envelope.version === SANDBOX_SESSION_STATE_VERSION &&
-          schemaVersion === CURRENT_SCHEMA_VERSION),
+          schemaVersionSupportsV118State(schemaVersion)),
     )
   ) {
     return;
@@ -1565,7 +2858,7 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
       !(envelope.version === 2 && supportsVersion2) &&
       !(
         envelope.version === SANDBOX_SESSION_STATE_VERSION &&
-        schemaVersion === CURRENT_SCHEMA_VERSION
+        schemaVersionSupportsV118State(schemaVersion)
       ),
   )?.version;
   throw new UserError(
@@ -3591,6 +4884,20 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   options: RunStateContextOverrideOptions<TContext> = {},
 ): Promise<RunState<TContext, TAgent>> {
   const schemaVersion = stateJson.$schemaVersion as SupportedSchemaVersion;
+  if (
+    schemaVersionSupportsV118State(schemaVersion) &&
+    (stateJson.context.approvalInvocations === undefined ||
+      stateJson.completedToolInvocations === undefined ||
+      stateJson.completedToolInvocationEvidence === undefined ||
+      stateJson.ambiguousToolInvocationCallIds === undefined)
+  ) {
+    throw new UserError(
+      'RunState schema 1.18 requires explicit approval, completed, completion-evidence, and ambiguous invocation records.',
+    );
+  }
+  if (schemaVersionSupportsV118State(schemaVersion)) {
+    validateCurrentApprovalInvocationRecords(stateJson.context);
+  }
   const agentMap = schemaVersionSupportsAgentIdentity(schemaVersion)
     ? buildAgentIdentityMap(initialAgent).byIdentity
     : buildAgentMap(initialAgent);
@@ -3604,13 +4911,19 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   //
   // Rebuild the context
   //
-  const context =
-    contextOverride ??
-    new RunContext<TContext>(stateJson.context.context as TContext);
+  const context = contextOverride
+    ? contextOverride._cloneForRunStateDeserialization()
+    : new RunContext<TContext>(stateJson.context.context as TContext);
   context._validateFunctionApprovalOwners(
     stateJson.context.functionApprovals ?? [],
     agentMap,
   );
+  if (schemaVersionSupportsV118State(schemaVersion)) {
+    context._validateApprovalInvocations(
+      stateJson.context.approvalInvocations ?? [],
+      agentMap,
+    );
+  }
   if (contextOverride) {
     if (contextStrategy === 'merge') {
       if (schemaVersionSupportsV116State(schemaVersion)) {
@@ -3622,6 +4935,12 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
         context._mergeLegacyFunctionApprovals(
           stateJson.context.legacyFunctionApprovals ?? {},
         );
+        if (schemaVersionSupportsV118State(schemaVersion)) {
+          context._mergeApprovalInvocations(
+            stateJson.context.approvalInvocations ?? [],
+            agentMap,
+          );
+        }
       } else {
         deferredLegacyApprovalContext = new RunContext<TContext>(
           stateJson.context.context as TContext,
@@ -3644,6 +4963,12 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       schemaVersionSupportsV116State(schemaVersion)
         ? (stateJson.context.legacyFunctionApprovals ?? {})
         : stateJson.context.approvals,
+    );
+    context._rebuildApprovalInvocations(
+      schemaVersionSupportsV118State(schemaVersion)
+        ? (stateJson.context.approvalInvocations ?? [])
+        : [],
+      agentMap,
     );
   }
   const shouldRestoreSerializedContext =
@@ -3705,6 +5030,35 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
     Object.entries(stateJson.pendingAgentToolRuns ?? {}),
   );
   state._pendingAgentToolRunAliases = new Map();
+  state._completedToolInvocations = schemaVersionSupportsV118State(
+    schemaVersion,
+  )
+    ? deserializeAgentInvocationRecords(
+        stateJson.completedToolInvocations ?? [],
+        agentMap,
+      )
+    : new Map();
+  state._completedToolInvocationEvidence = schemaVersionSupportsV118State(
+    schemaVersion,
+  )
+    ? deserializeAgentInvocationEvidence(
+        stateJson.completedToolInvocationEvidence ?? [],
+        agentMap,
+        generatedItems,
+      )
+    : new Map();
+  state._observedToolInvocations = new Map();
+  state._ambiguousToolInvocationCallIds = schemaVersionSupportsV118State(
+    schemaVersion,
+  )
+    ? deserializeAgentCallIdSets(
+        stateJson.ambiguousToolInvocationCallIds ?? [],
+        agentMap,
+      )
+    : new Map();
+  if (schemaVersionSupportsV118State(schemaVersion)) {
+    validateCurrentCompletedToolInvocations(state, generatedItems);
+  }
 
   // rebuild current agent span
   if (stateJson.currentAgentSpan) {
@@ -3884,6 +5238,40 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       deferredLegacyApprovalContext,
       legacyFunctionApprovalKeys,
     );
+  }
+  if (!schemaVersionSupportsV118State(schemaVersion)) {
+    rebuildLegacyCompletedToolInvocations(state, generatedItems);
+    for (const run of state._lastProcessedResponse?.functions ?? []) {
+      const owner = state._lastProcessedResponse?.newItems.find(
+        (item): item is RunToolCallItem =>
+          item instanceof RunToolCallItem && item.rawItem === run.toolCall,
+      )?.agent;
+      context._bindLegacyApprovalInvocation(
+        new RunToolApprovalItem(
+          run.toolCall,
+          owner ?? state._currentAgent,
+          run.tool.name,
+          getFunctionToolStateKey(run.tool) ??
+            getFunctionToolStateKeyForCall(run.toolCall, run.tool.name),
+        ),
+      );
+    }
+    for (const interruption of state.getInterruptions()) {
+      context._bindLegacyApprovalInvocation(interruption);
+    }
+  }
+  if (contextOverride) {
+    const commitCandidate = contextOverride._cloneForRunStateDeserialization();
+    commitCandidate._mergeApprovalState(context);
+    contextOverride._replaceApprovalState(commitCandidate);
+    if (
+      contextStrategy === 'merge' &&
+      contextOverride.toolInput === undefined &&
+      context.toolInput !== undefined
+    ) {
+      contextOverride.toolInput = context.toolInput;
+    }
+    state._context = contextOverride;
   }
   state._serializedCurrentStep = state._currentStep;
   return state;

--- a/packages/agents-core/src/runner/mcpApprovals.ts
+++ b/packages/agents-core/src/runner/mcpApprovals.ts
@@ -9,6 +9,9 @@ import type { ToolRunMCPApprovalRequest } from './types';
 type ResolveApproval = (
   rawItem: protocol.HostedToolCallItem,
 ) => boolean | undefined;
+type ResolveRejectionMessage = (
+  rawItem: protocol.HostedToolCallItem,
+) => string | undefined;
 
 type HandleHostedMcpApprovalsParams<TContext> = {
   requests: ToolRunMCPApprovalRequest[];
@@ -17,6 +20,7 @@ type HandleHostedMcpApprovalsParams<TContext> = {
   functionResults: FunctionToolResult<TContext>[];
   appendIfNew: (item: RunItem) => void;
   resolveApproval?: ResolveApproval;
+  resolveRejectionMessage?: ResolveRejectionMessage;
 };
 
 export type HandleHostedMcpApprovalsResult = {
@@ -35,6 +39,7 @@ export async function handleHostedMcpApprovals<TContext>({
   functionResults,
   appendIfNew,
   resolveApproval,
+  resolveRejectionMessage,
 }: HandleHostedMcpApprovalsParams<TContext>): Promise<HandleHostedMcpApprovalsResult> {
   const pendingApprovals = new Set<RunToolApprovalItem>();
   const pendingApprovalIds = new Set<string>();
@@ -55,15 +60,26 @@ export async function handleHostedMcpApprovals<TContext>({
       ProviderData.HostedMCPTool<TContext> | undefined;
     const approvalRequestId = rawItem.id ?? providerData.id;
 
-    if (toolData?.on_approval) {
-      const approvalResult = await toolData.on_approval(
-        state._context,
-        approvalRequest.requestItem,
-      );
+    const approvalDecision =
+      typeof resolveApproval === 'function'
+        ? resolveApproval(rawItem)
+        : undefined;
+
+    if (typeof approvalDecision !== 'undefined' && approvalRequestId) {
+      const rejectionReason =
+        approvalDecision === false
+          ? typeof resolveRejectionMessage === 'function'
+            ? resolveRejectionMessage(rawItem)
+            : state._context._getToolInvocationRejectionMessage(
+                agent,
+                rawItem.name,
+                rawItem,
+              )
+          : undefined;
       const approvalResponseData: ProviderData.HostedMCPApprovalResponse = {
-        approve: approvalResult.approve,
-        approval_request_id: approvalRequestId ?? providerData.id,
-        reason: approvalResult.reason,
+        approve: approvalDecision,
+        approval_request_id: approvalRequestId,
+        reason: rejectionReason,
       };
       appendIfNew(
         new RunToolCallItem(
@@ -79,23 +95,22 @@ export async function handleHostedMcpApprovals<TContext>({
       continue;
     }
 
-    const approvalDecision =
-      typeof resolveApproval === 'function'
-        ? resolveApproval(rawItem)
-        : undefined;
-    if (typeof approvalDecision !== 'undefined' && approvalRequestId) {
-      const rejectionReason =
-        approvalDecision === false
-          ? state._context.getRejectionMessage(
-              rawItem.name,
-              approvalRequestId,
-              { functionTool: false },
-            )
-          : undefined;
+    if (toolData?.on_approval) {
+      const approvalResult = await toolData.on_approval(
+        state._context,
+        approvalRequest.requestItem,
+      );
+      if (approvalResult.approve) {
+        state.approve(approvalRequest.requestItem);
+      } else {
+        state.reject(approvalRequest.requestItem, {
+          message: approvalResult.reason,
+        });
+      }
       const approvalResponseData: ProviderData.HostedMCPApprovalResponse = {
-        approve: approvalDecision,
-        approval_request_id: approvalRequestId,
-        reason: rejectionReason,
+        approve: approvalResult.approve,
+        approval_request_id: approvalRequestId ?? providerData.id,
+        reason: approvalResult.reason,
       };
       appendIfNew(
         new RunToolCallItem(

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -109,6 +109,7 @@ function ensureProgrammaticToolCallingAvailable<TContext>(
 
 type ModelResponseProcessingOptions = {
   allowPromptSuppliedTools?: boolean;
+  beforeClientToolSearch?: () => void;
 };
 
 const MCP_HOSTED_CALL_TYPES = new Set([
@@ -1039,6 +1040,8 @@ export async function processModelResponseAsync<TContext>(
       processingOptions,
     );
   }
+
+  processingOptions.beforeClientToolSearch?.();
 
   const items: RunItem[] = [];
   const runHandoffs: ToolRunHandoff[] = [];

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -42,9 +42,10 @@ export function applyTurnResult<
     onStepItems,
   } = options;
   onStepItems?.(turnResult);
+  state._commitToolInvocations(turnResult.toolInvocationCommitItems);
   state._toolUseTracker.addToolUse(agent, toolsUsed);
   state._originalInput = turnResult.originalInput;
-  state._generatedItems = turnResult.generatedItems;
+  state._replaceGeneratedItems(turnResult.generatedItems);
   if (
     resetTurnPersistence &&
     turnResult.nextStep.type === 'next_step_run_again'
@@ -96,12 +97,11 @@ export async function resumeInterruptedTurn<
     return (
       toolName !== undefined &&
       callId !== undefined &&
-      state._context.isToolApproved({
+      state._context._resolveToolInvocationApproval(
+        item.agent,
         toolName,
-        callId,
-        functionTool: false,
-        ...(rawItem.type === 'function_call' ? { agent: item.agent } : {}),
-      }) === true
+        rawItem,
+      ) === true
     );
   });
   const turnResult = await resolveInterruptedTurn<TContext>(

--- a/packages/agents-core/src/runner/steps.ts
+++ b/packages/agents-core/src/runner/steps.ts
@@ -32,6 +32,7 @@ export class SingleStepResult {
     public newStepItems: RunItem[],
     public nextStep: NextStep,
     public finalOutputSource?: FinalOutputSource,
+    public toolInvocationCommitItems: RunItem[] = newStepItems,
   ) {}
 
   get generatedItems(): RunItem[] {

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1531,7 +1531,6 @@ type LocalApprovalDecision = {
 async function resolveToolApproval(options: {
   runContext: RunContext;
   toolName: string;
-  callId: string;
   approvalItem: RunToolApprovalItem;
   needsApproval: () => Promise<boolean>;
   onApproval?:
@@ -1545,18 +1544,17 @@ async function resolveToolApproval(options: {
   const {
     runContext,
     toolName,
-    callId,
     approvalItem,
     needsApproval,
     onApproval,
     isCancelled,
   } = options;
 
-  const existingApproval = runContext.isToolApproved({
+  const existingApproval = runContext._resolveToolInvocationApproval(
+    approvalItem.agent,
     toolName,
-    callId,
-    functionTool: false,
-  });
+    approvalItem.rawItem,
+  );
 
   if (existingApproval === true) {
     return 'approved';
@@ -1600,11 +1598,11 @@ async function resolveToolApproval(options: {
     }
   }
 
-  const approval = runContext.isToolApproved({
+  const approval = runContext._resolveToolInvocationApproval(
+    approvalItem.agent,
     toolName,
-    callId,
-    functionTool: false,
-  });
+    approvalItem.rawItem,
+  );
 
   if (approval === true) {
     return 'approved';
@@ -1622,7 +1620,6 @@ type ApprovalDecisionResult =
 async function handleToolApprovalDecision(options: {
   runContext: RunContext;
   toolName: string;
-  callId: string;
   approvalItem: RunToolApprovalItem;
   needsApproval: () => Promise<boolean>;
   onApproval?:
@@ -1638,7 +1635,6 @@ async function handleToolApprovalDecision(options: {
   const {
     runContext,
     toolName,
-    callId,
     approvalItem,
     needsApproval,
     onApproval,
@@ -1650,7 +1646,6 @@ async function handleToolApprovalDecision(options: {
   const approvalState = await resolveToolApproval({
     runContext,
     toolName,
-    callId,
     approvalItem,
     needsApproval,
     onApproval,
@@ -1800,7 +1795,6 @@ export async function executeShellActions(
     const approvalDecision = await handleToolApprovalDecision({
       runContext,
       toolName: shellTool.name,
-      callId: toolCallKey,
       approvalItem,
       needsApproval: () =>
         shellTool.needsApproval(runContext, toolCall.action, toolCallKey),
@@ -1947,7 +1941,6 @@ export async function executeApplyPatchOperations(
     const approvalDecision = await handleToolApprovalDecision({
       runContext,
       toolName: applyPatchTool.name,
-      callId: toolCallKey,
       approvalItem,
       needsApproval: () =>
         applyPatchTool.needsApproval(
@@ -2151,7 +2144,6 @@ export async function executeComputerActions(
     const approvalDecision = await handleToolApprovalDecision({
       runContext,
       toolName: computerTool.name,
-      callId: toolCall.callId,
       approvalItem,
       needsApproval: async () => {
         if (typeof needsApprovalCandidate !== 'function') {
@@ -2509,6 +2501,8 @@ export async function executeHandoffCalls<
       runner.emit('agent_handoff', runContext, agent, newAgent);
       agent.emit('agent_handoff', runContext, newAgent);
 
+      const toolInvocationCommitItems = [...newStepItems];
+
       if (inputFilter != null) {
         logger.debug('Filtering inputs for handoff');
 
@@ -2534,6 +2528,8 @@ export async function executeHandoffCalls<
         preStepItems,
         newStepItems,
         { type: 'next_step_handoff', newAgent },
+        undefined,
+        toolInvocationCommitItems,
       );
     },
     {

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
 import { Agent } from '../agent';
+import type { Handoff } from '../handoff';
 import { ModelBehaviorError, ModelRefusalError } from '../errors';
 import {
+  RunHandoffCallItem,
   RunItem,
   RunMessageOutputItem,
   RunToolApprovalItem,
+  RunToolCallItem,
   RunToolCallOutputItem,
 } from '../items';
 import logger, { logToolActionWarning } from '../logger';
@@ -46,11 +49,15 @@ import { handleHostedMcpApprovals } from './mcpApprovals';
 import * as ProviderData from '../types/providerData';
 import * as protocol from '../types/protocol';
 import { AgentInputItem } from '../types';
-import type { FunctionToolResult } from '../tool';
+import type { FunctionTool, FunctionToolResult, Tool } from '../tool';
 import {
+  buildFunctionToolLookupMap,
   getFunctionToolStateKey,
   getFunctionToolStateKeyForCall,
+  getFunctionToolStateKeyForResolvedCall,
   getFunctionToolStateKeys,
+  getToolCallNamespace,
+  resolveFunctionToolCall,
 } from '../toolIdentity';
 import type { RunErrorData, RunErrorHandlers } from './errorHandlers';
 import {
@@ -67,9 +74,244 @@ import {
   buildShellAbortResult,
 } from './streamReconciliation';
 import { runWithSiblingCancellation } from './siblingCancellation';
+import {
+  getHandoffToolInvocationName,
+  getToolInvocationCallId,
+  getToolInvocationFingerprint,
+  type ApprovalCapableToolCall,
+} from '../toolInvocation';
 
 const DEFAULT_TOOL_NOT_FOUND_MESSAGE = (toolName: string) =>
   `Tool '${toolName}' not found.`;
+
+export function preflightModelResponseToolInvocations<TContext>(
+  agent: Agent<TContext, any>,
+  state: RunState<TContext, Agent<TContext, any>>,
+  modelResponse: ModelResponse,
+  tools: Tool<TContext>[],
+  handoffs: Handoff<any, any>[],
+): void {
+  const functionMap = buildFunctionToolLookupMap(
+    tools.filter(
+      (tool): tool is FunctionTool<TContext> => tool.type === 'function',
+    ),
+  );
+  const handoffMap = new Map(
+    handoffs.map((handoff) => [handoff.toolName, handoff]),
+  );
+  const computer = tools.find((tool) => tool.type === 'computer');
+  const shell = tools.find((tool) => tool.type === 'shell');
+  const applyPatch = tools.find((tool) => tool.type === 'apply_patch');
+  const seen = new Map<string, string>();
+  const validate = (
+    toolName: string | undefined,
+    rawItem: ApprovalCapableToolCall,
+  ) => {
+    if (!toolName) {
+      return;
+    }
+    const { callId, fingerprint } = state._context._validateToolInvocation(
+      agent,
+      toolName,
+      rawItem,
+    );
+    state._preflightToolInvocation(agent, callId, fingerprint);
+    const previous = seen.get(callId);
+    if (previous !== undefined && previous !== fingerprint) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${callId} was reused for different tool invocations in the same model response.`,
+        state,
+      );
+    }
+    seen.set(callId, fingerprint);
+  };
+
+  for (const output of modelResponse.output) {
+    if (output.type === 'function_call') {
+      const handoff = !getToolCallNamespace(output)
+        ? handoffMap.get(output.name)
+        : undefined;
+      if (handoff) {
+        validate(getHandoffToolInvocationName(handoff.toolName), output);
+        continue;
+      }
+      const resolvedTool = resolveFunctionToolCall(output, functionMap);
+      validate(
+        resolvedTool
+          ? getFunctionToolStateKeyForResolvedCall(output, resolvedTool)
+          : getFunctionToolStateKeyForCall(output, output.name),
+        output,
+      );
+      continue;
+    }
+    if (output.type === 'computer_call') {
+      validate(computer?.name ?? 'computer', output);
+      continue;
+    }
+    if (output.type === 'shell_call') {
+      validate(shell?.name ?? 'shell', output);
+      continue;
+    }
+    if (output.type === 'apply_patch_call') {
+      validate(applyPatch?.name ?? 'apply_patch', output);
+      continue;
+    }
+    if (
+      output.type === 'hosted_tool_call' &&
+      (output.providerData?.type === 'mcp_approval_request' ||
+        output.name === 'mcp_approval_request')
+    ) {
+      const providerData = output.providerData as
+        { name?: unknown } | undefined;
+      validate(
+        typeof providerData?.name === 'string'
+          ? providerData.name
+          : output.name,
+        output,
+      );
+    }
+  }
+}
+
+export function preflightToolInvocations<TContext>(
+  agent: Agent<TContext, any>,
+  state: RunState<TContext, Agent<TContext, any>>,
+  processedResponse: ProcessedResponse<TContext>,
+): Set<ApprovalCapableToolCall> {
+  const suppressed = new Set<ApprovalCapableToolCall>();
+  const seen = new Map<string, string>();
+  const observe = (
+    toolName: string | undefined,
+    rawItem: ApprovalCapableToolCall,
+  ) => {
+    if (!toolName) {
+      return undefined;
+    }
+    const { callId, fingerprint } = state._context._validateToolInvocation(
+      agent,
+      toolName,
+      rawItem,
+    );
+    const completed = state._observeToolInvocation(agent, callId, fingerprint);
+    const previous = seen.get(callId);
+    const shouldSuppress = completed || previous === fingerprint;
+    if (shouldSuppress) {
+      suppressed.add(rawItem);
+    }
+    seen.set(callId, fingerprint);
+    return { callId, fingerprint, shouldSuppress };
+  };
+
+  for (const run of processedResponse.functions ?? []) {
+    observe(
+      getFunctionToolStateKey(run.tool) ??
+        getFunctionToolStateKeyForCall(run.toolCall, run.tool.name),
+      run.toolCall,
+    );
+  }
+  for (const run of processedResponse.functionToolsNotFound ?? []) {
+    observe(
+      getFunctionToolStateKeyForCall(run.toolCall, run.toolName),
+      run.toolCall,
+    );
+  }
+  for (const run of processedResponse.computerActions ?? []) {
+    observe(run.computer.name, run.toolCall);
+  }
+  for (const run of processedResponse.shellActions ?? []) {
+    observe(run.shell.name, run.toolCall);
+  }
+  for (const run of processedResponse.applyPatchActions ?? []) {
+    observe(run.applyPatch.name, run.toolCall);
+  }
+  const claimedHostedMcpItems = new Set<ApprovalCapableToolCall>();
+  for (const run of processedResponse.mcpApprovalRequests ?? []) {
+    const toolName = run.requestItem.name;
+    const observation = observe(toolName, run.requestItem.rawItem);
+    if (!toolName || !observation) {
+      continue;
+    }
+    const sourceRawItems: ApprovalCapableToolCall[] = [];
+    for (const item of processedResponse.newItems) {
+      if (
+        !(item instanceof RunToolCallItem) ||
+        item.rawItem.type !== 'hosted_tool_call'
+      ) {
+        continue;
+      }
+      const rawItem = item.rawItem;
+      if (claimedHostedMcpItems.has(rawItem)) {
+        continue;
+      }
+      const providerData = rawItem.providerData as
+        { type?: unknown; id?: unknown } | undefined;
+      const isApprovalRequest =
+        providerData?.type === 'mcp_approval_request' ||
+        rawItem.name === 'mcp_approval_request';
+      const sourceReferenceId =
+        typeof providerData?.id === 'string'
+          ? providerData.id
+          : getToolInvocationCallId(rawItem);
+      if (isApprovalRequest && sourceReferenceId === observation.callId) {
+        sourceRawItems.push(rawItem);
+      }
+    }
+    if (sourceRawItems.length !== 1) {
+      throw new ModelBehaviorError(
+        `Hosted MCP approval request ${observation.callId} does not have exactly one source tool invocation.`,
+      );
+    }
+    const sourceRawItem = sourceRawItems[0];
+    claimedHostedMcpItems.add(sourceRawItem);
+    if (
+      getToolInvocationFingerprint(toolName, sourceRawItem) !==
+      observation.fingerprint
+    ) {
+      throw new ModelBehaviorError(
+        `Hosted MCP approval request ${observation.callId} does not match its source tool invocation.`,
+      );
+    }
+    if (observation.shouldSuppress) {
+      suppressed.add(sourceRawItem);
+    }
+  }
+  for (const run of processedResponse.handoffs ?? []) {
+    observe(getHandoffToolInvocationName(run.handoff.toolName), run.toolCall);
+  }
+
+  return suppressed;
+}
+
+function isSuppressedToolCallItem(
+  item: RunItem,
+  suppressed: ReadonlySet<ApprovalCapableToolCall>,
+): boolean {
+  if (
+    !(item instanceof RunToolCallItem) &&
+    !(item instanceof RunHandoffCallItem) &&
+    !(item instanceof RunToolApprovalItem)
+  ) {
+    return false;
+  }
+  const rawItem = item.rawItem;
+  if (
+    rawItem.type !== 'function_call' &&
+    rawItem.type !== 'computer_call' &&
+    rawItem.type !== 'shell_call' &&
+    rawItem.type !== 'apply_patch_call' &&
+    rawItem.type !== 'hosted_tool_call'
+  ) {
+    return false;
+  }
+  return suppressed.has(rawItem);
+}
+
+export function filterSuppressedToolCallItems(
+  items: readonly RunItem[],
+  suppressed: ReadonlySet<ApprovalCapableToolCall>,
+): RunItem[] {
+  return items.filter((item) => !isSuppressedToolCallItem(item, suppressed));
+}
 
 async function resolveToolNotFoundMessage<TContext>(
   state: RunState<TContext, Agent<TContext, any>>,
@@ -205,12 +447,11 @@ function resolveApprovalState(
 
   const approval = toolNames
     .map((candidate) =>
-      state._context.isToolApproved({
-        toolName: candidate,
-        callId,
-        functionTool: false,
-        ...(rawItem.type === 'function_call' ? { agent: item.agent } : {}),
-      }),
+      state._context._resolveToolInvocationApproval(
+        item.agent,
+        candidate,
+        rawItem,
+      ),
     )
     .find((decision) => typeof decision !== 'undefined');
   if (approval === true) {
@@ -730,6 +971,11 @@ export async function resolveInterruptedTurn<TContext>(
   agentToolParentRunConfig?: Partial<RunConfig>,
   signal?: AbortSignal,
 ): Promise<SingleStepResult> {
+  const suppressedToolCalls = preflightToolInvocations(
+    agent,
+    state,
+    processedResponse as ProcessedResponse<TContext>,
+  );
   // call_ids for function tools
   const functionCallIds = originalPreStepItems
     .filter(
@@ -815,6 +1061,9 @@ export async function resolveInterruptedTurn<TContext>(
   }
   // Run function tools that require approval or are resuming a nested agent tool run.
   const functionToolRuns = processedResponse.functions.filter((run) => {
+    if (suppressedToolCalls.has(run.toolCall)) {
+      return false;
+    }
     const callId = run.toolCall.callId;
     if (!callId) {
       return false;
@@ -833,7 +1082,9 @@ export async function resolveInterruptedTurn<TContext>(
   const shellRuns = filterPendingActions(
     filterActionsByApproval(
       originalPreStepItems,
-      processedResponse.shellActions,
+      (processedResponse.shellActions ?? []).filter(
+        (run) => !suppressedToolCalls.has(run.toolCall),
+      ),
       'shell_call',
     ),
     {
@@ -844,7 +1095,9 @@ export async function resolveInterruptedTurn<TContext>(
   const pendingComputerActions = filterPendingActions(
     filterActionsByApproval(
       originalPreStepItems,
-      processedResponse.computerActions,
+      (processedResponse.computerActions ?? []).filter(
+        (run) => !suppressedToolCalls.has(run.toolCall),
+      ),
       'computer_call',
     ),
     {
@@ -855,7 +1108,9 @@ export async function resolveInterruptedTurn<TContext>(
   const applyPatchRuns = filterPendingActions(
     filterActionsByApproval(
       originalPreStepItems,
-      processedResponse.applyPatchActions,
+      (processedResponse.applyPatchActions ?? []).filter(
+        (run) => !suppressedToolCalls.has(run.toolCall),
+      ),
       'apply_patch_call',
     ),
     {
@@ -901,7 +1156,9 @@ export async function resolveInterruptedTurn<TContext>(
         })
       : [];
   const pendingFunctionToolsNotFound = filterPendingActions(
-    processedResponse.functionToolsNotFound ?? [],
+    (processedResponse.functionToolsNotFound ?? []).filter(
+      (run) => !suppressedToolCalls.has(run.toolCall),
+    ),
     {
       completedCallIds: completedFunctionCallIds,
     },
@@ -947,7 +1204,9 @@ export async function resolveInterruptedTurn<TContext>(
   );
 
   const hostedMcpApprovals = await handleHostedMcpApprovals({
-    requests: processedResponse.mcpApprovalRequests,
+    requests: (processedResponse.mcpApprovalRequests ?? []).filter(
+      (run) => !suppressedToolCalls.has(run.requestItem.rawItem),
+    ),
     agent,
     state,
     functionResults,
@@ -959,12 +1218,18 @@ export async function resolveInterruptedTurn<TContext>(
       if (!approvalRequestId) {
         return undefined;
       }
-      return state._context.isToolApproved({
-        toolName: rawItem.name,
-        callId: approvalRequestId,
-        functionTool: false,
-      });
+      return state._context._resolveToolInvocationApproval(
+        agent,
+        rawItem.name,
+        rawItem,
+      );
     },
+    resolveRejectionMessage: (rawItem) =>
+      state._context._getToolInvocationRejectionMessage(
+        agent,
+        rawItem.name,
+        rawItem,
+      ),
   });
 
   // Server-managed conversations rely on preStepItems to re-surface pending approvals.
@@ -1065,7 +1330,11 @@ export async function resolveTurnAfterModelResponse<
   agentToolParentRunConfig?: Partial<RunConfig>,
   errorHandlers?: RunErrorHandlers<TContext, TAgent>,
   signal?: AbortSignal,
+  preflightedToolCalls?: ReadonlySet<ApprovalCapableToolCall>,
 ): Promise<SingleStepResult> {
+  const suppressedToolCalls =
+    preflightedToolCalls ??
+    preflightToolInvocations(agent, state, processedResponse);
   // Reuse the same array reference so we can compare object identity when deciding whether to
   // append new items, ensuring we never double-stream existing RunItems.
   const preStepItems = originalPreStepItems;
@@ -1075,6 +1344,9 @@ export async function resolveTurnAfterModelResponse<
     appendRunItemIfNew(item, newItems, appendContext);
 
   for (const item of processedResponse.newItems) {
+    if (isSuppressedToolCallItem(item, suppressedToolCalls)) {
+      continue;
+    }
     appendIfNew(item);
   }
 
@@ -1086,7 +1358,9 @@ export async function resolveTurnAfterModelResponse<
   ) =>
     executeFunctionToolCalls(
       agent,
-      processedResponse.functions,
+      processedResponse.functions.filter(
+        (run) => !suppressedToolCalls.has(run.toolCall),
+      ),
       runner,
       state,
       toolErrorFormatter,
@@ -1100,7 +1374,9 @@ export async function resolveTurnAfterModelResponse<
   ) =>
     executeComputerActions(
       agent,
-      processedResponse.computerActions,
+      processedResponse.computerActions.filter(
+        (run) => !suppressedToolCalls.has(run.toolCall),
+      ),
       runner,
       state._context,
       undefined,
@@ -1109,21 +1385,33 @@ export async function resolveTurnAfterModelResponse<
       cancelSiblingCategories,
     );
   const [functionResults, computerResults] =
-    processedResponse.functions.length > 0 &&
-    processedResponse.computerActions.length > 0
+    processedResponse.functions.some(
+      (run) => !suppressedToolCalls.has(run.toolCall),
+    ) &&
+    processedResponse.computerActions.some(
+      (run) => !suppressedToolCalls.has(run.toolCall),
+    )
       ? await runWithSiblingCancellation(
           [runFunctionTools, runComputerActions],
           signal,
         )
       : await Promise.all([runFunctionTools(), runComputerActions()]);
   const shellAndApplyPatchResults =
-    processedResponse.shellActions.length > 0 ||
-    processedResponse.applyPatchActions.length > 0
+    processedResponse.shellActions.some(
+      (run) => !suppressedToolCalls.has(run.toolCall),
+    ) ||
+    processedResponse.applyPatchActions.some(
+      (run) => !suppressedToolCalls.has(run.toolCall),
+    )
       ? await executeShellAndApplyPatchActionsInOrder({
           agent,
           sourceItems: processedResponse.newItems,
-          shellActions: processedResponse.shellActions,
-          applyPatchActions: processedResponse.applyPatchActions,
+          shellActions: processedResponse.shellActions.filter(
+            (run) => !suppressedToolCalls.has(run.toolCall),
+          ),
+          applyPatchActions: processedResponse.applyPatchActions.filter(
+            (run) => !suppressedToolCalls.has(run.toolCall),
+          ),
           runner,
           state,
           toolErrorFormatter,
@@ -1133,7 +1421,9 @@ export async function resolveTurnAfterModelResponse<
   const toolNotFoundResults = await buildToolNotFoundOutputItems(
     agent,
     state,
-    processedResponse.functionToolsNotFound ?? [],
+    (processedResponse.functionToolsNotFound ?? []).filter(
+      (run) => !suppressedToolCalls.has(run.toolCall),
+    ),
     toolErrorFormatter,
   );
 
@@ -1164,7 +1454,9 @@ export async function resolveTurnAfterModelResponse<
 
   if (processedResponse.mcpApprovalRequests.length > 0) {
     await handleHostedMcpApprovals({
-      requests: processedResponse.mcpApprovalRequests,
+      requests: processedResponse.mcpApprovalRequests.filter(
+        (run) => !suppressedToolCalls.has(run.requestItem.rawItem),
+      ),
       agent,
       state,
       functionResults,
@@ -1176,19 +1468,28 @@ export async function resolveTurnAfterModelResponse<
         if (!approvalRequestId) {
           return undefined;
         }
-        return state._context.isToolApproved({
-          toolName: rawItem.name,
-          callId: approvalRequestId,
-          functionTool: false,
-        });
+        return state._context._resolveToolInvocationApproval(
+          agent,
+          rawItem.name,
+          rawItem,
+        );
       },
+      resolveRejectionMessage: (rawItem) =>
+        state._context._getToolInvocationRejectionMessage(
+          agent,
+          rawItem.name,
+          rawItem,
+        ),
     });
   }
 
   // process handoffs
-  if (processedResponse.handoffs.length > 0) {
+  const handoffRuns = processedResponse.handoffs.filter(
+    (run) => !suppressedToolCalls.has(run.toolCall),
+  );
+  if (handoffRuns.length > 0) {
     if (signal?.aborted) {
-      for (const { toolCall } of processedResponse.handoffs) {
+      for (const { toolCall } of handoffRuns) {
         const rawItem = buildFunctionAbortResult(toolCall);
         appendIfNew(new RunToolCallOutputItem(rawItem, agent, rawItem.output));
       }
@@ -1199,7 +1500,7 @@ export async function resolveTurnAfterModelResponse<
         preStepItems,
         newItems,
         newResponse,
-        processedResponse.handoffs as ToolRunHandoff[],
+        handoffRuns as ToolRunHandoff[],
         runner,
         state._context,
         getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,

--- a/packages/agents-core/src/toolInvocation.ts
+++ b/packages/agents-core/src/toolInvocation.ts
@@ -1,0 +1,277 @@
+import type { RunToolApprovalItem } from './items';
+import type { Agent } from './agent';
+import type { RunContext } from './runContext';
+import { getFunctionToolStateKey } from './toolIdentity';
+import type * as protocol from './types/protocol';
+
+export type ApprovalCapableToolCall = RunToolApprovalItem['rawItem'];
+
+export type LocalToolCall =
+  | protocol.FunctionCallItem
+  | protocol.ComputerUseCallItem
+  | protocol.ShellCallItem
+  | protocol.ApplyPatchCallItem;
+
+export function getToolInvocationCallId(
+  toolCall: ApprovalCapableToolCall,
+): string | undefined {
+  if ('callId' in toolCall && typeof toolCall.callId === 'string') {
+    return toolCall.callId;
+  }
+  if (typeof toolCall.id === 'string') {
+    return toolCall.id;
+  }
+  const providerData = toolCall.providerData as
+    { id?: unknown; itemId?: unknown } | undefined;
+  if (typeof providerData?.id === 'string') {
+    return providerData.id;
+  }
+  return typeof providerData?.itemId === 'string'
+    ? providerData.itemId
+    : undefined;
+}
+
+export function getToolInvocationFingerprint(
+  toolName: string,
+  toolCall: ApprovalCapableToolCall,
+): string {
+  return stableStringify({
+    caller: getCanonicalToolCaller(toolCall),
+    type: toolCall.type,
+    toolName: canonicalizeToolName(toolName, toolCall),
+    payload: getInvocationPayload(toolCall),
+  });
+}
+
+export function getToolInvocationNameFromFingerprint(
+  fingerprint: string,
+): string | undefined {
+  try {
+    const value = JSON.parse(fingerprint) as { toolName?: unknown };
+    return typeof value.toolName === 'string' ? value.toolName : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function validateToolInvocationApproval(
+  context: RunContext<any>,
+  agent: Agent<any, any>,
+  tool: { name: string },
+  toolCall: ApprovalCapableToolCall,
+): { callId: string; fingerprint: string } {
+  const toolName = getCanonicalToolName(tool, toolCall);
+  return context._validateToolInvocation(agent, toolName, toolCall);
+}
+
+export function validateToolInvocationName(
+  context: RunContext<any>,
+  agent: Agent<any, any>,
+  toolName: string,
+  toolCall: ApprovalCapableToolCall,
+): { callId: string; fingerprint: string } {
+  return context._validateToolInvocation(agent, toolName, toolCall);
+}
+
+export function getHandoffToolInvocationName(handoffName: string): string {
+  return `handoff:${handoffName}`;
+}
+
+export function validateHandoffToolInvocation(
+  context: RunContext<any>,
+  agent: Agent<any, any>,
+  handoffName: string,
+  toolCall: protocol.FunctionCallItem,
+): { callId: string; fingerprint: string } {
+  return context._validateToolInvocation(
+    agent,
+    getHandoffToolInvocationName(handoffName),
+    toolCall,
+  );
+}
+
+export function getToolInvocationApproval(
+  context: RunContext<any>,
+  agent: Agent<any, any>,
+  tool: { name: string },
+  toolCall: ApprovalCapableToolCall,
+): boolean | undefined {
+  const toolName = getCanonicalToolName(tool, toolCall);
+  const { callId } = context._validateToolInvocation(agent, toolName, toolCall);
+  return context.isToolApproved({ toolName, callId, agent });
+}
+
+export function getToolInvocationRejectionMessage(
+  context: RunContext<any>,
+  agent: Agent<any, any>,
+  tool: { name: string },
+  toolCall: ApprovalCapableToolCall,
+): string | undefined {
+  const toolName = getCanonicalToolName(tool, toolCall);
+  const { callId } = context._validateToolInvocation(agent, toolName, toolCall);
+  return context._getFunctionRejectionMessage(toolName, callId, agent);
+}
+
+export function getBoundToolInvocationRejectionMessage(
+  context: RunContext<any>,
+  agent: Agent<any, any>,
+  toolName: string,
+  toolCall: ApprovalCapableToolCall,
+): string | undefined {
+  return context._getToolInvocationRejectionMessage(agent, toolName, toolCall);
+}
+
+function getCanonicalToolName(
+  tool: { name: string },
+  toolCall: ApprovalCapableToolCall,
+): string {
+  return toolCall.type === 'function_call'
+    ? (getFunctionToolStateKey(tool) ?? tool.name)
+    : tool.name;
+}
+
+function canonicalizeToolName(
+  toolName: string,
+  toolCall: ApprovalCapableToolCall,
+): string {
+  if (
+    toolCall.type === 'computer_call' &&
+    (toolName === 'computer' || toolName === 'computer_use_preview')
+  ) {
+    return 'computer';
+  }
+  return toolName;
+}
+
+export function getCanonicalToolCaller(toolCall: unknown): protocol.ToolCaller {
+  if (toolCall && typeof toolCall === 'object' && 'caller' in toolCall) {
+    const caller = (toolCall as { caller?: protocol.ToolCaller }).caller;
+    if (caller?.type === 'program') {
+      return { type: 'program', callerId: caller.callerId };
+    }
+  }
+  return { type: 'direct' };
+}
+
+function getInvocationPayload(toolCall: ApprovalCapableToolCall): unknown {
+  switch (toolCall.type) {
+    case 'function_call':
+      return normalizeJsonString(toolCall.arguments);
+    case 'hosted_tool_call': {
+      const providerData = toolCall.providerData as
+        | {
+            arguments?: unknown;
+            server_label?: unknown;
+            serverLabel?: unknown;
+          }
+        | undefined;
+      const args = toolCall.arguments ?? providerData?.arguments;
+      const serverLabel =
+        typeof providerData?.server_label === 'string'
+          ? providerData.server_label
+          : typeof providerData?.serverLabel === 'string'
+            ? providerData.serverLabel
+            : undefined;
+      return {
+        serverLabel,
+        arguments: typeof args === 'string' ? normalizeJsonString(args) : args,
+      };
+    }
+    case 'computer_call':
+      return toolCall.actions ?? toolCall.action;
+    case 'shell_call':
+      return toolCall.action;
+    case 'apply_patch_call':
+      return toolCall.operation;
+  }
+}
+
+function normalizeJsonString(value: string): unknown {
+  try {
+    return { format: 'json', value: JSON.parse(encodeJsonNumbers(value)) };
+  } catch {
+    return { format: 'raw', value };
+  }
+}
+
+const JSON_TOKEN_PREFIX = '\u0000openai-agents-json:';
+
+function encodeJsonNumbers(value: string): string {
+  let encoded = '';
+  let index = 0;
+  while (index < value.length) {
+    const character = value[index];
+    if (character === '"') {
+      let end = index + 1;
+      while (end < value.length) {
+        if (value[end] === '\\') {
+          end += 2;
+          continue;
+        }
+        if (value[end] === '"') {
+          end += 1;
+          break;
+        }
+        end += 1;
+      }
+      const token = value.slice(index, end);
+      const decoded = JSON.parse(token) as string;
+      encoded += decoded.startsWith(JSON_TOKEN_PREFIX)
+        ? JSON.stringify(`${JSON_TOKEN_PREFIX}string:${decoded}`)
+        : token;
+      index = end;
+      continue;
+    }
+    if (character === '-' || (character >= '0' && character <= '9')) {
+      const match = value
+        .slice(index)
+        .match(/^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/);
+      if (!match) {
+        throw new Error('Invalid JSON number.');
+      }
+      encoded += JSON.stringify(
+        `${JSON_TOKEN_PREFIX}number:${canonicalizeJsonNumber(match[0])}`,
+      );
+      index += match[0].length;
+      continue;
+    }
+    encoded += character;
+    index += 1;
+  }
+  return encoded;
+}
+
+function canonicalizeJsonNumber(value: string): string {
+  const lower = value.toLowerCase();
+  const [mantissa, exponentText = '0'] = lower.split('e');
+  const negative = mantissa.startsWith('-');
+  const unsignedMantissa = negative ? mantissa.slice(1) : mantissa;
+  const [integer, fraction = ''] = unsignedMantissa.split('.');
+  let digits = `${integer}${fraction}`.replace(/^0+/, '');
+  if (digits.length === 0) {
+    return negative ? '-0' : '0';
+  }
+  let exponent = BigInt(exponentText) - BigInt(fraction.length);
+  while (digits.endsWith('0')) {
+    digits = digits.slice(0, -1);
+    exponent += 1n;
+  }
+  return `${negative ? '-' : ''}${digits}e${exponent}`;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, currentValue) => {
+    if (
+      !currentValue ||
+      typeof currentValue !== 'object' ||
+      Array.isArray(currentValue)
+    ) {
+      return currentValue;
+    }
+    return Object.fromEntries(
+      Object.entries(currentValue as Record<string, unknown>).sort(
+        ([left], [right]) => (left < right ? -1 : left > right ? 1 : 0),
+      ),
+    );
+  });
+}

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -19,3 +19,11 @@ export {
   logToolActionError,
   logToolActionWarning,
 } from '../logger';
+export {
+  getBoundToolInvocationRejectionMessage,
+  getToolInvocationApproval,
+  getToolInvocationRejectionMessage,
+  validateHandoffToolInvocation,
+  validateToolInvocationApproval,
+  validateToolInvocationName,
+} from '../toolInvocation';

--- a/packages/agents-core/test/agentScenarios.test.ts
+++ b/packages/agents-core/test/agentScenarios.test.ts
@@ -2974,12 +2974,14 @@ describe('Agent scenarios (examples and docs patterns)', () => {
         functionToolCall(
           'translate_to_spanish',
           JSON.stringify({ input: 'Hi' }),
+          'translate-spanish',
         ),
       ],
       [
         functionToolCall(
           'translate_to_french',
           JSON.stringify({ input: 'Hi' }),
+          'translate-french',
         ),
       ],
       [textMessage('Summary complete')],

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -29,6 +29,7 @@ import {
   OutputGuardrailTripwireTriggered,
   RunContext,
   RunState,
+  hostedMcpTool,
   shellTool,
 } from '../src';
 import {
@@ -45,6 +46,7 @@ import { ServerConversationTracker } from '../src/runner/conversation';
 import logger from '../src/logger';
 import { getEventListeners } from 'node:events';
 import { InvalidToolInputError, ToolCallError } from '../src/errors';
+import { getToolInvocationFingerprint } from '../src/toolInvocation';
 
 function getFirstTextContent(item: AgentInputItem): string | undefined {
   if (item.type !== 'message') {
@@ -259,6 +261,92 @@ class AbortAfterStreamedProgramToolCallsModel implements Model {
 // Test for unhandled rejection when stream loop throws
 
 describe('Runner.run (streaming)', () => {
+  it('does not stream exact committed hosted MCP replay items', async () => {
+    const approvalCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'streamed-replay-source',
+      name: 'mcp_approval_request',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'streamed-replay-server',
+        name: 'lookup',
+        id: 'streamed-replay-call',
+        arguments: '{"account":"123"}',
+      },
+    };
+    const responses: ModelResponse[] = [
+      { output: [approvalCall], usage: new Usage() },
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ];
+    class HostedReplayStreamingModel implements Model {
+      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
+        throw new Error('Unexpected non-streaming model request');
+      }
+
+      async *getStreamedResponse(
+        _request: ModelRequest,
+      ): AsyncIterable<StreamEvent> {
+        const response = responses.shift();
+        if (!response) {
+          throw new Error('No response found');
+        }
+        yield {
+          type: 'response_done',
+          response: {
+            id: `streamed-replay-${responses.length}`,
+            usage: {
+              requests: 1,
+              inputTokens: 0,
+              outputTokens: 0,
+              totalTokens: 0,
+            },
+            output: response.output,
+          },
+        } as StreamEvent;
+      }
+    }
+
+    const mcpTool = hostedMcpTool({
+      serverLabel: 'streamed-replay-server',
+      serverUrl: 'https://example.com',
+      requireApproval: 'always',
+    });
+    const agent = new Agent({
+      name: 'StreamedHostedReplayAgent',
+      model: new HostedReplayStreamingModel(),
+      tools: [mcpTool],
+    });
+    const state = new RunState(new RunContext(), 'start', agent, 3);
+    state._completedToolInvocations.set(
+      agent,
+      new Map([
+        [
+          'streamed-replay-call',
+          getToolInvocationFingerprint('lookup', approvalCall),
+        ],
+      ]),
+    );
+
+    const result = await new Runner().run(agent, state, { stream: true });
+    const events: RunStreamEvent[] = [];
+    for await (const event of result) {
+      events.push(event);
+    }
+    await result.completed;
+
+    expect(result.finalOutput).toBe('done');
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'run_item_stream_event' &&
+          ((event.item as any).rawItem?.id === 'streamed-replay-source' ||
+            (event.item as any).rawItem?.providerData?.id ===
+              'streamed-replay-call'),
+      ),
+    ).toBe(false);
+  });
+
   beforeAll(() => {
     setTracingDisabled(true);
     setDefaultModelProvider(new FakeModelProvider());
@@ -3458,7 +3546,7 @@ describe('Runner.run (streaming)', () => {
       ).toBe(false);
     });
 
-    it('acknowledges ignored handoffs when streaming after a reused callId from an earlier turn', async () => {
+    it('rejects an ignored handoff that reuses a committed callId while streaming', async () => {
       const agentBModel = new TrackingStreamingModel([
         buildTurn([fakeModelMessage('done B')], 'resp-b'),
       ]);
@@ -3508,24 +3596,12 @@ describe('Runner.run (streaming)', () => {
         conversationId: 'conv-managed-reused-call-id',
       });
 
-      await drain(result);
-
-      expect(result.finalOutput).toBe('done B');
-      expect(agentBModel.requests).toHaveLength(1);
-      expect(agentCModel.requests).toHaveLength(0);
-      expect(agentBModel.requests[0].conversationId).toBe(
-        'conv-managed-reused-call-id',
+      await expect(drain(result)).rejects.toThrow(
+        'Tool call ID reused-call-id was reused for a different invocation after its output was committed.',
       );
-      expect(agentBModel.requests[0].input).toEqual([
-        expect.objectContaining({
-          type: 'function_call_result',
-          callId: acceptedCall.callId,
-        }),
-        expect.objectContaining({
-          type: 'function_call_result',
-          callId: ignoredCall.callId,
-        }),
-      ]);
+
+      expect(agentBModel.requests).toHaveLength(0);
+      expect(agentCModel.requests).toHaveLength(0);
     });
 
     it('replays managed handoff acknowledgements when resuming before streamed response completion', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -8339,7 +8339,7 @@ describe('Runner.run', () => {
       ).toBe(false);
     });
 
-    it('acknowledges ignored handoffs even when callIds were reused in earlier turns', async () => {
+    it('rejects an ignored handoff that reuses a committed callId', async () => {
       const agentBModel = new TrackingModel([
         buildResponse([fakeModelMessage('done B')], 'resp-b'),
       ]);
@@ -8383,24 +8383,16 @@ describe('Runner.run', () => {
         handoffs: [handoffToB, handoffToC],
       });
 
-      const result = await new Runner().run(agentA, 'hi', {
-        previousResponseId: 'initial-response',
-      });
+      await expect(
+        new Runner().run(agentA, 'hi', {
+          previousResponseId: 'initial-response',
+        }),
+      ).rejects.toThrow(
+        'Tool call ID reused-call-id was reused for a different invocation after its output was committed.',
+      );
 
-      expect(result.finalOutput).toBe('done B');
-      expect(agentBModel.requests).toHaveLength(1);
+      expect(agentBModel.requests).toHaveLength(0);
       expect(agentCModel.requests).toHaveLength(0);
-      expect(agentBModel.requests[0].previousResponseId).toBe('resp-handoff');
-      expect(agentBModel.requests[0].input).toEqual([
-        expect.objectContaining({
-          type: 'function_call_result',
-          callId: acceptedCall.callId,
-        }),
-        expect.objectContaining({
-          type: 'function_call_result',
-          callId: ignoredCall.callId,
-        }),
-      ]);
     });
 
     it('replays pending managed handoff acknowledgements when resuming in non-stream mode', async () => {

--- a/packages/agents-core/test/runner/mcpApprovals.test.ts
+++ b/packages/agents-core/test/runner/mcpApprovals.test.ts
@@ -15,12 +15,15 @@ import * as protocol from '../../src/types/protocol';
 
 const TEST_AGENT = new Agent({ name: 'TestAgent', outputType: 'text' });
 
-const buildApprovalRequest = (id = 'mcpr_1'): ToolRunMCPApprovalRequest => {
+const buildApprovalRequest = (
+  id = 'mcpr_1',
+  args = '{}',
+): ToolRunMCPApprovalRequest => {
   const providerData: HostedMCPApprovalRequest = {
     id,
     name: 'list_files',
     server_label: 'stub',
-    arguments: '{}',
+    arguments: args,
   };
 
   const requestItem = new RunToolApprovalItem(
@@ -87,6 +90,138 @@ describe('handleHostedMcpApprovals', () => {
     expect(result.pendingApprovals.size).toBe(0);
     expect(result.pendingApprovalIds.size).toBe(0);
   });
+
+  it('binds callback approval to the exact hosted MCP invocation', async () => {
+    const onApproval = vi.fn().mockResolvedValue({ approve: true });
+    const approvalRequest = buildApprovalRequest(
+      'mcpr_callback_bound',
+      '{"path":"safe"}',
+    );
+    approvalRequest.mcpTool = hostedMcpTool({
+      serverLabel: 'stub',
+      requireApproval: 'always',
+      onApproval,
+    });
+    const resolveApproval = (rawItem: protocol.HostedToolCallItem) =>
+      state._context._resolveToolInvocationApproval(
+        TEST_AGENT,
+        rawItem.name,
+        rawItem,
+      );
+
+    await handleHostedMcpApprovals({
+      requests: [approvalRequest],
+      agent: TEST_AGENT,
+      state,
+      functionResults,
+      appendIfNew: (item) => newItems.push(item),
+      resolveApproval,
+    });
+    newItems = [];
+    await handleHostedMcpApprovals({
+      requests: [approvalRequest],
+      agent: TEST_AGENT,
+      state,
+      functionResults,
+      appendIfNew: (item) => newItems.push(item),
+      resolveApproval,
+    });
+
+    expect(onApproval).toHaveBeenCalledTimes(1);
+    expect(newItems).toHaveLength(1);
+
+    const changedRequest = buildApprovalRequest(
+      'mcpr_callback_bound',
+      '{"path":"changed"}',
+    );
+    changedRequest.mcpTool = approvalRequest.mcpTool;
+    await expect(
+      handleHostedMcpApprovals({
+        requests: [changedRequest],
+        agent: TEST_AGENT,
+        state,
+        functionResults,
+        appendIfNew: (item) => newItems.push(item),
+        resolveApproval,
+      }),
+    ).rejects.toThrow(/reused for a different invocation/);
+    expect(onApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([false, true])(
+    'restores committed callback approval suppression from schema %s',
+    async (readAsLegacy) => {
+      const onApproval = vi.fn().mockResolvedValue({ approve: true });
+      const approvalRequest = buildApprovalRequest(
+        'mcpr_callback_committed',
+        '{"path":"safe"}',
+      );
+      approvalRequest.mcpTool = hostedMcpTool({
+        serverLabel: 'stub',
+        requireApproval: 'always',
+        onApproval,
+      });
+      const rawItem = approvalRequest.requestItem
+        .rawItem as protocol.HostedToolCallItem;
+      const invocation = state._context._validateToolInvocation(
+        TEST_AGENT,
+        rawItem.name,
+        rawItem,
+      );
+      state._observeToolInvocation(
+        TEST_AGENT,
+        invocation.callId,
+        invocation.fingerprint,
+      );
+
+      await handleHostedMcpApprovals({
+        requests: [approvalRequest],
+        agent: TEST_AGENT,
+        state,
+        functionResults,
+        appendIfNew: (item) => newItems.push(item),
+        resolveApproval: (item) =>
+          state._context._resolveToolInvocationApproval(
+            TEST_AGENT,
+            item.name,
+            item,
+          ),
+      });
+      const providerData = rawItem.providerData as HostedMCPApprovalRequest;
+      state._generatedItems.push(
+        new RunToolCallItem(
+          {
+            ...rawItem,
+            id: 'mcp-approval-source-item',
+            name: 'mcp_approval_request',
+            providerData,
+          },
+          TEST_AGENT,
+        ),
+        ...newItems,
+      );
+      state._commitToolInvocations(newItems);
+      const serialized = state.toJSON() as any;
+      if (readAsLegacy) {
+        serialized.$schemaVersion = '1.17';
+        delete serialized.context.approvalInvocations;
+        delete serialized.completedToolInvocations;
+      }
+
+      const restored = await RunState.fromString(
+        TEST_AGENT,
+        JSON.stringify(serialized),
+      );
+      expect(
+        restored._observeToolInvocation(
+          TEST_AGENT,
+          invocation.callId,
+          invocation.fingerprint,
+        ),
+      ).toBe(true);
+      expect(onApproval).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it('reuses prior approval decisions from context', async () => {
     const approvalRequest = buildApprovalRequest('mcpr_approved');

--- a/packages/agents-core/test/runner/turnResolution.test.ts
+++ b/packages/agents-core/test/runner/turnResolution.test.ts
@@ -8,6 +8,7 @@ import {
 import { Agent, AgentOutputType } from '../../src/agent';
 import { Computer } from '../../src/computer';
 import { ModelBehaviorError } from '../../src/errors';
+import { handoff } from '../../src/handoff';
 import {
   RunToolApprovalItem as ToolApprovalItem,
   RunToolCallItem as ToolCallItem,
@@ -91,6 +92,79 @@ describe('resolveTurnAfterModelResponse', () => {
     );
 
     expect(result.nextStep.type).toBe('next_step_run_again');
+  });
+
+  it('suppresses an exact committed handoff replay and rejects changed reuse', async () => {
+    const targetAgent = new Agent({ name: 'CommittedHandoffTarget' });
+    const onHandoff = vi.fn();
+    const handoffToTarget = handoff(targetAgent, { onHandoff });
+    const sourceAgent = new Agent({
+      name: 'CommittedHandoffSource',
+      handoffs: [handoffToTarget],
+    });
+    const handoffCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: handoffToTarget.toolName,
+      callId: 'committed-handoff-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const modelResponse: ModelResponse = {
+      output: [handoffCall],
+      usage: new Usage(),
+    };
+    const state = new RunState(new RunContext(), 'start', sourceAgent, 3);
+
+    const firstResult = await withTrace('test', () =>
+      resolveTurnAfterModelResponse(
+        sourceAgent,
+        'start',
+        [],
+        modelResponse,
+        processModelResponse(modelResponse, sourceAgent, [], [handoffToTarget]),
+        runner,
+        state,
+      ),
+    );
+    state._commitToolInvocations(firstResult.newStepItems);
+
+    const replayResult = await withTrace('test', () =>
+      resolveTurnAfterModelResponse(
+        sourceAgent,
+        'start',
+        firstResult.generatedItems,
+        modelResponse,
+        processModelResponse(modelResponse, sourceAgent, [], [handoffToTarget]),
+        runner,
+        state,
+      ),
+    );
+    expect(replayResult.nextStep.type).toBe('next_step_run_again');
+    expect(onHandoff).toHaveBeenCalledTimes(1);
+
+    const changedResponse: ModelResponse = {
+      output: [{ ...handoffCall, arguments: '{"changed":true}' }],
+      usage: new Usage(),
+    };
+    await expect(
+      withTrace('test', () =>
+        resolveTurnAfterModelResponse(
+          sourceAgent,
+          'start',
+          replayResult.generatedItems,
+          changedResponse,
+          processModelResponse(
+            changedResponse,
+            sourceAgent,
+            [],
+            [handoffToTarget],
+          ),
+          runner,
+          state,
+        ),
+      ),
+    ).rejects.toThrow(ModelBehaviorError);
+    expect(onHandoff).toHaveBeenCalledTimes(1);
   });
 
   it('runs apply_patch actions only after shell actions finish', async () => {
@@ -348,7 +422,7 @@ describe('resolveTurnAfterModelResponse', () => {
     expect(result.nextStep.type).toBe('next_step_run_again');
   });
 
-  it('runs shell and apply_patch actions without any call key', async () => {
+  it('runs shell and apply_patch actions with distinct call IDs', async () => {
     const shell = new FakeShell();
     const shellToolDef = shellTool({ shell });
     const editor = new FakeEditor();
@@ -359,11 +433,13 @@ describe('resolveTurnAfterModelResponse', () => {
     });
     const shellCall = {
       type: 'shell_call',
+      callId: 'shell-call',
       status: 'completed',
       action: { commands: ['echo hi'] },
     } as protocol.ShellCallItem;
     const patchCall = {
       type: 'apply_patch_call',
+      callId: 'patch-call',
       status: 'completed',
       operation: {
         type: 'update_file',
@@ -425,7 +501,7 @@ describe('resolveTurnAfterModelResponse', () => {
     };
     const approvalItem = new ToolApprovalItem(approvalCall, agent);
     const processedResponse: ProcessedResponse = {
-      newItems: [approvalItem],
+      newItems: [new ToolCallItem(approvalCall, agent), approvalItem],
       handoffs: [],
       functions: [],
       computerActions: [],
@@ -469,6 +545,207 @@ describe('resolveTurnAfterModelResponse', () => {
         }),
       }),
     );
+  });
+
+  it('rejects a hosted MCP approval wrapper without a source item', async () => {
+    const onApproval = vi.fn(async () => ({ approve: true }));
+    const mcpTool = hostedMcpTool({
+      serverLabel: 'server',
+      requireApproval: 'always',
+      onApproval,
+    });
+    const agent = new Agent({
+      name: 'MissingMcpSourceAgent',
+      tools: [mcpTool],
+    });
+    const approvalCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_request',
+      id: 'item-missing-mcp-source',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'server',
+        name: 'lookup',
+        id: 'missing-mcp-source',
+        arguments: '{}',
+      },
+    };
+    const modelResponse: ModelResponse = {
+      output: [approvalCall],
+      usage: new Usage(),
+    };
+    const processedResponse = processModelResponse(
+      modelResponse,
+      agent,
+      [mcpTool],
+      [],
+    );
+    processedResponse.newItems = [];
+
+    await expect(
+      resolveTurnAfterModelResponse(
+        agent,
+        'hello',
+        [],
+        modelResponse,
+        processedResponse,
+        runner,
+        new RunState(new RunContext(), 'hello', agent, 1),
+      ),
+    ).rejects.toThrow(ModelBehaviorError);
+    expect(onApproval).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the original hosted MCP item for an exact committed replay', async () => {
+    const onApproval = vi.fn(async () => ({ approve: true }));
+    const mcpTool = hostedMcpTool({
+      serverLabel: 'server',
+      requireApproval: 'always',
+      onApproval,
+    });
+    const agent = new Agent({
+      name: 'CommittedMcpReplayAgent',
+      tools: [mcpTool],
+    });
+    const approvalCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_request',
+      id: 'item-committed-mcp-request',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'server',
+        name: 'lookup',
+        id: 'committed-mcp-request',
+        arguments: '{"account":"123"}',
+      },
+    };
+    const modelResponse: ModelResponse = {
+      output: [approvalCall],
+      usage: new Usage(),
+    };
+    const localState = new RunState(new RunContext(), 'hello', agent, 3);
+
+    const firstResult = await resolveTurnAfterModelResponse(
+      agent,
+      'hello',
+      [],
+      modelResponse,
+      processModelResponse(modelResponse, agent, [mcpTool], []),
+      runner,
+      localState,
+    );
+    localState._commitToolInvocations(firstResult.newStepItems);
+
+    const replayResult = await resolveTurnAfterModelResponse(
+      agent,
+      'hello',
+      firstResult.generatedItems,
+      modelResponse,
+      processModelResponse(modelResponse, agent, [mcpTool], []),
+      runner,
+      localState,
+    );
+
+    expect(onApproval).toHaveBeenCalledTimes(1);
+    expect(replayResult.newStepItems).toEqual([]);
+
+    const changedSourceResponse: ModelResponse = {
+      output: [
+        {
+          ...approvalCall,
+          arguments: '{"account":"changed"}',
+        },
+      ],
+      usage: new Usage(),
+    };
+    await expect(
+      resolveTurnAfterModelResponse(
+        agent,
+        'hello',
+        firstResult.generatedItems,
+        changedSourceResponse,
+        processModelResponse(changedSourceResponse, agent, [mcpTool], []),
+        runner,
+        localState,
+      ),
+    ).rejects.toThrow(ModelBehaviorError);
+    expect(onApproval).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses hosted MCP source and approval items after a HITL commit', async () => {
+    const mcpTool = hostedMcpTool({
+      serverLabel: 'server',
+      requireApproval: 'always',
+    });
+    const agent = new Agent({
+      name: 'CommittedMcpHitlReplayAgent',
+      tools: [mcpTool],
+    });
+    const approvalCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'mcp_approval_request',
+      id: 'item-committed-mcp-hitl-request',
+      status: 'in_progress',
+      providerData: {
+        type: 'mcp_approval_request',
+        server_label: 'server',
+        name: 'lookup',
+        id: 'committed-mcp-hitl-request',
+        arguments: '{"account":"123"}',
+      },
+    };
+    const modelResponse: ModelResponse = {
+      output: [approvalCall],
+      usage: new Usage(),
+    };
+    const localState = new RunState(new RunContext(), 'hello', agent, 3);
+    const processedResponse = processModelResponse(
+      modelResponse,
+      agent,
+      [mcpTool],
+      [],
+    );
+
+    const firstResult = await resolveTurnAfterModelResponse(
+      agent,
+      'hello',
+      [],
+      modelResponse,
+      processedResponse,
+      runner,
+      localState,
+    );
+    const approvalItem = firstResult.generatedItems.find(
+      (item): item is ToolApprovalItem => item instanceof ToolApprovalItem,
+    );
+    expect(approvalItem).toBeDefined();
+    localState._generatedItems = firstResult.generatedItems;
+    localState._context.approveTool(approvalItem!);
+
+    const resumedResult = await resolveInterruptedTurn(
+      agent,
+      'hello',
+      firstResult.generatedItems,
+      modelResponse,
+      processedResponse,
+      runner,
+      localState,
+    );
+    localState._commitToolInvocations(resumedResult.newStepItems);
+
+    const replayResult = await resolveTurnAfterModelResponse(
+      agent,
+      'hello',
+      resumedResult.generatedItems,
+      modelResponse,
+      processModelResponse(modelResponse, agent, [mcpTool], []),
+      runner,
+      localState,
+    );
+
+    expect(replayResult.newStepItems).toEqual([]);
   });
 
   it('does not finalize when tools are used in the same turn (structured output); runs again', async () => {
@@ -1123,7 +1400,7 @@ describe('resolveInterruptedTurn', () => {
     const originalPreStepItems = [approvalItem];
 
     const processedResponse: ProcessedResponse = {
-      newItems: [approvalItem],
+      newItems: [new ToolCallItem(approvalCall, agent), approvalItem],
       handoffs: [],
       functions: [],
       computerActions: [],
@@ -2047,7 +2324,7 @@ describe('resolveInterruptedTurn', () => {
     const originalPreStepItems = [approvalItem];
 
     const processedResponse: ProcessedResponse = {
-      newItems: [approvalItem],
+      newItems: [new ToolCallItem(approvalCall, agent), approvalItem],
       handoffs: [],
       functions: [],
       computerActions: [],

--- a/packages/agents-core/test/toolInvocationReplay.test.ts
+++ b/packages/agents-core/test/toolInvocationReplay.test.ts
@@ -1,0 +1,1478 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Agent } from '../src/agent';
+import { ModelBehaviorError, UserError } from '../src/errors';
+import { handoff } from '../src/handoff';
+import {
+  RunToolApprovalItem,
+  RunToolCallItem,
+  RunToolCallOutputItem,
+} from '../src/items';
+import type { ModelResponse } from '../src/model';
+import { Runner } from '../src/run';
+import { RunContext } from '../src/runContext';
+import { RunState } from '../src/runState';
+import {
+  applyPatchTool,
+  attachClientToolSearchExecutor,
+  computerTool,
+  shellTool,
+  tool,
+} from '../src/tool';
+import {
+  getToolInvocationApproval,
+  getToolInvocationFingerprint,
+} from '../src/toolInvocation';
+import { getFunctionToolStateKey } from '../src/toolIdentity';
+import type * as protocol from '../src/types/protocol';
+import { Usage } from '../src/usage';
+import {
+  FakeComputer,
+  FakeEditor,
+  FakeModel,
+  FakeShell,
+  fakeModelMessage,
+} from './stubs';
+
+function response(output: protocol.ModelItem[]): ModelResponse {
+  return { output, usage: new Usage() };
+}
+
+function functionCall(
+  callId: string,
+  name: string,
+  args: Record<string, unknown>,
+): protocol.FunctionCallItem {
+  return {
+    type: 'function_call',
+    callId,
+    name,
+    status: 'completed',
+    arguments: JSON.stringify(args),
+  };
+}
+
+function shellCall(callId: string, commands: string[]): protocol.ShellCallItem {
+  return {
+    type: 'shell_call',
+    callId,
+    status: 'completed',
+    action: { commands },
+  };
+}
+
+function computerCall(callId: string): protocol.ComputerUseCallItem {
+  return {
+    type: 'computer_call',
+    id: callId,
+    callId,
+    status: 'completed',
+    action: { type: 'screenshot' },
+  };
+}
+
+function applyPatchCall(callId: string): protocol.ApplyPatchCallItem {
+  return {
+    type: 'apply_patch_call',
+    callId,
+    status: 'completed',
+    operation: {
+      type: 'update_file',
+      path: 'README.md',
+      diff: 'diff --git',
+    },
+  };
+}
+
+describe('tool invocation replay binding', () => {
+  it('canonicalizes Unicode object keys without locale-dependent ordering', () => {
+    const call = functionCall('unicode-order', 'unicode_tool', {
+      ä: 1,
+      z: 2,
+    });
+
+    const fingerprint = getToolInvocationFingerprint(call.name, call);
+    expect(fingerprint.indexOf('"z"')).toBeLessThan(fingerprint.indexOf('"ä"'));
+    expect(fingerprint).toContain('"toolName":"unicode_tool"');
+  });
+
+  it('canonicalizes JSON numbers without unsafe-integer collisions', () => {
+    const firstCall: protocol.FunctionCallItem = {
+      ...functionCall('unsafe-number', 'numeric_tool', {}),
+      arguments: '{"n":9007199254740992}',
+    };
+    const secondCall: protocol.FunctionCallItem = {
+      ...firstCall,
+      arguments: '{"n":9007199254740993}',
+    };
+    const firstHostedCall: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      name: 'numeric_hosted_tool',
+      status: 'completed',
+      providerData: {
+        id: 'unsafe-hosted-number',
+        server_label: 'server',
+        arguments: firstCall.arguments,
+      },
+    };
+
+    expect(getToolInvocationFingerprint(firstCall.name, firstCall)).not.toBe(
+      getToolInvocationFingerprint(secondCall.name, secondCall),
+    );
+    expect(
+      getToolInvocationFingerprint(firstHostedCall.name, firstHostedCall),
+    ).not.toBe(
+      getToolInvocationFingerprint(firstHostedCall.name, {
+        ...firstHostedCall,
+        providerData: {
+          ...firstHostedCall.providerData,
+          arguments: secondCall.arguments,
+        },
+      }),
+    );
+    expect(
+      getToolInvocationFingerprint(firstCall.name, {
+        ...firstCall,
+        arguments: '{"n":-0}',
+      }),
+    ).not.toBe(
+      getToolInvocationFingerprint(firstCall.name, {
+        ...firstCall,
+        arguments: '{"n":0}',
+      }),
+    );
+  });
+
+  it('canonicalizes direct callers and distinguishes program ownership', () => {
+    const call = functionCall('caller-identity', 'owned_tool', {
+      value: 'safe',
+    });
+
+    expect(
+      getToolInvocationFingerprint(call.name, {
+        ...call,
+        caller: { type: 'direct' },
+      }),
+    ).toBe(getToolInvocationFingerprint(call.name, call));
+    expect(
+      getToolInvocationFingerprint(call.name, {
+        ...call,
+        caller: { type: 'program', callerId: 'program-call-a' },
+      }),
+    ).not.toBe(
+      getToolInvocationFingerprint(call.name, {
+        ...call,
+        caller: { type: 'program', callerId: 'program-call-b' },
+      }),
+    );
+  });
+
+  it('serializes explicit invocation state for the current schema', () => {
+    const agent = new Agent({ name: 'EmptyInvocationStateAgent' });
+    const serialized = new RunState(
+      new RunContext(),
+      'start',
+      agent,
+      1,
+    ).toJSON() as any;
+
+    expect(serialized.$schemaVersion).toBe('1.18');
+    expect(serialized.context.approvalInvocations).toEqual([]);
+    expect(serialized.completedToolInvocations).toEqual([]);
+    expect(serialized.completedToolInvocationEvidence).toEqual([]);
+    expect(serialized.ambiguousToolInvocationCallIds).toEqual([]);
+  });
+
+  it.each([
+    'approvalInvocations',
+    'completedToolInvocations',
+    'completedToolInvocationEvidence',
+    'ambiguousToolInvocationCallIds',
+  ] as const)(
+    'rejects current-schema state missing %s',
+    async (missingField) => {
+      const agent = new Agent({ name: 'IncompleteInvocationStateAgent' });
+      const serialized = new RunState(
+        new RunContext(),
+        'start',
+        agent,
+        1,
+      ).toJSON() as any;
+      if (missingField === 'approvalInvocations') {
+        delete serialized.context.approvalInvocations;
+      } else if (missingField === 'completedToolInvocations') {
+        delete serialized.completedToolInvocations;
+      } else if (missingField === 'completedToolInvocationEvidence') {
+        delete serialized.completedToolInvocationEvidence;
+      } else {
+        delete serialized.ambiguousToolInvocationCallIds;
+      }
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(UserError);
+    },
+  );
+
+  it('rejects a current-schema per-call approval missing its invocation binding', async () => {
+    const approvalTool = tool({
+      name: 'tampered_approval_tool',
+      description: 'Requires an exact invocation binding.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: async () => 'unused',
+    });
+    const agent = new Agent({
+      name: 'TamperedApprovalBindingAgent',
+      tools: [approvalTool],
+    });
+    const call = functionCall('tampered-approval', approvalTool.name, {
+      value: 'safe',
+    });
+    const context = new RunContext();
+    context.approveTool(new RunToolApprovalItem(call, agent));
+    const serialized = new RunState(context, 'start', agent, 1).toJSON() as any;
+    delete serialized.context.approvalInvocations[0].invocations[call.callId];
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(UserError);
+  });
+
+  it('validates invocation conflicts before mutating a merged context', async () => {
+    const approvalTool = tool({
+      name: 'merge_conflict_tool',
+      description: 'Uses an exact per-call approval.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: async () => 'unused',
+    });
+    const agent = new Agent({
+      name: 'AtomicApprovalMergeAgent',
+      tools: [approvalTool],
+    });
+    const callId = 'merge-conflict-call';
+    const sourceContext = new RunContext();
+    sourceContext.approveTool(
+      new RunToolApprovalItem(
+        shellCall('source-shell', ['echo source']),
+        agent,
+        'shell',
+      ),
+      { alwaysApprove: true },
+    );
+    sourceContext.approveTool(
+      new RunToolApprovalItem(
+        functionCall(callId, approvalTool.name, { value: 'changed' }),
+        agent,
+      ),
+    );
+    const serialized = new RunState(
+      sourceContext,
+      'start',
+      agent,
+      1,
+    ).toString();
+
+    const overrideContext = new RunContext();
+    overrideContext.approveTool(
+      new RunToolApprovalItem(
+        functionCall(callId, approvalTool.name, { value: 'safe' }),
+        agent,
+      ),
+    );
+
+    await expect(
+      RunState.fromStringWithContext(agent, serialized, overrideContext, {
+        contextStrategy: 'merge',
+      }),
+    ).rejects.toThrow(ModelBehaviorError);
+    expect(
+      overrideContext.isToolApproved({
+        toolName: 'shell',
+        callId: 'unrelated-shell-call',
+        functionTool: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('keeps non-function approvals scoped to their owning agent after serialization', async () => {
+    const secondAgent = new Agent({ name: 'SecondShellApprovalOwner' });
+    const firstAgent = new Agent({
+      name: 'FirstShellApprovalOwner',
+      handoffs: [secondAgent],
+    });
+    const context = new RunContext();
+    const approvedCall = shellCall('shared-shell-approval', ['echo safe']);
+    context.approveTool(
+      new RunToolApprovalItem(approvedCall, firstAgent, 'shell'),
+    );
+    context.rejectTool(
+      new RunToolApprovalItem(approvedCall, secondAgent, 'shell'),
+      { message: 'second agent rejected' },
+    );
+
+    expect(
+      context._resolveToolInvocationApproval(firstAgent, 'shell', approvedCall),
+    ).toBe(true);
+    expect(
+      context._resolveToolInvocationApproval(
+        secondAgent,
+        'shell',
+        approvedCall,
+      ),
+    ).toBe(false);
+    expect(
+      context._getToolInvocationRejectionMessage(
+        secondAgent,
+        'shell',
+        approvedCall,
+      ),
+    ).toBe('second agent rejected');
+
+    const restored = await RunState.fromString(
+      firstAgent,
+      JSON.stringify(new RunState(context, 'start', firstAgent, 1).toJSON()),
+    );
+    expect(
+      restored._context._resolveToolInvocationApproval(
+        firstAgent,
+        'shell',
+        approvedCall,
+      ),
+    ).toBe(true);
+    expect(
+      restored._context._resolveToolInvocationApproval(
+        secondAgent,
+        'shell',
+        approvedCall,
+      ),
+    ).toBe(false);
+    expect(
+      restored._context._getToolInvocationRejectionMessage(
+        secondAgent,
+        'shell',
+        approvedCall,
+      ),
+    ).toBe('second agent rejected');
+  });
+
+  it('binds serialized approvals to program caller ownership', async () => {
+    const approvalTool = tool({
+      name: 'program_owned_approval',
+      description: 'Requires approval from the owning program call.',
+      parameters: z.object({ value: z.string() }),
+      allowedCallers: ['programmatic'],
+      needsApproval: true,
+      execute: async () => 'unused',
+    });
+    const agent = new Agent({
+      name: 'ProgramOwnedApprovalAgent',
+      tools: [approvalTool],
+    });
+    const approvedCall: protocol.FunctionCallItem = {
+      ...functionCall('program-owned-approval', approvalTool.name, {
+        value: 'safe',
+      }),
+      caller: { type: 'program', callerId: 'program-call-a' },
+    };
+    const context = new RunContext();
+    context.approveTool(new RunToolApprovalItem(approvedCall, agent));
+
+    const restored = await RunState.fromString(
+      agent,
+      new RunState(context, 'start', agent, 1).toString(),
+    );
+
+    expect(
+      getToolInvocationApproval(
+        restored._context,
+        agent,
+        approvalTool,
+        approvedCall,
+      ),
+    ).toBe(true);
+    expect(() =>
+      getToolInvocationApproval(restored._context, agent, approvalTool, {
+        ...approvedCall,
+        caller: { type: 'program', callerId: 'program-call-b' },
+      }),
+    ).toThrow(ModelBehaviorError);
+  });
+
+  it.each([
+    ['unsafe integers', '9007199254740992', '9007199254740993'],
+    ['signed zero', '-0', '0'],
+  ])('binds approvals to distinct %s', (_label, approved, changed) => {
+    const approvalTool = tool({
+      name: 'numeric_approval',
+      description: 'Requires approval for an exact numeric argument.',
+      parameters: z.object({ n: z.number() }),
+      needsApproval: true,
+      execute: async () => 'unused',
+    });
+    const agent = new Agent({
+      name: 'NumericApprovalAgent',
+      tools: [approvalTool],
+    });
+    const approvedCall: protocol.FunctionCallItem = {
+      ...functionCall('numeric-approval-call', approvalTool.name, {}),
+      arguments: `{"n":${approved}}`,
+    };
+    const context = new RunContext();
+    context.approveTool(new RunToolApprovalItem(approvedCall, agent));
+
+    expect(() =>
+      getToolInvocationApproval(context, agent, approvalTool, {
+        ...approvedCall,
+        arguments: `{"n":${changed}}`,
+      }),
+    ).toThrow(ModelBehaviorError);
+  });
+
+  it.each([
+    ['unsafe integers', '9007199254740992', '9007199254740993'],
+    ['signed zero', '-0', '0'],
+  ])(
+    'rejects changed %s after a committed execution',
+    async (_label, first, changed) => {
+      const execute = vi.fn(async () => 'executed');
+      const localTool = tool({
+        name: 'numeric_execution',
+        description: 'Executes for one exact numeric argument.',
+        parameters: z.object({ n: z.number() }),
+        execute,
+      });
+      const firstCall: protocol.FunctionCallItem = {
+        ...functionCall('numeric-execution-call', localTool.name, {}),
+        arguments: `{"n":${first}}`,
+      };
+      const model = new FakeModel([
+        response([firstCall]),
+        response([
+          {
+            ...firstCall,
+            arguments: `{"n":${changed}}`,
+          },
+        ]),
+      ]);
+      const agent = new Agent({
+        name: 'NumericExecutionAgent',
+        model,
+        tools: [localTool],
+      });
+
+      await expect(new Runner().run(agent, 'start')).rejects.toThrow(
+        ModelBehaviorError,
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('rejects changed program caller ownership before tool execution', async () => {
+    const execute = vi.fn(async () => 'executed');
+    const localTool = tool({
+      name: 'program_owned_execution',
+      description: 'Runs only for the canonical program invocation.',
+      parameters: z.object({ value: z.string() }),
+      allowedCallers: ['programmatic'],
+      execute,
+    });
+    const firstCall: protocol.FunctionCallItem = {
+      ...functionCall('program-owned-call', localTool.name, { value: 'safe' }),
+      caller: { type: 'program', callerId: 'program-call-a' },
+    };
+    const model = new FakeModel([
+      response([firstCall]),
+      response([firstCall]),
+      response([
+        {
+          ...firstCall,
+          caller: {
+            type: 'program' as const,
+            callerId: 'program-call-b',
+          },
+        },
+      ]),
+    ]);
+    const agent = new Agent({
+      name: 'ProgramOwnedExecutionAgent',
+      model,
+      tools: [localTool],
+    });
+
+    await expect(new Runner().run(agent, 'start')).rejects.toThrow(
+      ModelBehaviorError,
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects an empty call ID before any tool side effect', async () => {
+    const execute = vi.fn(async () => 'unexpected');
+    const localTool = tool({
+      name: 'empty_id_tool',
+      description: 'Must not run without a call ID.',
+      parameters: z.object({ value: z.string() }),
+      execute,
+    });
+    const model = new FakeModel([
+      response([
+        functionCall('', localTool.name, { value: 'first' }),
+        functionCall('', localTool.name, { value: 'changed' }),
+      ]),
+    ]);
+    const agent = new Agent({
+      name: 'EmptyCallIdAgent',
+      model,
+      tools: [localTool],
+    });
+
+    await expect(new Runner().run(agent, 'start')).rejects.toThrow(
+      ModelBehaviorError,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it.each(['approve', 'reject'] as const)(
+    'binds a hosted MCP %s decision to the server identity',
+    (decision) => {
+      const agent = new Agent({ name: 'HostedMcpApprovalAgent' });
+      const context = new RunContext();
+      const callId = `hosted-${decision}`;
+      const approvalItem = new RunToolApprovalItem(
+        {
+          type: 'hosted_tool_call',
+          id: callId,
+          name: 'lookup',
+          arguments: '{"account":"123"}',
+          status: 'in_progress',
+          providerData: { server_label: 'server_a' },
+        },
+        agent,
+      );
+      context[decision === 'approve' ? 'approveTool' : 'rejectTool'](
+        approvalItem,
+      );
+
+      expect(() =>
+        context._validateToolInvocation(agent, 'lookup', {
+          ...approvalItem.rawItem,
+          providerData: { server_label: 'server_b' },
+        }),
+      ).toThrow(ModelBehaviorError);
+    },
+  );
+
+  it('fails changed arguments before any sibling tool side effect', async () => {
+    const approvedExecute = vi.fn(
+      async ({ value }: { value: string }) => value,
+    );
+    const siblingExecute = vi.fn(async () => 'sibling');
+    const approvedTool = tool({
+      name: 'approved_tool',
+      description: 'Requires per-call approval.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: approvedExecute,
+    });
+    const siblingTool = tool({
+      name: 'sibling_tool',
+      description: 'Must not run after invalid call ID reuse.',
+      parameters: z.object({}),
+      execute: siblingExecute,
+    });
+    const callId = 'reused-arguments';
+    const model = new FakeModel([
+      response([functionCall(callId, approvedTool.name, { value: 'safe' })]),
+      response([
+        functionCall(callId, approvedTool.name, { value: 'changed' }),
+        functionCall('sibling-call', siblingTool.name, {}),
+      ]),
+    ]);
+    const agent = new Agent({
+      name: 'ChangedArgumentsAgent',
+      model,
+      tools: [approvedTool, siblingTool],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    interrupted.state.approve(interrupted.interruptions[0]);
+
+    await expect(runner.run(agent, interrupted.state)).rejects.toThrow(
+      ModelBehaviorError,
+    );
+    expect(approvedExecute).toHaveBeenCalledTimes(1);
+    expect(approvedExecute.mock.calls[0][0]).toEqual({ value: 'safe' });
+    expect(siblingExecute).not.toHaveBeenCalled();
+  });
+
+  it('fails changed arguments before a sibling client tool-search callback', async () => {
+    const approvedTool = tool({
+      name: 'tool_search_preflight_approval',
+      description: 'Requires per-call approval.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: async ({ value }) => value,
+    });
+    const toolSearchExecute = vi.fn(async () => approvedTool);
+    const toolSearch = attachClientToolSearchExecutor(
+      {
+        type: 'hosted_tool',
+        name: 'tool_search',
+        providerData: {
+          type: 'tool_search',
+          execution: 'client',
+          parameters: {
+            type: 'object',
+            properties: {},
+            required: [],
+            additionalProperties: false,
+          },
+        },
+      },
+      toolSearchExecute,
+    );
+    const callId = 'tool-search-preflight-call';
+    const model = new FakeModel([
+      response([
+        functionCall(callId, approvedTool.name, { value: 'approved' }),
+      ]),
+      response([
+        functionCall(callId, approvedTool.name, { value: 'changed' }),
+        {
+          type: 'tool_search_call',
+          id: 'tool-search-preflight-item',
+          status: 'completed',
+          arguments: {},
+          providerData: { call_id: 'tool-search-preflight-search' },
+        } as protocol.ToolSearchCallItem,
+      ]),
+    ]);
+    const agent = new Agent({
+      name: 'ToolSearchPreflightAgent',
+      model,
+      tools: [approvedTool, toolSearch],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    interrupted.state.approve(interrupted.interruptions[0]);
+
+    await expect(runner.run(agent, interrupted.state)).rejects.toThrow(
+      ModelBehaviorError,
+    );
+    expect(toolSearchExecute).not.toHaveBeenCalled();
+  });
+
+  it('fails changed tool identity before the replacement tool executes', async () => {
+    const firstExecute = vi.fn(async () => 'first');
+    const secondExecute = vi.fn(async () => 'second');
+    const firstTool = tool({
+      name: 'first_tool',
+      description: 'Requires approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: firstExecute,
+    });
+    const secondTool = tool({
+      name: 'second_tool',
+      description: 'Reuses the first call ID.',
+      parameters: z.object({}),
+      execute: secondExecute,
+    });
+    const callId = 'reused-tool';
+    const model = new FakeModel([
+      response([functionCall(callId, firstTool.name, {})]),
+      response([functionCall(callId, secondTool.name, {})]),
+    ]);
+    const agent = new Agent({
+      name: 'ChangedToolAgent',
+      model,
+      tools: [firstTool, secondTool],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    interrupted.state.approve(interrupted.interruptions[0]);
+
+    await expect(runner.run(agent, interrupted.state)).rejects.toThrow(
+      ModelBehaviorError,
+    );
+    expect(firstExecute).toHaveBeenCalledTimes(1);
+    expect(secondExecute).not.toHaveBeenCalled();
+  });
+
+  it('binds a per-call rejection to the rejected invocation', async () => {
+    const execute = vi.fn(async () => 'unexpected');
+    const rejectedTool = tool({
+      name: 'rejected_tool',
+      description: 'Requires approval.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute,
+    });
+    const callId = 'reused-rejection';
+    const model = new FakeModel([
+      response([
+        functionCall(callId, rejectedTool.name, { value: 'rejected' }),
+      ]),
+      response([functionCall(callId, rejectedTool.name, { value: 'changed' })]),
+    ]);
+    const agent = new Agent({
+      name: 'ChangedRejectionAgent',
+      model,
+      tools: [rejectedTool],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    interrupted.state.reject(interrupted.interruptions[0]);
+
+    await expect(runner.run(agent, interrupted.state)).rejects.toThrow(
+      ModelBehaviorError,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('suppresses a semantically exact committed function replay', async () => {
+    const execute = vi.fn(async () => 'executed');
+    const approvalTool = tool({
+      name: 'approval_tool',
+      description: 'Requires approval.',
+      parameters: z.object({ first: z.number(), second: z.number() }),
+      needsApproval: true,
+      execute,
+    });
+    const callId = 'exact-replay';
+    const model = new FakeModel([
+      response([
+        functionCall(callId, approvalTool.name, { first: 1, second: 2 }),
+      ]),
+      response([
+        functionCall(callId, approvalTool.name, { second: 2, first: 1 }),
+      ]),
+      response([fakeModelMessage('done')]),
+    ]);
+    const agent = new Agent({
+      name: 'ExactReplayAgent',
+      model,
+      tools: [approvalTool],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    interrupted.state.approve(interrupted.interruptions[0]);
+    const result = await runner.run(agent, interrupted.state);
+
+    expect(result.finalOutput).toBe('done');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([undefined, '1.17'] as const)(
+    'preserves committed replay suppression through %s RunState serialization',
+    async (legacySchemaVersion) => {
+      const calls: string[] = [];
+      const approvalTool = tool({
+        name: 'serialized_tool',
+        description: 'Requires approval.',
+        parameters: z.object({ value: z.string() }),
+        needsApproval: true,
+        execute: async ({ value }) => {
+          calls.push(value);
+          return value;
+        },
+      });
+      const firstCallId = 'serialized-first';
+      const secondCallId = 'serialized-second';
+      const model = new FakeModel([
+        response([
+          functionCall(firstCallId, approvalTool.name, { value: 'first' }),
+        ]),
+        response([
+          functionCall(secondCallId, approvalTool.name, { value: 'second' }),
+        ]),
+        response([
+          functionCall(firstCallId, approvalTool.name, { value: 'first' }),
+        ]),
+        response([fakeModelMessage('done')]),
+      ]);
+      const agent = new Agent({
+        name: 'SerializedReplayAgent',
+        model,
+        tools: [approvalTool],
+      });
+      const runner = new Runner();
+
+      const firstInterruption = await runner.run(agent, 'start');
+      firstInterruption.state.approve(firstInterruption.interruptions[0]);
+      const secondInterruption = await runner.run(
+        agent,
+        firstInterruption.state,
+      );
+      expect(calls).toEqual(['first']);
+
+      const serialized = secondInterruption.state.toJSON() as any;
+      expect(serialized.$schemaVersion).toBe('1.18');
+      expect(
+        serialized.context.approvalInvocations[0].invocations[firstCallId],
+      ).toBeTypeOf('string');
+      expect(
+        serialized.completedToolInvocations[0].invocations[firstCallId],
+      ).toBeTypeOf('string');
+      if (legacySchemaVersion) {
+        serialized.$schemaVersion = legacySchemaVersion;
+        delete serialized.context.approvalInvocations;
+        delete serialized.completedToolInvocations;
+        delete serialized.completedToolInvocationEvidence;
+        delete serialized.ambiguousToolInvocationCallIds;
+      }
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      restored.approve(restored.getInterruptions()[0]);
+      const result = await runner.run(agent, restored);
+
+      expect(result.finalOutput).toBe('done');
+      expect(calls).toEqual(['first', 'second']);
+    },
+  );
+
+  it('rejects current state whose history completion is missing from replay records', async () => {
+    const calls: string[] = [];
+    const executedTool = tool({
+      name: 'tampered_completion_tool',
+      description: 'Runs before serialization pauses.',
+      parameters: z.object({ value: z.string() }),
+      execute: async ({ value }) => {
+        calls.push(value);
+        return value;
+      },
+    });
+    const pauseTool = tool({
+      name: 'tampered_completion_pause',
+      description: 'Pauses after the first tool output.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'unused',
+    });
+    const completedCallId = 'tampered-completed-call';
+    const model = new FakeModel([
+      response([
+        functionCall(completedCallId, executedTool.name, { value: 'once' }),
+      ]),
+      response([functionCall('tampered-pause', pauseTool.name, {})]),
+    ]);
+    const agent = new Agent({
+      name: 'TamperedCompletionAgent',
+      model,
+      tools: [executedTool, pauseTool],
+    });
+    const interrupted = await new Runner().run(agent, 'start');
+    expect(calls).toEqual(['once']);
+    interrupted.state._context.approveTool(
+      new RunToolApprovalItem(
+        shellCall('serialized-sticky-shell', ['echo source']),
+        agent,
+        'shell',
+      ),
+      { alwaysApprove: true },
+    );
+    const serialized = interrupted.state.toJSON() as any;
+    delete serialized.completedToolInvocations[0].invocations[completedCallId];
+    const overrideContext = new RunContext();
+
+    await expect(
+      RunState.fromStringWithContext(
+        agent,
+        JSON.stringify(serialized),
+        overrideContext,
+        { contextStrategy: 'merge' },
+      ),
+    ).rejects.toThrow(UserError);
+    expect(calls).toEqual(['once']);
+    expect(
+      overrideContext.isToolApproved({
+        toolName: 'shell',
+        callId: 'unrelated-shell-call',
+        functionTool: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('rejects current state with completion authority absent from history', async () => {
+    const agent = new Agent({ name: 'InjectedCompletionAgent' });
+    const injectedCall = functionCall(
+      'injected-completed-call',
+      'injected_tool',
+      { value: 'never-ran' },
+    );
+    const serialized = new RunState(
+      new RunContext(),
+      'start',
+      agent,
+      1,
+    ).toJSON() as any;
+    serialized.completedToolInvocations.push({
+      agentIdentity:
+        serialized.currentAgent.identity ?? serialized.currentAgent.name,
+      invocations: {
+        [injectedCall.callId]: getToolInvocationFingerprint(
+          injectedCall.name,
+          injectedCall,
+        ),
+      },
+    });
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(UserError);
+  });
+
+  it('rejects history-filter evidence without a correlated completion', async () => {
+    const localTool = tool({
+      name: 'uncorrelated_filtered_tool',
+      description: 'Provides an invocation without a committed result.',
+      parameters: z.object({ value: z.string() }),
+      execute: async () => 'unused',
+    });
+    const agent = new Agent({
+      name: 'UncorrelatedFilteredEvidenceAgent',
+      tools: [localTool],
+    });
+    const call = functionCall('uncorrelated-filtered-call', localTool.name, {
+      value: 'never-ran',
+    });
+    const state = new RunState(new RunContext(), 'start', agent, 1);
+    state._generatedItems.push(new RunToolCallItem(call, agent));
+    const serialized = state.toJSON() as any;
+    const serializedCall = serialized.generatedItems.pop();
+    const agentIdentity =
+      serialized.currentAgent.identity ?? serialized.currentAgent.name;
+    serialized.completedToolInvocations.push({
+      agentIdentity,
+      invocations: {
+        [call.callId]: getToolInvocationFingerprint(
+          getFunctionToolStateKey(localTool)!,
+          call,
+        ),
+      },
+    });
+    serialized.completedToolInvocationEvidence.push({
+      agentIdentity,
+      invocations: {
+        [call.callId]: {
+          fingerprint: getToolInvocationFingerprint(
+            getFunctionToolStateKey(localTool)!,
+            call,
+          ),
+          items: [{ item: serializedCall }, { item: serializedCall }],
+        },
+      },
+    });
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(UserError);
+  });
+
+  it('rejects a hosted MCP completion with changed caller ownership', async () => {
+    const agent = new Agent({ name: 'HostedMcpResultCallerAgent' });
+    const callId = 'hosted-mcp-caller-binding';
+    const caller = { type: 'program', callerId: 'program-a' } as const;
+    const request = {
+      type: 'hosted_tool_call',
+      id: 'hosted-mcp-request-item',
+      name: 'mcp_approval_request',
+      arguments: '{"account":"123"}',
+      status: 'in_progress',
+      caller,
+      providerData: {
+        type: 'mcp_approval_request',
+        id: callId,
+        name: 'lookup',
+        server_label: 'accounts',
+      },
+    } as protocol.HostedToolCallItem;
+    const approvalResponse = {
+      type: 'hosted_tool_call',
+      id: 'hosted-mcp-response-item',
+      name: 'mcp_approval_response',
+      status: 'completed',
+      caller,
+      providerData: { approval_request_id: callId, approve: true },
+    } as protocol.HostedToolCallItem;
+    const state = new RunState(new RunContext(), 'start', agent, 1);
+    state._generatedItems.push(
+      new RunToolCallItem(request, agent),
+      new RunToolCallItem(approvalResponse, agent),
+    );
+    const serialized = state.toJSON() as any;
+    const serializedResponse = serialized.generatedItems.find(
+      (item: any) => item.rawItem.name === 'mcp_approval_response',
+    );
+    serializedResponse.rawItem.caller = {
+      type: 'program',
+      callerId: 'program-b',
+    };
+
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(UserError);
+  });
+
+  it.each(['tool identity', 'caller ownership'] as const)(
+    'rejects current state whose function result changes %s',
+    async (changedField) => {
+      const functionTool = tool({
+        name: 'result_binding_tool',
+        description: 'Provides a canonical result identity.',
+        parameters: z.object({}),
+        execute: async () => 'unused',
+      });
+      const agent = new Agent({
+        name: 'ResultBindingAgent',
+        tools: [functionTool],
+      });
+      const call: protocol.FunctionCallItem = {
+        ...functionCall('result-binding-call', functionTool.name, {}),
+        caller: { type: 'program', callerId: 'owner-a' },
+      };
+      const result: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: functionTool.name,
+        callId: call.callId,
+        status: 'completed',
+        caller: call.caller,
+        output: 'done',
+      };
+      const state = new RunState(new RunContext(), 'start', agent, 1);
+      state._generatedItems.push(
+        new RunToolCallItem(call, agent),
+        new RunToolCallOutputItem(result, agent, result.output),
+      );
+      const serialized = state.toJSON() as any;
+      const serializedResult = serialized.generatedItems.find(
+        (item: any) => item.rawItem.type === 'function_call_result',
+      ).rawItem;
+      if (changedField === 'tool identity') {
+        serializedResult.name = 'different_tool';
+      } else {
+        serializedResult.caller = {
+          type: 'program',
+          callerId: 'owner-b',
+        };
+      }
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(UserError);
+    },
+  );
+
+  it('round-trips the runtime-selected first local tool identity', async () => {
+    const firstShell = shellTool({
+      name: 'first_runtime_shell',
+      shell: new FakeShell(),
+    });
+    const secondShell = shellTool({
+      name: 'second_runtime_shell',
+      shell: new FakeShell(),
+    });
+    const agent = new Agent({
+      name: 'FirstShellSelectionAgent',
+      tools: [firstShell, secondShell],
+    });
+    const call = shellCall('first-shell-selection', ['echo once']);
+    const result: protocol.ShellCallResultItem = {
+      type: 'shell_call_output',
+      callId: call.callId,
+      output: [
+        { stdout: 'once', stderr: '', outcome: { type: 'exit', exitCode: 0 } },
+      ],
+    };
+    const fingerprint = getToolInvocationFingerprint(firstShell.name, call);
+    const state = new RunState(new RunContext(), 'start', agent, 1);
+    state._generatedItems.push(
+      new RunToolCallItem(call, agent),
+      new RunToolCallOutputItem(result, agent, result.output),
+    );
+    state._completedToolInvocations.set(
+      agent,
+      new Map([[call.callId, fingerprint]]),
+    );
+
+    const restored = await RunState.fromString(agent, state.toString());
+    expect(
+      restored._preflightToolInvocation(agent, call.callId, fingerprint),
+    ).toBe(true);
+  });
+
+  it('round-trips an execution-time injected local tool identity', async () => {
+    const agent = new Agent({ name: 'InjectedApplyPatchAgent' });
+    const call = applyPatchCall('injected-apply-patch-call');
+    const result: protocol.ApplyPatchCallResultItem = {
+      type: 'apply_patch_call_output',
+      callId: call.callId,
+      status: 'completed',
+      output: 'Done!',
+    };
+    const fingerprint = getToolInvocationFingerprint('apply_patch', call);
+    const state = new RunState(new RunContext(), 'start', agent, 1);
+    const items = [
+      new RunToolCallItem(call, agent),
+      new RunToolCallOutputItem(result, agent, result.output ?? ''),
+    ];
+    state._observeToolInvocation(agent, call.callId, fingerprint);
+    state._commitToolInvocations(items);
+    state._generatedItems.push(...items);
+
+    const restored = await RunState.fromString(agent, state.toString());
+    expect(
+      restored._preflightToolInvocation(agent, call.callId, fingerprint),
+    ).toBe(true);
+  });
+
+  it('references retained generated items without duplicating large tool payloads', async () => {
+    const localTool = tool({
+      name: 'large_output_tool',
+      description: 'Produces a large result.',
+      parameters: z.object({}),
+      execute: async () => 'unused',
+    });
+    const agent = new Agent({
+      name: 'LargeOutputEvidenceAgent',
+      tools: [localTool],
+    });
+    const call = functionCall('large-output-call', localTool.name, {});
+    const output = 'x'.repeat(10_000);
+    const result: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: localTool.name,
+      callId: call.callId,
+      status: 'completed',
+      output,
+    };
+    const state = new RunState(new RunContext(), 'start', agent, 1);
+    state._generatedItems.push(
+      new RunToolCallItem(call, agent),
+      new RunToolCallOutputItem(result, agent, output),
+    );
+
+    const serialized = state.toJSON() as any;
+    const evidence =
+      serialized.completedToolInvocationEvidence[0].invocations[call.callId];
+    expect(evidence.items).toEqual([
+      { generatedItemIndex: 0 },
+      { generatedItemIndex: 1 },
+    ]);
+    expect(JSON.stringify(evidence)).not.toContain(output);
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    expect(
+      restored._preflightToolInvocation(
+        agent,
+        call.callId,
+        getToolInvocationFingerprint(getFunctionToolStateKey(localTool)!, call),
+      ),
+    ).toBe(true);
+
+    evidence.items[0].generatedItemIndex = 999;
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow(UserError);
+  });
+
+  it('preserves same-turn completion authority through a handoff filter', async () => {
+    const calls: string[] = [];
+    const executedTool = tool({
+      name: 'filtered_completion_tool',
+      description: 'Runs before a handoff filters its history.',
+      parameters: z.object({ value: z.string() }),
+      execute: async ({ value }) => {
+        calls.push(value);
+        return value;
+      },
+    });
+    const pauseTool = tool({
+      name: 'filtered_completion_pause',
+      description: 'Pauses after the filtered handoff.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'unused',
+    });
+    const completedCallId = 'filtered-completed-call';
+    const completedCall = functionCall(completedCallId, executedTool.name, {
+      value: 'once',
+    });
+    const targetAgent = new Agent({
+      name: 'FilteredCompletionTarget',
+      model: new FakeModel([
+        response([
+          functionCall('filtered-completion-pause', pauseTool.name, {}),
+        ]),
+      ]),
+      tools: [pauseTool],
+    });
+    const transfer = handoff(targetAgent, {
+      inputFilter: (data) => ({
+        ...data,
+        newItems: [],
+      }),
+    });
+    const sourceAgent = new Agent({
+      name: 'FilteredCompletionSource',
+      model: new FakeModel([
+        response([
+          completedCall,
+          functionCall('filtered-completion-handoff', transfer.toolName, {}),
+        ]),
+      ]),
+      tools: [executedTool],
+      handoffs: [transfer],
+    });
+
+    const interrupted = await new Runner().run(sourceAgent, 'start');
+
+    expect(calls).toEqual(['once']);
+    expect(
+      interrupted.state._generatedItems.some(
+        (item) =>
+          'callId' in item.rawItem && item.rawItem.callId === completedCallId,
+      ),
+    ).toBe(false);
+    const serialized = interrupted.state.toJSON() as any;
+    const evidenceItems =
+      serialized.completedToolInvocationEvidence[0].invocations[completedCallId]
+        .items;
+    expect(
+      evidenceItems.map((reference: any) => reference.item.rawItem.type),
+    ).toEqual(['function_call', 'function_call_result']);
+    const restored = await RunState.fromString(
+      sourceAgent,
+      JSON.stringify(serialized),
+    );
+    expect(
+      restored._preflightToolInvocation(
+        sourceAgent,
+        completedCallId,
+        getToolInvocationFingerprint(
+          getFunctionToolStateKey(executedTool)!,
+          completedCall,
+        ),
+      ),
+    ).toBe(true);
+    expect(calls).toEqual(['once']);
+  });
+
+  it('binds local shell approvals to the approved command', async () => {
+    const shell = new FakeShell();
+    const localShell = shellTool({ shell, needsApproval: true });
+    const callId = 'reused-shell';
+    const model = new FakeModel([
+      response([shellCall(callId, ['echo safe'])]),
+      response([shellCall(callId, ['echo changed'])]),
+    ]);
+    const agent = new Agent({
+      name: 'ChangedShellAgent',
+      model,
+      tools: [localShell],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    interrupted.state.approve(interrupted.interruptions[0]);
+
+    await expect(runner.run(agent, interrupted.state)).rejects.toThrow(
+      ModelBehaviorError,
+    );
+    expect(shell.calls).toEqual([{ commands: ['echo safe'] }]);
+  });
+
+  it('reconstructs unapproved shell completion from schema 1.17 state', async () => {
+    const shell = new FakeShell();
+    const localShell = shellTool({ shell });
+    const pauseTool = tool({
+      name: 'pause_for_serialization',
+      description: 'Creates a resumable state after shell execution.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const shellCallId = 'legacy-shell';
+    const model = new FakeModel([
+      response([shellCall(shellCallId, ['echo once'])]),
+      response([functionCall('pause-call', pauseTool.name, {})]),
+      response([shellCall(shellCallId, ['echo once'])]),
+      response([fakeModelMessage('done')]),
+    ]);
+    const agent = new Agent({
+      name: 'LegacyShellReplayAgent',
+      model,
+      tools: [localShell, pauseTool],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    expect(shell.calls).toEqual([{ commands: ['echo once'] }]);
+    const serialized = interrupted.state.toJSON() as any;
+    serialized.$schemaVersion = '1.17';
+    delete serialized.context.approvalInvocations;
+    delete serialized.completedToolInvocations;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    restored.approve(restored.getInterruptions()[0]);
+    const result = await runner.run(agent, restored);
+
+    expect(result.finalOutput).toBe('done');
+    expect(shell.calls).toEqual([{ commands: ['echo once'] }]);
+  });
+
+  it('does not let a later legacy approval rename an earlier completion', async () => {
+    const firstShell = shellTool({
+      name: 'first_shell',
+      shell: new FakeShell(),
+    });
+    const secondShell = shellTool({
+      name: 'second_shell',
+      shell: new FakeShell(),
+    });
+    const agent = new Agent({
+      name: 'OrderedLegacyShellAgent',
+      tools: [firstShell, secondShell],
+    });
+    const callId = 'legacy-reused-shell';
+    const firstCall = shellCall(callId, ['echo once']);
+    const secondCall = shellCall(callId, ['echo once']);
+    const output: protocol.ShellCallResultItem = {
+      type: 'shell_call_output',
+      callId,
+      output: [
+        { stdout: 'once', stderr: '', outcome: { type: 'exit', exitCode: 0 } },
+      ],
+    };
+    const state = new RunState(new RunContext(), 'start', agent, 1);
+    state._generatedItems.push(
+      new RunToolCallItem(firstCall, agent),
+      new RunToolApprovalItem(firstCall, agent, firstShell.name),
+      new RunToolCallOutputItem(output, agent, output.output),
+      new RunToolCallItem(secondCall, agent),
+      new RunToolApprovalItem(secondCall, agent, secondShell.name),
+    );
+    const serialized = state.toJSON() as any;
+    serialized.$schemaVersion = '1.17';
+    delete serialized.context.approvalInvocations;
+    delete serialized.completedToolInvocations;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const secondFingerprint = getToolInvocationFingerprint(
+      secondShell.name,
+      secondCall,
+    );
+
+    expect(() =>
+      restored._observeToolInvocation(agent, callId, secondFingerprint),
+    ).toThrow(ModelBehaviorError);
+
+    const upgraded = await RunState.fromString(agent, restored.toString());
+    expect(() =>
+      upgraded._observeToolInvocation(agent, callId, secondFingerprint),
+    ).toThrow(ModelBehaviorError);
+  });
+
+  it('reconstructs unapproved computer completion from schema 1.17 state', async () => {
+    const computer = new FakeComputer();
+    const screenshot = vi.spyOn(computer, 'screenshot');
+    const localComputer = computerTool({ computer });
+    const pauseTool = tool({
+      name: 'pause_after_computer',
+      description: 'Creates a resumable state after computer execution.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const callId = 'legacy-computer';
+    const model = new FakeModel([
+      response([computerCall(callId)]),
+      response([functionCall('pause-computer', pauseTool.name, {})]),
+      response([computerCall(callId)]),
+      response([fakeModelMessage('done')]),
+    ]);
+    const agent = new Agent({
+      name: 'LegacyComputerReplayAgent',
+      model,
+      tools: [localComputer, pauseTool],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    expect(screenshot).toHaveBeenCalledTimes(2);
+    const serialized = interrupted.state.toJSON() as any;
+    serialized.$schemaVersion = '1.17';
+    delete serialized.context.approvalInvocations;
+    delete serialized.completedToolInvocations;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    restored.approve(restored.getInterruptions()[0]);
+    const result = await runner.run(agent, restored);
+
+    expect(result.finalOutput).toBe('done');
+    expect(screenshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('reconstructs unapproved apply-patch completion from schema 1.17 state', async () => {
+    const editor = new FakeEditor();
+    const localApplyPatch = applyPatchTool({ editor });
+    const pauseTool = tool({
+      name: 'pause_after_patch',
+      description: 'Creates a resumable state after patch execution.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'approved',
+    });
+    const callId = 'legacy-apply-patch';
+    const model = new FakeModel([
+      response([applyPatchCall(callId)]),
+      response([functionCall('pause-patch', pauseTool.name, {})]),
+      response([applyPatchCall(callId)]),
+      response([fakeModelMessage('done')]),
+    ]);
+    const agent = new Agent({
+      name: 'LegacyApplyPatchReplayAgent',
+      model,
+      tools: [localApplyPatch, pauseTool],
+    });
+    const runner = new Runner();
+
+    const interrupted = await runner.run(agent, 'start');
+    expect(editor.operations).toHaveLength(1);
+    const serialized = interrupted.state.toJSON() as any;
+    serialized.$schemaVersion = '1.17';
+    delete serialized.context.approvalInvocations;
+    delete serialized.completedToolInvocations;
+
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    restored.approve(restored.getInterruptions()[0]);
+    const result = await runner.run(agent, restored);
+
+    expect(result.finalOutput).toBe('done');
+    expect(editor.operations).toHaveLength(1);
+  });
+});

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -18,9 +18,15 @@ import { RuntimeEventEmitter } from '@openai/agents-core/_shims';
 import { isZodObject, toSmartString } from '@openai/agents-core/utils';
 import {
   getSafeErrorType,
+  getBoundToolInvocationRejectionMessage,
   hasDynamicFunctionToolApprovalPolicy,
   hasInspectableFunctionToolArguments,
+  getToolInvocationApproval,
+  getToolInvocationRejectionMessage,
   logToolActionError,
+  validateHandoffToolInvocation,
+  validateToolInvocationApproval,
+  validateToolInvocationName,
 } from '@openai/agents-core/utils/internal';
 import type {
   RealtimeSessionConfig,
@@ -245,6 +251,39 @@ type PendingRealtimeFunctionCall<TBaseContext> = {
   agent: SessionRealtimeAgent<TBaseContext>;
   dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>;
   approvalItem: RunToolApprovalItem;
+  fingerprint: string;
+  connectionGeneration: number;
+};
+
+type CompletedRealtimeToolCall = {
+  fingerprint: string;
+  output: string;
+  startResponse: boolean;
+};
+
+type ActiveRealtimeToolCall = {
+  fingerprint: string;
+  completion: Promise<CompletedRealtimeToolCall | undefined>;
+  resolve: (outcome: CompletedRealtimeToolCall | undefined) => void;
+};
+
+type CanonicalRealtimeToolInvocation = {
+  callId: string;
+  fingerprint: string;
+  connectionGeneration: number;
+};
+
+type IssuedRealtimeApproval<TBaseContext> = {
+  kind: 'function' | 'mcp';
+  connectionGeneration: number;
+  agent: SessionRealtimeAgent<TBaseContext>;
+  callId: string;
+  fingerprint: string;
+  toolName: string;
+  rawName: string;
+  tool?: RealtimeFunctionTool<TBaseContext>;
+  trustedApprovalItem: RunToolApprovalItem;
+  decisionState: 'pending' | 'sending' | 'decided';
 };
 
 type OutputGuardrailDeltaSource = 'audio' | 'text';
@@ -323,8 +362,28 @@ export class RealtimeSession<
   #pendingResponseDispatchSnapshot:
     RealtimeDispatchSnapshot<TBaseContext> | undefined;
   #pendingFunctionCalls = new Map<
-    string,
-    PendingRealtimeFunctionCall<TBaseContext>
+    SessionRealtimeAgent<TBaseContext>,
+    Map<string, PendingRealtimeFunctionCall<TBaseContext>>
+  >();
+  #issuedApprovals = new WeakMap<
+    RunToolApprovalItem,
+    IssuedRealtimeApproval<TBaseContext>
+  >();
+  #mcpApprovalInvocations = new Map<
+    SessionRealtimeAgent<TBaseContext>,
+    Map<string, IssuedRealtimeApproval<TBaseContext>>
+  >();
+  #completedToolCalls = new Map<
+    SessionRealtimeAgent<TBaseContext>,
+    Map<string, CompletedRealtimeToolCall>
+  >();
+  #sendingToolCallOutputs = new Map<
+    SessionRealtimeAgent<TBaseContext>,
+    Set<string>
+  >();
+  #activeToolCalls = new Map<
+    SessionRealtimeAgent<TBaseContext>,
+    Map<string, ActiveRealtimeToolCall>
   >();
   #context: RunContext<RealtimeContextData<TBaseContext>>;
   #outputGuardrails: RealtimeOutputGuardrailDefinition[] = [];
@@ -339,6 +398,7 @@ export class RealtimeSession<
   #activeResponseId: string | undefined;
   #responseGeneration = 0;
   #connectionGeneration = 0;
+  #connectedGeneration: number | undefined;
   #audioStarted = false;
   // Tracks all MCP tools fetched per server label (from mcp_list_tools results).
   #allMcpToolsByServer: Map<string, RealtimeMcpToolInfo[]> = new Map();
@@ -517,14 +577,16 @@ export class RealtimeSession<
 
   async #getSessionConfig(
     additionalConfig: Partial<RealtimeSessionConfig> = {},
+    preparedAgent?: PreparedRealtimeAgentState<TBaseContext>,
+    connectionGeneration?: number,
   ): Promise<Partial<RealtimeSessionConfig>> {
+    const configAgent = preparedAgent?.agent ?? this.#currentAgent;
+    const configTools = preparedAgent?.toolDefinitions ?? this.#currentTools;
     const overridesConfig: Partial<RealtimeSessionConfig> =
       additionalConfig ?? {};
     const optionsConfig: Partial<RealtimeSessionConfig> =
       this.options.config ?? {};
-    const instructions = await this.#currentAgent.getSystemPrompt(
-      this.#context,
-    );
+    const instructions = await configAgent.getSystemPrompt(this.#context);
     const getAudioOutputVoiceOverride = (
       config: Partial<RealtimeSessionConfig>,
     ): string | undefined => {
@@ -566,7 +628,7 @@ export class RealtimeSession<
         ? audioOutputVoiceOverride
         : typeof topLevelVoiceOverride !== 'undefined'
           ? topLevelVoiceOverride
-          : this.#currentAgent.voice;
+          : configAgent.voice;
 
     // Start from any previously-sent config (so we preserve values like audio formats)
     // and the original options.config provided by the user. Preference order:
@@ -587,17 +649,22 @@ export class RealtimeSession<
       instructions,
       voice: resolvedVoice,
       model: this.options.model,
-      tools: this.#currentTools,
+      tools: configTools,
       tracing: tracingConfig,
       prompt:
-        typeof this.#currentAgent.prompt === 'function'
-          ? await this.#currentAgent.prompt(this.#context, this.#currentAgent)
-          : this.#currentAgent.prompt,
+        typeof configAgent.prompt === 'function'
+          ? await configAgent.prompt(this.#context, configAgent)
+          : configAgent.prompt,
     };
 
     // Update our cache so subsequent updates inherit the full set including any
     // dynamic fields we just overwrote.
-    this.#lastSessionConfig = fullConfig;
+    if (
+      connectionGeneration === undefined ||
+      connectionGeneration === this.#connectionGeneration
+    ) {
+      this.#lastSessionConfig = fullConfig;
+    }
 
     return fullConfig;
   }
@@ -664,32 +731,286 @@ export class RealtimeSession<
     toolCall: TransportToolCallEvent,
     handoff: Handoff,
     sourceAgent: SessionRealtimeAgent<TBaseContext>,
+    invocation: CanonicalRealtimeToolInvocation,
   ) {
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return undefined;
+    }
     const newAgent = (await handoff.onInvokeHandoff(
       this.#context,
       toolCall.arguments,
     )) as RealtimeAgent<TBaseContext>;
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return undefined;
+    }
     const prepared = await this.#prepareAgent(newAgent);
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return undefined;
+    }
+    const sessionConfig = await this.#getSessionConfig(
+      {},
+      prepared,
+      invocation.connectionGeneration,
+    );
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return undefined;
+    }
+    await this.#transport.updateSessionConfig(sessionConfig);
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return undefined;
+    }
 
     sourceAgent.emit('agent_handoff', this.#context, newAgent);
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return undefined;
+    }
     this.emit('agent_handoff', this.#context, sourceAgent, newAgent);
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return undefined;
+    }
 
     // update session with new agent
     this.#applyPreparedAgent(prepared);
-    await this.#transport.updateSessionConfig(await this.#getSessionConfig());
     const output = getTransferMessage(newAgent);
-    this.#transport.sendFunctionCallOutput(toolCall, output, true);
+    this.#sendCommittedFunctionCallOutput(
+      sourceAgent,
+      invocation,
+      toolCall,
+      output,
+      true,
+    );
 
     return newAgent;
   }
 
-  async #resolveApprovalRejectionMessage(
-    toolName: string,
+  #getPendingFunctionCalls(
+    agent: SessionRealtimeAgent<TBaseContext>,
+  ): Map<string, PendingRealtimeFunctionCall<TBaseContext>> {
+    let calls = this.#pendingFunctionCalls.get(agent);
+    if (!calls) {
+      calls = new Map();
+      this.#pendingFunctionCalls.set(agent, calls);
+    }
+    return calls;
+  }
+
+  #getMcpApprovalInvocations(
+    agent: SessionRealtimeAgent<TBaseContext>,
+  ): Map<string, IssuedRealtimeApproval<TBaseContext>> {
+    let invocations = this.#mcpApprovalInvocations.get(agent);
+    if (!invocations) {
+      invocations = new Map();
+      this.#mcpApprovalInvocations.set(agent, invocations);
+    }
+    return invocations;
+  }
+
+  #deletePendingFunctionCall(
+    agent: SessionRealtimeAgent<TBaseContext>,
     callId: string,
+  ): void {
+    const calls = this.#pendingFunctionCalls.get(agent);
+    calls?.delete(callId);
+    if (calls?.size === 0) {
+      this.#pendingFunctionCalls.delete(agent);
+    }
+  }
+
+  #sendCommittedFunctionCallOutput(
+    agent: SessionRealtimeAgent<TBaseContext>,
+    invocation: CanonicalRealtimeToolInvocation,
+    toolCall: TransportToolCallEvent,
+    output: string,
+    startResponse: boolean,
+  ): void {
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
+    let sending = this.#sendingToolCallOutputs.get(agent);
+    if (!sending) {
+      sending = new Set();
+      this.#sendingToolCallOutputs.set(agent, sending);
+    }
+    if (sending.has(invocation.callId)) {
+      return;
+    }
+    let calls = this.#completedToolCalls.get(agent);
+    if (!calls) {
+      calls = new Map();
+      this.#completedToolCalls.set(agent, calls);
+    }
+    calls.set(invocation.callId, {
+      fingerprint: invocation.fingerprint,
+      output,
+      startResponse,
+    });
+    sending.add(invocation.callId);
+    try {
+      this.#transport.sendFunctionCallOutput(toolCall, output, startResponse);
+    } finally {
+      sending.delete(invocation.callId);
+      if (sending.size === 0) {
+        this.#sendingToolCallOutputs.delete(agent);
+      }
+    }
+  }
+
+  #isCurrentRealtimeInvocation(
+    invocation: CanonicalRealtimeToolInvocation,
+  ): boolean {
+    return (
+      invocation.connectionGeneration === this.#connectionGeneration &&
+      invocation.connectionGeneration === this.#connectedGeneration
+    );
+  }
+
+  async #runRealtimeToolInvocation(
+    agent: SessionRealtimeAgent<TBaseContext>,
+    invocation: CanonicalRealtimeToolInvocation,
+    toolCall: TransportToolCallEvent,
+    execute: () => Promise<unknown>,
+  ): Promise<void> {
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
+    const completed = this.#completedToolCalls
+      .get(agent)
+      ?.get(invocation.callId);
+    if (completed) {
+      if (completed.fingerprint !== invocation.fingerprint) {
+        throw new ModelBehaviorError(
+          `Tool call ID ${invocation.callId} was reused for a different realtime invocation after completion.`,
+        );
+      }
+      this.#sendCommittedFunctionCallOutput(
+        agent,
+        invocation,
+        toolCall,
+        completed.output,
+        completed.startResponse,
+      );
+      return;
+    }
+
+    const activeCalls = this.#getActiveToolCalls(agent);
+    const active = activeCalls.get(invocation.callId);
+    if (active) {
+      if (active.fingerprint !== invocation.fingerprint) {
+        throw new ModelBehaviorError(
+          `Tool call ID ${invocation.callId} was reused for a different realtime invocation while execution was active.`,
+        );
+      }
+      const activeOutcome = await active.completion;
+      if (
+        activeOutcome &&
+        invocation.connectionGeneration === this.#connectionGeneration
+      ) {
+        this.#sendCommittedFunctionCallOutput(
+          agent,
+          invocation,
+          toolCall,
+          activeOutcome.output,
+          activeOutcome.startResponse,
+        );
+      }
+      return;
+    }
+
+    let resolveCompletion: (
+      outcome: CompletedRealtimeToolCall | undefined,
+    ) => void = () => {};
+    const completion = new Promise<CompletedRealtimeToolCall | undefined>(
+      (resolve) => {
+        resolveCompletion = resolve;
+      },
+    );
+    const activeCall = {
+      fingerprint: invocation.fingerprint,
+      completion,
+      resolve: resolveCompletion,
+    };
+    activeCalls.set(invocation.callId, activeCall);
+    try {
+      if (this.#isCurrentRealtimeInvocation(invocation)) {
+        await execute();
+      }
+    } finally {
+      resolveCompletion(
+        this.#completedToolCalls.get(agent)?.get(invocation.callId),
+      );
+      if (activeCalls.get(invocation.callId) === activeCall) {
+        activeCalls.delete(invocation.callId);
+      }
+      if (
+        activeCalls.size === 0 &&
+        this.#activeToolCalls.get(agent) === activeCalls
+      ) {
+        this.#activeToolCalls.delete(agent);
+      }
+    }
+  }
+
+  #transferActiveToolCallToPendingApproval(
+    agent: SessionRealtimeAgent<TBaseContext>,
+    invocation: CanonicalRealtimeToolInvocation,
+  ): void {
+    const activeCalls = this.#activeToolCalls.get(agent);
+    const active = activeCalls?.get(invocation.callId);
+    if (!active) {
+      return;
+    }
+    if (active.fingerprint !== invocation.fingerprint) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${invocation.callId} changed while transferring realtime approval ownership.`,
+      );
+    }
+    active.resolve(undefined);
+    activeCalls?.delete(invocation.callId);
+    if (
+      activeCalls?.size === 0 &&
+      this.#activeToolCalls.get(agent) === activeCalls
+    ) {
+      this.#activeToolCalls.delete(agent);
+    }
+  }
+
+  #getActiveToolCalls(
+    agent: SessionRealtimeAgent<TBaseContext>,
+  ): Map<string, ActiveRealtimeToolCall> {
+    let calls = this.#activeToolCalls.get(agent);
+    if (!calls) {
+      calls = new Map();
+      this.#activeToolCalls.set(agent, calls);
+    }
+    return calls;
+  }
+
+  #resetToolInvocationState(): void {
+    for (const calls of this.#activeToolCalls.values()) {
+      for (const active of calls.values()) {
+        active.resolve(undefined);
+      }
+    }
+    this.#pendingFunctionCalls.clear();
+    this.#mcpApprovalInvocations.clear();
+    this.#completedToolCalls.clear();
+    this.#sendingToolCallOutputs.clear();
+    this.#activeToolCalls.clear();
+  }
+
+  async #resolveApprovalRejectionMessage(
+    tool: RealtimeFunctionTool<TBaseContext>,
+    toolCall: TransportToolCallEvent,
+    agent: SessionRealtimeAgent<TBaseContext>,
     toolType: ToolErrorFormatterArgs['toolType'] = 'function',
   ): Promise<string> {
     // Per-call message from state.reject(item, { message }) takes precedence.
-    const perCallMessage = this.#context.getRejectionMessage(toolName, callId);
+    const perCallMessage = getToolInvocationRejectionMessage(
+      this.#context,
+      agent,
+      tool,
+      toolCall,
+    );
     if (typeof perCallMessage === 'string') {
       return perCallMessage;
     }
@@ -703,8 +1024,8 @@ export class RealtimeSession<
       const formattedMessage = await toolErrorFormatter({
         kind: 'approval_rejected',
         toolType,
-        toolName,
-        callId,
+        toolName: tool.name,
+        callId: toolCall.callId,
         defaultMessage: TOOL_APPROVAL_REJECTION_MESSAGE,
         runContext: this.#context,
       });
@@ -736,6 +1057,42 @@ export class RealtimeSession<
     dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>,
   ) {
     const toolCall = normalizeRealtimeFunctionCallId(incomingToolCall);
+    const invocation = {
+      ...validateToolInvocationApproval(this.#context, agent, tool, toolCall),
+      connectionGeneration: this.#connectionGeneration,
+    };
+    const pending = this.#pendingFunctionCalls
+      .get(agent)
+      ?.get(invocation.callId);
+    if (pending) {
+      if (pending.fingerprint !== invocation.fingerprint) {
+        throw new ModelBehaviorError(
+          `Tool call ID ${invocation.callId} was reused for a different realtime invocation while approval was pending.`,
+        );
+      }
+      return;
+    }
+    await this.#runRealtimeToolInvocation(agent, invocation, toolCall, () =>
+      this.#executeFunctionToolCall(
+        toolCall,
+        tool,
+        agent,
+        dispatchSnapshot,
+        invocation,
+      ),
+    );
+  }
+
+  async #executeFunctionToolCall(
+    toolCall: TransportToolCallEvent,
+    tool: RealtimeFunctionTool<TBaseContext>,
+    agent: SessionRealtimeAgent<TBaseContext>,
+    dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>,
+    invocation: CanonicalRealtimeToolInvocation,
+  ) {
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
     this.#context.context.history = JSON.parse(JSON.stringify(this.#history)); // deep copy of the history
     let parsedArgs: any = toolCall.arguments;
     const dynamicApprovalPolicy = hasDynamicFunctionToolApprovalPolicy(tool);
@@ -759,36 +1116,49 @@ export class RealtimeSession<
       (argumentParseError !== undefined ||
         !hasInspectableFunctionToolArguments(parsedArgs));
     const existingApproval = dynamicApprovalPolicy
-      ? this.context.isToolApproved({
-          toolName: tool.name,
-          callId: toolCall.callId,
-        })
+      ? getToolInvocationApproval(this.context, agent, tool, toolCall)
       : undefined;
     const needsApproval =
       forceApproval ||
       existingApproval !== undefined ||
       (await tool.needsApproval(this.#context, parsedArgs, toolCall.callId));
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
     if (needsApproval) {
       const approval =
         existingApproval ??
-        this.context.isToolApproved({
-          toolName: tool.name,
-          callId: toolCall.callId,
-        });
+        getToolInvocationApproval(this.context, agent, tool, toolCall);
       if (approval === false) {
-        this.#pendingFunctionCalls.delete(toolCall.callId);
+        this.#deletePendingFunctionCall(agent, toolCall.callId);
         this.emit('agent_tool_start', this.#context, agent, tool, {
           toolCall,
         });
+        if (!this.#isCurrentRealtimeInvocation(invocation)) {
+          return;
+        }
         agent.emit('agent_tool_start', this.#context, tool, {
           toolCall,
         });
+        if (!this.#isCurrentRealtimeInvocation(invocation)) {
+          return;
+        }
 
         const result = await this.#resolveApprovalRejectionMessage(
-          tool.name,
-          toolCall.callId,
+          tool,
+          toolCall,
+          agent,
         );
-        this.#transport.sendFunctionCallOutput(toolCall, result, true);
+        if (!this.#isCurrentRealtimeInvocation(invocation)) {
+          return;
+        }
+        this.#sendCommittedFunctionCallOutput(
+          agent,
+          invocation,
+          toolCall,
+          result,
+          true,
+        );
         this.emit('agent_tool_end', this.#context, agent, tool, result, {
           toolCall,
         });
@@ -804,9 +1174,14 @@ export class RealtimeSession<
             agent,
             toolCall: toolCall as any,
           });
+          if (!this.#isCurrentRealtimeInvocation(invocation)) {
+            return;
+          }
 
           if (inputGuardrailResult.type === 'reject') {
-            this.#transport.sendFunctionCallOutput(
+            this.#sendCommittedFunctionCallOutput(
+              agent,
+              invocation,
               toolCall,
               inputGuardrailResult.message,
               true,
@@ -814,14 +1189,37 @@ export class RealtimeSession<
             return;
           }
         }
-        const approvalItem = new RunToolApprovalItem(toolCall, agent);
-        this.#pendingFunctionCalls.set(toolCall.callId, {
-          toolCall,
+        const trustedToolCall = { ...toolCall };
+        const trustedApprovalItem = new RunToolApprovalItem(
+          trustedToolCall,
+          agent,
+        );
+        const approvalItem = new RunToolApprovalItem(
+          { ...trustedToolCall },
+          agent,
+        );
+        this.#getPendingFunctionCalls(agent).set(toolCall.callId, {
+          toolCall: trustedToolCall,
           tool,
           agent,
           dispatchSnapshot,
-          approvalItem,
+          approvalItem: trustedApprovalItem,
+          fingerprint: invocation.fingerprint,
+          connectionGeneration: invocation.connectionGeneration,
         });
+        this.#issuedApprovals.set(approvalItem, {
+          kind: 'function',
+          connectionGeneration: invocation.connectionGeneration,
+          agent,
+          callId: invocation.callId,
+          fingerprint: invocation.fingerprint,
+          toolName: tool.name,
+          rawName: trustedToolCall.name,
+          tool,
+          trustedApprovalItem,
+          decisionState: 'pending',
+        });
+        this.#transferActiveToolCallToPendingApproval(agent, invocation);
         this.emit('tool_approval_requested', this.#context, agent, {
           type: 'function_approval' as const,
           tool,
@@ -831,10 +1229,16 @@ export class RealtimeSession<
       }
     }
 
-    this.#pendingFunctionCalls.delete(toolCall.callId);
+    this.#deletePendingFunctionCall(agent, toolCall.callId);
     if (argumentParseError !== undefined) {
       const errorMessage = `An error occurred while parsing tool arguments. Please try again with valid JSON. Error: ${toErrorMessage(argumentParseError)}`;
-      this.#transport.sendFunctionCallOutput(toolCall, errorMessage, true);
+      this.#sendCommittedFunctionCallOutput(
+        agent,
+        invocation,
+        toolCall,
+        errorMessage,
+        true,
+      );
       return;
     }
 
@@ -844,13 +1248,22 @@ export class RealtimeSession<
       agent,
       toolCall: toolCall as any,
     });
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
 
     this.emit('agent_tool_start', this.#context, agent, tool, {
       toolCall,
     });
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
     agent.emit('agent_tool_start', this.#context, tool, {
       toolCall,
     });
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
 
     this.#context.context.history = JSON.parse(JSON.stringify(this.#history)); // deep copy of the history
     const result =
@@ -864,6 +1277,9 @@ export class RealtimeSession<
               toolCall,
             },
           });
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
     const guardedResult =
       inputGuardrailResult.type === 'reject'
         ? result
@@ -874,14 +1290,29 @@ export class RealtimeSession<
             toolCall: toolCall as any,
             toolOutput: result,
           });
+    if (!this.#isCurrentRealtimeInvocation(invocation)) {
+      return;
+    }
     let stringResult: string;
     if (isBackgroundResult(guardedResult)) {
       // Don't generate a new response, just send the result
       stringResult = toSmartString(guardedResult.content);
-      this.#transport.sendFunctionCallOutput(toolCall, stringResult, false);
+      this.#sendCommittedFunctionCallOutput(
+        agent,
+        invocation,
+        toolCall,
+        stringResult,
+        false,
+      );
     } else {
       stringResult = toSmartString(guardedResult);
-      this.#transport.sendFunctionCallOutput(toolCall, stringResult, true);
+      this.#sendCommittedFunctionCallOutput(
+        agent,
+        invocation,
+        toolCall,
+        stringResult,
+        true,
+      );
     }
     this.emit('agent_tool_end', this.#context, agent, tool, stringResult, {
       toolCall,
@@ -892,72 +1323,136 @@ export class RealtimeSession<
   }
 
   async #handleFunctionCall(
-    toolCall: TransportToolCallEvent,
+    incomingToolCall: TransportToolCallEvent,
     dispatchSnapshot: RealtimeDispatchSnapshot<TBaseContext>,
   ) {
-    const [toolEnabled, handoffEnabled] = await Promise.all([
-      Promise.all(
-        dispatchSnapshot.functionTools.map((tool) =>
-          tool.isEnabled(this.#context, dispatchSnapshot.agent),
-        ),
-      ),
-      Promise.all(
-        dispatchSnapshot.handoffs.map((handoff) =>
-          handoff.isEnabled({
-            runContext: this.#context,
-            agent: dispatchSnapshot.agent,
-          }),
-        ),
-      ),
-    ]);
-    const filteredSnapshot: RealtimeDispatchSnapshot<TBaseContext> = {
-      agent: dispatchSnapshot.agent,
-      functionTools: dispatchSnapshot.functionTools.filter(
-        (_tool, index) => toolEnabled[index],
-      ),
-      handoffs: dispatchSnapshot.handoffs.filter(
-        (_handoff, index) => handoffEnabled[index],
-      ),
+    const toolCall = normalizeRealtimeFunctionCallId(incomingToolCall);
+    const candidateFunctionTool = dispatchSnapshot.functionTools.find(
+      (tool) => tool.name === toolCall.name,
+    );
+    const candidateHandoff = dispatchSnapshot.handoffs.find(
+      (handoff) => handoff.toolName === toolCall.name,
+    );
+    const validatedInvocation = candidateFunctionTool
+      ? validateToolInvocationApproval(
+          this.#context,
+          dispatchSnapshot.agent,
+          candidateFunctionTool,
+          toolCall,
+        )
+      : candidateHandoff
+        ? validateHandoffToolInvocation(
+            this.#context,
+            dispatchSnapshot.agent,
+            candidateHandoff.toolName,
+            toolCall,
+          )
+        : validateToolInvocationName(
+            this.#context,
+            dispatchSnapshot.agent,
+            toolCall.name,
+            toolCall,
+          );
+    const invocation = {
+      ...validatedInvocation,
+      connectionGeneration: this.#connectionGeneration,
     };
-    validateRealtimeToolNames(
-      filteredSnapshot.functionTools,
-      filteredSnapshot.handoffs,
-    );
-
-    const functionToolMap = new Map(
-      filteredSnapshot.functionTools.map((tool) => [tool.name, tool]),
-    );
-    const handoffMap = new Map(
-      filteredSnapshot.handoffs.map((handoff) => [handoff.toolName, handoff]),
-    );
-
-    const functionTool = functionToolMap.get(toolCall.name);
-    if (functionTool) {
-      await this.#handleFunctionToolCall(
-        toolCall,
-        functionTool,
-        filteredSnapshot.agent,
-        filteredSnapshot,
-      );
+    const pending = this.#pendingFunctionCalls
+      .get(dispatchSnapshot.agent)
+      ?.get(invocation.callId);
+    if (pending) {
+      if (pending.fingerprint !== invocation.fingerprint) {
+        throw new ModelBehaviorError(
+          `Tool call ID ${invocation.callId} was reused for a different realtime invocation while approval was pending.`,
+        );
+      }
       return;
     }
 
-    const possibleHandoff = handoffMap.get(toolCall.name);
-    if (possibleHandoff) {
-      await this.#handleHandoff(
-        toolCall,
-        possibleHandoff,
-        filteredSnapshot.agent,
-      );
-      return;
-    }
+    await this.#runRealtimeToolInvocation(
+      dispatchSnapshot.agent,
+      invocation,
+      toolCall,
+      async () => {
+        const [toolEnabled, handoffEnabled] = await Promise.all([
+          Promise.all(
+            dispatchSnapshot.functionTools.map((tool) =>
+              tool.isEnabled(this.#context, dispatchSnapshot.agent),
+            ),
+          ),
+          Promise.all(
+            dispatchSnapshot.handoffs.map((handoff) =>
+              handoff.isEnabled({
+                runContext: this.#context,
+                agent: dispatchSnapshot.agent,
+              }),
+            ),
+          ),
+        ]);
+        if (!this.#isCurrentRealtimeInvocation(invocation)) {
+          return;
+        }
+        const filteredSnapshot: RealtimeDispatchSnapshot<TBaseContext> = {
+          agent: dispatchSnapshot.agent,
+          functionTools: dispatchSnapshot.functionTools.filter(
+            (_tool, index) => toolEnabled[index],
+          ),
+          handoffs: dispatchSnapshot.handoffs.filter(
+            (_handoff, index) => handoffEnabled[index],
+          ),
+        };
+        validateRealtimeToolNames(
+          filteredSnapshot.functionTools,
+          filteredSnapshot.handoffs,
+        );
 
-    const message = `Tool ${toolCall.name} not found`;
-    this.#transport.sendFunctionCallOutput(toolCall, message, false);
-    this.emit('error', {
-      type: 'error',
-      error: new ModelBehaviorError(message),
-    });
+        const functionToolMap = new Map(
+          filteredSnapshot.functionTools.map((tool) => [tool.name, tool]),
+        );
+        const handoffMap = new Map(
+          filteredSnapshot.handoffs.map((handoff) => [
+            handoff.toolName,
+            handoff,
+          ]),
+        );
+
+        const functionTool = functionToolMap.get(toolCall.name);
+        if (functionTool) {
+          await this.#executeFunctionToolCall(
+            toolCall,
+            functionTool,
+            filteredSnapshot.agent,
+            filteredSnapshot,
+            invocation,
+          );
+          return;
+        }
+
+        const possibleHandoff = handoffMap.get(toolCall.name);
+        if (possibleHandoff) {
+          await this.#handleHandoff(
+            toolCall,
+            possibleHandoff,
+            filteredSnapshot.agent,
+            invocation,
+          );
+          return;
+        }
+
+        const message = `Tool ${toolCall.name} not found`;
+        this.#sendCommittedFunctionCallOutput(
+          filteredSnapshot.agent,
+          invocation,
+          toolCall,
+          message,
+          false,
+        );
+        this.emit('error', {
+          type: 'error',
+          error: new ModelBehaviorError(message),
+        });
+      },
+    );
   }
 
   async #runOutputGuardrails(
@@ -1268,6 +1763,9 @@ export class RealtimeSession<
 
     this.#transport.on('function_call', async (event) => {
       try {
+        if (this.#connectedGeneration !== this.#connectionGeneration) {
+          return;
+        }
         if (!event.responseId) {
           throw new ModelBehaviorError(
             'Realtime function call is missing a responseId and cannot be dispatched safely.',
@@ -1326,13 +1824,69 @@ export class RealtimeSession<
     });
 
     this.#transport.on('mcp_approval_request', (approvalRequest) => {
-      this.emit('tool_approval_requested', this.#context, this.#currentAgent, {
-        type: 'mcp_approval_request' as const,
-        approvalItem: realtimeApprovalItemToApprovalItem(
-          this.#currentAgent,
+      try {
+        if (this.#connectedGeneration !== this.#connectionGeneration) {
+          return;
+        }
+        const agent = this.#currentAgent;
+        const trustedApprovalItem = realtimeApprovalItemToApprovalItem(
+          agent,
           approvalRequest,
-        ),
-      });
+        );
+        if (trustedApprovalItem.rawItem.type !== 'hosted_tool_call') {
+          throw new ModelBehaviorError(
+            'Realtime MCP approval could not be normalized safely.',
+          );
+        }
+        const toolName = trustedApprovalItem.rawItem.name;
+        const invocation = validateToolInvocationName(
+          this.#context,
+          agent,
+          toolName,
+          trustedApprovalItem.rawItem,
+        );
+        const agentInvocations = this.#getMcpApprovalInvocations(agent);
+        const existing = agentInvocations.get(invocation.callId);
+        if (existing) {
+          if (existing.fingerprint !== invocation.fingerprint) {
+            throw new ModelBehaviorError(
+              `Tool call ID ${invocation.callId} was reused for a different realtime MCP approval invocation.`,
+            );
+          }
+          return;
+        }
+        const approvalItem = realtimeApprovalItemToApprovalItem(
+          agent,
+          approvalRequest,
+        );
+        const issued: IssuedRealtimeApproval<TBaseContext> = {
+          kind: 'mcp',
+          connectionGeneration: this.#connectionGeneration,
+          agent,
+          callId: invocation.callId,
+          fingerprint: invocation.fingerprint,
+          toolName,
+          rawName: trustedApprovalItem.rawItem.name,
+          trustedApprovalItem,
+          decisionState: 'pending',
+        };
+        this.#issuedApprovals.set(approvalItem, issued);
+        agentInvocations.set(invocation.callId, issued);
+        this.emit('tool_approval_requested', this.#context, agent, {
+          type: 'mcp_approval_request' as const,
+          approvalItem,
+        });
+      } catch (error) {
+        logToolActionError(
+          logger,
+          'Error handling MCP approval request',
+          error,
+        );
+        this.emit('error', {
+          type: 'error',
+          error,
+        });
+      }
     });
   }
 
@@ -1390,6 +1944,9 @@ export class RealtimeSession<
    */
   async connect(options: RealtimeSessionConnectOptions) {
     this.#connectionGeneration += 1;
+    const connectionGeneration = this.#connectionGeneration;
+    this.#connectedGeneration = undefined;
+    this.#resetToolInvocationState();
     this.#responseGeneration = 0;
     this.#activeResponseId = undefined;
     this.#outputGuardrailDeltaState.clear();
@@ -1398,18 +1955,31 @@ export class RealtimeSession<
     this.#responseDispatchSnapshots.clear();
     // makes sure the current agent is correctly set and loads the tools
     await this.#setCurrentAgent(this.initialAgent);
+    if (connectionGeneration !== this.#connectionGeneration) {
+      return;
+    }
 
     if (!this.#eventListenersAttached) {
       this.#setEventListeners();
       this.#eventListenersAttached = true;
+    }
+    const initialSessionConfig = await this.#getSessionConfig(
+      this.options.config,
+    );
+    if (connectionGeneration !== this.#connectionGeneration) {
+      return;
     }
     await this.#transport.connect({
       apiKey: options.apiKey ?? this.options.apiKey,
       model: this.options.model,
       url: options.url,
       callId: options.callId,
-      initialSessionConfig: await this.#getSessionConfig(this.options.config),
+      initialSessionConfig,
     });
+    if (connectionGeneration !== this.#connectionGeneration) {
+      return;
+    }
+    this.#connectedGeneration = connectionGeneration;
     // Ensure the cached lastSessionConfig includes everything passed as the initial session config
     // (the call above already set it via #getSessionConfig but in case additional overrides were
     // passed directly here in the future we could merge them). For now it's a no-op.
@@ -1469,13 +2039,14 @@ export class RealtimeSession<
    * Disconnect from the session.
    */
   close() {
+    this.#connectedGeneration = undefined;
     this.#connectionGeneration += 1;
     this.#responseGeneration = 0;
     this.#activeResponseId = undefined;
     this.#outputGuardrailDeltaState.clear();
     this.#interruptedByGuardrail = {};
     this.#pendingResponseDispatchSnapshot = undefined;
-    this.#pendingFunctionCalls.clear();
+    this.#resetToolInvocationState();
     this.#responseDispatchSnapshots.clear();
     this.#transport.close();
   }
@@ -1498,6 +2069,73 @@ export class RealtimeSession<
     this.#transport.interrupt();
   }
 
+  #validateIssuedApproval(
+    approvalItem: RunToolApprovalItem,
+  ): IssuedRealtimeApproval<TBaseContext> | undefined {
+    let issued = this.#issuedApprovals.get(approvalItem);
+    if (
+      !issued &&
+      approvalItem.rawItem.type === 'hosted_tool_call' &&
+      approvalItem.agent instanceof RealtimeAgent
+    ) {
+      const agent = approvalItem.agent as SessionRealtimeAgent<TBaseContext>;
+      const { callId } = validateToolInvocationName(
+        this.#context,
+        agent,
+        approvalItem.rawItem.name,
+        approvalItem.rawItem,
+      );
+      issued = this.#mcpApprovalInvocations.get(agent)?.get(callId);
+    }
+    if (
+      issued !== undefined &&
+      (issued.connectionGeneration !== this.#connectionGeneration ||
+        issued.connectionGeneration !== this.#connectedGeneration)
+    ) {
+      throw new ModelBehaviorError(
+        'Tool approval belongs to a closed realtime connection.',
+      );
+    }
+    if (!issued) {
+      return undefined;
+    }
+    if (approvalItem.agent !== issued.agent) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${issued.callId} approval does not belong to its issuing realtime agent.`,
+      );
+    }
+    if (
+      !('name' in approvalItem.rawItem) ||
+      approvalItem.rawItem.name !== issued.rawName
+    ) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${issued.callId} approval changed its issued realtime tool name.`,
+      );
+    }
+    const supplied = issued.tool
+      ? validateToolInvocationApproval(
+          this.#context,
+          issued.agent,
+          issued.tool,
+          approvalItem.rawItem,
+        )
+      : validateToolInvocationName(
+          this.#context,
+          issued.agent,
+          issued.toolName,
+          approvalItem.rawItem,
+        );
+    if (
+      supplied.callId !== issued.callId ||
+      supplied.fingerprint !== issued.fingerprint
+    ) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${issued.callId} approval does not match its issued realtime invocation.`,
+      );
+    }
+    return issued;
+  }
+
   #resolvePendingFunctionCall(
     approvalItem: RunToolApprovalItem,
   ): PendingRealtimeFunctionCall<TBaseContext> | undefined {
@@ -1514,15 +2152,33 @@ export class RealtimeSession<
     const toolCall = normalizeRealtimeFunctionCallId(
       rawToolCall as TransportToolCallEvent,
     );
-    const pending = this.#pendingFunctionCalls.get(toolCall.callId);
-    if (pending) {
-      return pending;
-    }
-
     const agent =
       approvalItem.agent instanceof RealtimeAgent
         ? (approvalItem.agent as SessionRealtimeAgent<TBaseContext>)
         : this.#currentAgent;
+    const pending = this.#pendingFunctionCalls.get(agent)?.get(toolCall.callId);
+    if (pending) {
+      if (pending.connectionGeneration !== this.#connectionGeneration) {
+        throw new ModelBehaviorError(
+          `Tool call ID ${toolCall.callId} approval belongs to a closed realtime connection.`,
+        );
+      }
+      const suppliedInvocation = validateToolInvocationApproval(
+        this.#context,
+        agent,
+        pending.tool,
+        toolCall,
+      );
+      if (
+        toolCall.name !== pending.toolCall.name ||
+        suppliedInvocation.fingerprint !== pending.fingerprint
+      ) {
+        throw new ModelBehaviorError(
+          `Tool call ID ${toolCall.callId} approval does not match the pending realtime invocation.`,
+        );
+      }
+      return pending;
+    }
     const toolName = approvalItem.toolName ?? approvalItem.rawItem.name;
     const tool = agent.tools.find(
       (candidate): candidate is RealtimeFunctionTool<TBaseContext> =>
@@ -1536,11 +2192,17 @@ export class RealtimeSession<
       this.#currentDispatchSnapshot?.agent === agent
         ? this.#currentDispatchSnapshot
         : { agent, functionTools: [tool], handoffs: [] };
+    const invocation = {
+      ...validateToolInvocationApproval(this.#context, agent, tool, toolCall),
+      connectionGeneration: this.#connectionGeneration,
+    };
     return {
       toolCall,
       tool,
       agent,
       dispatchSnapshot,
+      fingerprint: invocation.fingerprint,
+      connectionGeneration: invocation.connectionGeneration,
       approvalItem:
         toolCall === approvalItem.rawItem
           ? approvalItem
@@ -1562,27 +2224,58 @@ export class RealtimeSession<
     approvalItem: RunToolApprovalItem,
     options: { alwaysApprove?: boolean } = { alwaysApprove: false },
   ) {
+    const issued = this.#validateIssuedApproval(approvalItem);
+    if (issued && issued.decisionState !== 'pending') {
+      return;
+    }
     const pending = this.#resolvePendingFunctionCall(approvalItem);
-    this.#context.approveTool(pending?.approvalItem ?? approvalItem, options);
+    if (issued?.kind === 'function' && !pending) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${issued.callId} no longer has a pending realtime invocation.`,
+      );
+    }
+    if (issued?.kind === 'function') {
+      issued.decisionState = 'decided';
+    }
+    const effectiveApprovalItem =
+      pending?.approvalItem ?? issued?.trustedApprovalItem ?? approvalItem;
+    this.#context.approveTool(effectiveApprovalItem, options);
     const toolName =
-      approvalItem.toolName ?? (approvalItem.rawItem as any).name;
+      effectiveApprovalItem.toolName ??
+      ('name' in effectiveApprovalItem.rawItem
+        ? effectiveApprovalItem.rawItem.name
+        : undefined);
     if (pending) {
-      this.#pendingFunctionCalls.delete(pending.toolCall.callId);
+      this.#deletePendingFunctionCall(pending.agent, pending.toolCall.callId);
       await this.#handleFunctionToolCall(
         pending.toolCall,
         pending.tool,
         pending.agent,
         pending.dispatchSnapshot,
       );
-    } else if (approvalItem.rawItem.type === 'hosted_tool_call') {
+    } else if (effectiveApprovalItem.rawItem.type === 'hosted_tool_call') {
       if (options.alwaysApprove) {
         logger.warn(
           'Always approving MCP tools is not supported. Use the allowed tools configuration instead.',
         );
       }
-      const mcpApprovalRequest =
-        approvalItemToRealtimeApprovalItem(approvalItem);
-      this.#transport.sendMcpResponse(mcpApprovalRequest, true);
+      const mcpApprovalRequest = approvalItemToRealtimeApprovalItem(
+        effectiveApprovalItem,
+      );
+      if (issued) {
+        issued.decisionState = 'sending';
+      }
+      try {
+        this.#transport.sendMcpResponse(mcpApprovalRequest, true);
+      } catch (error) {
+        if (issued) {
+          issued.decisionState = 'pending';
+        }
+        throw error;
+      }
+      if (issued) {
+        issued.decisionState = 'decided';
+      }
     } else {
       throw new ModelBehaviorError(`Tool ${toolName ?? 'unknown'} not found`);
     }
@@ -1602,37 +2295,70 @@ export class RealtimeSession<
       alwaysReject: false,
     },
   ) {
+    const issued = this.#validateIssuedApproval(approvalItem);
+    if (issued && issued.decisionState !== 'pending') {
+      return;
+    }
     const pending = this.#resolvePendingFunctionCall(approvalItem);
-    this.#context.rejectTool(pending?.approvalItem ?? approvalItem, options);
+    if (issued?.kind === 'function' && !pending) {
+      throw new ModelBehaviorError(
+        `Tool call ID ${issued.callId} no longer has a pending realtime invocation.`,
+      );
+    }
+    if (issued?.kind === 'function') {
+      issued.decisionState = 'decided';
+    }
+    const effectiveApprovalItem =
+      pending?.approvalItem ?? issued?.trustedApprovalItem ?? approvalItem;
+    this.#context.rejectTool(effectiveApprovalItem, options);
 
     // we still need to simulate a tool call to the agent to let the agent know
     const toolName =
-      approvalItem.toolName ?? (approvalItem.rawItem as any).name;
+      effectiveApprovalItem.toolName ??
+      ('name' in effectiveApprovalItem.rawItem
+        ? effectiveApprovalItem.rawItem.name
+        : undefined);
     if (pending) {
-      this.#pendingFunctionCalls.delete(pending.toolCall.callId);
+      this.#deletePendingFunctionCall(pending.agent, pending.toolCall.callId);
       await this.#handleFunctionToolCall(
         pending.toolCall,
         pending.tool,
         pending.agent,
         pending.dispatchSnapshot,
       );
-    } else if (approvalItem.rawItem.type === 'hosted_tool_call') {
+    } else if (effectiveApprovalItem.rawItem.type === 'hosted_tool_call') {
       if (options.alwaysReject) {
         logger.warn(
           'Always rejecting MCP tools is not supported. Use the allowed tools configuration instead.',
         );
       }
-      const mcpApprovalRequest =
-        approvalItemToRealtimeApprovalItem(approvalItem);
-      const rejectionReason = this.#context.getRejectionMessage(
-        toolName,
-        mcpApprovalRequest.itemId,
+      const mcpApprovalRequest = approvalItemToRealtimeApprovalItem(
+        effectiveApprovalItem,
       );
-      this.#transport.sendMcpResponse(
-        mcpApprovalRequest,
-        false,
-        rejectionReason,
+      const rejectionReason = getBoundToolInvocationRejectionMessage(
+        this.#context,
+        effectiveApprovalItem.agent,
+        effectiveApprovalItem.toolName ?? effectiveApprovalItem.rawItem.name,
+        effectiveApprovalItem.rawItem,
       );
+      if (issued) {
+        issued.decisionState = 'sending';
+      }
+      try {
+        this.#transport.sendMcpResponse(
+          mcpApprovalRequest,
+          false,
+          rejectionReason,
+        );
+      } catch (error) {
+        if (issued) {
+          issued.decisionState = 'pending';
+        }
+        throw error;
+      }
+      if (issued) {
+        issued.decisionState = 'decided';
+      }
     } else {
       throw new ModelBehaviorError(`Tool ${toolName ?? 'unknown'} not found`);
     }

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -884,6 +884,36 @@ describe('RealtimeSession', () => {
     expect(agentToolEnd).toHaveBeenCalledTimes(1);
   });
 
+  it('does not invoke a tool after a start listener closes the session', async () => {
+    const transport = new FakeTransport();
+    const execute = vi.fn(async () => 'unexpected');
+    const localTool = tool({
+      name: 'close_on_start',
+      description: 'Must not run after a synchronous close.',
+      parameters: z.object({}),
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'CloseOnToolStartAgent',
+      tools: [localTool],
+    });
+    const localSession = new RealtimeSession(agent, { transport });
+    localSession.on('agent_tool_start', () => localSession.close());
+    await localSession.connect({ apiKey: 'test-key' });
+
+    transport.emit('function_call', {
+      type: 'function_call',
+      name: localTool.name,
+      callId: 'close-on-start-call',
+      arguments: '{}',
+      responseId: 'close-on-start-response',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(transport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
   it('emits assistant transcript on agent_end when a tool call follows', async () => {
     const transport = new FakeTransport();
     const agent = new RealtimeAgent({ name: 'Listener' });
@@ -1464,6 +1494,141 @@ describe('RealtimeSession', () => {
     await expect(s2.reject(badApproval)).rejects.toBeInstanceOf(
       ModelBehaviorError,
     );
+  });
+
+  it.each(['approve', 'reject'] as const)(
+    'rejects a stale SDK-issued approval on %s after reconnecting',
+    async (action) => {
+      const execute = vi.fn(async () => 'executed');
+      const approvalTool = tool({
+        name: 'reconnect_approval',
+        description: 'Requires approval before execution.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute,
+      });
+      const agent = new RealtimeAgent({
+        name: 'ReconnectApprovalAgent',
+        tools: [approvalTool],
+      });
+      const localTransport = new FakeTransport();
+      const localSession = new RealtimeSession(agent, {
+        transport: localTransport,
+      });
+      await localSession.connect({ apiKey: 'test' });
+
+      const approvalRequest = waitForEvent<any[]>(
+        localSession,
+        'tool_approval_requested',
+      );
+      localTransport.emit('function_call', {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'reconnected-call',
+        arguments: '{}',
+        responseId: 'first-connection-response',
+      } as any);
+      const [, , payload] = await approvalRequest;
+
+      localSession.close();
+      await localSession.connect({ apiKey: 'test' });
+
+      const staleDecision =
+        action === 'approve'
+          ? localSession.approve(payload.approvalItem)
+          : localSession.reject(payload.approvalItem);
+      await expect(staleDecision).rejects.toBeInstanceOf(ModelBehaviorError);
+      expect(execute).not.toHaveBeenCalled();
+      expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+
+      const approvalSpy = vi.fn();
+      localSession.on('tool_approval_requested', approvalSpy);
+      localTransport.emit('function_call', {
+        type: 'function_call',
+        name: approvalTool.name,
+        callId: 'reconnected-call',
+        arguments: '{}',
+        responseId: 'second-connection-response',
+      } as any);
+      await vi.waitFor(() => expect(approvalSpy).toHaveBeenCalledTimes(1));
+      expect(execute).not.toHaveBeenCalled();
+      expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+    },
+  );
+
+  it('rejects mutated ownership on an SDK-issued function approval', async () => {
+    const execute = vi.fn(async () => 'unexpected');
+    const approvalTool = tool({
+      name: 'mutable_owner_approval',
+      description: 'Requires approval from its issuing agent.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute,
+    });
+    const issuingAgent = new RealtimeAgent({
+      name: 'IssuingApprovalAgent',
+      tools: [approvalTool],
+    });
+    const replacementAgent = new RealtimeAgent({
+      name: 'ReplacementApprovalAgent',
+      tools: [approvalTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(issuingAgent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: approvalTool.name,
+      callId: 'mutable-owner-call',
+      arguments: '{}',
+      responseId: 'mutable-owner-response',
+    } as any);
+    const [, , payload] = await approvalRequest;
+    (payload.approvalItem as any).agent = replacementAgent;
+
+    await expect(
+      localSession.approve(payload.approvalItem),
+    ).rejects.toBeInstanceOf(ModelBehaviorError);
+    expect(execute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
+  it('ignores function calls after the session is closed', async () => {
+    const execute = vi.fn(async () => 'unexpected output');
+    const localTool = tool({
+      name: 'closed_session_tool',
+      description: 'Must not run after close.',
+      parameters: z.object({}),
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ClosedSessionAgent',
+      tools: [localTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    localSession.close();
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: localTool.name,
+      callId: 'closed-session-call',
+      arguments: '{}',
+      responseId: 'closed-session-response',
+    } as any);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
   });
 
   it('requests tool approval when no decision exists', async () => {
@@ -2247,6 +2412,44 @@ describe('RealtimeSession', () => {
     expect(invokeSpy).not.toHaveBeenCalled();
   });
 
+  it('does not format a rejection after a start listener closes the session', async () => {
+    const formatter = vi.fn(() => 'unexpected');
+    const needsApprovalTool = tool({
+      name: 'close_before_rejection_formatter',
+      description: 'Must not format after a synchronous close.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: vi.fn(async () => 'unexpected'),
+    });
+    const agent = new RealtimeAgent({
+      name: 'CloseBeforeRejectionFormatterAgent',
+      tools: [needsApprovalTool],
+    });
+    const transport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport,
+      toolErrorFormatter: formatter,
+    });
+    const toolCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: needsApprovalTool.name,
+      callId: 'close-before-rejection-formatter-call',
+      arguments: '{}',
+      responseId: 'close-before-rejection-formatter-response',
+    };
+    localSession.context.rejectTool(
+      new RunToolApprovalItem(toolCall as any, agent),
+    );
+    localSession.on('agent_tool_start', () => localSession.close());
+    await localSession.connect({ apiKey: 'test' });
+
+    transport.emit('function_call', toolCall);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(formatter).not.toHaveBeenCalled();
+    expect(transport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
   it('falls back to default rejection response when toolErrorFormatter throws', async () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const needsApprovalTool = tool({
@@ -2297,6 +2500,874 @@ describe('RealtimeSession', () => {
       'toolErrorFormatter threw while formatting approval rejection: object',
     );
     warnSpy.mockRestore();
+  });
+
+  it('rejects changed arguments for an approved realtime call ID', async () => {
+    const execute = vi.fn(async () => 'unexpected');
+    const approvedTool = tool({
+      name: 'realtime_approved_tool',
+      description: 'Requires approval.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'RealtimeChangedArgumentsAgent',
+      handoffs: [],
+      tools: [approvedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const approvedCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: approvedTool.name,
+      callId: 'realtime-reused-arguments',
+      arguments: '{"value":"safe"}',
+      responseId: 'realtime-reused-arguments-response',
+    };
+    localSession.context.approveTool(
+      new RunToolApprovalItem(approvedCall as any, agent),
+    );
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+
+    localTransport.emit('function_call', {
+      ...approvedCall,
+      arguments: '{"value":"changed"}',
+    });
+
+    const [error] = await errorEvent;
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+    expect(execute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
+
+  it('rejects changed tool identity for an approved realtime call ID', async () => {
+    const firstExecute = vi.fn(async () => 'first');
+    const secondExecute = vi.fn(async () => 'unexpected');
+    const firstTool = tool({
+      name: 'realtime_first_tool',
+      description: 'Receives the approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: firstExecute,
+    });
+    const secondTool = tool({
+      name: 'realtime_second_tool',
+      description: 'Must not reuse the approval.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: secondExecute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'RealtimeChangedToolAgent',
+      handoffs: [],
+      tools: [firstTool, secondTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const approvedCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: firstTool.name,
+      callId: 'realtime-reused-tool',
+      arguments: '{}',
+      responseId: 'realtime-reused-tool-response',
+    };
+    localSession.context.approveTool(
+      new RunToolApprovalItem(approvedCall as any, agent),
+    );
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+
+    localTransport.emit('function_call', {
+      ...approvedCall,
+      name: secondTool.name,
+    });
+
+    const [error] = await errorEvent;
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+    expect(firstExecute).not.toHaveBeenCalled();
+    expect(secondExecute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
+
+  it('does not reuse a realtime approval across agent ownership', async () => {
+    const firstExecute = vi.fn(async () => 'first');
+    const secondExecute = vi.fn(async () => 'second');
+    const firstTool = tool({
+      name: 'shared_realtime_tool',
+      description: 'Owned by the first agent.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: firstExecute,
+    });
+    const secondTool = tool({
+      name: 'shared_realtime_tool',
+      description: 'Owned by the second agent.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: secondExecute,
+    });
+    const firstAgent = new RealtimeAgent({
+      name: 'FirstApprovalOwner',
+      handoffs: [],
+      tools: [firstTool],
+    });
+    const secondAgent = new RealtimeAgent({
+      name: 'SecondApprovalOwner',
+      handoffs: [],
+      tools: [secondTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(firstAgent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const callId = 'cross-agent-call';
+    localSession.context.approveTool(
+      new RunToolApprovalItem(
+        {
+          type: 'function_call',
+          name: firstTool.name,
+          callId,
+          arguments: '{"value":"first"}',
+        },
+        firstAgent,
+      ),
+    );
+    await localSession.updateAgent(secondAgent);
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: secondTool.name,
+      callId,
+      arguments: '{"value":"changed"}',
+      responseId: 'cross-agent-response',
+    });
+
+    const [, owner, payload] = await approvalRequest;
+    expect(owner).toBe(secondAgent);
+    expect(payload.approvalItem.agent).toBe(secondAgent);
+    expect(firstExecute).not.toHaveBeenCalled();
+    expect(secondExecute).not.toHaveBeenCalled();
+  });
+
+  it('does not replace a pending realtime approval with changed arguments', async () => {
+    const execute = vi.fn(async ({ value }: { value: string }) => value);
+    const approvalTool = tool({
+      name: 'pending_realtime_tool',
+      description: 'Requires approval.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'PendingApprovalAgent',
+      tools: [approvalTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const safeCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: approvalTool.name,
+      callId: 'pending-reused-call',
+      arguments: '{"value":"safe"}',
+      responseId: 'pending-reused-response',
+    };
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', safeCall);
+    const [, , payload] = await approvalRequest;
+
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+    localTransport.emit('function_call', {
+      ...safeCall,
+      arguments: '{"value":"changed"}',
+    });
+    const [error] = await errorEvent;
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+
+    const output = localTransport.waitForNextFunctionCallOutput();
+    await localSession.approve(payload.approvalItem);
+    expect((await output)[1]).toBe('safe');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0][0]).toEqual({ value: 'safe' });
+    errorSpy.mockRestore();
+  });
+
+  it('keeps same-ID pending approvals distinct across realtime agents', async () => {
+    const firstExecute = vi.fn(async () => 'first output');
+    const secondExecute = vi.fn(async () => 'second output');
+    const firstTool = tool({
+      name: 'shared_pending_tool',
+      description: 'Owned by the first agent.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: firstExecute,
+    });
+    const secondTool = tool({
+      name: 'shared_pending_tool',
+      description: 'Owned by the second agent.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute: secondExecute,
+    });
+    const firstAgent = new RealtimeAgent({
+      name: 'FirstPendingOwner',
+      tools: [firstTool],
+    });
+    const secondAgent = new RealtimeAgent({
+      name: 'SecondPendingOwner',
+      tools: [secondTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(firstAgent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const callId = 'cross-agent-pending-call';
+
+    const firstApproval = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: firstTool.name,
+      callId,
+      arguments: '{"value":"first"}',
+      responseId: 'first-pending-response',
+    } as any);
+    const [, firstOwner, firstPayload] = await firstApproval;
+
+    await localSession.updateAgent(secondAgent);
+    const secondApproval = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: secondTool.name,
+      callId,
+      arguments: '{"value":"second"}',
+      responseId: 'second-pending-response',
+    } as any);
+    const [, secondOwner, secondPayload] = await secondApproval;
+
+    const firstOutput = localTransport.waitForNextFunctionCallOutput();
+    await localSession.approve(firstPayload.approvalItem);
+    expect((await firstOutput)[1]).toBe('first output');
+    const secondOutput = localTransport.waitForNextFunctionCallOutput();
+    await localSession.approve(secondPayload.approvalItem);
+    expect((await secondOutput)[1]).toBe('second output');
+
+    expect(firstOwner).toBe(firstAgent);
+    expect(secondOwner).toBe(secondAgent);
+    expect(firstExecute).toHaveBeenCalledTimes(1);
+    expect(secondExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it('replays committed realtime output without invoking the tool twice', async () => {
+    const execute = vi.fn(async () => 'committed output');
+    const replayTool = tool({
+      name: 'realtime_replay_tool',
+      description: 'Runs only once for an exact replay.',
+      parameters: z.object({ value: z.string() }),
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'RealtimeReplayAgent',
+      tools: [replayTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const toolCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: replayTool.name,
+      callId: 'realtime-completed-replay',
+      arguments: '{"value":"safe"}',
+      responseId: 'realtime-completed-response',
+    };
+
+    const firstOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', toolCall);
+    expect((await firstOutput)[1]).toBe('committed output');
+    const replayOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', toolCall);
+    expect((await replayOutput)[1]).toBe('committed output');
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+    localTransport.emit('function_call', {
+      ...toolCall,
+      arguments: '{"value":"changed"}',
+    });
+    const [error] = await errorEvent;
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+    expect(execute).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
+  it('suppresses exact replay when output transport throws after accepting the send', async () => {
+    const execute = vi.fn(async () => 'accepted output');
+    const replayTool = tool({
+      name: 'transport_failure_replay_tool',
+      description: 'Runs only once when output delivery is uncertain.',
+      parameters: z.object({ value: z.string() }),
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'TransportFailureReplayAgent',
+      tools: [replayTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const toolCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: replayTool.name,
+      callId: 'transport-failure-replay',
+      arguments: '{"value":"safe"}',
+      responseId: 'transport-failure-response',
+    };
+    const originalSend =
+      localTransport.sendFunctionCallOutput.bind(localTransport);
+    const sendSpy = vi
+      .spyOn(localTransport, 'sendFunctionCallOutput')
+      .mockImplementationOnce((...args) => {
+        originalSend(...args);
+        throw new Error('transport failed after accepting output');
+      });
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const firstOutput = localTransport.waitForNextFunctionCallOutput();
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+    localTransport.emit('function_call', toolCall);
+    expect((await firstOutput)[1]).toBe('accepted output');
+    expect((await errorEvent)[0].error).toMatchObject({
+      message: 'transport failed after accepting output',
+    });
+
+    const replayOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', toolCall);
+    expect((await replayOutput)[1]).toBe('accepted output');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    sendSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('suppresses synchronous reentry while sending a committed function output', async () => {
+    const execute = vi.fn(async () => 'reentrant output');
+    const replayTool = tool({
+      name: 'synchronous_output_reentry_tool',
+      description:
+        'Sends one output when the transport reenters synchronously.',
+      parameters: z.object({ value: z.string() }),
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'SynchronousOutputReentryAgent',
+      tools: [replayTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const toolCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: replayTool.name,
+      callId: 'synchronous-output-reentry',
+      arguments: '{"value":"safe"}',
+      responseId: 'synchronous-output-response',
+    };
+    const originalSend =
+      localTransport.sendFunctionCallOutput.bind(localTransport);
+    let reentered = false;
+    const sendSpy = vi
+      .spyOn(localTransport, 'sendFunctionCallOutput')
+      .mockImplementation((...args) => {
+        originalSend(...args);
+        if (!reentered) {
+          reentered = true;
+          localTransport.emit('function_call', toolCall);
+        }
+      });
+
+    const output = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', toolCall);
+    expect((await output)[1]).toBe('reentrant output');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(1);
+    sendSpy.mockRestore();
+  });
+
+  it('serializes overlapping realtime replays before tool side effects', async () => {
+    let markStarted: () => void = () => {};
+    let releaseExecution: () => void = () => {};
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const executionReleased = new Promise<void>((resolve) => {
+      releaseExecution = resolve;
+    });
+    const execute = vi.fn(async () => {
+      markStarted();
+      await executionReleased;
+      return 'serialized output';
+    });
+    const replayTool = tool({
+      name: 'overlapping_realtime_tool',
+      description: 'Serializes overlapping replay attempts.',
+      parameters: z.object({ value: z.string() }),
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'OverlappingReplayAgent',
+      tools: [replayTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const toolCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: replayTool.name,
+      callId: 'overlapping-replay-call',
+      arguments: '{"value":"safe"}',
+      responseId: 'overlapping-replay-response',
+    };
+
+    localTransport.emit('function_call', toolCall);
+    await started;
+
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+    localTransport.emit('function_call', {
+      ...toolCall,
+      arguments: '{"value":"changed"}',
+    });
+    const [error] = await errorEvent;
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+
+    localTransport.emit('function_call', toolCall);
+    releaseExecution();
+    await vi.waitFor(() => {
+      expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(2);
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(
+      localTransport.sendFunctionCallOutputCalls.map(([, output]) => output),
+    ).toEqual(['serialized output', 'serialized output']);
+    errorSpy.mockRestore();
+  });
+
+  it('supports approving a realtime tool synchronously from the approval event', async () => {
+    const execute = vi.fn(async () => 'approved output');
+    const approvalTool = tool({
+      name: 'synchronous_approval_tool',
+      description: 'Can be approved directly from the approval event.',
+      parameters: z.object({ value: z.string() }),
+      needsApproval: true,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'SynchronousApprovalAgent',
+      tools: [approvalTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    let approvalPromise: Promise<void> | undefined;
+    localSession.on('tool_approval_requested', (_context, _agent, request) => {
+      approvalPromise = localSession.approve(request.approvalItem);
+    });
+    const toolCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: approvalTool.name,
+      callId: 'synchronous-approval-call',
+      arguments: '{"value":"safe"}',
+      responseId: 'synchronous-approval-response',
+    };
+
+    localTransport.emit('function_call', toolCall);
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    await approvalPromise;
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(1);
+    expect(localTransport.sendFunctionCallOutputCalls[0]?.[1]).toBe(
+      'approved output',
+    );
+
+    localTransport.emit('function_call', toolCall);
+    await vi.waitFor(() =>
+      expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(2),
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let stale tool completion cross a realtime reconnect', async () => {
+    let releaseFirstExecution: () => void = () => {};
+    const firstExecutionReleased = new Promise<void>((resolve) => {
+      releaseFirstExecution = resolve;
+    });
+    const execute = vi.fn(async ({ value }: { value: string }) => {
+      if (value === 'first') {
+        await firstExecutionReleased;
+      }
+      return `${value} output`;
+    });
+    const reconnectTool = tool({
+      name: 'reconnect_generation_tool',
+      description: 'Keeps tool completion scoped to one connection.',
+      parameters: z.object({ value: z.string() }),
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ReconnectGenerationAgent',
+      tools: [reconnectTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    const toolEnd = vi.fn();
+    localSession.on('agent_tool_end', toolEnd);
+    await localSession.connect({ apiKey: 'test' });
+    const firstCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: reconnectTool.name,
+      callId: 'reconnect-generation-call',
+      arguments: '{"value":"first"}',
+      responseId: 'first-generation-response',
+    };
+
+    localTransport.emit('function_call', firstCall);
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(1));
+    localTransport.emit('function_call', firstCall);
+    localSession.close();
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('function_call', {
+      ...firstCall,
+      arguments: '{"value":"second"}',
+      responseId: 'second-generation-response',
+    });
+    await vi.waitFor(() =>
+      expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(1),
+    );
+    expect(localTransport.sendFunctionCallOutputCalls[0]?.[1]).toBe(
+      'second output',
+    );
+
+    releaseFirstExecution();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(toolEnd).toHaveBeenCalledTimes(1);
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(1);
+    expect(execute).toHaveBeenCalledTimes(2);
+  });
+
+  it('reserves a realtime call ID before awaiting dynamic enablement', async () => {
+    let markEnablementStarted: () => void = () => {};
+    let releaseEnablement: () => void = () => {};
+    const enablementStarted = new Promise<void>((resolve) => {
+      markEnablementStarted = resolve;
+    });
+    const enablementReleased = new Promise<void>((resolve) => {
+      releaseEnablement = resolve;
+    });
+    const isEnabled = vi.fn(async () => {
+      if (isEnabled.mock.calls.length === 1) {
+        return true;
+      }
+      markEnablementStarted();
+      await enablementReleased;
+      return true;
+    });
+    const execute = vi.fn(async () => 'safe output');
+    const dynamicTool = tool({
+      name: 'dynamic_enablement_tool',
+      description: 'Waits before dynamic enablement resolves.',
+      parameters: z.object({ value: z.string() }),
+      isEnabled,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'DynamicEnablementReplayAgent',
+      tools: [dynamicTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const safeCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: dynamicTool.name,
+      callId: 'dynamic-enablement-call',
+      arguments: '{"value":"safe"}',
+      responseId: 'dynamic-enablement-response',
+    };
+
+    localTransport.emit('function_call', safeCall);
+    await enablementStarted;
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const errors: any[] = [];
+    localSession.on('error', (error) => errors.push(error));
+    localTransport.emit('function_call', {
+      ...safeCall,
+      arguments: '{"value":"changed"}',
+    });
+
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+    const error = errors[0];
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+    expect(isEnabled).toHaveBeenCalledTimes(2);
+    expect(execute).not.toHaveBeenCalled();
+
+    const output = localTransport.waitForNextFunctionCallOutput();
+    releaseEnablement();
+    expect((await output)[1]).toBe('safe output');
+    expect(execute).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+  });
+
+  it('does not execute a tool whose enablement resolves after reconnecting', async () => {
+    let deferEnablement = false;
+    let markEnablementStarted: () => void = () => {};
+    let releaseEnablement: () => void = () => {};
+    const enablementStarted = new Promise<void>((resolve) => {
+      markEnablementStarted = resolve;
+    });
+    const enablementReleased = new Promise<void>((resolve) => {
+      releaseEnablement = resolve;
+    });
+    const execute = vi.fn(async () => 'stale output');
+    const dynamicTool = tool({
+      name: 'reconnect_enablement_tool',
+      description: 'Waits while its connection can be replaced.',
+      parameters: z.object({}),
+      isEnabled: async () => {
+        if (!deferEnablement) {
+          return true;
+        }
+        markEnablementStarted();
+        await enablementReleased;
+        return true;
+      },
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ReconnectEnablementAgent',
+      tools: [dynamicTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    deferEnablement = true;
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: dynamicTool.name,
+      callId: 'stale-enablement-call',
+      arguments: '{}',
+      responseId: 'stale-enablement-response',
+    } as any);
+    await enablementStarted;
+
+    localSession.close();
+    deferEnablement = false;
+    await localSession.connect({ apiKey: 'test' });
+    releaseEnablement();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
+  it('does not apply a handoff that resolves after reconnecting', async () => {
+    let markHandoffStarted: () => void = () => {};
+    let releaseHandoff: () => void = () => {};
+    const handoffStarted = new Promise<void>((resolve) => {
+      markHandoffStarted = resolve;
+    });
+    const handoffReleased = new Promise<void>((resolve) => {
+      releaseHandoff = resolve;
+    });
+    const targetAgent = new RealtimeAgent({ name: 'StaleHandoffTarget' });
+    const delayedHandoff = handoff(targetAgent, {
+      onHandoff: async () => {
+        markHandoffStarted();
+        await handoffReleased;
+      },
+    });
+    const sourceAgent = new RealtimeAgent({
+      name: 'StaleHandoffSource',
+      handoffs: [delayedHandoff],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+    });
+    const sessionHandoff = vi.fn();
+    const sourceHandoff = vi.fn();
+    localSession.on('agent_handoff', sessionHandoff);
+    sourceAgent.on('agent_handoff', sourceHandoff);
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: delayedHandoff.toolName,
+      callId: 'stale-handoff-call',
+      arguments: '{}',
+      responseId: 'stale-handoff-response',
+    } as any);
+    await handoffStarted;
+
+    localSession.close();
+    await localSession.connect({ apiKey: 'test' });
+    releaseHandoff();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(localSession.currentAgent).toBe(sourceAgent);
+    expect(sessionHandoff).not.toHaveBeenCalled();
+    expect(sourceHandoff).not.toHaveBeenCalled();
+    expect(localTransport.updateSessionConfigCalls).toHaveLength(0);
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
+  it('does not apply a handoff after a handoff listener closes the session', async () => {
+    const targetAgent = new RealtimeAgent({ name: 'CloseHandoffTarget' });
+    const localHandoff = handoff(targetAgent);
+    const sourceAgent = new RealtimeAgent({
+      name: 'CloseHandoffSource',
+      handoffs: [localHandoff],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+    });
+    localSession.on('agent_handoff', () => localSession.close());
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: localHandoff.toolName,
+      callId: 'close-handoff-call',
+      arguments: '{}',
+      responseId: 'close-handoff-response',
+    } as any);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(localSession.currentAgent).toBe(sourceAgent);
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
+  it('commits missing realtime tool responses to the replay authority', async () => {
+    const agent = new RealtimeAgent({ name: 'MissingToolReplayAgent' });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const missingCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: 'missing_realtime_tool',
+      callId: 'missing-realtime-call',
+      arguments: '{"value":"safe"}',
+      responseId: 'missing-realtime-response',
+    };
+    const errors: any[] = [];
+    localSession.on('error', (error) => errors.push(error));
+    const firstOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', missingCall);
+    expect((await firstOutput)[1]).toBe('Tool missing_realtime_tool not found');
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+
+    const replayOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', missingCall);
+    expect((await replayOutput)[1]).toBe(
+      'Tool missing_realtime_tool not found',
+    );
+
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    localTransport.emit('function_call', {
+      ...missingCall,
+      arguments: '{"value":"changed"}',
+    });
+    await vi.waitFor(() => expect(errors).toHaveLength(2));
+    const error = errors[1];
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(2);
+    errorSpy.mockRestore();
+  });
+
+  it('replays a committed realtime handoff without invoking it twice', async () => {
+    const targetAgent = new RealtimeAgent({ name: 'ReplayTarget' });
+    const sourceAgent = new RealtimeAgent({
+      name: 'ReplaySource',
+      handoffs: [targetAgent],
+    });
+    const handoffSpy = vi.fn();
+    sourceAgent.on('agent_handoff', handoffSpy);
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(sourceAgent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    localTransport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'handoff-replay-response' } },
+    });
+    const toolCall: TransportToolCallEvent = {
+      type: 'function_call',
+      name: 'transfer_to_ReplayTarget',
+      callId: 'realtime-handoff-replay',
+      arguments: '{}',
+      responseId: 'handoff-replay-response',
+    };
+
+    const firstOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', toolCall);
+    await firstOutput;
+    const replayOutput = localTransport.waitForNextFunctionCallOutput();
+    localTransport.emit('function_call', toolCall);
+    await replayOutput;
+
+    expect(localSession.currentAgent).toBe(targetAgent);
+    expect(handoffSpy).toHaveBeenCalledTimes(1);
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(2);
   });
 
   it('redacts toolErrorFormatter failures when tool-data logging is disabled', async () => {
@@ -2867,6 +3938,338 @@ describe('RealtimeSession', () => {
       itemId: 'item-3',
       serverLabel: 'server-3',
     });
+  });
+
+  it('binds SDK-issued MCP approvals to immutable invocation data', async () => {
+    const agent = new RealtimeAgent({ name: 'Bound MCP' });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('mcp_approval_request', {
+      itemId: 'bound-mcp-approval',
+      type: 'mcp_approval_request',
+      serverLabel: 'server',
+      name: 'lookup',
+      arguments: { account: '123' },
+      approved: null,
+    });
+    const [, , payload] = await approvalRequest;
+    (payload.approvalItem.rawItem as any).arguments = '{"account":"changed"}';
+
+    await expect(
+      localSession.approve(payload.approvalItem),
+    ).rejects.toBeInstanceOf(ModelBehaviorError);
+    expect(localTransport.sendMcpResponseCalls).toHaveLength(0);
+  });
+
+  it.each(['approve', 'reject'] as const)(
+    'binds reconstructed SDK-issued MCP approvals on %s',
+    async (action) => {
+      const agent = new RealtimeAgent({ name: 'Reconstructed MCP approval' });
+      const localTransport = new FakeTransport();
+      const localSession = new RealtimeSession(agent, {
+        transport: localTransport,
+      });
+      await localSession.connect({ apiKey: 'test' });
+      const approvalRequest = waitForEvent<any[]>(
+        localSession,
+        'tool_approval_requested',
+      );
+      localTransport.emit('mcp_approval_request', {
+        itemId: `reconstructed-mcp-${action}`,
+        type: 'mcp_approval_request',
+        serverLabel: 'server',
+        name: 'lookup',
+        arguments: { account: '123' },
+        approved: null,
+      });
+      const [, , payload] = await approvalRequest;
+      const original = payload.approvalItem as RunToolApprovalItem;
+      const exactApproval = new RunToolApprovalItem(
+        {
+          ...original.rawItem,
+          providerData: { ...original.rawItem.providerData },
+        } as any,
+        agent,
+        original.toolName,
+      );
+      const changedApproval = new RunToolApprovalItem(
+        {
+          ...original.rawItem,
+          arguments: '{"account":"changed"}',
+          providerData: { ...original.rawItem.providerData },
+        } as any,
+        agent,
+        original.toolName,
+      );
+
+      const changedDecision =
+        action === 'approve'
+          ? localSession.approve(changedApproval)
+          : localSession.reject(changedApproval);
+      await expect(changedDecision).rejects.toBeInstanceOf(ModelBehaviorError);
+      expect(localTransport.sendMcpResponseCalls).toHaveLength(0);
+
+      const exactDecision =
+        action === 'approve'
+          ? localSession.approve(exactApproval)
+          : localSession.reject(exactApproval);
+      await expect(exactDecision).resolves.toBeUndefined();
+      const repeatedDecision =
+        action === 'approve'
+          ? localSession.approve(exactApproval)
+          : localSession.reject(exactApproval);
+      await expect(repeatedDecision).resolves.toBeUndefined();
+      expect(localTransport.sendMcpResponseCalls).toHaveLength(1);
+      expect(localTransport.sendMcpResponseCalls[0]?.[1]).toBe(
+        action === 'approve',
+      );
+    },
+  );
+
+  it('fails changed MCP ID reuse and suppresses exact repeats', async () => {
+    const agent = new RealtimeAgent({ name: 'MCP replay binding' });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    const approvalSpy = vi.fn();
+    localSession.on('tool_approval_requested', approvalSpy);
+    await localSession.connect({ apiKey: 'test' });
+    const request = {
+      itemId: 'reused-mcp-approval',
+      type: 'mcp_approval_request' as const,
+      serverLabel: 'server',
+      name: 'lookup',
+      arguments: { account: '123' },
+      approved: null,
+    };
+    const approvalRequest = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('mcp_approval_request', request);
+    const [, , payload] = await approvalRequest;
+
+    localTransport.emit('mcp_approval_request', request);
+    expect(approvalSpy).toHaveBeenCalledTimes(1);
+
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    localTransport.emit('mcp_approval_request', {
+      ...request,
+      arguments: { account: 'changed' },
+    });
+    const [error] = await errorEvent;
+    expect(error.error).toBeInstanceOf(ModelBehaviorError);
+    expect(approvalSpy).toHaveBeenCalledTimes(1);
+
+    await localSession.approve(payload.approvalItem);
+    await localSession.approve(payload.approvalItem);
+    expect(localTransport.sendMcpResponseCalls).toHaveLength(1);
+    errorSpy.mockRestore();
+  });
+
+  it('keeps same-ID MCP approvals distinct across realtime agents', async () => {
+    const firstAgent = new RealtimeAgent({ name: 'First MCP owner' });
+    const secondAgent = new RealtimeAgent({ name: 'Second MCP owner' });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(firstAgent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const callId = 'cross-agent-mcp-approval';
+
+    const firstApproval = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('mcp_approval_request', {
+      itemId: callId,
+      type: 'mcp_approval_request',
+      serverLabel: 'first-server',
+      name: 'first_lookup',
+      arguments: { account: 'first' },
+      approved: null,
+    });
+    const [, firstOwner, firstPayload] = await firstApproval;
+
+    await localSession.updateAgent(secondAgent);
+    const secondApproval = waitForEvent<any[]>(
+      localSession,
+      'tool_approval_requested',
+    );
+    localTransport.emit('mcp_approval_request', {
+      itemId: callId,
+      type: 'mcp_approval_request',
+      serverLabel: 'second-server',
+      name: 'second_lookup',
+      arguments: { account: 'second' },
+      approved: null,
+    });
+    const [, secondOwner, secondPayload] = await secondApproval;
+
+    expect(firstOwner).toBe(firstAgent);
+    expect(secondOwner).toBe(secondAgent);
+    expect(firstPayload.approvalItem.agent).toBe(firstAgent);
+    expect(secondPayload.approvalItem.agent).toBe(secondAgent);
+
+    await localSession.approve(firstPayload.approvalItem);
+    await localSession.approve(secondPayload.approvalItem);
+    expect(localTransport.sendMcpResponseCalls).toHaveLength(2);
+  });
+
+  it.each(['approve', 'reject'] as const)(
+    'keeps an SDK-issued MCP approval retryable when %s response sending fails',
+    async (action) => {
+      const agent = new RealtimeAgent({ name: 'MCP response retry' });
+      const localTransport = new FakeTransport();
+      const localSession = new RealtimeSession(agent, {
+        transport: localTransport,
+      });
+      await localSession.connect({ apiKey: 'test' });
+      const approvalRequest = waitForEvent<any[]>(
+        localSession,
+        'tool_approval_requested',
+      );
+      localTransport.emit('mcp_approval_request', {
+        itemId: `retry-mcp-${action}`,
+        type: 'mcp_approval_request',
+        serverLabel: 'server',
+        name: 'lookup',
+        arguments: { account: '123' },
+        approved: null,
+      });
+      const [, , payload] = await approvalRequest;
+      vi.spyOn(localTransport, 'sendMcpResponse').mockImplementationOnce(() => {
+        throw new Error('transport disconnected');
+      });
+
+      const firstDecision =
+        action === 'approve'
+          ? localSession.approve(payload.approvalItem)
+          : localSession.reject(payload.approvalItem);
+      await expect(firstDecision).rejects.toThrow('transport disconnected');
+      expect(localTransport.sendMcpResponseCalls).toHaveLength(0);
+
+      const retryDecision =
+        action === 'approve'
+          ? localSession.approve(payload.approvalItem)
+          : localSession.reject(payload.approvalItem);
+      await expect(retryDecision).resolves.toBeUndefined();
+      expect(localTransport.sendMcpResponseCalls).toHaveLength(1);
+      expect(localTransport.sendMcpResponseCalls[0]?.[1]).toBe(
+        action === 'approve',
+      );
+    },
+  );
+
+  it.each(['approve', 'reject'] as const)(
+    'suppresses synchronous reentry while sending an MCP %s response',
+    async (action) => {
+      const agent = new RealtimeAgent({ name: 'MCP response reentry' });
+      const localTransport = new FakeTransport();
+      const localSession = new RealtimeSession(agent, {
+        transport: localTransport,
+      });
+      await localSession.connect({ apiKey: 'test' });
+      const approvalRequest = waitForEvent<any[]>(
+        localSession,
+        'tool_approval_requested',
+      );
+      localTransport.emit('mcp_approval_request', {
+        itemId: `reentrant-mcp-${action}`,
+        type: 'mcp_approval_request',
+        serverLabel: 'server',
+        name: 'lookup',
+        arguments: { account: '123' },
+        approved: null,
+      });
+      const [, , payload] = await approvalRequest;
+      let nestedDecision: Promise<void> | undefined;
+      const sendSpy = vi
+        .spyOn(localTransport, 'sendMcpResponse')
+        .mockImplementation((request, approved, reason) => {
+          localTransport.sendMcpResponseCalls.push([request, approved, reason]);
+          nestedDecision =
+            action === 'approve'
+              ? localSession.approve(payload.approvalItem)
+              : localSession.reject(payload.approvalItem);
+        });
+
+      const decision =
+        action === 'approve'
+          ? localSession.approve(payload.approvalItem)
+          : localSession.reject(payload.approvalItem);
+      await expect(decision).resolves.toBeUndefined();
+      await expect(nestedDecision).resolves.toBeUndefined();
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      expect(localTransport.sendMcpResponseCalls).toHaveLength(1);
+    },
+  );
+
+  it.each(['approve', 'reject'] as const)(
+    'rejects a stale SDK-issued MCP approval on %s after reconnecting',
+    async (action) => {
+      const agent = new RealtimeAgent({ name: 'MCP reconnect' });
+      const localTransport = new FakeTransport();
+      const localSession = new RealtimeSession(agent, {
+        transport: localTransport,
+      });
+      await localSession.connect({ apiKey: 'test' });
+      const approvalRequest = waitForEvent<any[]>(
+        localSession,
+        'tool_approval_requested',
+      );
+      localTransport.emit('mcp_approval_request', {
+        itemId: 'stale-mcp-approval',
+        type: 'mcp_approval_request',
+        serverLabel: 'server',
+        name: 'lookup',
+        arguments: { account: '123' },
+        approved: null,
+      });
+      const [, , payload] = await approvalRequest;
+
+      localSession.close();
+      await localSession.connect({ apiKey: 'test' });
+
+      const staleDecision =
+        action === 'approve'
+          ? localSession.approve(payload.approvalItem)
+          : localSession.reject(payload.approvalItem);
+      await expect(staleDecision).rejects.toBeInstanceOf(ModelBehaviorError);
+      expect(localTransport.sendMcpResponseCalls).toHaveLength(0);
+    },
+  );
+
+  it('ignores MCP approval requests after the session is closed', async () => {
+    const agent = new RealtimeAgent({ name: 'Closed MCP' });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    const approvalSpy = vi.fn();
+    localSession.on('tool_approval_requested', approvalSpy);
+    await localSession.connect({ apiKey: 'test' });
+    localSession.close();
+
+    localTransport.emit('mcp_approval_request', {
+      itemId: 'closed-mcp-approval',
+      type: 'mcp_approval_request',
+      serverLabel: 'server',
+      name: 'lookup',
+      arguments: {},
+      approved: null,
+    });
+
+    expect(approvalSpy).not.toHaveBeenCalled();
   });
 
   it('handles usage and audio interrupted events', () => {


### PR DESCRIPTION
This pull request fixes a replay-safety issue where a provider-reused call ID could inherit an approval or completed result from a different tool invocation. It binds per-call decisions and committed outputs to canonical tool identity and semantic arguments across core runs, RunState resume, hosted MCP approvals, and Realtime sessions.

Changed invocations now fail before tool side effects, while exact committed replays remain suppressed. The change also preserves legacy RunState reads, persists ambiguous replay authority, restores contexts transactionally, and scopes Realtime invocation ownership across approvals and connection lifecycles.