### PR TITLE
fix(extensions): align Twilio interruption playback

### DIFF
--- a/.changeset/fix-twilio-playback-ownership.md
+++ b/.changeset/fix-twilio-playback-ownership.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: keep Twilio interruption truncation aligned with item-owned playback

--- a/.changeset/fix-twilio-playback-ownership.md
+++ b/.changeset/fix-twilio-playback-ownership.md
@@ -2,4 +2,4 @@
 '@openai/agents-extensions': patch
 ---
 
-fix: keep Twilio interruption truncation aligned with item-owned playback
+fix: align Twilio playback ownership and recover missing input silence

--- a/examples/realtime-twilio/README.md
+++ b/examples/realtime-twilio/README.md
@@ -13,3 +13,18 @@ Start the server with:
 ```bash
 pnpm -F realtime-twilio start
 ```
+
+For Twilio's standard 8 kHz mono PCMU media format, the transport fills missing inbound media intervals with silence so Realtime voice activity detection can complete a turn even when the phone connection omits silent audio. While speech is active, it waits 750ms for another media message before adding silence. You can tune or disable this fallback when constructing the transport:
+
+```ts
+const transport = new TwilioRealtimeTransportLayer({
+  twilioWebSocket: connection,
+  inputAudioInactivityTimeoutMs: 500, // Set to null to disable the fallback.
+});
+```
+
+To inspect session events, Twilio media timing and levels, response status, and WebSocket closure details without logging raw audio, start the example with diagnostics enabled:
+
+```bash
+DEBUG=diagnostics pnpm -F realtime-twilio start
+```

--- a/examples/realtime-twilio/README.md
+++ b/examples/realtime-twilio/README.md
@@ -1,16 +1,12 @@
 # Realtime Twilio Integration
 
-This example demonstrates how to connect the OpenAI Realtime API to a phone call using Twilio's Media Streams.
-The script in `index.ts` starts a Fastify server that serves TwiML for incoming calls and creates a WebSocket
-endpoint for streaming audio. When a call connects, the audio stream is forwarded through a
-`TwilioRealtimeTransportLayer` to a `RealtimeSession` so the `RealtimeAgent` can respond in real time.
+This example demonstrates how to connect the OpenAI Realtime API to a phone call using Twilio's Media Streams. The script in `index.ts` starts a Fastify server that serves TwiML for incoming calls and creates a WebSocket endpoint for streaming audio. When a call connects, the audio stream is forwarded through a `TwilioRealtimeTransportLayer` to a `RealtimeSession` so the `RealtimeAgent` can respond in real time.
 
-The demo agent mirrors the [realtime-next](../realtime-next) example. It includes the same MCP integrations
-(`dnd` and `deepwiki`) as well as local sample tools for weather lookups and a secret number helper. Ask the
-agent to "look that up in Deep Wiki" or "roll a Dungeons and Dragons character" to try the hosted MCP tools.
+The demo uses a friendly voice assistant with a hosted DeepWiki MCP integration and local sample tools for weather lookups and a secret number helper. Ask the agent to "look that up in DeepWiki" to try the hosted MCP tool.
 
-To try it out you must have a Twilio phone number.
-Expose your localhost with a tunneling service such as ngrok and set the phone number's incoming call URL to `https://<your-tunnel-url>/incoming-call`.
+When a call connects, start speaking after the prompt. To try an interruption, ask the agent for a longer answer and speak while it is responding.
+
+To try it out you must have a Twilio phone number. Expose your localhost with a tunneling service such as ngrok and set the phone number's incoming call URL to `https://<your-tunnel-url>/incoming-call`.
 
 Start the server with:
 

--- a/examples/realtime-twilio/index.ts
+++ b/examples/realtime-twilio/index.ts
@@ -3,12 +3,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import dotenv from 'dotenv';
 import fastifyFormBody from '@fastify/formbody';
 import fastifyWs from '@fastify/websocket';
-import {
-  RealtimeAgent,
-  RealtimeSession,
-  backgroundResult,
-  tool,
-} from '@openai/agents/realtime';
+import { RealtimeAgent, RealtimeSession, tool } from '@openai/agents/realtime';
 import { TwilioRealtimeTransportLayer } from '@openai/agents-extensions';
 import { hostedMcpTool } from '@openai/agents';
 import { z } from 'zod';
@@ -59,7 +54,7 @@ const weatherTool = tool({
     location: z.string(),
   }),
   execute: async ({ location }: { location: string }) => {
-    return backgroundResult(`The weather in ${location} is sunny.`);
+    return `The weather in ${location} is sunny.`;
   },
 });
 

--- a/examples/realtime-twilio/index.ts
+++ b/examples/realtime-twilio/index.ts
@@ -25,6 +25,28 @@ if (!OPENAI_API_KEY) {
 }
 const PORT = +(process.env.PORT || 5050);
 
+const debugRealtimeEventTypes = new Set([
+  'session.created',
+  'session.updated',
+  'input_audio_buffer.speech_started',
+  'input_audio_buffer.speech_stopped',
+  'input_audio_buffer.committed',
+  'conversation.item.input_audio_transcription.completed',
+  'response.created',
+  'response.output_audio.done',
+  'response.done',
+  'error',
+]);
+
+function decodeMuLawSample(value: number): number {
+  const sample = ~value & 0xff;
+  const sign = sample & 0x80;
+  const exponent = (sample >> 4) & 0x07;
+  const mantissa = sample & 0x0f;
+  const magnitude = ((mantissa << 3) + 0x84) * 2 ** exponent - 0x84;
+  return sign === 0 ? magnitude : -magnitude;
+}
+
 // Initialize Fastify
 const fastify = Fastify();
 fastify.register(fastifyFormBody);
@@ -114,6 +136,201 @@ fastify.register(async (scopedFastify: FastifyInstance) => {
           },
         },
       });
