### PR TITLE
test: update sandbox storage mount integration fixture

### DIFF
--- a/.changeset/calm-mounts-verify.md
+++ b/.changeset/calm-mounts-verify.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+test: cover trusted external rclone config paths

--- a/integration-tests/node/azure-emulator-rclone.conf
+++ b/integration-tests/node/azure-emulator-rclone.conf
@@ -1,0 +1,2 @@
+[azure_emulator]
+use_emulator = true

--- a/integration-tests/node/sandbox-storage-mounts.mjs
+++ b/integration-tests/node/sandbox-storage-mounts.mjs
@@ -10,6 +10,7 @@ import {
 import { DockerSandboxClient } from '@openai/agents/sandbox/local';
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 
 const mountImage =
   process.env.SANDBOX_STORAGE_MOUNT_IMAGE ??
@@ -24,6 +25,10 @@ const azureAccountName = 'devstoreaccount1';
 const azureAccountKey =
   'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==';
 const azureContainer = 'azurite-smoke';
+const azureRcloneConfigPath = '/run/openai-agents/azure-emulator-rclone.conf';
+const azureRcloneConfigHostPath = fileURLToPath(
+  new URL('./azure-emulator-rclone.conf', import.meta.url),
+);
 
 const s3Bucket = 'minio-smoke';
 const s3AccessKeyId = 'minioadmin';
@@ -223,6 +228,13 @@ async function smokeAzureBlobMount() {
   }
 
   const manifest = new Manifest({
+    extraPathGrants: [
+      {
+        path: azureRcloneConfigPath,
+        hostPath: azureRcloneConfigHostPath,
+        readOnly: true,
+      },
+    ],
     entries: {
       azure: azureBlobMount({
         container: azureContainer,
@@ -234,22 +246,13 @@ async function smokeAzureBlobMount() {
           pattern: mountPattern({
             type: 'rclone',
             mode: 'fuse',
-            args: [
-              '--azureblob-use-emulator',
-              '--contimeout',
-              '5s',
-              '--timeout',
-              '10s',
-              '--retries',
-              '1',
-              '--low-level-retries',
-              '1',
-            ],
+            remoteName: 'azure_emulator',
+            configFilePath: azureRcloneConfigPath,
           }),
         }),
       }),
     },
-  });
+  }).withInContainerMountCredentialExposureAllowed('azure');
 
   const client = new DockerSandboxClient({ image: mountImage });
   const session = await client.create(manifest);
@@ -318,21 +321,11 @@ async function smokeS3Mount() {
           pattern: mountPattern({
             type: 'rclone',
             mode: 'fuse',
-            args: [
-              '--contimeout',
-              '5s',
-              '--timeout',
-              '10s',
-              '--retries',
-              '1',
-              '--low-level-retries',
-              '1',
-            ],
           }),
         }),
       }),
     },
-  });
+  }).withInContainerMountCredentialExposureAllowed('s3');
 
   const client = new DockerSandboxClient({ image: mountImage });
   const session = await client.create(manifest);

--- a/packages/agents-core/test/sandboxMountSecurity.test.ts
+++ b/packages/agents-core/test/sandboxMountSecurity.test.ts
@@ -325,6 +325,38 @@ describe('sandbox mount credential boundaries', () => {
     );
   });
 
+  it('allows a trusted external rclone config path', () => {
+    const manifest = new Manifest({
+      extraPathGrants: [
+        {
+          path: '/run/openai-agents/rclone.conf',
+          hostPath: '/tmp/rclone.conf',
+          readOnly: true,
+        },
+      ],
+      entries: {
+        remote: s3Mount({
+          bucket: 'example',
+          mountStrategy: inContainerMountStrategy({
+            pattern: {
+              type: 'rclone',
+              configFilePath: '/run/openai-agents/rclone.conf',
+            },
+          }),
+        }),
+      },
+    });
+
+    expect(() => validateMountCredentialBoundaries(manifest)).toThrow(
+      /model-controlled sandbox/u,
+    );
+    expect(() =>
+      validateMountCredentialBoundaries(
+        manifest.withInContainerMountCredentialExposureAllowed('remote'),
+      ),
+    ).not.toThrow();
+  });
+
   it('rejects explicit and environment credential files in manifest entries', () => {
     const explicit = new Manifest({
       entries: {


### PR DESCRIPTION
This pull request fixes the sandbox storage mount integration fixture after mount security validation began rejecting opaque rclone arguments.

It replaces the Azure emulator argument with a trusted read-only rclone configuration file, explicitly acknowledges the Azure and S3 in-container credential boundaries, and adds regression coverage for trusted external rclone configuration paths. Arbitrary rclone arguments remain fail-closed, and no runtime or public API behavior is changed.