### PR TITLE
feat(models): preserve raw usage payloads

### DIFF
--- a/.changeset/tidy-models-preserve.md
+++ b/.changeset/tidy-models-preserve.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+'@openai/agents-extensions': patch
+---
+
+feat: preserve raw provider usage payloads on request

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -357,6 +357,12 @@ export type ModelSettings = {
    * Runtime-only retry configuration for the model request.
    */
   retry?: ModelRetrySettings;
+
+  /**
+   * Whether to preserve a JSON-compatible snapshot of provider usage before
+   * the Agents SDK normalizes it. Defaults to false if not provided.
+   */
+  preserveRawUsage?: boolean;
 };
 
 export type ModelTracing = boolean | 'enabled_without_data';
@@ -615,6 +621,12 @@ export type ModelResponse = {
    * Raw response data from the underlying model provider.
    */
   providerData?: Record<string, any>;
+
+  /**
+   * A detached JSON-compatible snapshot of provider usage captured before
+   * the Agents SDK normalizes missing values. Only populated when requested.
+   */
+  rawUsage?: Record<string, unknown>;
 };
 
 /**

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -47,6 +47,7 @@ import { includeTaskAndTurnSpans, mergeTracingConfig } from './tracing/config';
 import { Usage } from './usage';
 import { convertAgentOutputTypeToSerializable } from './utils/tools';
 import { isDataRedactedError } from './utils/finalOutputError';
+import { snapshotRawUsage } from './utils/rawUsage';
 import { DEFAULT_MAX_TURNS } from './runner/constants';
 import { StreamEventResponseCompleted } from './types/protocol';
 import type { Session, SessionInputCallback } from './memory/session';
@@ -2306,12 +2307,36 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               );
               if (event.type === 'response_done') {
                 assertValidCompactionItems(event.response.output);
-                const parsed = StreamEventResponseCompleted.parse(event);
+                let rawUsage: Record<string, unknown> | undefined;
+                if (modelRequest.modelSettings.preserveRawUsage === true) {
+                  try {
+                    rawUsage = snapshotRawUsage(event.response.rawUsage);
+                  } catch {
+                    rawUsage = undefined;
+                  }
+                }
+                const parsed = StreamEventResponseCompleted.parse({
+                  type: event.type,
+                  ...(event.providerData
+                    ? { providerData: event.providerData }
+                    : {}),
+                  response: {
+                    id: event.response.id,
+                    requestId: event.response.requestId,
+                    usage: event.response.usage,
+                    output: event.response.output,
+                    ...(event.response.providerData
+                      ? { providerData: event.response.providerData }
+                      : {}),
+                    ...(rawUsage !== undefined ? { rawUsage } : {}),
+                  },
+                });
                 finalResponse = {
                   usage: new Usage(parsed.response.usage),
                   output: parsed.response.output,
                   responseId: parsed.response.id,
                   requestId: parsed.response.requestId,
+                  ...(rawUsage !== undefined ? { rawUsage } : {}),
                 };
                 result.state._context.usage.add(finalResponse.usage);
                 recordUsage(finalResponse.usage);

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -1007,6 +1007,11 @@ export const StreamEventResponseCompleted = SharedBase.extend({
     usage: UsageData,
 
     /**
+     * Provider usage captured before SDK normalization, when requested.
+     */
+    rawUsage: z.record(z.string(), z.unknown()).optional(),
+
+    /**
      * The output from the model.
      */
     output: z.array(OutputModelItem),

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -5,6 +5,7 @@ export {
   CompactionItemValidationError,
 } from '../runner/items';
 export { normalizeToolAllowedCallers } from './toolCallers';
+export { snapshotRawUsage } from './rawUsage';
 export {
   hasDynamicFunctionToolApprovalPolicy,
   hasInspectableFunctionToolArguments,

--- a/packages/agents-core/src/utils/rawUsage.ts
+++ b/packages/agents-core/src/utils/rawUsage.ts
@@ -1,0 +1,88 @@
+const INVALID_JSON_VALUE = Symbol('invalidJsonValue');
+
+type JsonClone =
+  null | boolean | number | string | JsonClone[] | { [key: string]: JsonClone };
+
+/**
+ * Creates a detached JSON-compatible snapshot of a provider usage object.
+ */
+export function snapshotRawUsage(
+  rawUsage: unknown,
+): Record<string, unknown> | undefined {
+  if (
+    typeof rawUsage !== 'object' ||
+    rawUsage === null ||
+    Array.isArray(rawUsage)
+  ) {
+    return undefined;
+  }
+
+  try {
+    const snapshot = cloneJsonValue(rawUsage, new Set<object>());
+    return snapshot === INVALID_JSON_VALUE ||
+      snapshot === null ||
+      typeof snapshot !== 'object' ||
+      Array.isArray(snapshot)
+      ? undefined
+      : snapshot;
+  } catch {
+    return undefined;
+  }
+}
+
+function cloneJsonValue(
+  value: unknown,
+  ancestors: Set<object>,
+): JsonClone | typeof INVALID_JSON_VALUE {
+  if (value === null) {
+    return null;
+  }
+  if (
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    return value;
+  }
+  if (typeof value === 'undefined') {
+    return INVALID_JSON_VALUE;
+  }
+  if (typeof value !== 'object' || ancestors.has(value)) {
+    return INVALID_JSON_VALUE;
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      const result: JsonClone[] = [];
+      for (const entry of value) {
+        const cloned = cloneJsonValue(entry, ancestors);
+        if (cloned === INVALID_JSON_VALUE) {
+          return INVALID_JSON_VALUE;
+        }
+        result.push(cloned);
+      }
+      return result;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return INVALID_JSON_VALUE;
+    }
+
+    const entries: Array<[string, JsonClone]> = [];
+    for (const [key, entry] of Object.entries(value)) {
+      if (typeof entry === 'undefined') {
+        continue;
+      }
+      const cloned = cloneJsonValue(entry, ancestors);
+      if (cloned === INVALID_JSON_VALUE) {
+        return INVALID_JSON_VALUE;
+      }
+      entries.push([key, cloned]);
+    }
+    return Object.fromEntries(entries);
+  } finally {
+    ancestors.delete(value);
+  }
+}

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -4905,6 +4905,112 @@ describe('Runner.run (streaming)', () => {
     expect(result.rawResponses[0].requestId).toBe('req_stream_123');
   });
 