+
+      session.on('error', (error: unknown) => {
+        console.error('Realtime session error.', error);
+      });
+
+      if (process.env.DEBUG) {
+        connection.addEventListener('close', (event: any) => {
+          console.log(
+            'Twilio WebSocket closed:',
+            JSON.stringify({
+              code: event.code,
+              reason: event.reason ? String(event.reason) : undefined,
+            }),
+          );
+        });
+        let inputSampleCount = 0;
+        let inputSquareSum = 0;
+        let inputPeak = 0;
+        let mediaFrameCount = 0;
+        let mediaByteCount = 0;
+        let minimumMediaBytes = Number.POSITIVE_INFINITY;
+        let maximumMediaBytes = 0;
+        let previousMediaTimestamp: number | undefined;
+        let previousMediaArrivalTime: number | undefined;
+        let previousMediaChunk: string | undefined;
+        const mediaTracks = new Set<string>();
+
+        session.on(
+          'transport_event',
+          (event: {
+            type: string;
+            message?: {
+              event?: string;
+              start?: {
+                mediaFormat?: {
+                  encoding?: string;
+                  sampleRate?: number;
+                  channels?: number;
+                };
+              };
+              media?: {
+                payload?: string;
+                track?: string;
+                chunk?: string;
+                timestamp?: string;
+              };
+            };
+            session?: {
+              audio?: {
+                input?: {
+                  format?: unknown;
+                  noise_reduction?: unknown;
+                  turn_detection?: unknown;
+                };
+              };
+            };
+            response?: {
+              status?: string;
+              status_details?: unknown;
+            };
+          }) => {
+            if (debugRealtimeEventTypes.has(event.type)) {
+              console.log(`Realtime transport event: ${event.type}`);
+            }
+            if (
+              event.type === 'twilio_message' &&
+              event.message?.event === 'start'
+            ) {
+              console.log(
+                'Twilio media format:',
+                JSON.stringify(event.message.start?.mediaFormat),
+              );
+            }
+            if (
+              event.type === 'twilio_message' &&
+              event.message?.event === 'stop'
+            ) {
+              console.log('Twilio media stream stopped.');
+            }
+            if (
+              event.type === 'twilio_message' &&
+              event.message?.event === 'media' &&
+              typeof event.message.media?.payload === 'string'
+            ) {
+              const payload = event.message.media.payload;
+              const media = event.message.media;
+              const audio = Buffer.from(payload, 'base64');
+              const arrivalTime = Date.now();
+              const mediaTimestamp = Number(media.timestamp);
+              const arrivalGap =
+                previousMediaArrivalTime === undefined
+                  ? undefined
+                  : arrivalTime - previousMediaArrivalTime;
+              const timestampGap =
+                previousMediaTimestamp === undefined ||
+                !Number.isFinite(mediaTimestamp)
+                  ? undefined
+                  : mediaTimestamp - previousMediaTimestamp;
+
+              if (typeof media.track === 'string') {
+                mediaTracks.add(media.track);
+              }
+              mediaFrameCount += 1;
+              mediaByteCount += audio.byteLength;
+              minimumMediaBytes = Math.min(minimumMediaBytes, audio.byteLength);
+              maximumMediaBytes = Math.max(maximumMediaBytes, audio.byteLength);
+
+              if (
+                (arrivalGap !== undefined && arrivalGap > 100) ||
+                (timestampGap !== undefined && timestampGap > 100)
+              ) {
+                console.log(
+                  'Twilio media gap:',
+                  JSON.stringify({
+                    arrivalMs: arrivalGap,
+                    timestampMs: timestampGap,
+                    previousChunk: previousMediaChunk,
+                    chunk: media.chunk,
+                  }),
+                );
+              }
+
+              if (mediaFrameCount % 50 === 0) {
+                console.log(
+                  'Twilio media frames:',
+                  JSON.stringify({
+                    frames: mediaFrameCount,
+                    averageBytes: Math.round(mediaByteCount / mediaFrameCount),
+                    minimumBytes: minimumMediaBytes,
+                    maximumBytes: maximumMediaBytes,
+                    tracks: [...mediaTracks],
+                    latestTimestamp: Number.isFinite(mediaTimestamp)
+                      ? mediaTimestamp
+                      : media.timestamp,
+                  }),
+                );
+              }
+
+              previousMediaArrivalTime = arrivalTime;
+              previousMediaTimestamp = Number.isFinite(mediaTimestamp)
+                ? mediaTimestamp
+                : undefined;
+              previousMediaChunk = media.chunk;
+
+              for (const value of audio) {
+                const sample = decodeMuLawSample(value);
+                inputSampleCount += 1;
+                inputSquareSum += sample * sample;
+                inputPeak = Math.max(inputPeak, Math.abs(sample));
+              }
+              if (inputSampleCount >= 8000) {
+                const rms = Math.sqrt(inputSquareSum / inputSampleCount);
+                const rmsDbfs = rms === 0 ? -96 : 20 * Math.log10(rms / 32768);
+                const peakDbfs =
+                  inputPeak === 0 ? -96 : 20 * Math.log10(inputPeak / 32768);
+                console.log(
+                  `Twilio input level: rms=${rmsDbfs.toFixed(1)} dBFS peak=${peakDbfs.toFixed(1)} dBFS`,
+                );
+                inputSampleCount = 0;
+                inputSquareSum = 0;
+                inputPeak = 0;
+              }
+            }
+            if (event.type === 'session.updated') {
+              const inputAudio = event.session?.audio?.input;
+              console.log(
+                'Realtime input configuration:',
+                JSON.stringify({
+                  format: inputAudio?.format,
+                  noiseReduction: inputAudio?.noise_reduction,
+                  turnDetection: inputAudio?.turn_detection,
+                }),
+              );
+            }
+            if (event.type === 'response.done') {
+              console.log(
+                'Realtime response completed:',
+                JSON.stringify({
+                  status: event.response?.status,
+                  statusDetails: event.response?.status_details,
+                }),
+              );
+            }
+          },
+        );
+        session.on('audio_start', () => {
+          console.log('Realtime audio started.');
+        });
+        session.on('audio_stopped', () => {
+          console.log('Realtime audio stopped.');
+        });
+        session.on('audio_interrupted', () => {
+          console.log('Realtime audio interrupted.');
+        });
+      }
 
       session.on('mcp_tools_changed', (tools: { name: string }[]) => {
         const toolNames = tools.map((tool) => tool.name).join(', ');

--- a/examples/realtime-twilio/index.ts
+++ b/examples/realtime-twilio/index.ts
@@ -58,9 +58,9 @@ const secretTool = tool({
 });
 
 const agent = new RealtimeAgent({
-  name: 'Greeter',
+  name: 'Voice Assistant',
   instructions:
-    'You are a friendly assistant. When you use a tool always first say what you are about to do.',
+    'You are a friendly voice assistant. Respond naturally and concisely. When you use a tool, always first say what you are about to do.',
   tools: [
     hostedMcpTool({
       serverLabel: 'deepwiki',

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -21,6 +21,26 @@ type LegacyRealtimeAudioConfig = Partial<RealtimeSessionConfig> & {
   outputAudioFormat?: 'pcm16' | 'g711_ulaw' | 'g711_alaw';
 };
 
+type TwilioPlaybackItem = {
+  itemId: string;
+  contentIndex: number;
+  sentDurationMs: number;
+  playedDurationMs: number;
+  doneMarkSent: boolean;
+};
+
+type TwilioPlaybackMark = {
+  item: TwilioPlaybackItem;
+  audioEndMs: number;
+  kind: 'audio' | 'done';
+};
+
+type TwilioTruncationSnapshot = {
+  itemId: string;
+  contentIndex: number;
+  audioEndMs: number;
+};
+
 function withTwilioLegacyAudioDefaults(
   config: LegacyRealtimeAudioConfig = {},
 ): Partial<RealtimeSessionConfig> {
@@ -72,14 +92,19 @@ export type TwilioRealtimeTransportLayerOptions =
 export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #twilioWebSocket: WebSocket | NodeWebSocket;
   #streamSid: string | null = null;
-  #audioChunkCount: number = 0;
-  #lastPlayedChunkCount: number = 0;
-  #previousItemId: string | null = null;
+  #playbackGeneration: number = 0;
+  #markSequence: number = 0;
+  #playbackItems: TwilioPlaybackItem[] = [];
+  #pendingMarks = new Map<string, TwilioPlaybackMark>();
+  #clearedMarkNames = new Set<string>();
+  #discardedItemIds = new Set<string>();
+  #nextAudioMetadata: { itemId: string; contentIndex: number } | null = null;
   #logger = getLogger('openai-agents:extensions:twilio');
 
   constructor(options: TwilioRealtimeTransportLayerOptions) {
     super(options);
     this.#twilioWebSocket = options.twilioWebSocket;
+    this.#registerEventListeners();
   }
 
   _setInputAndOutputAudioFormat(
@@ -116,7 +141,10 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     options.initialSessionConfig = this._setInputAndOutputAudioFormat(
       options.initialSessionConfig,
     );
-    // listen to Twilio messages as quickly as possible
+    await super.connect(options);
+  }
+
+  #registerEventListeners() {
     this.#twilioWebSocket.addEventListener(
       'message',
       (message: MessageEvent | NodeMessageEvent) => {
@@ -140,32 +168,11 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
               }
               break;
             case 'mark':
-              if (
-                !data.mark.name.startsWith('done:') &&
-                data.mark.name.includes(':')
-              ) {
-                // keeping track of what the last chunk was that the user heard fully
-                const count = Number(data.mark.name.split(':')[1]);
-                if (Number.isFinite(count)) {
-                  this.#lastPlayedChunkCount = count;
-                } else {
-                  if (this.#logger.dontLogModelData) {
-                    this.#logger.warn(
-                      'Invalid mark name received. Mark data is redacted.',
-                    );
-                  } else {
-                    this.#logger.warn(
-                      'Invalid mark name received:',
-                      data.mark.name,
-                    );
-                  }
-                }
-              } else if (data.mark.name.startsWith('done:')) {
-                this.#lastPlayedChunkCount = 0;
-              }
+              this.#handleTwilioMark(data.mark?.name);
               break;
             case 'start':
               this.#streamSid = data.start.streamSid;
+              this.#startPlaybackGeneration();
               break;
             default:
               break;
@@ -200,18 +207,15 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
         this.close();
       },
     );
-    this.on('audio_done', () => {
-      this.#twilioWebSocket.send(
-        JSON.stringify({
-          event: 'mark',
-          mark: {
-            name: `done:${this.currentItemId}`,
-          },
-          streamSid: this.#streamSid,
-        }),
-      );
+    this.on('response.output_audio.done', (event) => {
+      this.#sendDoneMark(event.item_id, event.content_index);
     });
-    await super.connect(options);
+    this.on('response.output_audio.delta', (event) => {
+      this.#nextAudioMetadata = {
+        itemId: event.item_id,
+        contentIndex: event.content_index,
+      };
+    });
   }
 
   updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
@@ -219,24 +223,231 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     super.updateSessionConfig(newConfig);
   }
 
-  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
-    const elapsedTime = this.#lastPlayedChunkCount + 50; /* 50ms buffer */
-    this.#logger.debug(
-      `Interruption detected, clearing Twilio audio and truncating OpenAI audio after ${elapsedTime}ms`,
+  protected override _onClose() {
+    this.#clearPlaybackGeneration();
+    this.#discardedItemIds.clear();
+    super._onClose();
+  }
+
+  #startPlaybackGeneration() {
+    this.#playbackGeneration += 1;
+    this.#markSequence = 0;
+    this.#playbackItems = [];
+    this.#pendingMarks.clear();
+    this.#clearedMarkNames.clear();
+    this.#discardedItemIds.clear();
+    this.#nextAudioMetadata = null;
+  }
+
+  #clearPlaybackGeneration() {
+    this.#playbackGeneration += 1;
+    for (const markName of this.#pendingMarks.keys()) {
+      this.#clearedMarkNames.add(markName);
+    }
+    this.#playbackItems = [];
+    this.#pendingMarks.clear();
+    this.#nextAudioMetadata = null;
+  }
+
+  #findPlaybackItem(itemId: string, contentIndex: number) {
+    return this.#playbackItems.find(
+      (item) => item.itemId === itemId && item.contentIndex === contentIndex,
     );
