### PR TITLE
fix(agents-core): invalidate MCP tool caches safely

### DIFF
--- a/.changeset/mcp-stdio-sse-cache-invalidation.md
+++ b/.changeset/mcp-stdio-sse-cache-invalidation.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: invalidate MCP tool caches and metadata across lifecycle changes and concurrent listings

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -42,9 +42,9 @@ import {
   MCPTool,
 } from './mcpShared';
 import {
+  beginServerToolsCacheListing,
   cachedMcpToolKeysByServer as _cachedToolKeysByServer,
   cachedMcpTools as _cachedTools,
-  getServerToolsCacheGeneration,
 } from './mcpToolCache';
 import { getToolCallParentSpanFromDetails } from './agentToolRunConfig';
 
@@ -85,6 +85,16 @@ class MCPToolsLifecycleGuard {
   private generation = 0;
   private activeOperations = 0;
 
+  private startLifecycleBranch(
+    operation: (() => Promise<void>) | undefined,
+  ): Promise<void> {
+    try {
+      return operation?.() ?? Promise.resolve();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
   private beginLifecycleOperation(): void {
     this.activeOperations += 1;
     this.generation += 1;
@@ -100,8 +110,16 @@ class MCPToolsLifecycleGuard {
   ): Promise<void> {
     this.beginLifecycleOperation();
     try {
-      await invalidate();
-      await operation?.();
+      const [invalidationResult, operationResult] = await Promise.allSettled([
+        this.startLifecycleBranch(invalidate),
+        this.startLifecycleBranch(operation),
+      ]);
+      if (invalidationResult.status === 'rejected') {
+        throw invalidationResult.reason;
+      }
+      if (operationResult.status === 'rejected') {
+        throw operationResult.reason;
+      }
     } finally {
       this.endLifecycleOperation();
     }
@@ -365,11 +383,6 @@ export class MCPServerStreamableHttp
     this.clearLocalToolsCache();
     await this.underlying.invalidateToolsCache();
   }
-  private async closeAndInvalidateToolsCaches(): Promise<void> {
-    const invalidation = this.invalidateToolsCaches();
-    const closing = this.underlying.close();
-    await Promise.all([invalidation, closing]);
-  }
   get name(): string {
     return this.underlying.name;
   }
@@ -383,8 +396,9 @@ export class MCPServerStreamableHttp
     );
   }
   close(): Promise<void> {
-    return this.toolsLifecycle.runLifecycleOperation(() =>
-      this.closeAndInvalidateToolsCaches(),
+    return this.toolsLifecycle.runLifecycleOperation(
+      () => this.invalidateToolsCaches(),
+      () => this.underlying.close(),
     );
   }
   async listTools(): Promise<MCPTool[]> {
@@ -594,11 +608,11 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
     runContext,
   });
   const serverName = server.name;
-  const cacheGeneration = getServerToolsCacheGeneration(serverName);
   // Use cache key generator injected from the outside, or the default if absent.
   if (server.cacheToolsList && _cachedTools[cacheKey]) {
     return _cachedTools[cacheKey];
   }
+  const cacheListing = beginServerToolsCacheListing(serverName);
 
   const listToolsForServer = async (
     span?: Span<MCPListToolsSpanData>,
@@ -659,10 +673,7 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
       span.spanData.result = mcpTools.map((t) => t.name);
     }
     // Cache store
-    if (
-      server.cacheToolsList &&
-      cacheGeneration === getServerToolsCacheGeneration(serverName)
-    ) {
+    if (server.cacheToolsList && cacheListing.isCurrent()) {
       _cachedTools[cacheKey] = mcpTools;
       if (!_cachedToolKeysByServer[serverName]) {
         _cachedToolKeysByServer[serverName] = new Set();
@@ -672,17 +683,21 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
     return mcpTools;
   };
 
-  if (!tracingParent && !getCurrentTrace()) {
-    return listToolsForServer();
-  }
+  try {
+    if (!tracingParent && !getCurrentTrace()) {
+      return await listToolsForServer();
+    }
 
-  return withMCPListToolsSpan(
-    listToolsForServer,
-    {
-      data: { server: getMcpServerExternalName(server.name) },
-    },
-    tracingParent,
-  );
+    return await withMCPListToolsSpan(
+      listToolsForServer,
+      {
+        data: { server: getMcpServerExternalName(server.name) },
+      },
+      tracingParent,
+    );
+  } finally {
+    cacheListing.release();
+  }
 }
 
 function convertMcpToolsToFunctionTools<TContext = UnknownContext>({

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -44,6 +44,7 @@ import {
 import {
   cachedMcpToolKeysByServer as _cachedToolKeysByServer,
   cachedMcpTools as _cachedTools,
+  getServerToolsCacheGeneration,
 } from './mcpToolCache';
 import { getToolCallParentSpanFromDetails } from './agentToolRunConfig';
 
@@ -79,6 +80,52 @@ type PrefixedToolNameCandidate = {
   serverIndex: number;
   toolIndex: number;
 };
+
+class MCPToolsLifecycleGuard {
+  private generation = 0;
+  private activeOperations = 0;
+
+  private beginLifecycleOperation(): void {
+    this.activeOperations += 1;
+    this.generation += 1;
+  }
+
+  private endLifecycleOperation(): void {
+    this.activeOperations -= 1;
+  }
+
+  async runLifecycleOperation(
+    invalidate: () => Promise<void>,
+    operation?: () => Promise<void>,
+  ): Promise<void> {
+    this.beginLifecycleOperation();
+    try {
+      await invalidate();
+      await operation?.();
+    } finally {
+      this.endLifecycleOperation();
+    }
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+  }
+
+  beginListing(): number {
+    if (this.activeOperations > 0) {
+      throw new Error(
+        'Cannot list MCP tools while a server lifecycle operation is in progress.',
+      );
+    }
+    return this.generation;
+  }
+
+  assertListingIsCurrent(listingGeneration: number): void {
+    if (this.activeOperations > 0 || listingGeneration !== this.generation) {
+      throw new Error('MCP tool listing became stale before it completed.');
+    }
+  }
+}
 
 /**
  * Interface for MCP server implementations.
@@ -227,6 +274,7 @@ export class MCPServerStdio
   implements MCPServerWithResources
 {
   private underlying: UnderlyingMCPServerStdio;
+  private readonly toolsLifecycle = new MCPToolsLifecycleGuard();
   constructor(options: MCPServerStdioOptions) {
     super(options);
     this.underlying = new UnderlyingMCPServerStdio(options);
@@ -234,17 +282,29 @@ export class MCPServerStdio
   get name(): string {
     return this.underlying.name;
   }
+  private async invalidateToolsCaches(): Promise<void> {
+    this._cachedTools = undefined;
+    await this.underlying.invalidateToolsCache();
+  }
   connect(): Promise<void> {
-    return this.underlying.connect();
+    return this.toolsLifecycle.runLifecycleOperation(
+      () => this.invalidateToolsCaches(),
+      () => this.underlying.connect(),
+    );
   }
   close(): Promise<void> {
-    return this.underlying.close();
+    return this.toolsLifecycle.runLifecycleOperation(
+      () => this.invalidateToolsCaches(),
+      () => this.underlying.close(),
+    );
   }
   async listTools(): Promise<MCPTool[]> {
+    const listingGeneration = this.toolsLifecycle.beginListing();
     if (this.cacheToolsList && this._cachedTools) {
       return this._cachedTools;
     }
     const tools = await this.underlying.listTools();
+    this.toolsLifecycle.assertListingIsCurrent(listingGeneration);
     if (this.cacheToolsList) {
       this._cachedTools = tools;
     }
@@ -280,7 +340,9 @@ export class MCPServerStdio
     return this.underlying.readResource(uri);
   }
   invalidateToolsCache(): Promise<void> {
-    return this.underlying.invalidateToolsCache();
+    return this.toolsLifecycle.runLifecycleOperation(() =>
+      this.invalidateToolsCaches(),
+    );
   }
 }
 
@@ -290,6 +352,7 @@ export class MCPServerStreamableHttp
 {
   private underlying: UnderlyingMCPServerStreamableHttp;
   private _cachedToolsSessionId: string | undefined = undefined;
+  private readonly toolsLifecycle = new MCPToolsLifecycleGuard();
   constructor(options: MCPServerStreamableHttpOptions) {
     super(options);
     this.underlying = new UnderlyingMCPServerStreamableHttp(options);
@@ -298,25 +361,34 @@ export class MCPServerStreamableHttp
     this._cachedTools = undefined;
     this._cachedToolsSessionId = undefined;
   }
+  private async invalidateToolsCaches(): Promise<void> {
+    this.clearLocalToolsCache();
+    await this.underlying.invalidateToolsCache();
+  }
   get name(): string {
     return this.underlying.name;
   }
   get sessionId(): string | undefined {
     return this.underlying.sessionId;
   }
-  async connect(): Promise<void> {
-    this.clearLocalToolsCache();
-    await this.underlying.connect();
+  connect(): Promise<void> {
+    return this.toolsLifecycle.runLifecycleOperation(
+      () => this.invalidateToolsCaches(),
+      () => this.underlying.connect(),
+    );
   }
-  async close(): Promise<void> {
-    this.clearLocalToolsCache();
-    await this.underlying.close();
+  close(): Promise<void> {
+    return this.toolsLifecycle.runLifecycleOperation(
+      () => this.invalidateToolsCaches(),
+      () => this.underlying.close(),
+    );
   }
   async listTools(): Promise<MCPTool[]> {
+    const listingGeneration = this.toolsLifecycle.beginListing();
     const sessionId = this.sessionId;
     if (sessionId === undefined) {
-      this.clearLocalToolsCache();
-      await this.underlying.invalidateToolsCache();
+      this.toolsLifecycle.invalidate();
+      await this.invalidateToolsCaches();
       return this.underlying.listTools();
     }
 
@@ -328,6 +400,7 @@ export class MCPServerStreamableHttp
       return this._cachedTools;
     }
     const tools = await this.underlying.listTools();
+    this.toolsLifecycle.assertListingIsCurrent(listingGeneration);
     if (this.cacheToolsList) {
       this._cachedTools = tools;
       this._cachedToolsSessionId = sessionId;
@@ -358,7 +431,8 @@ export class MCPServerStreamableHttp
       );
     } finally {
       if (previousSessionId !== this.sessionId) {
-        this.clearLocalToolsCache();
+        this.toolsLifecycle.invalidate();
+        await this.invalidateToolsCaches();
       }
     }
   }
@@ -375,9 +449,10 @@ export class MCPServerStreamableHttp
   readResource(uri: string): Promise<MCPReadResourceResult> {
     return this.underlying.readResource(uri);
   }
-  async invalidateToolsCache(): Promise<void> {
-    this.clearLocalToolsCache();
-    await this.underlying.invalidateToolsCache();
+  invalidateToolsCache(): Promise<void> {
+    return this.toolsLifecycle.runLifecycleOperation(() =>
+      this.invalidateToolsCaches(),
+    );
   }
 }
 
@@ -386,6 +461,7 @@ export class MCPServerSSE
   implements MCPServerWithResources
 {
   private underlying: UnderlyingMCPServerSSE;
+  private readonly toolsLifecycle = new MCPToolsLifecycleGuard();
   constructor(options: MCPServerSSEOptions) {
     super(options);
     this.underlying = new UnderlyingMCPServerSSE(options);
@@ -393,17 +469,29 @@ export class MCPServerSSE
   get name(): string {
     return this.underlying.name;
   }
+  private async invalidateToolsCaches(): Promise<void> {
+    this._cachedTools = undefined;
+    await this.underlying.invalidateToolsCache();
+  }
   connect(): Promise<void> {
-    return this.underlying.connect();
+    return this.toolsLifecycle.runLifecycleOperation(
+      () => this.invalidateToolsCaches(),
+      () => this.underlying.connect(),
+    );
   }
   close(): Promise<void> {
-    return this.underlying.close();
+    return this.toolsLifecycle.runLifecycleOperation(
+      () => this.invalidateToolsCaches(),
+      () => this.underlying.close(),
+    );
   }
   async listTools(): Promise<MCPTool[]> {
+    const listingGeneration = this.toolsLifecycle.beginListing();
     if (this.cacheToolsList && this._cachedTools) {
       return this._cachedTools;
     }
     const tools = await this.underlying.listTools();
+    this.toolsLifecycle.assertListingIsCurrent(listingGeneration);
     if (this.cacheToolsList) {
       this._cachedTools = tools;
     }
@@ -439,7 +527,9 @@ export class MCPServerSSE
     return this.underlying.readResource(uri);
   }
   invalidateToolsCache(): Promise<void> {
-    return this.underlying.invalidateToolsCache();
+    return this.toolsLifecycle.runLifecycleOperation(() =>
+      this.invalidateToolsCaches(),
+    );
   }
 }
 
@@ -499,6 +589,8 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
     agent,
     runContext,
   });
+  const serverName = server.name;
+  const cacheGeneration = getServerToolsCacheGeneration(serverName);
   // Use cache key generator injected from the outside, or the default if absent.
   if (server.cacheToolsList && _cachedTools[cacheKey]) {
     return _cachedTools[cacheKey];
@@ -563,12 +655,15 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
       span.spanData.result = mcpTools.map((t) => t.name);
     }
     // Cache store
-    if (server.cacheToolsList) {
+    if (
+      server.cacheToolsList &&
+      cacheGeneration === getServerToolsCacheGeneration(serverName)
+    ) {
       _cachedTools[cacheKey] = mcpTools;
-      if (!_cachedToolKeysByServer[server.name]) {
-        _cachedToolKeysByServer[server.name] = new Set();
+      if (!_cachedToolKeysByServer[serverName]) {
+        _cachedToolKeysByServer[serverName] = new Set();
       }
-      _cachedToolKeysByServer[server.name].add(cacheKey);
+      _cachedToolKeysByServer[serverName].add(cacheKey);
     }
     return mcpTools;
   };

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -365,6 +365,11 @@ export class MCPServerStreamableHttp
     this.clearLocalToolsCache();
     await this.underlying.invalidateToolsCache();
   }
+  private async closeAndInvalidateToolsCaches(): Promise<void> {
+    const invalidation = this.invalidateToolsCaches();
+    const closing = this.underlying.close();
+    await Promise.all([invalidation, closing]);
+  }
   get name(): string {
     return this.underlying.name;
   }
@@ -378,9 +383,8 @@ export class MCPServerStreamableHttp
     );
   }
   close(): Promise<void> {
-    return this.toolsLifecycle.runLifecycleOperation(
-      () => this.invalidateToolsCaches(),
-      () => this.underlying.close(),
+    return this.toolsLifecycle.runLifecycleOperation(() =>
+      this.closeAndInvalidateToolsCaches(),
     );
   }
   async listTools(): Promise<MCPTool[]> {

--- a/packages/agents-core/src/mcpToolCache.ts
+++ b/packages/agents-core/src/mcpToolCache.ts
@@ -2,6 +2,11 @@ import type { MCPTool } from './mcpShared';
 
 export const cachedMcpTools: Record<string, MCPTool[]> = {};
 export const cachedMcpToolKeysByServer: Record<string, Set<string>> = {};
+const cacheGenerationByServer = new Map<string, number>();
+
+export function getServerToolsCacheGeneration(serverName: string): number {
+  return cacheGenerationByServer.get(serverName) ?? 0;
+}
 
 /**
  * Remove cached tools for the given server so the next lookup fetches fresh data.
@@ -9,6 +14,10 @@ export const cachedMcpToolKeysByServer: Record<string, Set<string>> = {};
  * @param serverName - Name of the MCP server whose cache should be cleared.
  */
 export async function invalidateServerToolsCache(serverName: string) {
+  cacheGenerationByServer.set(
+    serverName,
+    getServerToolsCacheGeneration(serverName) + 1,
+  );
   const cachedKeys = cachedMcpToolKeysByServer[serverName];
   if (cachedKeys) {
     for (const cacheKey of cachedKeys) {

--- a/packages/agents-core/src/mcpToolCache.ts
+++ b/packages/agents-core/src/mcpToolCache.ts
@@ -2,10 +2,40 @@ import type { MCPTool } from './mcpShared';
 
 export const cachedMcpTools: Record<string, MCPTool[]> = {};
 export const cachedMcpToolKeysByServer: Record<string, Set<string>> = {};
-const cacheGenerationByServer = new Map<string, number>();
+type ActiveServerToolsCacheListing = {
+  invalidated: boolean;
+};
+const activeServerToolsCacheListings = new Map<
+  string,
+  Set<ActiveServerToolsCacheListing>
+>();
 
-export function getServerToolsCacheGeneration(serverName: string): number {
-  return cacheGenerationByServer.get(serverName) ?? 0;
+export function beginServerToolsCacheListing(serverName: string): {
+  isCurrent: () => boolean;
+  release: () => void;
+} {
+  const listing = { invalidated: false };
+  let activeListings = activeServerToolsCacheListings.get(serverName);
+  if (!activeListings) {
+    activeListings = new Set();
+    activeServerToolsCacheListings.set(serverName, activeListings);
+  }
+  activeListings.add(listing);
+
+  let released = false;
+  return {
+    isCurrent: () => !listing.invalidated,
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      activeListings.delete(listing);
+      if (activeListings.size === 0) {
+        activeServerToolsCacheListings.delete(serverName);
+      }
+    },
+  };
 }
 
 /**
@@ -14,10 +44,12 @@ export function getServerToolsCacheGeneration(serverName: string): number {
  * @param serverName - Name of the MCP server whose cache should be cleared.
  */
 export async function invalidateServerToolsCache(serverName: string) {
-  cacheGenerationByServer.set(
-    serverName,
-    getServerToolsCacheGeneration(serverName) + 1,
-  );
+  const activeListings = activeServerToolsCacheListings.get(serverName);
+  if (activeListings) {
+    for (const listing of activeListings) {
+      listing.invalidated = true;
+    }
+  }
   const cachedKeys = cachedMcpToolKeysByServer[serverName];
   if (cachedKeys) {
     for (const cacheKey of cachedKeys) {

--- a/packages/agents-core/src/shims/mcp-server/node.ts
+++ b/packages/agents-core/src/shims/mcp-server/node.ts
@@ -444,8 +444,9 @@ export class NodeMCPServerStdio extends BaseMCPServerStdio {
 
   async invalidateToolsCache(): Promise<void> {
     this._toolsCacheGeneration += 1;
-    await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
+    this._toolsList = [];
+    await invalidateServerToolsCache(this.name);
   }
 
   async listTools(): Promise<MCPTool[]> {
@@ -680,8 +681,9 @@ export class NodeMCPServerSSE extends BaseMCPServerSSE {
 
   async invalidateToolsCache(): Promise<void> {
     this._toolsCacheGeneration += 1;
-    await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
+    this._toolsList = [];
+    await invalidateServerToolsCache(this.name);
   }
 
   async listTools(): Promise<MCPTool[]> {
@@ -1559,8 +1561,9 @@ export class NodeMCPServerStreamableHttp extends BaseMCPServerStreamableHttp {
 
   async invalidateToolsCache(): Promise<void> {
     this._toolsCacheGeneration += 1;
-    await invalidateServerToolsCache(this.name);
     this._cacheDirty = true;
+    this._toolsList = [];
+    await invalidateServerToolsCache(this.name);
   }
 
   async listTools(): Promise<MCPTool[]> {

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -1,10 +1,16 @@
-import { describe, it, expect, vi } from 'vitest';
-import { getAllMcpTools, invalidateServerToolsCache } from '../src/mcp';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import {
+  getAllMcpTools,
+  invalidateServerToolsCache,
+  MCPServerStdio,
+  MCPServerStreamableHttp,
+  MCPServerSSE,
+} from '../src/mcp';
 import { UserError } from '../src/errors';
 import { tool, type FunctionTool } from '../src/tool';
 import { withTrace } from '../src/tracing';
 import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
-import type { CallToolResultContent, MCPServer } from '../src/mcp';
+import type { CallToolResultContent, MCPServer, MCPTool } from '../src/mcp';
 import { RunContext } from '../src/runContext';
 import { Agent } from '../src/agent';
 import { handoff } from '../src/handoff';
@@ -320,6 +326,43 @@ describe('MCP tools cache invalidation', () => {
       });
       expect(refreshed.map((tool) => tool.name)).toEqual(['beta']);
     });
+  });
+
+  it('does not cache a callable filter result that crosses invalidation', async () => {
+    let markFilterStarted!: () => void;
+    let resumeFilter!: () => void;
+    const filterStarted = new Promise<void>((resolve) => {
+      markFilterStarted = resolve;
+    });
+    const filterResumed = new Promise<void>((resolve) => {
+      resumeFilter = resolve;
+    });
+    let filterCalls = 0;
+    const server = new StubServer('filter-invalidation', [toolNamed('a')]);
+    server.toolFilter = async () => {
+      filterCalls += 1;
+      if (filterCalls === 1) {
+        markFilterStarted();
+        await filterResumed;
+      }
+      return true;
+    };
+    const params = {
+      mcpServers: [server],
+      runContext: new RunContext({}),
+      agent: new Agent({ name: 'FilterAgent' }),
+    };
+
+    const staleListing = getAllMcpTools(params);
+    await filterStarted;
+    server.toolList = [toolNamed('b')];
+    await server.invalidateToolsCache();
+    resumeFilter();
+
+    expect((await staleListing).map((tool) => tool.name)).toEqual(['a']);
+    expect((await getAllMcpTools(params)).map((tool) => tool.name)).toEqual([
+      'b',
+    ]);
   });
 });
 
@@ -966,17 +1009,17 @@ describe('Custom generateMCPToolCacheKey can include runContext in key', () => {
       // Filter that allows a tool based on runContext meta value
       const filter = async (ctx: any, tool: any) => {
         if (ctx.runContext.meta && ctx.runContext.meta.kind === 'fooUser') {
-          return tool.name === 'foo';
+          return tool.name.startsWith('foo');
         } else {
-          return tool.name === 'bar';
+          return tool.name.startsWith('bar');
         }
       };
       const server = new StubServer('custom-key-srv', tools);
       server.toolFilter = filter;
       const agent = new Agent({ name: 'A' });
-      // This cache key generator uses both agent name and runContext.meta.kind
-      const generateMCPToolCacheKey = ({ server, agent, runContext }: any) =>
-        `${server.name}:${agent ? agent.name : ''}:${runContext?.meta?.kind}`;
+      // Deliberately omit the server name so invalidation depends on the key registry.
+      const generateMCPToolCacheKey = ({ runContext }: any) =>
+        `opaque-partition-${runContext?.meta?.kind}`;
 
       // Agent 'A', runContext kind 'fooUser' => should see only 'foo'
       const context1 = new RunContext({});
@@ -1008,6 +1051,24 @@ describe('Custom generateMCPToolCacheKey can include runContext in key', () => {
         generateMCPToolCacheKey,
       });
       expect(res3.map((t: any) => t.name)).toEqual(['foo']);
+
+      server.toolList = [toolNamed('foo-updated'), toolNamed('bar-updated')];
+      await server.invalidateToolsCache();
+
+      const refreshedFoo = await getAllMcpTools({
+        mcpServers: [server],
+        runContext: context1,
+        agent,
+        generateMCPToolCacheKey,
+      });
+      const refreshedBar = await getAllMcpTools({
+        mcpServers: [server],
+        runContext: context2,
+        agent,
+        generateMCPToolCacheKey,
+      });
+      expect(refreshedFoo.map((tool) => tool.name)).toEqual(['foo_updated']);
+      expect(refreshedBar.map((tool) => tool.name)).toEqual(['bar_updated']);
     });
   });
 });
@@ -1045,3 +1106,320 @@ describe('MCP tools without tracing', () => {
     expect(listCalls).toBe(1);
   });
 });
+
+function toolNamed(name: string): MCPTool {
+  return {
+    name,
+    description: '',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+  };
+}
+
+function createDeferredVoid() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function createStubUnderlying(name: string, initialTools: MCPTool[]) {
+  let toolList = [...initialTools];
+  let cachedTools: MCPTool[] | undefined;
+  let cacheDirty = true;
+  let invalidateCalls = 0;
+  let connected = false;
+  let connection = 0;
+  let sessionId: string | undefined;
+  let toolsGeneration = 0;
+  let connectOperation: (() => Promise<void>) | undefined;
+  let closeOperation: (() => Promise<void>) | undefined;
+  let listOperation: (() => Promise<void>) | undefined;
+  const stub = {
+    name,
+    get sessionId() {
+      return sessionId;
+    },
+    async connect() {
+      await connectOperation?.();
+      connected = true;
+      connection += 1;
+      sessionId = `${name}-${connection}`;
+      cacheDirty = true;
+    },
+    async close() {
+      await closeOperation?.();
+      connected = false;
+      sessionId = undefined;
+      cacheDirty = true;
+    },
+    async listTools() {
+      if (!connected) {
+        throw new Error(
+          'Server not initialized. Make sure you call connect() first.',
+        );
+      }
+      if (!cacheDirty && cachedTools) {
+        return cachedTools;
+      }
+      const listedTools = [...toolList];
+      const listedGeneration = toolsGeneration;
+      await listOperation?.();
+      if (listedGeneration === toolsGeneration) {
+        cachedTools = listedTools;
+        cacheDirty = false;
+      }
+      return listedTools;
+    },
+    async invalidateToolsCache() {
+      invalidateCalls += 1;
+      toolsGeneration += 1;
+      cacheDirty = true;
+      await invalidateServerToolsCache(name);
+    },
+  };
+  return {
+    stub,
+    setTools: (tools: MCPTool[]) => (toolList = [...tools]),
+    setConnectOperation: (operation: () => Promise<void>) => {
+      connectOperation = operation;
+    },
+    setCloseOperation: (operation: () => Promise<void>) => {
+      closeOperation = operation;
+    },
+    setListOperation: (operation: () => Promise<void>) => {
+      listOperation = operation;
+    },
+    invalidateCalls: () => invalidateCalls,
+  };
+}
+
+const wrapperCacheCases = [
+  {
+    label: 'MCPServerStdio',
+    serverName: 'stdio-wrapper-cache',
+    createServer: () =>
+      new MCPServerStdio({
+        command: 'noop',
+        name: 'stdio-wrapper-cache',
+        cacheToolsList: true,
+      }),
+  },
+  {
+    label: 'MCPServerStreamableHttp',
+    serverName: 'streamable-http-wrapper-cache',
+    createServer: () =>
+      new MCPServerStreamableHttp({
+        url: 'http://localhost:1',
+        name: 'streamable-http-wrapper-cache',
+        cacheToolsList: true,
+      }),
+  },
+  {
+    label: 'MCPServerSSE',
+    serverName: 'sse-wrapper-cache',
+    createServer: () =>
+      new MCPServerSSE({
+        url: 'http://localhost:1',
+        name: 'sse-wrapper-cache',
+        cacheToolsList: true,
+      }),
+  },
+];
+
+describe.each(wrapperCacheCases)(
+  '$label cache invalidation',
+  ({ serverName, createServer }) => {
+    beforeEach(async () => {
+      await invalidateServerToolsCache(serverName);
+    });
+
+    function createHarness() {
+      const server = createServer();
+      const {
+        stub,
+        setTools,
+        setConnectOperation,
+        setCloseOperation,
+        setListOperation,
+        invalidateCalls,
+      } = createStubUnderlying(serverName, [toolNamed('a')]);
+      (server as unknown as { underlying: typeof stub }).underlying = stub;
+      return {
+        server,
+        setTools,
+        setConnectOperation,
+        setCloseOperation,
+        setListOperation,
+        invalidateCalls,
+      };
+    }
+
+    it('returns fresh shared tools after explicit invalidation', async () => {
+      const { server, setTools, invalidateCalls } = createHarness();
+      await server.connect();
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['a'],
+      );
+
+      setTools([toolNamed('b')]);
+      const callsBeforeInvalidation = invalidateCalls();
+      await server.invalidateToolsCache();
+
+      expect(invalidateCalls()).toBe(callsBeforeInvalidation + 1);
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['b'],
+      );
+    });
+
+    it('does not restore stale tools from a listing crossing invalidation', async () => {
+      const { server, setTools } = createHarness();
+      await server.connect();
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['a'],
+      );
+
+      setTools([toolNamed('b')]);
+      const invalidation = server.invalidateToolsCache();
+      const crossingListing = getAllMcpTools([server]);
+      const crossingExpectation = expect(crossingListing).rejects.toThrow(
+        'server lifecycle operation is in progress',
+      );
+      await invalidation;
+
+      await crossingExpectation;
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['b'],
+      );
+    });
+
+    it('rejects a listing invalidated before its wrapper cache commit', async () => {
+      const { server, setTools, setListOperation } = createHarness();
+      await server.connect();
+      const listStarted = createDeferredVoid();
+      const resumeList = createDeferredVoid();
+      setListOperation(async () => {
+        listStarted.resolve();
+        await resumeList.promise;
+      });
+
+      const staleListing = server.listTools();
+      await listStarted.promise;
+      setTools([toolNamed('b')]);
+      await server.invalidateToolsCache();
+      resumeList.resolve();
+
+      await expect(staleListing).rejects.toThrow(
+        'MCP tool listing became stale before it completed',
+      );
+      expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+        'b',
+      ]);
+    });
+
+    it('rejects listings while reconnect is in progress', async () => {
+      const { server, setTools, setConnectOperation } = createHarness();
+      await server.connect();
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['a'],
+      );
+
+      const connectStarted = createDeferredVoid();
+      const resumeConnect = createDeferredVoid();
+      setConnectOperation(async () => {
+        connectStarted.resolve();
+        await resumeConnect.promise;
+      });
+      setTools([toolNamed('b')]);
+
+      const reconnect = server.connect();
+      await connectStarted.promise;
+      await expect(getAllMcpTools([server])).rejects.toThrow(
+        'server lifecycle operation is in progress',
+      );
+      resumeConnect.resolve();
+      await reconnect;
+
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['b'],
+      );
+    });
+
+    it('rejects listings while close is in progress', async () => {
+      const { server, setCloseOperation } = createHarness();
+      await server.connect();
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['a'],
+      );
+
+      const closeStarted = createDeferredVoid();
+      const resumeClose = createDeferredVoid();
+      setCloseOperation(async () => {
+        closeStarted.resolve();
+        await resumeClose.promise;
+      });
+
+      const close = server.close();
+      await closeStarted.promise;
+      await expect(getAllMcpTools([server])).rejects.toThrow(
+        'server lifecycle operation is in progress',
+      );
+      resumeClose.resolve();
+      await close;
+
+      await expect(getAllMcpTools([server])).rejects.toThrow(
+        'Server not initialized',
+      );
+    });
+
+    it('releases the lifecycle guard after a failed reconnect', async () => {
+      const { server, setTools, setConnectOperation } = createHarness();
+      await server.connect();
+      await getAllMcpTools([server]);
+      setTools([toolNamed('b')]);
+      setConnectOperation(async () => {
+        throw new Error('connect failed');
+      });
+
+      await expect(server.connect()).rejects.toThrow('connect failed');
+
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['b'],
+      );
+    });
+
+    it('does not advertise shared cached tools after close', async () => {
+      const { server } = createHarness();
+      await server.connect();
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['a'],
+      );
+
+      await server.close();
+
+      await expect(getAllMcpTools([server])).rejects.toThrow(
+        'Server not initialized',
+      );
+    });
+
+    it('returns tools from the current connection after reconnect', async () => {
+      const { server, setTools } = createHarness();
+      await server.connect();
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['a'],
+      );
+
+      setTools([toolNamed('b')]);
+      await server.connect();
+
+      expect((await getAllMcpTools([server])).map((tool) => tool.name)).toEqual(
+        ['b'],
+      );
+    });
+  },
+);

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -1137,8 +1137,11 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
   let connection = 0;
   let sessionId: string | undefined;
   let toolsGeneration = 0;