+  it.each([
+    ['omitted', undefined, undefined],
+    ['disabled', false, undefined],
+    ['enabled', true, { input_tokens_details: { cached_tokens: 0 } }],
+  ] as const)(
+    'exposes streamed raw usage only when preservation is %s',
+    async (_label, preserveRawUsage, expectedRawUsage) => {
+      const agent = new Agent({
+        name: 'StreamRawUsage',
+        model: new ImmediateStreamingModel({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+          rawUsage: { input_tokens_details: { cached_tokens: 0 } },
+        }),
+        modelSettings: { preserveRawUsage },
+      });
+
+      const result = await run(agent, 'hello', { stream: true });
+      await result.completed;
+
+      expect(result.rawResponses[0].rawUsage).toEqual(expectedRawUsage);
+    },
+  );
+
+  it('detaches raw usage retained by a streamed result from the terminal event', async () => {
+    const agent = new Agent({
+      name: 'DetachedStreamRawUsage',
+      model: new ImmediateStreamingModel({
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+        rawUsage: { input_tokens_details: { cached_tokens: 0 } },
+      }),
+      modelSettings: { preserveRawUsage: true },
+    });
+
+    const result = await run(agent, 'hello', { stream: true });
+    for await (const event of result.toStream()) {
+      if (
+        event.type === 'raw_model_stream_event' &&
+        event.data.type === 'response_done' &&
+        event.data.response.rawUsage
+      ) {
+        (
+          event.data.response.rawUsage.input_tokens_details as {
+            cached_tokens: number;
+          }
+        ).cached_tokens = 99;
+      }
+    }
+    await result.completed;
+
+    expect(result.rawResponses[0].rawUsage).toEqual({
+      input_tokens_details: { cached_tokens: 0 },
+    });
+  });
+
+  it.each(['non-plain', 'cyclic', 'throwing getter'] as const)(
+    'ignores %s raw usage from a terminal model event',
+    async (variant) => {
+      class InvalidRawUsageStreamingModel implements Model {
+        async getResponse(): Promise<ModelResponse> {
+          throw new Error('Unexpected call to getResponse');
+        }
+
+        async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+          const response: Record<string, unknown> = {
+            id: 'r',
+            usage: {
+              requests: 1,
+              inputTokens: 1,
+              outputTokens: 1,
+              totalTokens: 2,
+            },
+            output: [fakeModelMessage('done')],
+          };
+          if (variant === 'throwing getter') {
+            Object.defineProperty(response, 'rawUsage', {
+              enumerable: true,
+              get() {
+                throw new Error('raw usage is unavailable');
+              },
+            });
+          } else if (variant === 'cyclic') {
+            const rawUsage: Record<string, unknown> = {};
+            rawUsage.self = rawUsage;
+            response.rawUsage = rawUsage;
+          } else {
+            response.rawUsage = new Map([['input_tokens', 1]]);
+          }
+          yield { type: 'response_done', response } as any;
+        }
+      }
+
+      const agent = new Agent({
+        name: 'InvalidRawUsage',
+        model: new InvalidRawUsageStreamingModel(),
+        modelSettings: { preserveRawUsage: true },
+      });
+      const result = await run(agent, 'hello', { stream: true });
+      await result.completed;
+
+      expect(result.finalOutput).toBe('done');
+      expect(result.rawResponses[0].rawUsage).toBeUndefined();
+    },
+  );
+
   it('runs blocking input guardrails before streaming starts', async () => {
     let guardrailFinished = false;
 
@@ -4991,6 +5097,7 @@ class ImmediateStreamingModel implements Model {
           outputTokens: usage.outputTokens,
           totalTokens: usage.totalTokens,
         },
+        rawUsage: this.response.rawUsage,
         output,
       },
     } satisfies StreamEvent;

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -422,16 +422,23 @@ export function registerRunStateCoreTests(): void {
           output: [TEST_MODEL_MESSAGE],
           responseId: 'resp_123',
           requestId: 'req_123',
+          rawUsage: { input_tokens: 1, provider_metric: 0 },
         },
       ];
       state._lastTurnResponse = state._modelResponses[0];
+
+      const serialized = state.toJSON() as any;
+      expect(serialized.modelResponses[0]).not.toHaveProperty('rawUsage');
+      expect(serialized.lastModelResponse).not.toHaveProperty('rawUsage');
 
       const restored = await RunState.fromString(agent, state.toString());
 
       expect(restored._modelResponses).toHaveLength(1);
       expect(restored._modelResponses[0].responseId).toBe('resp_123');
       expect(restored._modelResponses[0].requestId).toBe('req_123');
+      expect(restored._modelResponses[0].rawUsage).toBeUndefined();
       expect(restored._lastTurnResponse?.requestId).toBe('req_123');