+  }
+
+  #getOrCreatePlaybackItem(itemId: string, contentIndex: number) {
+    const existing = this.#findPlaybackItem(itemId, contentIndex);
+    if (existing) {
+      return existing;
+    }
+
+    const item: TwilioPlaybackItem = {
+      itemId,
+      contentIndex,
+      sentDurationMs: 0,
+      playedDurationMs: 0,
+      doneMarkSent: false,
+    };
+    this.#playbackItems.push(item);
+    return item;
+  }
+
+  #createMarkName(item: TwilioPlaybackItem, kind: 'audio' | 'done') {
+    this.#markSequence += 1;
+    const suffix = `g${this.#playbackGeneration}:m${this.#markSequence}`;
+    if (kind === 'done') {
+      return `done:${item.itemId}:${suffix}`;
+    }
+    return `${item.itemId}:${Math.floor(item.sentDurationMs)}:${suffix}`;
+  }
+
+  #sendMark(item: TwilioPlaybackItem, kind: 'audio' | 'done') {
+    if (this.#streamSid == null) {
+      return;
+    }
+
+    const name = this.#createMarkName(item, kind);
+    this.#pendingMarks.set(name, {
+      item,
+      audioEndMs: item.sentDurationMs,
+      kind,
+    });
+    this.#twilioWebSocket.send(
+      JSON.stringify({
+        event: 'mark',
+        streamSid: this.#streamSid,
+        mark: { name },
+      }),
+    );
+  }
+
+  #sendDoneMark(itemId: string, contentIndex: number) {
+    const item = this.#findPlaybackItem(itemId, contentIndex);
+    if (!item || item.doneMarkSent) {
+      return;
+    }
+    item.doneMarkSent = true;
+    this.#sendMark(item, 'done');
+  }
+
+  #warnUnknownMark(markName: unknown) {
+    if (this.#logger.dontLogModelData) {
+      this.#logger.warn('Invalid mark name received. Mark data is redacted.');
+    } else {
+      this.#logger.warn('Invalid mark name received:', markName);
+    }
+  }
+
+  #handleTwilioMark(markName: unknown) {
+    if (typeof markName !== 'string') {
+      this.#warnUnknownMark(markName);
+      return;
+    }
+    if (this.#clearedMarkNames.delete(markName)) {
+      return;
+    }
+
+    const mark = this.#pendingMarks.get(markName);
+    if (!mark) {
+      this.#warnUnknownMark(markName);
+      return;
+    }
+    this.#pendingMarks.delete(markName);
+    if (!this.#playbackItems.includes(mark.item)) {
+      return;
+    }
+    if (mark.kind === 'audio') {
+      mark.item.playedDurationMs = Math.max(
+        mark.item.playedDurationMs,
+        mark.audioEndMs,
+      );
+      return;
+    }
+
+    this.#playbackItems = this.#playbackItems.filter(
+      (candidate) => candidate !== mark.item,
+    );
+  }
+
+  #createTruncationSnapshots(): TwilioTruncationSnapshot[] {
+    return this.#playbackItems.map((item, index) => {
+      const audioEndMs =
+        index === 0 || item.playedDurationMs > 0
+          ? Math.min(item.sentDurationMs, item.playedDurationMs + 50)
+          : 0;
+      return {
+        itemId: item.itemId,
+        contentIndex: item.contentIndex,
+        audioEndMs: Math.max(0, Math.floor(audioEndMs)),
+      };
+    });
+  }
+
+  #clearTwilioAudio() {
+    if (this.#streamSid == null) {
+      this.#logger.debug('Skipping Twilio clear before streamSid is set.');
+      return;
+    }
+    this.#logger.debug('Clearing Twilio audio.');
     this.#twilioWebSocket.send(
       JSON.stringify({
         event: 'clear',
         streamSid: this.#streamSid,
       }),
     );
-    super._interrupt(elapsedTime, cancelOngoingResponse);
+  }
+
+  #interruptPlayback(cancelOngoingResponse: boolean) {
+    if (this.status !== 'connected') {
+      return;
+    }
+    const truncations = this.#createTruncationSnapshots();
+    for (const item of this.#playbackItems) {
+      this.#discardedItemIds.add(item.itemId);
+    }
+    this.#clearPlaybackGeneration();
+
+    try {
+      this.#clearTwilioAudio();
+      if (cancelOngoingResponse) {
+        this._cancelResponse();
+      }
+      if (truncations.length === 0) {
+        return;
+      }
+
+      this.emit('audio_interrupted');
+      for (const truncation of truncations) {
+        if (this.#logger.dontLogModelData) {
+          this.#logger.debug('Truncating OpenAI item. Item data is redacted.');
+        } else {
+          this.#logger.debug(
+            `Truncating OpenAI item ${truncation.itemId} after ${truncation.audioEndMs}ms.`,
+          );
+        }
+        this.sendEvent({
+          type: 'conversation.item.truncate',
+          item_id: truncation.itemId,
+          content_index: truncation.contentIndex,
+          audio_end_ms: truncation.audioEndMs,
+        });
+      }
+    } finally {
+      super._afterAudioDoneEvent();
+    }
+  }
+
+  interrupt(cancelOngoingResponse: boolean = true) {
+    this.#interruptPlayback(cancelOngoingResponse);
+  }
+
+  _interrupt(_elapsedTime: number, cancelOngoingResponse: boolean = true) {
+    this.#interruptPlayback(cancelOngoingResponse);
   }
 
   protected _onAudio(audioEvent: TransportLayerAudio) {
     this.#logger.debug(
       `Sending audio to Twilio ${audioEvent.responseId}: (${audioEvent.data.byteLength} bytes)`,
     );
+    const itemId = this.currentItemId;
+    if (itemId == null) {
+      this.#logger.warn('Skipping Twilio audio without an item ID.');
+      this.emit('audio', audioEvent);
+      return;
+    }
+    if (this.#discardedItemIds.has(itemId)) {
+      this.emit('audio', audioEvent);
+      return;
+    }
+
+    const contentIndex =
+      this.#nextAudioMetadata?.itemId === itemId
+        ? this.#nextAudioMetadata.contentIndex
+        : 0;
+    this.#nextAudioMetadata = null;
+    const item = this.#getOrCreatePlaybackItem(itemId, contentIndex);
+    item.sentDurationMs += audioEvent.data.byteLength / 8;
+
     const audioDelta = {
       event: 'media',
       streamSid: this.#streamSid,
@@ -244,21 +455,8 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
         payload: utils.arrayBufferToBase64(audioEvent.data),
       },
     };
-    if (this.#previousItemId !== this.currentItemId && this.currentItemId) {
-      this.#previousItemId = this.currentItemId;
-      this.#audioChunkCount = 0;
-    }
-    this.#audioChunkCount += audioEvent.data.byteLength / 8;
     this.#twilioWebSocket.send(JSON.stringify(audioDelta));
-    this.#twilioWebSocket.send(
-      JSON.stringify({
-        event: 'mark',
-        streamSid: this.#streamSid,
-        mark: {
-          name: `${this.currentItemId}:${this.#audioChunkCount}`,
-        },
-      }),
-    );
+    this.#sendMark(item, 'audio');
     this.emit('audio', audioEvent);
   }
 }

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -42,6 +42,21 @@ type TwilioTruncationSnapshot = {
   audioEndMs: number;
 };
 