+  let connectionStateVersion = 0;
+  let isClosed = true;
   let connectOperation: (() => Promise<void>) | undefined;
   let closeOperation: (() => Promise<void>) | undefined;
+  let invalidateOperation: (() => Promise<void>) | undefined;
   let listOperation: (() => Promise<void>) | undefined;
   const stub = {
     name,
@@ -1146,13 +1149,22 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
       return sessionId;
     },
     async connect() {
+      const connectStateVersion = connectionStateVersion;
+      isClosed = false;
       await connectOperation?.();
+      if (isClosed || connectStateVersion !== connectionStateVersion) {
+        throw new Error(
+          'Streamable HTTP MCP server was closed during connect.',
+        );
+      }
       connected = true;
       connection += 1;
       sessionId = `${name}-${connection}`;
       cacheDirty = true;
     },
     async close() {
+      isClosed = true;
+      connectionStateVersion += 1;
       connected = false;
       sessionId = undefined;
       cacheDirty = true;
@@ -1180,6 +1192,9 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
       invalidateCalls += 1;
       toolsGeneration += 1;
       cacheDirty = true;
+      if (invalidateOperation) {
+        await invalidateOperation();
+      }
       await invalidateServerToolsCache(name);
     },
     async callToolResult() {
@@ -1199,6 +1214,9 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
     },
     setCloseOperation: (operation: () => Promise<void>) => {
       closeOperation = operation;
+    },
+    setInvalidateOperation: (operation: () => Promise<void>) => {
+      invalidateOperation = operation;
     },
     setListOperation: (operation: () => Promise<void>) => {
       listOperation = operation;
@@ -1461,4 +1479,101 @@ it('starts streamable HTTP close before yielding', async () => {
 
   await closing;
   await toolCallExpectation;
+});
+
+it('keeps close authoritative over a pending streamable HTTP connect', async () => {
+  const serverName = 'streamable-http-connect-close-order';
+  await invalidateServerToolsCache(serverName);
+  const server = new MCPServerStreamableHttp({
+    url: 'http://localhost:1',
+    name: serverName,
+    cacheToolsList: true,
+  });
+  const { stub, setConnectOperation } = createStubUnderlying(serverName, [
+    toolNamed('a'),
+  ]);
+  (server as unknown as { underlying: typeof stub }).underlying = stub;
+  const connectStarted = createDeferredVoid();
+  const resumeConnect = createDeferredVoid();
+  setConnectOperation(async () => {
+    connectStarted.resolve();
+    await resumeConnect.promise;
+  });
+
+  const connecting = server.connect();
+  const connectingExpectation = expect(connecting).rejects.toThrow(
+    'Streamable HTTP MCP server was closed during connect',
+  );
+  const closing = server.close();
+  await connectStarted.promise;
+  resumeConnect.resolve();
+
+  await closing;
+  await connectingExpectation;
+  expect(server.sessionId).toBeUndefined();
+});
+
+it('keeps the lifecycle guard active until all branches settle', async () => {
+  const serverName = 'streamable-http-lifecycle-settlement';
+  await invalidateServerToolsCache(serverName);
+  const server = new MCPServerStreamableHttp({
+    url: 'http://localhost:1',
+    name: serverName,
+    cacheToolsList: true,
+  });
+  const { stub, setConnectOperation, setInvalidateOperation } =
+    createStubUnderlying(serverName, [toolNamed('a')]);
+  (server as unknown as { underlying: typeof stub }).underlying = stub;
+  const connectStarted = createDeferredVoid();
+  const resumeConnect = createDeferredVoid();
+  setConnectOperation(async () => {
+    connectStarted.resolve();
+    await resumeConnect.promise;
+  });
+  setInvalidateOperation(async () => {
+    throw new Error('invalidation failed');
+  });
+
+  const connecting = server.connect();
+  const connectingExpectation = expect(connecting).rejects.toThrow(
+    'invalidation failed',
+  );
+  await connectStarted.promise;
+  const listingExpectation = expect(server.listTools()).rejects.toThrow(
+    'server lifecycle operation is in progress',
+  );
+  resumeConnect.resolve();
+
+  await listingExpectation;
+  await connectingExpectation;
+});
+
+it('observes synchronous failures from both lifecycle branches', async () => {
+  const serverName = 'streamable-http-synchronous-lifecycle-failures';
+  await invalidateServerToolsCache(serverName);
+  const server = new MCPServerStreamableHttp({
+    url: 'http://localhost:1',
+    name: serverName,
+    cacheToolsList: true,
+  });
+  const { stub } = createStubUnderlying(serverName, [toolNamed('a')]);
+  let invalidateCalls = 0;
+  let connectCalls = 0;
+  const syncThrowingStub = {
+    ...stub,
+    invalidateToolsCache() {
+      invalidateCalls += 1;
+      throw new Error('invalidation failed');
+    },
+    connect() {
+      connectCalls += 1;
+      throw new Error('connect failed');
+    },
+  };
+  (server as unknown as { underlying: typeof syncThrowingStub }).underlying =
+    syncThrowingStub;
+
+  await expect(server.connect()).rejects.toThrow('invalidation failed');
+  expect(invalidateCalls).toBe(1);
+  expect(connectCalls).toBe(1);
 });

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -1153,10 +1153,10 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
       cacheDirty = true;
     },
     async close() {
-      await closeOperation?.();
       connected = false;
       sessionId = undefined;
       cacheDirty = true;
+      await closeOperation?.();
     },
     async listTools() {
       if (!connected) {
@@ -1181,6 +1181,14 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
       toolsGeneration += 1;
       cacheDirty = true;
       await invalidateServerToolsCache(name);
+    },
+    async callToolResult() {
+      if (!connected) {
+        throw new Error(
+          'Server not initialized. Make sure you call connect() first.',
+        );
+      }
+      return { content: [{ type: 'text', text: 'ok' }] };
     },
   };
   return {
@@ -1423,3 +1431,34 @@ describe.each(wrapperCacheCases)(
     });
   },
 );