+      expect(restored._lastTurnResponse?.rawUsage).toBeUndefined();
     });
 
     it('preserves toolInput after serialization', async () => {

--- a/packages/agents-core/test/utils/rawUsage.test.ts
+++ b/packages/agents-core/test/utils/rawUsage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { snapshotRawUsage } from '../../src/utils/rawUsage';
+
+describe('snapshotRawUsage', () => {
+  it('preserves field presence and returns a detached JSON object', () => {
+    const rawUsage = {
+      input_tokens: 3,
+      input_tokens_details: { cached_tokens: 0 },
+      provider_metric: null,
+      omitted_metric: undefined,
+    };
+
+    const snapshot = snapshotRawUsage(rawUsage);
+    rawUsage.input_tokens_details.cached_tokens = 9;
+
+    expect(snapshot).toEqual({
+      input_tokens: 3,
+      input_tokens_details: { cached_tokens: 0 },
+      provider_metric: null,
+    });
+  });
+
+  it('returns undefined for absent or non-JSON-compatible usage', () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    expect(snapshotRawUsage(undefined)).toBeUndefined();
+    expect(snapshotRawUsage([])).toBeUndefined();
+    expect(snapshotRawUsage({ provider_metric: 1n })).toBeUndefined();
+    expect(
+      snapshotRawUsage({ provider_metric: new Map([['key', 'value']]) }),
+    ).toBeUndefined();
+
+    const throwingUsage = {
+      get input_tokens(): number {
+        throw new Error('unavailable');
+      },
+    };
+    expect(snapshotRawUsage(throwingUsage)).toBeUndefined();
+    expect(snapshotRawUsage(cyclic)).toBeUndefined();
+  });
+});

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -44,6 +44,7 @@ import {
 import {
   formatInlineData,
   getInlineMediaType,
+  snapshotRawUsage,
 } from '@openai/agents-core/utils/internal';
 import { isZodObject } from '@openai/agents/utils';
 import { extractUsage, toTracingUsage } from './usage';
@@ -2201,6 +2202,14 @@ export class AiSdkModel implements Model {
         }
 
         const result = await this.#model.doGenerate(aiSdkRequest);
+        const rawUsage =
+          request.modelSettings.preserveRawUsage === true
+            ? snapshotRawUsage((result as any).usage)
+            : undefined;
+        const preservedUsage =
+          rawUsage !== undefined
+            ? extractUsage((result as any).usage)
+            : undefined;
         const baseProviderData = buildBaseProviderData(
           this.#model,
           (result as any).response?.id,
@@ -2335,18 +2344,20 @@ export class AiSdkModel implements Model {
         }
         flushPendingText();
         await this.#transformOutputTextItems(output, request, false);
+        const usage = preservedUsage ?? extractUsage((result as any).usage);
 
         if (span && request.tracing === true) {
           span.spanData.output = output;
         }
-
-        const usage = extractUsage((result as any).usage);
 
         const response = {
           responseId: (result as any).response?.id ?? 'FAKE_ID',
           usage: new Usage(usage),
           output,
           providerData: result,
+          ...(request.modelSettings.preserveRawUsage === true
+            ? { rawUsage }
+            : {}),
         } as const;
 
         if (span && request.tracing === true) {
@@ -2504,6 +2515,13 @@ export class AiSdkModel implements Model {
       let usageCompletionTokens = 0;
       let usageInputTokensDetails: Record<string, number> | undefined;
       let usageOutputTokensDetails: Record<string, number> | undefined;
+      let rawUsage: Record<string, unknown> | undefined;
+      const recordUsage = (usage: ReturnType<typeof extractUsage>) => {
+        usagePromptTokens = usage.inputTokens;
+        usageCompletionTokens = usage.outputTokens;
+        usageInputTokensDetails = usage.inputTokensDetails;
+        usageOutputTokensDetails = usage.outputTokensDetails;
+      };
       type StreamOutputEntry =
         | { kind: 'reasoning'; reasoningId: string }
         | {
@@ -2587,6 +2605,18 @@ export class AiSdkModel implements Model {
       };
 
       for await (const part of stream) {
+        const preservedFinishUsage =
+          part.type === 'finish' &&
+          request.modelSettings.preserveRawUsage === true
+            ? snapshotRawUsage((part as any).usage)
+            : undefined;
+        if (part.type === 'finish') {
+          rawUsage = preservedFinishUsage;
+          if (preservedFinishUsage !== undefined) {
+            recordUsage(extractUsage(preservedFinishUsage));
+          }
+        }
+
         if (!started) {
           started = true;
           yield { type: 'response_started' };
@@ -2704,11 +2734,9 @@ export class AiSdkModel implements Model {
             break;
           }
           case 'finish': {
-            const usage = extractUsage((part as any).usage);
-            usagePromptTokens = usage.inputTokens;
-            usageCompletionTokens = usage.outputTokens;
-            usageInputTokensDetails = usage.inputTokensDetails;
-            usageOutputTokensDetails = usage.outputTokensDetails;
+            if (preservedFinishUsage === undefined) {
+              recordUsage(extractUsage((part as any).usage));
+            }
             break;
           }
           case 'error': {
@@ -2795,6 +2823,9 @@ export class AiSdkModel implements Model {
                 }
               : {}),
           },
+          ...(request.modelSettings.preserveRawUsage === true && rawUsage
+            ? { rawUsage }
+            : {}),
           output: outputs,
         },
       };

--- a/packages/agents-extensions/test/ai-sdk/GoogleFormat.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/GoogleFormat.test.ts
@@ -74,17 +74,19 @@ class CollectingProcessor implements TracingProcessor {
 
 describe('AiSdkModel issue #802', () => {
   test('handles object usage in doGenerate (Google AI SDK compatibility)', async () => {
+    const rawUsage = {
+      inputTokens: { total: 10, noCache: 10, cacheRead: 0 },
+      outputTokens: { total: 20 },
+      totalTokens: { total: 30 },
+      providerMetric: null,
+    };
     const model = new AiSdkModel(
       stubModel({
         async doGenerate() {
           return {
             content: [{ type: 'text', text: 'ok' }],
             // Simulating Google AI SDK behavior where tokens are objects
-            usage: {
-              inputTokens: { total: 10, noCache: 10, cacheRead: 0 } as any,
-              outputTokens: { total: 20 } as any,
-              totalTokens: { total: 30 } as any,
-            },
+            usage: rawUsage,
             providerMetadata: {},
             response: { id: 'id' },
             finishReason: 'stop',
@@ -92,6 +94,13 @@ describe('AiSdkModel issue #802', () => {
           } as any;
         },
       }),
+      {
+        async transformOutputText(text) {
+          await Promise.resolve();
+          rawUsage.inputTokens.cacheRead = 9;
+          return text;
+        },
+      },
     );
 
     const res = await withTrace('t', () =>
@@ -99,7 +108,7 @@ describe('AiSdkModel issue #802', () => {
         input: 'hi',
         tools: [],
         handoffs: [],
-        modelSettings: {},
+        modelSettings: { preserveRawUsage: true },
         outputType: 'text',
         tracing: false,
       } as any),
@@ -114,7 +123,66 @@ describe('AiSdkModel issue #802', () => {
       outputTokensDetails: [],
       requestUsageEntries: undefined,
     });
+    rawUsage.inputTokens.cacheRead = 11;
+    expect(res.rawUsage).toEqual({
+      inputTokens: { total: 10, noCache: 10, cacheRead: 0 },
+      outputTokens: { total: 20 },
+      totalTokens: { total: 30 },
+      providerMetric: null,
+    });
   });
+
+  test.each([
+    ['disabled', false, false],
+    ['invalid snapshot', true, true],
+  ])(
+    'keeps post-transform usage extraction when preservation is %s',
+    async (_label, preserveRawUsage, useClassInstance) => {
+      const usage = {
+        inputTokens: { total: 10 },
+        outputTokens: { total: 20 },
+      };
+      const providerUsage = useClassInstance
+        ? Object.assign(Object.create({ provider: 'google' }), usage)
+        : usage;
+      const model = new AiSdkModel(
+        stubModel({
+          async doGenerate() {
+            return {
+              content: [{ type: 'text', text: 'ok' }],
+              usage: providerUsage,
+              providerMetadata: {},
+              response: { id: 'id' },
+              finishReason: 'stop',
+              warnings: [],
+            } as any;
+          },
+        }),
+        {
+          async transformOutputText(text) {
+            await Promise.resolve();
+            providerUsage.inputTokens.total = 99;
+            return text;
+          },
+        },
+      );
+
+      const result = await withTrace('t', () =>
+        model.getResponse({
+          input: 'hi',
+          tools: [],
+          handoffs: [],
+          modelSettings: { preserveRawUsage },
+          outputType: 'text',
+          tracing: false,
+        } as any),
+      );
+
+      expect(result.rawUsage).toBeUndefined();
+      expect(result.usage.inputTokens).toBe(99);
+      expect(result.usage.totalTokens).toBe(119);
+    },
+  );
 
   test('maps cacheRead/cacheWrite usage in generation spans (#945, #955)', async () => {
     const processor = new CollectingProcessor();
@@ -208,18 +276,24 @@ describe('AiSdkModel issue #802', () => {
     );
 
     let finalUsage: any;
+    let finalRawUsage: any;
     try {
       await withTrace('t', async () => {
         for await (const ev of model.getStreamedResponse({
           input: 'hi',
           tools: [],
           handoffs: [],
-          modelSettings: {},
+          modelSettings: { preserveRawUsage: true },
           outputType: 'text',
           tracing: true,
         } as any)) {
+          if (ev.type === 'model' && (ev.event as any).type === 'finish') {
+            (ev.event as any).usage.inputTokens.cacheRead = 99;
+            (ev.event as any).usage.outputTokens.reasoning = 77;
+          }
           if (ev.type === 'response_done') {
             finalUsage = ev.response.usage;
+            finalRawUsage = ev.response.rawUsage;
           }
         }
       });
@@ -230,6 +304,10 @@ describe('AiSdkModel issue #802', () => {
         totalTokens: 13,
         inputTokensDetails: { cached_tokens: 1, cache_write_tokens: 2 },
         outputTokensDetails: { reasoning_tokens: 2, text_tokens: 6 },
+      });
+      expect(finalRawUsage).toEqual({
+        inputTokens: { total: 5, cacheRead: 1, cacheWrite: 2 },
+        outputTokens: { total: 8, text: 6, reasoning: 2 },
       });
 
       const generationSpan = processor.spans.find(
@@ -247,6 +325,58 @@ describe('AiSdkModel issue #802', () => {
       setTraceProcessors([new BatchTraceProcessor(new ConsoleSpanExporter())]);
     }
   });
+
+  test.each([
+    ['disabled', false, false],
+    ['invalid snapshot', true, true],
+  ])(
+    'keeps post-event usage extraction when streaming preservation is %s',
+    async (_label, preserveRawUsage, useClassInstance) => {
+      const usage = {
+        inputTokens: { total: 5 },
+        outputTokens: { total: 8 },
+      };
+      const providerUsage = useClassInstance
+        ? Object.assign(Object.create({ provider: 'google' }), usage)
+        : usage;
+      const model = new AiSdkModel(
+        stubModel({
+          async doStream() {
+            return {
+              stream: partsStream([
+                {
+                  type: 'finish',
+                  finishReason: 'stop',
+                  usage: providerUsage,
+                },
+              ]),
+            } as any;
+          },
+        }),
+      );
+      let finalEvent: any;
+
+      for await (const event of model.getStreamedResponse({
+        input: 'hi',
+        tools: [],
+        handoffs: [],
+        modelSettings: { preserveRawUsage },
+        outputType: 'text',
+        tracing: false,
+      } as any)) {
+        if (event.type === 'model' && (event.event as any).type === 'finish') {
+          (event.event as any).usage.inputTokens.total = 99;
+        }
+        if (event.type === 'response_done') {
+          finalEvent = event;
+        }
+      }
+
+      expect(finalEvent.response.rawUsage).toBeUndefined();
+      expect(finalEvent.response.usage.inputTokens).toBe(99);
+      expect(finalEvent.response.usage.totalTokens).toBe(107);
+    },
+  );
 
   test('preserves toolChoice and provider options through streaming tool calls', async () => {
     const parts = [

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -44,6 +44,7 @@ import {
   CONTENT_FILTER_REFUSAL_MESSAGE,
   shouldSynthesizeContentFilterRefusal,
 } from './openaiChatCompletionsContentFilter';
+import { snapshotRawUsage } from '@openai/agents-core/utils/internal';
 
 type ModelTracingParent = Parameters<typeof createGenerationSpan>[1];
 
@@ -115,61 +116,72 @@ export class OpenAIChatCompletionsModel implements Model {
     this.#handleUnsupportedPrompt(request);
     this.#handleUnsupportedReasoningSettings(request);
 
-    const { response, rawResponse } = await withGenerationSpan(
-      async (span) => {
-        span.spanData.model = this.#model;
-        span.spanData.model_config = request.modelSettings
-          ? {
-              temperature: request.modelSettings.temperature,
-              top_p: request.modelSettings.topP,
-              frequency_penalty: request.modelSettings.frequencyPenalty,
-              presence_penalty: request.modelSettings.presencePenalty,
-              reasoning_effort: request.modelSettings.reasoning?.effort,
-              verbosity: request.modelSettings.text?.verbosity,
-            }
-          : { base_url: this.#client.baseURL };
-        const rawResponse = await this.#fetchResponse(request, span, false);
-        let response = rawResponse;
-        const firstChoice = rawResponse.choices?.[0];
-        const message = firstChoice?.message;
-        // Some providers signal a filtered completion only through the finish reason.
-        // Normalize that terminal signal before tracing and protocol conversion.
-        if (
-          firstChoice &&
-          message &&
-          shouldSynthesizeContentFilterRefusal({
-            finishReason: firstChoice.finish_reason,
-            hasOutput: Boolean(
-              message.content ||
-              message.refusal ||
-              message.tool_calls?.length ||
-              message.audio,
-            ),
-          })
-        ) {
-          response = {
-            ...rawResponse,
-            choices: [
-              {
-                ...firstChoice,
-                message: {
-                  ...message,
-                  content: null,
-                  refusal: CONTENT_FILTER_REFUSAL_MESSAGE,
+    const { response, rawResponse, rawUsage, preservedUsage } =
+      await withGenerationSpan(
+        async (span) => {
+          span.spanData.model = this.#model;
+          span.spanData.model_config = request.modelSettings
+            ? {
+                temperature: request.modelSettings.temperature,
+                top_p: request.modelSettings.topP,
+                frequency_penalty: request.modelSettings.frequencyPenalty,
+                presence_penalty: request.modelSettings.presencePenalty,
+                reasoning_effort: request.modelSettings.reasoning?.effort,
+                verbosity: request.modelSettings.text?.verbosity,
+              }
+            : { base_url: this.#client.baseURL };
+          const rawResponse = await this.#fetchResponse(request, span, false);
+          const rawUsage =
+            request.modelSettings.preserveRawUsage === true
+              ? snapshotRawUsage(rawResponse.usage)
+              : undefined;
+          const preservedUsage =
+            rawUsage !== undefined
+              ? new Usage(
+                  toResponseUsage(rawUsage as unknown as CompletionUsage),
+                )
+              : undefined;
+          let response = rawResponse;
+          const firstChoice = rawResponse.choices?.[0];
+          const message = firstChoice?.message;
+          // Some providers signal a filtered completion only through the finish reason.
+          // Normalize that terminal signal before tracing and protocol conversion.
+          if (
+            firstChoice &&
+            message &&
+            shouldSynthesizeContentFilterRefusal({
+              finishReason: firstChoice.finish_reason,
+              hasOutput: Boolean(
+                message.content ||
+                message.refusal ||
+                message.tool_calls?.length ||
+                message.audio,
+              ),
+            })
+          ) {
+            response = {
+              ...rawResponse,
+              choices: [
+                {
+                  ...firstChoice,
+                  message: {
+                    ...message,
+                    content: null,
+                    refusal: CONTENT_FILTER_REFUSAL_MESSAGE,
+                  },
                 },
-              },
-              ...rawResponse.choices.slice(1),
-            ],
-          };
-        }
-        if (span && request.tracing === true) {
-          span.spanData.output = [response];
-        }
-        return { response, rawResponse };
-      },
-      undefined,
-      getModelTracingParent(request),
-    );
+                ...rawResponse.choices.slice(1),
+              ],
+            };
+          }
+          if (span && request.tracing === true) {
+            span.spanData.output = [response];
+          }
+          return { response, rawResponse, rawUsage, preservedUsage };
+        },
+        undefined,
+        getModelTracingParent(request),
+      );
 
     const output: protocol.OutputModelItem[] = [];
     if (response.choices && response.choices[0]) {
@@ -273,12 +285,15 @@ export class OpenAIChatCompletionsModel implements Model {
       }
     }
     const modelResponse: ModelResponse = {
-      usage: response.usage
-        ? new Usage(toResponseUsage(response.usage))
-        : new Usage(),
+      usage:
+        preservedUsage ??
+        (response.usage
+          ? new Usage(toResponseUsage(response.usage))
+          : new Usage()),
       output,
       responseId: response.id,
       providerData: rawResponse,
+      ...(rawUsage !== undefined ? { rawUsage } : {}),
     };
 
     return modelResponse;
@@ -327,7 +342,12 @@ export class OpenAIChatCompletionsModel implements Model {
       for await (const event of convertChatCompletionsStreamToResponses(
         response,
         stream,
-        { strictFeatureValidation: this.#strictFeatureValidation },
+        {
+          strictFeatureValidation: this.#strictFeatureValidation,
+          ...(request.modelSettings.preserveRawUsage === true
+            ? { preserveRawUsage: true }
+            : {}),
+        },
       )) {
         if (
           event.type === 'response_done' &&

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -1,6 +1,7 @@
 import type { Stream } from 'openai/streaming';
 import type { CompletionUsage } from 'openai/resources/completions';
 import { protocol, UserError } from '@openai/agents-core';
+import { snapshotRawUsage } from '@openai/agents-core/utils/internal';
 import { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat';
 import { FAKE_ID } from './openaiChatCompletionsModel';
 import { OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
@@ -25,9 +26,13 @@ type StreamingState = {
 export async function* convertChatCompletionsStreamToResponses(
   response: ChatCompletion,
   stream: Stream<ChatCompletionChunk>,
-  options: { strictFeatureValidation?: boolean } = {},
+  options: {
+    strictFeatureValidation?: boolean;
+    preserveRawUsage?: boolean;
+  } = {},
 ): AsyncIterable<protocol.StreamEvent> {
   let usage: CompletionUsage | undefined = undefined;
+  let rawUsage: Record<string, unknown> | undefined;
   const state: StreamingState = {
     started: false,
     text_content: null,
@@ -42,6 +47,19 @@ export async function* convertChatCompletionsStreamToResponses(
   const strictFeatureValidation = options.strictFeatureValidation ?? false;
 
   for await (const chunk of stream) {
+    // Usage is not always reported on the final chunk: some OpenAI-compatible
+    // providers or gateways may emit a later chunk without usage after
+    // reporting usage, so only overwrite it when the current chunk actually
+    // carries usage data. Capture raw usage before exposing the chunk to the
+    // consumer so later mutations cannot change the snapshot.
+    if ((chunk as any).usage) {
+      const usagePayload = (chunk as any).usage as CompletionUsage;
+      if (options.preserveRawUsage === true) {
+        rawUsage = snapshotRawUsage(usagePayload);
+      }
+      usage = (rawUsage as CompletionUsage | undefined) ?? usagePayload;
+    }
+
     if (chunk.id && (response.id === FAKE_ID || !response.id)) {
       response.id = chunk.id;
     }
@@ -64,14 +82,6 @@ export async function* convertChatCompletionsStreamToResponses(
         rawModelEventSource: OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE,
       },
     };
-
-    // Usage is not always reported on the final chunk: some OpenAI-compatible
-    // providers or gateways may emit a later chunk without usage after
-    // reporting usage, so only overwrite it when the current chunk actually
-    // carries usage data.
-    if ((chunk as any).usage) {
-      usage = (chunk as any).usage;
-    }
 
     if (!chunk.choices || chunk.choices.length === 0) continue;
 
@@ -260,6 +270,7 @@ export async function* convertChatCompletionsStreamToResponses(
             (usage as any)?.completion_tokens_details?.reasoning_tokens ?? 0,
         },
       },
+      ...(options.preserveRawUsage === true ? { rawUsage } : {}),
       output: outputs,
     },
   };

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -81,6 +81,7 @@ import {
   assertValidCompactionItems,
   formatInlineData,
   getInlineMediaType,
+  snapshotRawUsage,
 } from '@openai/agents-core/utils/internal';
 
 type ModelTracingParent = Parameters<typeof createResponseSpan>[1];
@@ -3534,9 +3535,15 @@ export class OpenAIResponsesModel implements Model {
    * @returns A promise that resolves to the response from the model.
    */
   async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    const response = await withResponseSpan(
+    const { response, rawUsage, preservedUsage } = await withResponseSpan(
       async (span) => {
         const response = await this._fetchResponse(request, false);
+        const rawUsage =
+          request.modelSettings.preserveRawUsage === true
+            ? snapshotRawUsage(response.usage)
+            : undefined;
+        const preservedUsage =
+          rawUsage !== undefined ? this._getResponseUsage(response) : undefined;
 
         if (request.tracing) {
           span.spanData.response_id = response.id;
@@ -3544,7 +3551,7 @@ export class OpenAIResponsesModel implements Model {
           span.spanData._response = response;
         }
 
-        return response;
+        return { response, rawUsage, preservedUsage };
       },
       undefined,
       getModelTracingParent(request),
@@ -3552,13 +3559,14 @@ export class OpenAIResponsesModel implements Model {
 
     const responseForSDKOutput = this._getResponseForSDKOutput(response);
     const output: ModelResponse = {
-      usage: this._getResponseUsage(response),
+      usage: preservedUsage ?? this._getResponseUsage(response),
       output: this._convertResponseOutputItems(
         responseForSDKOutput.output as Array<Record<string, any>>,
       ),
       responseId: response.id,
       requestId: getOpenAIResponseRequestId(response),
       providerData: response,
+      ...(rawUsage !== undefined ? { rawUsage } : {}),
     };
 
     return output;
@@ -3637,6 +3645,9 @@ export class OpenAIResponsesModel implements Model {
                 responseForSDKOutput.output as Array<Record<string, any>>,
               ),
               usage: this._getStreamedResponseUsage(response),
+              ...(request.modelSettings.preserveRawUsage === true
+                ? { rawUsage: snapshotRawUsage(response.usage) }
+                : {}),
               providerData: remainingResponse,
             },
             providerData: remainingEvent,

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -105,6 +105,114 @@ describe('OpenAIChatCompletionsModel', () => {
         ],
       },
     ]);
+    expect(result.rawUsage).toBeUndefined();
+  });
+
+  it('preserves raw usage field presence before normalization when enabled', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: 'hi' } }],
+      usage: {
+        prompt_tokens: 3,
+        completion_tokens: 2,
+        total_tokens: 5,
+        prompt_tokens_details: {
+          cached_tokens: 0,
+          provider_metric: null,
+        },
+      },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const result = await withTrace('t', () =>
+      model.getResponse({
+        input: 'u',
+        modelSettings: { preserveRawUsage: true },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      } as any),
+    );
+
+    response.usage.prompt_tokens_details.cached_tokens = 9;
+
+    expect(result.rawUsage).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 2,
+      total_tokens: 5,
+      prompt_tokens_details: {
+        cached_tokens: 0,
+        provider_metric: null,
+      },
+    });
+    expect(result.rawUsage?.prompt_tokens_details).not.toHaveProperty(
+      'cache_write_tokens',
+    );
+    expect(result.usage.inputTokensDetails).toEqual([{ cached_tokens: 0 }]);
+  });
+
+  it('captures raw and normalized usage before tracing processors can mutate it', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create.mockResolvedValue({
+      id: 'r',
+      choices: [{ message: { content: 'hi' } }],
+      usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+    } as any);
+    const processor = new RecordingProcessor();
+    processor.onSpanEnd = async (span) => {
+      const response = span.spanData.output?.[0] as any;
+      if (response?.usage) {
+        response.usage.prompt_tokens = 99;
+      }
+      processor.spansEnded.push(span);
+    };
+    setTracingDisabled(false);
+    setTraceProcessors([processor]);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const result = await withTrace('t', () =>
+      model.getResponse({
+        input: 'u',
+        modelSettings: { preserveRawUsage: true },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+      } as any),
+    );
+
+    expect(result.rawUsage).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 2,
+      total_tokens: 5,
+    });
+    expect(result.usage.inputTokens).toBe(3);
+  });
+
+  it('leaves raw usage undefined when the provider omits usage', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create.mockResolvedValue({
+      id: 'r',
+      choices: [{ message: { content: 'hi' } }],
+    } as any);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const result = await withTrace('t', () =>
+      model.getResponse({
+        input: 'u',
+        modelSettings: { preserveRawUsage: true },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      } as any),
+    );
+
+    expect(result.rawUsage).toBeUndefined();
+    expect(result.usage.totalTokens).toBe(0);
   });
 
   it('sends placeholder for non-text-only tool output by default', async () => {
@@ -1631,7 +1739,7 @@ describe('OpenAIChatCompletionsModel', () => {
     const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
     const req: any = {
       input: 'hi',
-      modelSettings: {},
+      modelSettings: { preserveRawUsage: true },
       tools: [],
       outputType: 'text',
       handoffs: [],
@@ -1651,7 +1759,7 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(convertChatCompletionsStreamToResponses).toHaveBeenCalled();
     expect(
       vi.mocked(convertChatCompletionsStreamToResponses).mock.calls[0]?.[2],
-    ).toEqual({ strictFeatureValidation: false });
+    ).toEqual({ strictFeatureValidation: false, preserveRawUsage: true });
     expect(events).toEqual([{ type: 'first' }, { type: 'second' }]);
   });
 

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -356,7 +356,15 @@ describe('convertChatCompletionsStreamToResponses', () => {
       // reporting usage)...
       yield makeChunk(
         { content: 'Hello' },
-        { prompt_tokens: 100, completion_tokens: 5, total_tokens: 105 },
+        {
+          prompt_tokens: 100,
+          completion_tokens: 5,
+          total_tokens: 105,
+          prompt_tokens_details: {
+            cached_tokens: 0,
+            provider_metric: null,
+          },
+        },
       );
       // ...and the terminal chunk carries no usage at all.
       yield {
@@ -369,12 +377,26 @@ describe('convertChatCompletionsStreamToResponses', () => {
     }
 
     const resp = { id: 'r' } as any;
-    const events: any[] = [];
-    for await (const e of convertChatCompletionsStreamToResponses(
+    const iterator = convertChatCompletionsStreamToResponses(
       resp,
       stream() as any,
-    )) {
-      events.push(e);
+      { preserveRawUsage: true },
+    )[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(first.value.type).toBe('response_started');
+    (first.value as any).providerData.usage.prompt_tokens = 999;
+    (
+      first.value as any
+    ).providerData.usage.prompt_tokens_details.cached_tokens = 88;
+
+    const events: any[] = [first.value];
+    for (
+      let next = await iterator.next();
+      !next.done;
+      next = await iterator.next()
+    ) {
+      events.push(next.value);
     }
 
     const final = events[events.length - 1];
@@ -383,6 +405,15 @@ describe('convertChatCompletionsStreamToResponses', () => {
       inputTokens: 100,
       outputTokens: 5,
       totalTokens: 105,
+    });
+    expect(final.response.rawUsage).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 5,
+      total_tokens: 105,
+      prompt_tokens_details: {
+        cached_tokens: 0,
+        provider_metric: null,
+      },
     });
     expect(resp.usage).toMatchObject({
       prompt_tokens: 100,

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 import {
   OpenAIResponsesModel,
   OpenAIResponsesWSModel,
@@ -13,6 +13,7 @@ import {
   type AgentInputItem,
   type Session,
   setDefaultModelProvider,
+  setTraceProcessors,
   setTracingDisabled,
   withTrace,
   type ResponseStreamEvent,
@@ -28,6 +29,10 @@ describe('OpenAIResponsesModel', () => {
         throw new Error('not used');
       },
     });
+  });
+  afterEach(() => {
+    setTracingDisabled(true);
+    setTraceProcessors([]);
   });
   it('getResponse returns correct ModelResponse and calls client with right parameters', async () => {
     await withTrace('test', async () => {
@@ -91,7 +96,105 @@ describe('OpenAIResponsesModel', () => {
         },
       ]);
       expect(result.responseId).toBe('res1');
+      expect(result.rawUsage).toBeUndefined();
     });
+  });
+
+  it.each([
+    ['omitted', {}, {}],
+    ['explicit zero', { cached_tokens: 0 }, { cached_tokens: 0 }],
+  ])(
+    'getResponse preserves %s cached token field presence when enabled',
+    async (_label, inputTokensDetails, expectedInputTokensDetails) => {
+      await withTrace('test', async () => {
+        const fakeResponse = {
+          id: 'res-raw-usage',
+          usage: {
+            input_tokens: 3,
+            output_tokens: 2,
+            total_tokens: 5,
+            input_tokens_details: inputTokensDetails,
+            output_tokens_details: { reasoning_tokens: 0 },
+            provider_metric: null,
+          },
+          output: [],
+        };
+        const createMock = vi.fn().mockResolvedValue(fakeResponse);
+        const model = new OpenAIResponsesModel(
+          { responses: { create: createMock } } as unknown as OpenAI,
+          'gpt-test',
+        );
+
+        const result = await model.getResponse({
+          input: 'hello',
+          modelSettings: { preserveRawUsage: true },
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+        } as any);
+
+        expect(result.rawUsage).toEqual({
+          input_tokens: 3,
+          output_tokens: 2,
+          total_tokens: 5,
+          input_tokens_details: expectedInputTokensDetails,
+          output_tokens_details: { reasoning_tokens: 0 },
+          provider_metric: null,
+        });
+      });
+    },
+  );
+
+  it('captures raw and normalized usage before tracing processors can mutate it', async () => {
+    const fakeResponse = {
+      id: 'res-traced-raw-usage',
+      usage: {
+        input_tokens: 3,
+        output_tokens: 2,
+        total_tokens: 5,
+      },
+      output: [],
+    };
+    const createMock = vi.fn().mockResolvedValue(fakeResponse);
+    setTracingDisabled(false);
+    setTraceProcessors([
+      {
+        async onTraceStart() {},
+        async onTraceEnd() {},
+        async onSpanStart() {},
+        async onSpanEnd(span: Span<any>) {
+          const response = span.spanData._response as any;
+          if (response?.usage) {
+            response.usage.input_tokens = 99;
+          }
+        },
+        async shutdown() {},
+        async forceFlush() {},
+      },
+    ]);
+    const model = new OpenAIResponsesModel(
+      { responses: { create: createMock } } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    const result = await withTrace('test', () =>
+      model.getResponse({
+        input: 'hello',
+        modelSettings: { preserveRawUsage: true },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+      } as any),
+    );
+
+    expect(result.rawUsage).toEqual({
+      input_tokens: 3,
+      output_tokens: 2,
+      total_tokens: 5,
+    });
+    expect(result.usage.inputTokens).toBe(3);
   });
 
   it('getResponse exposes the OpenAI request ID on ModelResponse', async () => {
@@ -4594,6 +4697,7 @@ describe('OpenAIResponsesModel', () => {
             total_tokens: 16,
             input_tokens_details: { cached_tokens: 2 },
             output_tokens_details: { reasoning_tokens: 3 },
+            provider_metric: null,
           },
         },
         sequence_number: 1,
@@ -4611,7 +4715,7 @@ describe('OpenAIResponsesModel', () => {
       const request = {
         systemInstructions: undefined,
         input: 'payload',
-        modelSettings: {},
+        modelSettings: { preserveRawUsage: true },
         tools: [],
         outputType: 'text',
         handoffs: [],
@@ -4643,6 +4747,14 @@ describe('OpenAIResponsesModel', () => {
             endpoint: 'responses.create',
           },
         ],
+      });
+      expect((responseDone as any).response.rawUsage).toEqual({
+        input_tokens: 11,
+        output_tokens: 5,
+        total_tokens: 16,
+        input_tokens_details: { cached_tokens: 2 },
+        output_tokens_details: { reasoning_tokens: 3 },
+        provider_metric: null,
       });
     });
   });


### PR DESCRIPTION
This pull request adds an opt-in `preserveRawUsage` model setting and exposes detached, pre-normalization provider usage on completed model responses.

It wires preservation through OpenAI Responses, Chat Completions, and AI SDK streaming and non-streaming paths while keeping default normalized usage, provider requests, tracing, and RunState serialization unchanged. It also documents the behavior and adds patch changesets for the affected packages.

see also: https://github.com/openai/openai-agents-python/pull/4279