+const TWILIO_MULAW_BYTES_PER_MILLISECOND = 8;
+const TWILIO_MULAW_SILENCE_BYTE = 0xff;
+const MAX_TWILIO_SILENCE_PADDING_MS = 10_000;
+const DEFAULT_TWILIO_INPUT_INACTIVITY_TIMEOUT_MS = 750;
+const TWILIO_INPUT_INACTIVITY_SILENCE_MS = 1_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function parseTwilioMediaTimestamp(value: unknown): number | null {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    return null;
+  }
+  const timestamp = Number(value);
+  return Number.isSafeInteger(timestamp) ? timestamp : null;
+}
+
 function withTwilioLegacyAudioDefaults(
   config: LegacyRealtimeAudioConfig = {},
 ): Partial<RealtimeSessionConfig> {
@@ -62,6 +77,12 @@ export type TwilioRealtimeTransportLayerOptions =
      * connection gets passed into your request handler when running your WebSocket server.
      */
     twilioWebSocket: WebSocket | NodeWebSocket;
+    /**
+     * How long to wait for more Twilio input media while speech is active before padding the
+     * missing input with silence. Defaults to 750ms. The maximum supported value is 2,147,483,647ms.
+     * Set to `null` to disable inactivity padding.
+     */
+    inputAudioInactivityTimeoutMs?: number | null;
   };
 
 /**
@@ -100,6 +121,13 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #clearedMarkNames = new Set<string>();
   #activeResponseId: string | null = null;
   #discardedResponseIds = new Set<string>();
+  #nextInputTimestampMs: number | null = null;
+  #lastInputMediaAtMs: number | null = null;
+  #inputSpeechActive = false;
+  #inputGapAlreadyPadded = false;
+  #canPadInputAudio = false;
+  #inputInactivityTimer: ReturnType<typeof setTimeout> | null = null;
+  #inputAudioInactivityTimeoutMs: number | null;
   #nextAudioMetadata: {
     responseId: string;
     itemId: string;
@@ -109,6 +137,21 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
 
   constructor(options: TwilioRealtimeTransportLayerOptions) {
     super(options);
+    const inputAudioInactivityTimeoutMs =
+      options.inputAudioInactivityTimeoutMs === undefined
+        ? DEFAULT_TWILIO_INPUT_INACTIVITY_TIMEOUT_MS
+        : options.inputAudioInactivityTimeoutMs;
+    if (
+      inputAudioInactivityTimeoutMs !== null &&
+      (!Number.isFinite(inputAudioInactivityTimeoutMs) ||
+        inputAudioInactivityTimeoutMs <= 0 ||
+        inputAudioInactivityTimeoutMs > MAX_TIMER_DELAY_MS)
+    ) {
+      throw new RangeError(
+        `inputAudioInactivityTimeoutMs must be a positive finite number no greater than ${MAX_TIMER_DELAY_MS}, or null.`,
+      );
+    }
+    this.#inputAudioInactivityTimeoutMs = inputAudioInactivityTimeoutMs;
     this.#twilioWebSocket = options.twilioWebSocket;
     this.#registerEventListeners();
   }
@@ -144,6 +187,9 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   }
 
   async connect(options: RealtimeTransportLayerConnectOptions) {
+    if (this.status === 'disconnected') {
+      this.#resetInputTiming();
+    }
     options.initialSessionConfig = this._setInputAndOutputAudioFormat(
       options.initialSessionConfig,
     );
@@ -170,7 +216,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
           switch (data.event) {
             case 'media':
               if (this.status === 'connected') {
-                this.sendAudio(utils.base64ToArrayBuffer(data.media.payload));
+                this.#sendTwilioAudio(data.media);
               }
               break;
             case 'mark':
@@ -178,6 +224,11 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
               break;
             case 'start':
               this.#streamSid = data.start.streamSid;
+              this.#resetInputTiming();
+              this.#canPadInputAudio =
+                data.start.mediaFormat?.encoding === 'audio/x-mulaw' &&
+                data.start.mediaFormat?.sampleRate === 8_000 &&
+                data.start.mediaFormat?.channels === 1;
               this.#startPlaybackGeneration();
               break;
             default:
@@ -199,6 +250,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
       },
     );
     this.#twilioWebSocket.addEventListener('close', () => {
+      this.#resetTwilioStream();
       if (this.status !== 'disconnected') {
         this.close();
       }
@@ -206,6 +258,7 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     this.#twilioWebSocket.addEventListener(
       'error',
       (error: ErrorEvent | NodeErrorEvent) => {
+        this.#resetTwilioStream();
         this.emit('error', {
           type: 'error',
           error,
@@ -238,6 +291,14 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
         this.#activeResponseId = null;
       }
     });
+    this.on('input_audio_buffer.speech_started', () => {
+      this.#inputSpeechActive = true;
+      this.#scheduleInputInactivityPadding();
+    });
+    this.on('input_audio_buffer.speech_stopped', () => {
+      this.#inputSpeechActive = false;
+      this.#clearInputInactivityTimer();
+    });
   }
 
   updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
@@ -249,7 +310,109 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     this.#clearPlaybackGeneration();
     this.#activeResponseId = null;
     this.#discardedResponseIds.clear();
+    this.#resetInputTiming();
     super._onClose();
+  }
+
+  #sendTwilioAudio(media: { payload: string; timestamp?: unknown }) {
+    this.#clearInputInactivityTimer();
+    const audio = utils.base64ToArrayBuffer(media.payload);
+    const timestamp = this.#canPadInputAudio
+      ? parseTwilioMediaTimestamp(media.timestamp)
+      : null;
+    if (!this.#canPadInputAudio || timestamp === null) {
+      this.#nextInputTimestampMs = null;
+    } else if (
+      this.#nextInputTimestampMs !== null &&
+      timestamp < this.#nextInputTimestampMs
+    ) {
+      this.#nextInputTimestampMs = null;
+    } else {
+      if (
+        !this.#inputGapAlreadyPadded &&
+        this.#nextInputTimestampMs !== null &&
+        timestamp > this.#nextInputTimestampMs
+      ) {
+        const missingDurationMs = Math.floor(
+          timestamp - this.#nextInputTimestampMs,
+        );
+        const paddingDurationMs = Math.min(
+          missingDurationMs,
+          MAX_TWILIO_SILENCE_PADDING_MS,
+        );
+        this.#logger.debug(
+          `Padding ${paddingDurationMs}ms of missing Twilio input audio with silence.`,
+        );
+        this.#sendInputSilence(paddingDurationMs);
+      }
+      this.#nextInputTimestampMs =
+        timestamp + audio.byteLength / TWILIO_MULAW_BYTES_PER_MILLISECOND;
+    }
+    this.#inputGapAlreadyPadded = false;
+    this.sendAudio(audio);
+    this.#lastInputMediaAtMs = Date.now();
+    this.#scheduleInputInactivityPadding();
+  }
+
+  #sendInputSilence(durationMs: number) {
+    const silence = new Uint8Array(
+      durationMs * TWILIO_MULAW_BYTES_PER_MILLISECOND,
+    );
+    silence.fill(TWILIO_MULAW_SILENCE_BYTE);
+    this.sendAudio(silence.buffer);
+  }
+
+  #scheduleInputInactivityPadding() {
+    this.#clearInputInactivityTimer();
+    if (
+      this.#inputAudioInactivityTimeoutMs === null ||
+      !this.#canPadInputAudio ||
+      !this.#inputSpeechActive ||
+      this.#lastInputMediaAtMs === null
+    ) {
+      return;
+    }
+    const delayMs = Math.max(
+      0,
+      this.#inputAudioInactivityTimeoutMs -
+        (Date.now() - this.#lastInputMediaAtMs),
+    );
+    const timer = setTimeout(() => {
+      if (this.#inputInactivityTimer !== timer) {
+        return;
+      }
+      this.#inputInactivityTimer = null;
+      if (this.status !== 'connected' || !this.#inputSpeechActive) {
+        return;
+      }
+      this.#logger.debug(
+        `Padding ${TWILIO_INPUT_INACTIVITY_SILENCE_MS}ms of inactive Twilio input audio with silence.`,
+      );
+      this.#sendInputSilence(TWILIO_INPUT_INACTIVITY_SILENCE_MS);
+      this.#inputGapAlreadyPadded = true;
+    }, delayMs);
+    this.#inputInactivityTimer = timer;
+    (timer as { unref?: () => void }).unref?.();
+  }
+
+  #clearInputInactivityTimer() {
+    if (this.#inputInactivityTimer !== null) {
+      clearTimeout(this.#inputInactivityTimer);
+      this.#inputInactivityTimer = null;
+    }
+  }
+
+  #resetInputTiming() {
+    this.#clearInputInactivityTimer();
+    this.#nextInputTimestampMs = null;
+    this.#lastInputMediaAtMs = null;
+    this.#inputSpeechActive = false;
+    this.#inputGapAlreadyPadded = false;
+  }
+
+  #resetTwilioStream() {
+    this.#resetInputTiming();
+    this.#canPadInputAudio = false;
   }
 
   #startPlaybackGeneration() {
@@ -411,9 +574,14 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     if (this.status !== 'connected') {
       return;
     }
+    if (this.#activeResponseId === null && this.#playbackItems.length === 0) {
+      return;
+    }
+    const activeResponseId = this.#activeResponseId;
+    this.#activeResponseId = null;
     const truncations = this.#createTruncationSnapshots();
-    if (this.#activeResponseId !== null) {
-      this.#discardedResponseIds.add(this.#activeResponseId);
+    if (activeResponseId !== null) {
+      this.#discardedResponseIds.add(activeResponseId);
     }
     for (const item of this.#playbackItems) {
       this.#discardedResponseIds.add(item.responseId);

--- a/packages/agents-extensions/src/TwilioRealtimeTransport.ts
+++ b/packages/agents-extensions/src/TwilioRealtimeTransport.ts
@@ -22,6 +22,7 @@ type LegacyRealtimeAudioConfig = Partial<RealtimeSessionConfig> & {
 };
 
 type TwilioPlaybackItem = {
+  responseId: string;
   itemId: string;
   contentIndex: number;
   sentDurationMs: number;
@@ -97,8 +98,13 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
   #playbackItems: TwilioPlaybackItem[] = [];
   #pendingMarks = new Map<string, TwilioPlaybackMark>();
   #clearedMarkNames = new Set<string>();
-  #discardedItemIds = new Set<string>();
-  #nextAudioMetadata: { itemId: string; contentIndex: number } | null = null;
+  #activeResponseId: string | null = null;
+  #discardedResponseIds = new Set<string>();
+  #nextAudioMetadata: {
+    responseId: string;
+    itemId: string;
+    contentIndex: number;
+  } | null = null;
   #logger = getLogger('openai-agents:extensions:twilio');
 
   constructor(options: TwilioRealtimeTransportLayerOptions) {
@@ -208,13 +214,29 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
       },
     );
     this.on('response.output_audio.done', (event) => {
-      this.#sendDoneMark(event.item_id, event.content_index);
+      this.#sendDoneMark(event.response_id, event.item_id, event.content_index);
     });
     this.on('response.output_audio.delta', (event) => {
       this.#nextAudioMetadata = {
+        responseId: event.response_id,
         itemId: event.item_id,
         contentIndex: event.content_index,
       };
+    });
+    this.on('response.created', (event) => {
+      if (typeof event.response.id === 'string') {
+        this.#activeResponseId = event.response.id;
+      }
+    });
+    this.on('response.done', (event) => {
+      const responseId = event.response.id;
+      if (typeof responseId !== 'string') {
+        return;
+      }
+      this.#discardedResponseIds.delete(responseId);
+      if (this.#activeResponseId === responseId) {
+        this.#activeResponseId = null;
+      }
     });
   }
 
@@ -225,7 +247,8 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
 
   protected override _onClose() {
     this.#clearPlaybackGeneration();
-    this.#discardedItemIds.clear();
+    this.#activeResponseId = null;
+    this.#discardedResponseIds.clear();
     super._onClose();
   }
 
@@ -235,7 +258,6 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     this.#playbackItems = [];
     this.#pendingMarks.clear();
     this.#clearedMarkNames.clear();
-    this.#discardedItemIds.clear();
     this.#nextAudioMetadata = null;
   }
 
@@ -249,19 +271,27 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     this.#nextAudioMetadata = null;
   }
 
-  #findPlaybackItem(itemId: string, contentIndex: number) {
+  #findPlaybackItem(responseId: string, itemId: string, contentIndex: number) {
     return this.#playbackItems.find(
-      (item) => item.itemId === itemId && item.contentIndex === contentIndex,
+      (item) =>
+        item.responseId === responseId &&
+        item.itemId === itemId &&
+        item.contentIndex === contentIndex,
     );
   }
 
-  #getOrCreatePlaybackItem(itemId: string, contentIndex: number) {
-    const existing = this.#findPlaybackItem(itemId, contentIndex);
+  #getOrCreatePlaybackItem(
+    responseId: string,
+    itemId: string,
+    contentIndex: number,
+  ) {
+    const existing = this.#findPlaybackItem(responseId, itemId, contentIndex);
     if (existing) {
       return existing;
     }
 
     const item: TwilioPlaybackItem = {
+      responseId,
       itemId,
       contentIndex,
       sentDurationMs: 0,
@@ -301,8 +331,8 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     );
   }
 
-  #sendDoneMark(itemId: string, contentIndex: number) {
-    const item = this.#findPlaybackItem(itemId, contentIndex);
+  #sendDoneMark(responseId: string, itemId: string, contentIndex: number) {
+    const item = this.#findPlaybackItem(responseId, itemId, contentIndex);
     if (!item || item.doneMarkSent) {
       return;
     }
@@ -382,8 +412,11 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
       return;
     }
     const truncations = this.#createTruncationSnapshots();
+    if (this.#activeResponseId !== null) {
+      this.#discardedResponseIds.add(this.#activeResponseId);
+    }
     for (const item of this.#playbackItems) {
-      this.#discardedItemIds.add(item.itemId);
+      this.#discardedResponseIds.add(item.responseId);
     }
     this.#clearPlaybackGeneration();
 
@@ -429,23 +462,28 @@ export class TwilioRealtimeTransportLayer extends OpenAIRealtimeWebSocket {
     this.#logger.debug(
       `Sending audio to Twilio ${audioEvent.responseId}: (${audioEvent.data.byteLength} bytes)`,
     );
+    const metadata = this.#nextAudioMetadata;
+    this.#nextAudioMetadata = null;
+    if (this.#discardedResponseIds.has(audioEvent.responseId)) {
+      return;
+    }
+
     const itemId = this.currentItemId;
     if (itemId == null) {
       this.#logger.warn('Skipping Twilio audio without an item ID.');
       this.emit('audio', audioEvent);
       return;
     }
-    if (this.#discardedItemIds.has(itemId)) {
-      this.emit('audio', audioEvent);
-      return;
-    }
-
     const contentIndex =
-      this.#nextAudioMetadata?.itemId === itemId
-        ? this.#nextAudioMetadata.contentIndex
+      metadata?.responseId === audioEvent.responseId &&
+      metadata.itemId === itemId
+        ? metadata.contentIndex
         : 0;
-    this.#nextAudioMetadata = null;
-    const item = this.#getOrCreatePlaybackItem(itemId, contentIndex);
+    const item = this.#getOrCreatePlaybackItem(
+      audioEvent.responseId,
+      itemId,
+      contentIndex,
+    );
     item.sentDurationMs += audioEvent.data.byteLength / 8;
 
     const audioDelta = {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.interruption.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.interruption.test.ts
@@ -91,6 +91,14 @@ function emitOpenAIEvent(event: unknown) {
   openAIWebSocket?.emit('message', { data: JSON.stringify(event) });
 }
 
+function emitResponseCreated(responseId: string) {
+  emitOpenAIEvent({
+    type: 'response.created',
+    event_id: `created-${responseId}`,
+    response: { id: responseId, status: 'in_progress' },
+  });
+}
+
 function emitAudioDelta(
   itemId: string,
   responseId: string,
@@ -250,12 +258,40 @@ describe('TwilioRealtimeTransportLayer interruption ownership', () => {
     });
   });
 
-  test('does not forward late audio for an interrupted item', async () => {
+  test('does not emit or forward late audio for an interrupted item', async () => {
     const { transport, twilio } = await createConnectedTransport();
     const audioListener = vi.fn();
     transport.on('audio', audioListener);
 
+    emitResponseCreated('response-a');
     emitAudioDelta('item-a', 'response-a');
+    transport.interrupt(false);
+    const mediaCountAfterInterrupt = payloads(twilio.sent).filter(
+      (payload) => payload.event === 'media',
+    ).length;
+    emitAudioDelta('item-a', 'response-a');
+    emitAudioDelta('item-b', 'response-a');
+    emitTwilioMessage(twilio, {
+      event: 'start',
+      start: { streamSid: 'stream-2' },
+    });
+    emitAudioDelta('item-c', 'response-a');
+
+    emitResponseCreated('response-b');
+    emitAudioDelta('item-d', 'response-b');
+
+    expect(
+      payloads(twilio.sent).filter((payload) => payload.event === 'media'),
+    ).toHaveLength(mediaCountAfterInterrupt + 1);
+    expect(audioListener).toHaveBeenCalledTimes(2);
+  });
+
+  test('drops an interrupted response before its first audio delta', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+    const audioListener = vi.fn();
+    transport.on('audio', audioListener);
+
+    emitResponseCreated('response-a');
     transport.interrupt(false);
     const mediaCountAfterInterrupt = payloads(twilio.sent).filter(
       (payload) => payload.event === 'media',
@@ -265,7 +301,7 @@ describe('TwilioRealtimeTransportLayer interruption ownership', () => {
     expect(
       payloads(twilio.sent).filter((payload) => payload.event === 'media'),
     ).toHaveLength(mediaCountAfterInterrupt);
-    expect(audioListener).toHaveBeenCalledTimes(2);
+    expect(audioListener).not.toHaveBeenCalled();
   });
 
   test('invalidates playback ownership when locally closed', async () => {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.interruption.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.interruption.test.ts
@@ -1,0 +1,419 @@
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type {
+  MessageEvent as NodeMessageEvent,
+  WebSocket as NodeWebSocket,
+} from 'ws';
+import type { MessageEvent } from 'undici-types';
+
+let openAIWebSocket: any;
+
+function setOpenAIWebSocket(socket: any) {
+  openAIWebSocket = socket;
+}
+
+vi.mock('ws', () => ({
+  WebSocket: class {
+    listeners: Record<string, ((event: any) => void)[]> = {};
+    sent: string[] = [];
+
+    constructor(_url: string, _options?: unknown) {
+      setOpenAIWebSocket(this);
+      setTimeout(() => this.emit('open', {}));
+    }
+
+    addEventListener(type: string, listener: (event: any) => void) {
+      this.listeners[type] = this.listeners[type] ?? [];
+      this.listeners[type].push(listener);
+    }
+
+    send(data: string) {
+      this.sent.push(data);
+    }
+
+    close() {
+      this.emit('close', {});
+    }
+
+    emit(type: string, event: any) {
+      for (const listener of this.listeners[type] ?? []) {
+        listener(event);
+      }
+    }
+  },
+}));
+
+import { TwilioRealtimeTransportLayer } from '../src/TwilioRealtimeTransport';
+
+class FakeTwilioWebSocket extends EventEmitter {
+  sent: string[] = [];
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  addEventListener(
+    type: string,
+    listener: (event: MessageEvent | NodeMessageEvent) => void,
+  ) {
+    this.on(type, (event) =>
+      listener(type === 'message' ? ({ data: event } as any) : event),
+    );
+  }
+}
+
+const asTwilioWebSocket = (
+  socket: FakeTwilioWebSocket,
+): WebSocket | NodeWebSocket => socket as unknown as WebSocket | NodeWebSocket;
+
+function payloads(sent: string[]) {
+  return sent.map((payload) => JSON.parse(payload));
+}
+
+function twilioMarks(twilio: FakeTwilioWebSocket) {
+  return payloads(twilio.sent).filter((payload) => payload.event === 'mark');
+}
+
+function openAIEvents() {
+  return payloads(openAIWebSocket?.sent ?? []);
+}
+
+function emitTwilioMessage(twilio: FakeTwilioWebSocket, message: unknown) {
+  twilio.emit('message', JSON.stringify(message));
+}
+
+function returnTwilioMark(twilio: FakeTwilioWebSocket, name: string) {
+  emitTwilioMessage(twilio, { event: 'mark', mark: { name } });
+}
+
+function emitOpenAIEvent(event: unknown) {
+  openAIWebSocket?.emit('message', { data: JSON.stringify(event) });
+}
+
+function emitAudioDelta(
+  itemId: string,
+  responseId: string,
+  byteLength: number = 800,
+  contentIndex: number = 0,
+) {
+  emitOpenAIEvent({
+    type: 'response.output_audio.delta',
+    event_id: `delta-${itemId}-${Math.random()}`,
+    item_id: itemId,
+    content_index: contentIndex,
+    output_index: 0,
+    response_id: responseId,
+    delta: Buffer.alloc(byteLength).toString('base64'),
+  });
+}
+
+function emitAudioDone(
+  itemId: string,
+  responseId: string,
+  contentIndex: number = 0,
+) {
+  emitOpenAIEvent({
+    type: 'response.output_audio.done',
+    event_id: `done-${itemId}`,
+    item_id: itemId,
+    content_index: contentIndex,
+    output_index: 0,
+    response_id: responseId,
+  });
+}
+
+async function createConnectedTransport() {
+  const twilio = new FakeTwilioWebSocket();
+  const transport = new TwilioRealtimeTransportLayer({
+    twilioWebSocket: asTwilioWebSocket(twilio),
+  });
+  const connecting = transport.connect({ apiKey: 'ek_test', model: 'test' });
+  await vi.runAllTimersAsync();
+  await connecting;
+  emitTwilioMessage(twilio, {
+    event: 'start',
+    start: { streamSid: 'stream-1' },
+  });
+  return { transport, twilio };
+}
+
+describe('TwilioRealtimeTransportLayer interruption ownership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    openAIWebSocket = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  test('truncates one item at its last acknowledged playback position', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a');
+    const playedMark = twilioMarks(twilio).at(-1).mark.name;
+    returnTwilioMark(twilio, playedMark);
+    emitAudioDelta('item-a', 'response-a');
+    emitAudioDone('item-a', 'response-a');
+
+    transport.interrupt(false);
+
+    expect(openAIEvents()).toContainEqual({
+      type: 'conversation.item.truncate',
+      item_id: 'item-a',
+      content_index: 0,
+      audio_end_ms: 150,
+    });
+    expect(payloads(twilio.sent)).toContainEqual({
+      event: 'clear',
+      streamSid: 'stream-1',
+    });
+  });
+
+  test('clamps and floors a fully acknowledged fractional duration', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a', 161);
+    const playedMark = twilioMarks(twilio).at(-1).mark.name;
+    returnTwilioMark(twilio, playedMark);
+
+    transport.interrupt(false);
+
+    const truncation = openAIEvents().find(
+      (event) => event.type === 'conversation.item.truncate',
+    );
+    expect(truncation).toEqual({
+      type: 'conversation.item.truncate',
+      item_id: 'item-a',
+      content_index: 0,
+      audio_end_ms: 20,
+    });
+    expect(Number.isInteger(truncation.audio_end_ms)).toBe(true);
+  });
+
+  test('truncates overlapping items at their own playback positions', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a');
+    const playedMark = twilioMarks(twilio).at(-1).mark.name;
+    returnTwilioMark(twilio, playedMark);
+    emitAudioDelta('item-a', 'response-a');
+    emitAudioDone('item-a', 'response-a');
+    emitAudioDelta('item-b', 'response-b');
+
+    transport.interrupt(false);
+
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'conversation.item.truncate',
+      ),
+    ).toEqual([
+      {
+        type: 'conversation.item.truncate',
+        item_id: 'item-a',
+        content_index: 0,
+        audio_end_ms: 150,
+      },
+      {
+        type: 'conversation.item.truncate',
+        item_id: 'item-b',
+        content_index: 0,
+        audio_end_ms: 0,
+      },
+    ]);
+  });
+
+  test('does not apply clear-returned stale marks to a new generation', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a');
+    const firstMark = twilioMarks(twilio).at(-1).mark.name;
+    returnTwilioMark(twilio, firstMark);
+    emitAudioDelta('item-a', 'response-a');
+    const clearedMark = twilioMarks(twilio).at(-1).mark.name;
+    transport.interrupt(false);
+
+    returnTwilioMark(twilio, clearedMark);
+    emitAudioDelta('item-b', 'response-b');
+    transport.interrupt(false);
+
+    const truncations = openAIEvents().filter(
+      (event) => event.type === 'conversation.item.truncate',
+    );
+    expect(truncations.at(-1)).toEqual({
+      type: 'conversation.item.truncate',
+      item_id: 'item-b',
+      content_index: 0,
+      audio_end_ms: 50,
+    });
+  });
+
+  test('does not forward late audio for an interrupted item', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+    const audioListener = vi.fn();
+    transport.on('audio', audioListener);
+
+    emitAudioDelta('item-a', 'response-a');
+    transport.interrupt(false);
+    const mediaCountAfterInterrupt = payloads(twilio.sent).filter(
+      (payload) => payload.event === 'media',
+    ).length;
+    emitAudioDelta('item-a', 'response-a');
+
+    expect(
+      payloads(twilio.sent).filter((payload) => payload.event === 'media'),
+    ).toHaveLength(mediaCountAfterInterrupt);
+    expect(audioListener).toHaveBeenCalledTimes(2);
+  });
+
+  test('invalidates playback ownership when locally closed', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a');
+    transport.close();
+    const sentBeforeInterrupt = [...twilio.sent];
+
+    expect(() => transport.interrupt(false)).not.toThrow();
+    expect(twilio.sent).toEqual(sentBeforeInterrupt);
+  });
+
+  test('invalidates playback ownership when remotely closed', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a');
+    openAIWebSocket.emit('close', {});
+    const sentBeforeInterrupt = [...twilio.sent];
+
+    expect(() => transport.interrupt(false)).not.toThrow();
+    expect(twilio.sent).toEqual(sentBeforeInterrupt);
+  });
+
+  test('tracks only the new session playback after reconnecting', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    emitAudioDelta('item-a', 'response-a');
+    transport.close();
+    const reconnecting = transport.connect({
+      apiKey: 'ek_test',
+      model: 'test',
+    });
+    await vi.runAllTimersAsync();
+    await reconnecting;
+
+    openAIWebSocket.sent = [];
+    emitTwilioMessage(twilio, {
+      event: 'media',
+      media: { payload: Buffer.from([1]).toString('base64') },
+    });
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'input_audio_buffer.append',
+      ),
+    ).toHaveLength(1);
+
+    emitAudioDelta('item-b', 'response-b');
+    const playedMark = twilioMarks(twilio).at(-1).mark.name;
+    returnTwilioMark(twilio, playedMark);
+
+    transport.interrupt(false);
+
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'conversation.item.truncate',
+      ),
+    ).toEqual([
+      {
+        type: 'conversation.item.truncate',
+        item_id: 'item-b',
+        content_index: 0,
+        audio_end_ms: 100,
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('removes a fully played item when Twilio returns its done mark', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a');
+    emitAudioDone('item-a', 'response-a');
+    const [audioMark, doneMark] = twilioMarks(twilio).slice(-2);
+    returnTwilioMark(twilio, audioMark.mark.name);
+    returnTwilioMark(twilio, doneMark.mark.name);
+    emitAudioDelta('item-b', 'response-b');
+
+    transport.interrupt(false);
+
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'conversation.item.truncate',
+      ),
+    ).toEqual([
+      {
+        type: 'conversation.item.truncate',
+        item_id: 'item-b',
+        content_index: 0,
+        audio_end_ms: 50,
+      },
+    ]);
+  });
+
+  test('binds interleaved done events to their exact item', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a');
+    emitAudioDelta('item-b', 'response-b');
+    emitAudioDone('item-a', 'response-a');
+    const [itemAMark, itemBMark, doneMark] = twilioMarks(twilio).slice(-3);
+    expect(doneMark.mark.name).toMatch(/^done:item-a:/);
+    returnTwilioMark(twilio, itemAMark.mark.name);
+    returnTwilioMark(twilio, itemBMark.mark.name);
+    returnTwilioMark(twilio, doneMark.mark.name);
+
+    transport.interrupt(false);
+
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'conversation.item.truncate',
+      ),
+    ).toEqual([
+      {
+        type: 'conversation.item.truncate',
+        item_id: 'item-b',
+        content_index: 0,
+        audio_end_ms: 100,
+      },
+    ]);
+  });
+
+  test('binds done marks to the exact content index', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitAudioDelta('item-a', 'response-a', 800, 0);
+    emitAudioDelta('item-a', 'response-a', 800, 1);
+    emitAudioDone('item-a', 'response-a', 0);
+    const [contentZeroMark, contentOneMark, doneMark] =
+      twilioMarks(twilio).slice(-3);
+    returnTwilioMark(twilio, contentZeroMark.mark.name);
+    returnTwilioMark(twilio, contentOneMark.mark.name);
+    returnTwilioMark(twilio, doneMark.mark.name);
+
+    transport.interrupt(false);
+
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'conversation.item.truncate',
+      ),
+    ).toEqual([
+      {
+        type: 'conversation.item.truncate',
+        item_id: 'item-a',
+        content_index: 1,
+        audio_end_ms: 100,
+      },
+    ]);
+  });
+});

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.interruption.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.interruption.test.ts
@@ -141,7 +141,14 @@ async function createConnectedTransport() {
   await connecting;
   emitTwilioMessage(twilio, {
     event: 'start',
-    start: { streamSid: 'stream-1' },
+    start: {
+      streamSid: 'stream-1',
+      mediaFormat: {
+        encoding: 'audio/x-mulaw',
+        sampleRate: 8_000,
+        channels: 1,
+      },
+    },
   });
   return { transport, twilio };
 }
@@ -155,6 +162,30 @@ describe('TwilioRealtimeTransportLayer interruption ownership', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.useRealTimers();
+  });
+
+  test('does not clear Twilio before any response playback exists', async () => {
+    const { twilio } = await createConnectedTransport();
+
+    emitOpenAIEvent({
+      type: 'input_audio_buffer.speech_started',
+      event_id: 'speech-started-1',
+      item_id: 'input-item-1',
+      audio_start_ms: 0,
+    });
+
+    expect(payloads(twilio.sent)).not.toContainEqual({
+      event: 'clear',
+      streamSid: 'stream-1',
+    });
+    expect(openAIEvents()).not.toContainEqual({
+      type: 'response.cancel',
+    });
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'conversation.item.truncate',
+      ),
+    ).toEqual([]);
   });
 
   test('truncates one item at its last acknowledged playback position', async () => {
@@ -178,6 +209,27 @@ describe('TwilioRealtimeTransportLayer interruption ownership', () => {
       event: 'clear',
       streamSid: 'stream-1',
     });
+  });
+
+  test('claims interruption ownership only once before response completion', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    emitResponseCreated('response-a');
+    emitAudioDelta('item-a', 'response-a');
+    transport.interrupt();
+    transport.interrupt();
+
+    expect(
+      payloads(twilio.sent).filter((payload) => payload.event === 'clear'),
+    ).toHaveLength(1);
+    expect(
+      openAIEvents().filter((event) => event.type === 'response.cancel'),
+    ).toHaveLength(1);
+    expect(
+      openAIEvents().filter(
+        (event) => event.type === 'conversation.item.truncate',
+      ),
+    ).toHaveLength(1);
   });
 
   test('clamps and floors a fully acknowledged fractional duration', async () => {
@@ -369,6 +421,40 @@ describe('TwilioRealtimeTransportLayer interruption ownership', () => {
       },
     ]);
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('preserves Twilio input padding capability across OpenAI reconnects', async () => {
+    const { transport, twilio } = await createConnectedTransport();
+
+    transport.close();
+    const reconnecting = transport.connect({
+      apiKey: 'ek_test',
+      model: 'test',
+    });
+    await vi.runAllTimersAsync();
+    await reconnecting;
+
+    openAIWebSocket.sent = [];
+    emitTwilioMessage(twilio, {
+      event: 'media',
+      media: {
+        payload: Buffer.alloc(160).toString('base64'),
+        timestamp: '100',
+      },
+    });
+    emitOpenAIEvent({
+      type: 'input_audio_buffer.speech_started',
+      event_id: 'speech-started-after-reconnect',
+      item_id: 'input-item-after-reconnect',
+      audio_start_ms: 0,
+    });
+    await vi.advanceTimersByTimeAsync(750);
+
+    const inputAppends = openAIEvents().filter(
+      (event) => event.type === 'input_audio_buffer.append',
+    );
+    expect(inputAppends).toHaveLength(2);
+    expect(Buffer.from(inputAppends[1].audio, 'base64')).toHaveLength(8_000);
   });
 
   test('removes a fully played item when Twilio returns its done mark', async () => {

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -121,8 +121,8 @@ describe('TwilioRealtimeTransportLayer', () => {
   });
 
   test('connect handles messages and events', async () => {
-    allowConsole(['error', 'warn']);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
       twilioWebSocket: asTwilioWebSocket(twilio),
@@ -149,6 +149,9 @@ describe('TwilioRealtimeTransportLayer', () => {
     twilio.emit('message', {
       toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:5' } }),
     });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Invalid mark name received. Mark data is redacted.',
+    );
     transport._interrupt(0);
     expect(cancelSpy).toHaveBeenCalledTimes(1);
     expect(twilio.send).toHaveBeenCalledWith(
@@ -161,6 +164,7 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(errListener).toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith('Error parsing message:', 'object');
     errorSpy.mockRestore();
+    warnSpy.mockRestore();
 
     twilio.emit('close');
     expect(closeSpy).toHaveBeenCalled();
@@ -341,7 +345,6 @@ describe('TwilioRealtimeTransportLayer', () => {
   });
 
   test('resets playback state on new Twilio start and handles invalid marks', async () => {
-    allowConsole(['warn']);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src/TwilioRealtimeTransport';
 
@@ -24,6 +24,9 @@ vi.mock('@openai/agents/realtime', () => {
   FakeOpenAIRealtimeWebSocket.prototype.connect = vi.fn(async function (
     this: any,
   ) {
+    if (this.status !== 'disconnected') {
+      throw new Error('Transport is already connected.');
+    }
     this.status = 'connected';
   });
   FakeOpenAIRealtimeWebSocket.prototype.sendAudio = vi.fn();
@@ -64,9 +67,30 @@ const setCurrentItemId = (
 
 const base64 = (data: string) => Buffer.from(data).toString('base64');
 
+const startTwilioStream = (
+  twilio: FakeTwilioWebSocket,
+  mediaFormat: unknown = {
+    encoding: 'audio/x-mulaw',
+    sampleRate: 8_000,
+    channels: 1,
+  },
+) => {
+  twilio.emit('message', {
+    toString: () =>
+      JSON.stringify({
+        event: 'start',
+        start: { streamSid: 'sid', mediaFormat },
+      }),
+  });
+};
+
 describe('TwilioRealtimeTransportLayer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   test('_setInputAndOutputAudioFormat defaults g711', () => {
@@ -120,6 +144,25 @@ describe('TwilioRealtimeTransportLayer', () => {
     });
   });
 
+  test('validates the Twilio input inactivity timeout', () => {
+    expect(
+      () =>
+        new TwilioRealtimeTransportLayer({
+          twilioWebSocket: asTwilioWebSocket(new FakeTwilioWebSocket()),
+          inputAudioInactivityTimeoutMs: 0,
+        }),
+    ).toThrow(
+      'inputAudioInactivityTimeoutMs must be a positive finite number no greater than 2147483647, or null.',
+    );
+    expect(
+      () =>
+        new TwilioRealtimeTransportLayer({
+          twilioWebSocket: asTwilioWebSocket(new FakeTwilioWebSocket()),
+          inputAudioInactivityTimeoutMs: 2_147_483_648,
+        }),
+    ).toThrow(RangeError);
+  });
+
   test('connect handles messages and events', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -152,6 +195,9 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       'Invalid mark name received. Mark data is redacted.',
     );
+    transport.emit('response.created', {
+      response: { id: 'response-1' },
+    } as any);
     transport._interrupt(0);
     expect(cancelSpy).toHaveBeenCalledTimes(1);
     expect(twilio.send).toHaveBeenCalledWith(
@@ -170,6 +216,387 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(closeSpy).toHaveBeenCalled();
     twilio.emit('error', new Error('boom'));
     expect(closeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('pads missing Twilio media timestamps with PCMU silence', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('b'.repeat(160)), timestamp: '140' },
+        }),
+    });
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(3);
+    expect(new Uint8Array(sendAudioSpy.mock.calls[1][0])).toEqual(
+      new Uint8Array(160).fill(0xff),
+    );
+    expect(Buffer.from(sendAudioSpy.mock.calls[2][0]).toString()).toBe(
+      'b'.repeat(160),
+    );
+  });
+
+  test('does not synthesize silence for unsupported Twilio media formats', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio, {
+      encoding: 'audio/pcm',
+      sampleRate: 8_000,
+      channels: 1,
+    });
+
+    for (const [payload, timestamp] of [
+      ['a', '100'],
+      ['b', '10000'],
+    ]) {
+      twilio.emit('message', {
+        toString: () =>
+          JSON.stringify({
+            event: 'media',
+            media: { payload: base64(payload.repeat(160)), timestamp },
+          }),
+      });
+    }
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test.each([null, '', ' ', 'not-a-number'])(
+    'does not infer silence from an invalid Twilio timestamp %#',
+    async (timestamp) => {
+      const twilio = new FakeTwilioWebSocket();
+      const transport = new TwilioRealtimeTransportLayer({
+        twilioWebSocket: asTwilioWebSocket(twilio),
+      });
+      await transport.connect({ apiKey: 'ek_test' } as any);
+      const { OpenAIRealtimeWebSocket } =
+        await import('@openai/agents/realtime');
+      const sendAudioSpy = vi.mocked(
+        OpenAIRealtimeWebSocket.prototype.sendAudio,
+      );
+      startTwilioStream(twilio);
+
+      twilio.emit('message', {
+        toString: () =>
+          JSON.stringify({
+            event: 'media',
+            media: { payload: base64('a'.repeat(160)), timestamp },
+          }),
+      });
+      twilio.emit('message', {
+        toString: () =>
+          JSON.stringify({
+            event: 'media',
+            media: { payload: base64('b'.repeat(160)), timestamp: '10000' },
+          }),
+      });
+
+      expect(sendAudioSpy).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  test('resets timestamp inference after Twilio media moves backward', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    for (const [payload, timestamp] of [
+      ['a', '100'],
+      ['b', '80'],
+      ['c', '140'],
+    ]) {
+      twilio.emit('message', {
+        toString: () =>
+          JSON.stringify({
+            event: 'media',
+            media: { payload: base64(payload.repeat(160)), timestamp },
+          }),
+      });
+    }
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(3);
+  });
+
+  test('caps inferred Twilio timestamp silence at ten seconds', async () => {
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('b'.repeat(160)), timestamp: '20120' },
+        }),
+    });
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(3);
+    expect(new Uint8Array(sendAudioSpy.mock.calls[1][0])).toEqual(
+      new Uint8Array(80_000).fill(0xff),
+    );
+  });
+
+  test('pads active speech after Twilio input becomes inactive', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+    await vi.advanceTimersByTimeAsync(749);
+    expect(sendAudioSpy).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(2);
+    expect(new Uint8Array(sendAudioSpy.mock.calls[1][0])).toEqual(
+      new Uint8Array(8_000).fill(0xff),
+    );
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('b'.repeat(160)), timestamp: '5100' },
+        }),
+    });
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(3);
+    expect(Buffer.from(sendAudioSpy.mock.calls[2][0]).toString()).toBe(
+      'b'.repeat(160),
+    );
+  });
+
+  test('pads inactivity when speech detection arrives after the deadline', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(sendAudioSpy).toHaveBeenCalledTimes(1);
+
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(2);
+    expect(new Uint8Array(sendAudioSpy.mock.calls[1][0])).toEqual(
+      new Uint8Array(8_000).fill(0xff),
+    );
+  });
+
+  test('cancels inactivity padding when speech stops', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+    await vi.advanceTimersByTimeAsync(749);
+    transport.emit('input_audio_buffer.speech_stopped', {} as any);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses a configured Twilio input inactivity timeout', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+      inputAudioInactivityTimeoutMs: 250,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(sendAudioSpy).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('can disable Twilio input inactivity padding', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+      inputAudioInactivityTimeoutMs: null,
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('preserves active input timing when a duplicate connect is rejected', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+
+    await expect(
+      transport.connect({ apiKey: 'ek_test' } as any),
+    ).rejects.toThrow('Transport is already connected.');
+    await vi.advanceTimersByTimeAsync(750);
+
+    expect(sendAudioSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('resets Twilio input timestamps when a new stream starts', async () => {
+    vi.useFakeTimers();
+    const twilio = new FakeTwilioWebSocket();
+    const transport = new TwilioRealtimeTransportLayer({
+      twilioWebSocket: asTwilioWebSocket(twilio),
+    });
+    await transport.connect({ apiKey: 'ek_test' } as any);
+    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
+    const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
+    startTwilioStream(twilio);
+
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('a'.repeat(160)), timestamp: '100' },
+        }),
+    });
+    transport.emit('input_audio_buffer.speech_started', {} as any);
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'start',
+          start: {
+            streamSid: 'sid-2',
+            mediaFormat: {
+              encoding: 'audio/x-mulaw',
+              sampleRate: 8_000,
+              channels: 1,
+            },
+          },
+        }),
+    });
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({
+          event: 'media',
+          media: { payload: base64('b'.repeat(160)), timestamp: '1000' },
+        }),
+    });
+
+    await vi.advanceTimersByTimeAsync(750);
+    expect(sendAudioSpy).toHaveBeenCalledTimes(2);
   });
 
   test('redacts Twilio message and parse-error data when model logging is disabled', async () => {
@@ -375,6 +802,9 @@ describe('TwilioRealtimeTransportLayer', () => {
         JSON.stringify({ event: 'mark', mark: { name: 'done:u' } }),
     });
 
+    transport.emit('response.created', {
+      response: { id: 'response-1' },
+    } as any);
     transport._interrupt(0);
 
     expect(twilio.send).toHaveBeenCalledWith(

--- a/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
+++ b/packages/agents-extensions/test/TwilioRealtimeTransport.test.ts
@@ -27,8 +27,10 @@ vi.mock('@openai/agents/realtime', () => {
     this.status = 'connected';
   });
   FakeOpenAIRealtimeWebSocket.prototype.sendAudio = vi.fn();
+  FakeOpenAIRealtimeWebSocket.prototype.sendEvent = vi.fn();
+  FakeOpenAIRealtimeWebSocket.prototype._cancelResponse = vi.fn();
+  FakeOpenAIRealtimeWebSocket.prototype._afterAudioDoneEvent = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.close = vi.fn();
-  FakeOpenAIRealtimeWebSocket.prototype._interrupt = vi.fn();
   FakeOpenAIRealtimeWebSocket.prototype.updateSessionConfig = vi.fn();
   return { OpenAIRealtimeWebSocket: FakeOpenAIRealtimeWebSocket, utils };
 });
@@ -119,6 +121,7 @@ describe('TwilioRealtimeTransportLayer', () => {
   });
 
   test('connect handles messages and events', async () => {
+    allowConsole(['error', 'warn']);
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
@@ -128,8 +131,8 @@ describe('TwilioRealtimeTransportLayer', () => {
     const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
     const sendAudioSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.sendAudio);
     const closeSpy = vi.mocked(OpenAIRealtimeWebSocket.prototype.close);
-    const interruptSpy = vi.mocked(
-      OpenAIRealtimeWebSocket.prototype._interrupt,
+    const cancelSpy = vi.mocked(
+      OpenAIRealtimeWebSocket.prototype._cancelResponse,
     );
 
     const mediaPayload = base64('a');
@@ -147,7 +150,7 @@ describe('TwilioRealtimeTransportLayer', () => {
       toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:5' } }),
     });
     transport._interrupt(0);
-    expect(interruptSpy).toHaveBeenCalledWith(55, true);
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
     expect(twilio.send).toHaveBeenCalledWith(
       JSON.stringify({ event: 'clear', streamSid: 'sid' }),
     );
@@ -217,6 +220,11 @@ describe('TwilioRealtimeTransportLayer', () => {
     const audioListener = vi.fn();
     transport.on('audio', audioListener);
 
+    twilio.emit('message', {
+      toString: () =>
+        JSON.stringify({ event: 'start', start: { streamSid: 'sid' } }),
+    });
+
     setCurrentItemId(transport, 'a');
     transport['_onAudio']({
       responseId: 'FAKE_ID',
@@ -239,9 +247,9 @@ describe('TwilioRealtimeTransportLayer', () => {
     const marks = sendSpy.mock.calls
       .map((c: any) => JSON.parse(c[0]))
       .filter((d: any) => d.event === 'mark');
-    expect(marks[0].mark.name).toBe('a:1');
-    expect(marks[1].mark.name).toBe('a:3');
-    expect(marks[2].mark.name).toBe('b:1');
+    expect(marks[0].mark.name).toMatch(/^a:1:g\d+:m\d+$/);
+    expect(marks[1].mark.name).toMatch(/^a:3:g\d+:m\d+$/);
+    expect(marks[2].mark.name).toMatch(/^b:1:g\d+:m\d+$/);
     expect(audioListener).toHaveBeenCalledTimes(3);
   });
 
@@ -332,18 +340,14 @@ describe('TwilioRealtimeTransportLayer', () => {
     });
   });
 
-  test('resets counters on new Twilio start and handles invalid marks', async () => {
+  test('resets playback state on new Twilio start and handles invalid marks', async () => {
+    allowConsole(['warn']);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
       twilioWebSocket: asTwilioWebSocket(twilio),
     });
     await transport.connect({ apiKey: 'ek_test' } as any);
-    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
-    const interruptSpy = vi.mocked(
-      OpenAIRealtimeWebSocket.prototype._interrupt,
-    );
-
     twilio.emit('message', {
       toString: () =>
         JSON.stringify({ event: 'start', start: { streamSid: 'sid-1' } }),
@@ -370,42 +374,9 @@ describe('TwilioRealtimeTransportLayer', () => {
 
     transport._interrupt(0);
 
-    // After new start, previous counts are cleared; done mark resets to baseline 0 + 50 buffer.
-    expect(interruptSpy).toHaveBeenCalledWith(50, true);
     expect(twilio.send).toHaveBeenCalledWith(
       JSON.stringify({ event: 'clear', streamSid: 'sid-2' }),
     );
     warnSpy.mockRestore();
-  });
-
-  test('resets chunk count on done marks before interrupting', async () => {
-    const twilio = new FakeTwilioWebSocket();
-    const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: asTwilioWebSocket(twilio),
-    });
-    await transport.connect({ apiKey: 'ek_test' } as any);
-    const { OpenAIRealtimeWebSocket } = await import('@openai/agents/realtime');
-    const interruptSpy = vi.mocked(
-      OpenAIRealtimeWebSocket.prototype._interrupt,
-    );
-
-    twilio.emit('message', {
-      toString: () =>
-        JSON.stringify({ event: 'start', start: { streamSid: 'sid-1' } }),
-    });
-    twilio.emit('message', {
-      toString: () => JSON.stringify({ event: 'mark', mark: { name: 'u:7' } }),
-    });
-    twilio.emit('message', {
-      toString: () =>
-        JSON.stringify({ event: 'mark', mark: { name: 'done:u' } }),
-    });
-
-    transport._interrupt(0);
-
-    expect(interruptSpy).toHaveBeenCalledWith(50, true);
-    expect(twilio.send).toHaveBeenCalledWith(
-      JSON.stringify({ event: 'clear', streamSid: 'sid-1' }),
-    );
   });
 });

--- a/packages/agents-extensions/test/index.test.ts
+++ b/packages/agents-extensions/test/index.test.ts
@@ -1,7 +1,6 @@
 import { describe, test, expect, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src';
-import { allowConsole } from '../../../helpers/tests/console-guard';
 import type {
   MessageEvent as NodeMessageEvent,
   WebSocket as NodeWebSocket,
@@ -55,7 +54,7 @@ describe('TwilioRealtimeTransportLayer', () => {
   });
 
   test('ignores malformed mark names', async () => {
-    allowConsole(['warn']);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
       twilioWebSocket: asTwilioWebSocket(twilio),
@@ -75,5 +74,8 @@ describe('TwilioRealtimeTransportLayer', () => {
         (call) => (call[0] as any)?.type === 'conversation.item.truncate',
       ),
     ).toHaveLength(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Invalid mark name received. Mark data is redacted.',
+    );
   });
 });

--- a/packages/agents-extensions/test/index.test.ts
+++ b/packages/agents-extensions/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { TwilioRealtimeTransportLayer } from '../src';
+import { allowConsole } from '../../../helpers/tests/console-guard';
 import type {
   MessageEvent as NodeMessageEvent,
   WebSocket as NodeWebSocket,
@@ -45,17 +46,6 @@ const asTwilioWebSocket = (
   socket: FakeTwilioWebSocket,
 ): WebSocket | NodeWebSocket => socket as unknown as WebSocket | NodeWebSocket;
 
-const setAudioLengthMs = (
-  transport: TwilioRealtimeTransportLayer,
-  audioLengthMs: number,
-): void => {
-  (
-    transport as unknown as {
-      _audioLengthMs: number;
-    }
-  )._audioLengthMs = audioLengthMs;
-};
-
 describe('TwilioRealtimeTransportLayer', () => {
   test('should be available', () => {
     const transport = new TwilioRealtimeTransportLayer({
@@ -64,16 +54,14 @@ describe('TwilioRealtimeTransportLayer', () => {
     expect(transport).toBeDefined();
   });
 
-  test('malformed mark name does not produce NaN', async () => {
+  test('ignores malformed mark names', async () => {
+    allowConsole(['warn']);
     const twilio = new FakeTwilioWebSocket();
     const transport = new TwilioRealtimeTransportLayer({
       twilioWebSocket: asTwilioWebSocket(twilio),
     });
 
-    const sendEventSpy = vi.spyOn(
-      transport as TwilioRealtimeTransportLayer,
-      'sendEvent',
-    );
+    const sendEventSpy = vi.spyOn(transport as any, 'sendEvent');
 
     await transport.connect({ apiKey: 'ek_test' });
     sendEventSpy.mockClear();
@@ -82,39 +70,10 @@ describe('TwilioRealtimeTransportLayer', () => {
     twilio.emit('message', { toString: () => JSON.stringify(payload) });
 
     transport._interrupt(0, false);
-    setAudioLengthMs(transport, 500);
-    transport._interrupt(0, true);
-
-    const call = sendEventSpy.mock.calls
-      .filter((c) => c[0]?.type === 'conversation.item.truncate')
-      .at(-1);
-    expect(call?.[0].audio_end_ms).toBe(50);
-  });
-
-  test('interrupt clamps overshoot and emits integer audio_end_ms', async () => {
-    const twilio = new FakeTwilioWebSocket();
-    const transport = new TwilioRealtimeTransportLayer({
-      twilioWebSocket: asTwilioWebSocket(twilio),
-    });
-
-    const sendEventSpy = vi.spyOn(
-      transport as TwilioRealtimeTransportLayer,
-      'sendEvent',
-    );
-
-    await transport.connect({
-      apiKey: 'ek_test',
-      initialSessionConfig: { speed: 1.1 },
-    });
-    sendEventSpy.mockClear();
-
-    setAudioLengthMs(transport, 20);
-    transport._interrupt(0, true);
-
-    const call = sendEventSpy.mock.calls
-      .filter((c) => c[0]?.type === 'conversation.item.truncate')
-      .at(-1);
-    expect(call?.[0].audio_end_ms).toBe(20);
-    expect(Number.isInteger(call?.[0].audio_end_ms)).toBe(true);
+    expect(
+      sendEventSpy.mock.calls.filter(
+        (call) => (call[0] as any)?.type === 'conversation.item.truncate',
+      ),
+    ).toHaveLength(0);
   });
 });


### PR DESCRIPTION
This pull request builds on the Twilio interruption work originally proposed in #1343.

It fixes interruption truncation by tracking playback ownership for each Realtime audio item and content index. It clears queued Twilio audio, truncates the audible item at the acknowledged playback position, truncates later queued items at zero, and ignores stale marks and late audio from cleared playback generations.

The Twilio example remains a normal conversational voice assistant and now accurately documents its tools and how to test interruption during an ordinary conversation.

This PR resolves https://github.com/openai/openai-agents-js/issues/1173