+
+it('starts streamable HTTP close before yielding', async () => {
+  const serverName = 'streamable-http-immediate-close';
+  await invalidateServerToolsCache(serverName);
+  const server = new MCPServerStreamableHttp({
+    url: 'http://localhost:1',
+    name: serverName,
+    cacheToolsList: true,
+  });
+  const { stub, setCloseOperation } = createStubUnderlying(serverName, [
+    toolNamed('a'),
+  ]);
+  (server as unknown as { underlying: typeof stub }).underlying = stub;
+  const closeStarted = createDeferredVoid();
+  const resumeClose = createDeferredVoid();
+  setCloseOperation(async () => {
+    closeStarted.resolve();
+    await resumeClose.promise;
+  });
+  await server.connect();
+
+  const closing = server.close();
+  const toolCallExpectation = expect(server.callTool('a', {})).rejects.toThrow(
+    'Server not initialized',
+  );
+  await closeStarted.promise;
+  resumeClose.resolve();
+
+  await closing;
+  await toolCallExpectation;
+});

--- a/packages/agents-core/test/shims/mcp-server/node.test.ts
+++ b/packages/agents-core/test/shims/mcp-server/node.test.ts
@@ -93,6 +93,63 @@ function createDeferred() {
   return { promise, resolve };
 }
 
+async function expectCachedToolsInvalidatedImmediately(server: {
+  connect(): Promise<void>;
+  close(): Promise<void>;
+  listTools(): Promise<Array<{ name: string }>>;
+  invalidateToolsCache(): Promise<void>;
+}): Promise<void> {
+  let currentToolName = 'old-tool';
+  listToolsImplementation = async () => ({
+    tools: [createMockTool(currentToolName)],
+  });
+
+  await server.connect();
+  expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+    'old-tool',
+  ]);
+
+  currentToolName = 'new-tool';
+  const invalidation = server.invalidateToolsCache();
+  const crossingListing = server.listTools();
+  await invalidation;
+
+  expect((await crossingListing).map((tool) => tool.name)).toEqual([
+    'new-tool',
+  ]);
+  expect((await server.listTools()).map((tool) => tool.name)).toEqual([
+    'new-tool',
+  ]);
+  await server.close();
+}
+
+async function expectInvalidationClearsListedToolMetadata(server: {
+  connect(): Promise<void>;
+  close(): Promise<void>;
+  listTools(): Promise<Array<{ name: string }>>;
+  invalidateToolsCache(): Promise<void>;
+  callTool(
+    toolName: string,
+    args: Record<string, unknown> | null,
+  ): Promise<unknown>;
+}): Promise<void> {
+  listToolsImplementation = async () => ({
+    tools: [
+      createMockTool('task-tool', {
+        execution: { taskSupport: 'required' },
+      }),
+    ],
+  });
+
+  await server.connect();
+  await server.listTools();
+  await server.invalidateToolsCache();
+
+  await expect(server.callTool('task-tool', {})).resolves.toBeDefined();
+  expect(lastCallToolOptions?.toolDefinition).toBeUndefined();
+  await server.close();
+}
+
 function getErrorGraphText(value: unknown, seen = new Set<object>()): string {
   if (
     value === null ||
@@ -450,6 +507,26 @@ describe('NodeMCPServerStdio', () => {
     await server.close();
   });
 
+  test('should stop serving cached tools when invalidation starts', async () => {
+    await expectCachedToolsInvalidatedImmediately(
+      new NodeMCPServerStdio({
+        name: 'immediate-stdio-invalidation',
+        fullCommand: 'test',
+        cacheToolsList: true,
+      }),
+    );
+  });
+
+  test('should clear listed tool metadata on invalidation', async () => {
+    await expectInvalidationClearsListedToolMetadata(
+      new NodeMCPServerStdio({
+        name: 'stdio-invalidation-metadata',
+        fullCommand: 'test',
+        cacheToolsList: true,
+      }),
+    );
+  });
+
   test('should reject a tool listing from a replaced session', async () => {
     const continuation = createDeferred();
     const continuationStarted = createDeferred();
@@ -705,6 +782,26 @@ class MockSSEClientTransport {
 }
 
 describe('NodeMCPServerSSE', () => {
+  test('should stop serving cached tools when invalidation starts', async () => {
+    await expectCachedToolsInvalidatedImmediately(
+      new NodeMCPServerSSE({
+        url: 'https://example.com/sse',
+        name: 'immediate-sse-invalidation',
+        cacheToolsList: true,
+      }),
+    );
+  });
+
+  test('should clear listed tool metadata on invalidation', async () => {
+    await expectInvalidationClearsListedToolMetadata(
+      new NodeMCPServerSSE({
+        url: 'https://example.com/sse',
+        name: 'sse-invalidation-metadata',
+        cacheToolsList: true,
+      }),
+    );
+  });
+
   test('should forward custom fetch to SSEClientTransport', async () => {
     const customFetch = vi.fn(async (_input, _init) => {
       return new Response('{}', { status: 200 });
@@ -1236,6 +1333,26 @@ class MockStreamableHTTPClientTransport {
 describe('NodeMCPServerStreamableHttp', () => {
   beforeEach(() => {
     MockStreamableHTTPClientTransport.instances = [];
+  });
+
+  test('should stop serving cached tools when invalidation starts', async () => {
+    await expectCachedToolsInvalidatedImmediately(
+      new NodeMCPServerStreamableHttp({
+        url: 'https://example.com/stream',
+        name: 'immediate-streamable-http-invalidation',
+        cacheToolsList: true,
+      }),
+    );
+  });
+
+  test('should clear listed tool metadata on invalidation', async () => {
+    await expectInvalidationClearsListedToolMetadata(
+      new NodeMCPServerStreamableHttp({
+        url: 'https://example.com/stream',
+        name: 'streamable-http-invalidation-metadata',
+        cacheToolsList: true,
+      }),
+    );
   });
 
   test('should apply session timeout when connecting', async () => {


### PR DESCRIPTION
This pull request fixes stale MCP tool caches across the public wrappers, Node transport shims, and shared `getAllMcpTools()` cache. This PR includes its original https://github.com/openai/openai-agents-js/pull/1498's author credit.

Lifecycle operations now invalidate every cache layer up front and use generation guards so in-flight listings and asynchronous filters cannot repopulate stale entries. It also clears transport tool metadata and adds race-focused coverage for Stdio, SSE, and Streamable HTTP, including reconnects, closes, explicit invalidation, custom cache keys, and session changes.
