### PR TITLE
feat: use gpt-5.6-luna as default model

### DIFF
--- a/.changeset/gpt56-luna-default-model.md
+++ b/.changeset/gpt56-luna-default-model.md
@@ -1,0 +1,7 @@
+---
+'@openai/agents': minor
+'@openai/agents-core': minor
+'@openai/agents-openai': minor
+---
+
+feat: switch the default OpenAI model to gpt-5.6-luna when no model is explicitly configured

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -332,7 +332,7 @@ export interface AgentConfiguration<
    * The model implementation to use when invoking the LLM.
    *
    * By default, if not set, the agent will use the default model returned by
-   * getDefaultModel (currently "gpt-5.4-mini").
+   * getDefaultModel (currently "gpt-5.6-luna").
    */
   model: string | Model;
 

--- a/packages/agents-core/src/defaultModel.ts
+++ b/packages/agents-core/src/defaultModel.ts
@@ -72,7 +72,7 @@ export function isGpt5Default(): boolean {
 export function getDefaultModel(): string {
   const env = loadEnv();
   return (
-    env[OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]?.toLowerCase() ?? 'gpt-5.4-mini'
+    env[OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]?.toLowerCase() ?? 'gpt-5.6-luna'
   );
 }
 

--- a/packages/agents-core/test/defaultModel.test.ts
+++ b/packages/agents-core/test/defaultModel.test.ts
@@ -40,9 +40,9 @@ describe('gpt5ReasoningSettingsRequired', () => {
   });
 });
 describe('getDefaultModel', () => {
-  test('falls back to gpt-5.4-mini when env var missing', () => {
+  test('falls back to gpt-5.6-luna when env var missing', () => {
     mockedLoadEnv.mockReturnValue({});
-    expect(getDefaultModel()).toBe('gpt-5.4-mini');
+    expect(getDefaultModel()).toBe('gpt-5.6-luna');
   });
   test('lowercases provided env value', () => {
     mockedLoadEnv.mockReturnValue({
@@ -84,7 +84,7 @@ describe('isGpt5Default', () => {
   });
 });
 describe('getDefaultModelSettings', () => {
-  test('returns GPT-5.4 mini defaults when no model is specified', () => {
+  test('returns GPT-5.6 Luna defaults when no model is specified', () => {
     mockedLoadEnv.mockReturnValue({});
     expect(getDefaultModelSettings()).toEqual({
       reasoning: { effort: 'none' },

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -3,7 +3,7 @@ import METADATA from './metadata';
 import type { OpenAIClient } from './openaiClient';
 
 export const DEFAULT_OPENAI_API = 'responses';
-export const DEFAULT_OPENAI_MODEL = 'gpt-5.4-mini';
+export const DEFAULT_OPENAI_MODEL = 'gpt-5.6-luna';
 export const DEFAULT_OPENAI_RESPONSES_TRANSPORT = 'http';
 
 let _defaultOpenAIAPI = DEFAULT_OPENAI_API;

--- a/packages/agents-openai/test/defaults.test.ts
+++ b/packages/agents-openai/test/defaults.test.ts
@@ -15,8 +15,8 @@ import {
 import OpenAI from 'openai';
 
 describe('Defaults', () => {
-  test('Default OpenAI model is gpt-5.4-mini', () => {
-    expect(DEFAULT_OPENAI_MODEL).toBe('gpt-5.4-mini');
+  test('Default OpenAI model is gpt-5.6-luna', () => {
+    expect(DEFAULT_OPENAI_MODEL).toBe('gpt-5.6-luna');
   });
   test('get/setTracingExportApiKey', async () => {
     setTracingExportApiKey('foo');

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -276,7 +276,7 @@ describe('OpenAIResponsesCompactionSession', () => {
 
     expect(compact).toHaveBeenCalledTimes(1);
     const [request] = compact.mock.calls[0] ?? [];
-    expect(request).toMatchObject({ model: 'gpt-5.4-mini' });
+    expect(request).toMatchObject({ model: 'gpt-5.6-luna' });
     expect(request.previous_response_id).toBeUndefined();
     expect(request.input).toHaveLength(2);
     expect(request.input[0]).toMatchObject({
@@ -354,7 +354,7 @@ describe('OpenAIResponsesCompactionSession', () => {
 
     expect(compact).toHaveBeenCalledTimes(1);
     const [request] = compact.mock.calls[0] ?? [];
-    expect(request).toMatchObject({ model: 'gpt-5.4-mini' });
+    expect(request).toMatchObject({ model: 'gpt-5.6-luna' });
     expect(request.previous_response_id).toBeUndefined();
     expect(request.input).toHaveLength(2);
   });
@@ -459,7 +459,7 @@ describe('OpenAIResponsesCompactionSession', () => {
     expect(compact).toHaveBeenCalledTimes(1);
     expect(compact).toHaveBeenCalledWith({
       previous_response_id: 'resp_2',
-      model: 'gpt-5.4-mini',
+      model: 'gpt-5.6-luna',
     });
     expect(decisionHistoryLengths).toEqual([1]);
 
@@ -570,7 +570,7 @@ describe('OpenAIResponsesCompactionSession', () => {
 
     expect(compact).toHaveBeenCalledWith({
       previous_response_id: 'resp_store',
-      model: 'gpt-5.4-mini',
+      model: 'gpt-5.6-luna',
     });
     expect(await session.getItems()).toEqual([
       {
@@ -595,7 +595,7 @@ describe('OpenAIResponsesCompactionSession', () => {
     expect(compact).toHaveBeenCalledTimes(2);
     expect(compact).toHaveBeenLastCalledWith({
       previous_response_id: 'resp_store',
-      model: 'gpt-5.4-mini',
+      model: 'gpt-5.6-luna',
     });
     expect(await session.getItems()).toEqual([
       {


### PR DESCRIPTION
This pull request updates the Agents SDK default model from `gpt-5.4-mini` to `gpt-5.6-luna`.

Following the Luna pricing update, both models were reevaluated from scratch across 20 example-derived Agents SDK scenarios using the same script from https://github.com/openai/openai-agents-js/pull/1248. All figures below are drawn exclusively from three-session dataset.

The evaluation covered text and structured output, function tools, tool and output guardrails, streaming, handoffs, agents as tools, parallel orchestration, conversation continuation, image and PDF inputs, file outputs, and multi-agent workflows.

Both models used `reasoning.effort: "none"`, `text.verbosity: "low"`, and the same token ceiling. Each session used fresh agents, excluded warm-ups, alternated model execution order between attempts, and did not use a prompt cache key.

### Functional results

Across the three complete sessions:

| Result | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Measured attempts | 276 | 276 |
| Successful checks | 275 | 276 |
| Success rate | 99.6% | 100% |

Luna matched or exceeded `gpt-5.4-mini` across the primary evaluation. Both models completed all 267 checks outside the multi-agent story workflow successfully.

The only primary failure was one `gpt-5.4-mini` attempt in the story workflow's model-graded quality gate. Because this creative workflow showed variability, it was evaluated in three additional interleaved control batches:

| Story workflow | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Primary sessions | 8/9 | 9/9 |
| Additional control | 9/9 | 7/9 |
| Combined | 17/18 | 16/18 |

Including the focused control, the overall result was 284/285 for `gpt-5.4-mini` and 283/285 for Luna, or 99.6% versus 99.3%. The difference was one check out of 285 and was limited to the stochastic creative-story quality gate.

No failures occurred for factual or constrained responses, structured output, streaming, tools, guardrails, handoffs, parallel orchestration, conversation state, image/PDF inputs, or file handling.

### Usage and cost

The primary three-session workload produced the same number of API requests for both models, while Luna used fewer tokens:

| Metric | `gpt-5.4-mini` | `gpt-5.6-luna` | Difference |
|---|---:|---:|---:|
| API requests | 498 | 498 | 0% |
| Input tokens | 53,994 | 52,978 | -1.9% |
| Output tokens | 10,704 | 10,345 | -3.4% |
| Total tokens | 64,698 | 63,323 | -2.1% |

Under the current [Standard API pricing](https://developers.openai.com/api/docs/pricing), Luna's input and output token rates are both approximately 73.3% lower:

| Price per 1M tokens | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Input | `$0.75` | `$0.20` |
| Output | `$4.50` | `$1.20` |

Using the uncached Standard rates as a conservative estimate, the measured workload cost approximately:

| Model | Estimated cost |
|---|---:|
| `gpt-5.4-mini` | `$0.088664` |
| `gpt-5.6-luna` | `$0.023010` |

Luna reduced the estimated workload cost by approximately 74.0%.

### Response-time comparison

Latency was measured on a machine shared with other tasks, so the results are presented as directional relative averages rather than absolute timings.

For each session and workflow, mean latency was calculated and normalized with `gpt-5.4-mini` set to `1.00`. The table averages those normalized results across the three fresh sessions. Lower values are faster.

| Workflow group | `gpt-5.4-mini` | `gpt-5.6-luna` |
|---|---:|---:|
| Text and structured output | 1.00 | 1.06 |
| Tools and guardrails | 1.00 | 1.02 |
| Handoffs and orchestration | 1.00 | 1.06 |
| Conversations and files | 1.00 | 1.15 |
| Overall average | 1.00 | 1.07 |

Luna's normalized mean latency was approximately 7% higher overall and remained in the same general response-time range. Both models had double-digit-second outliers caused by shared-environment variability; none were excluded.

Taken together, the fresh results show near-equivalent functional behavior, slightly lower token usage, comparable response performance, and a substantial cost-efficiency improvement. The observed functional difference was one stochastic creative-quality check out of 285, while Luna reduced the measured workload cost by approximately 74.0%. This supports using Luna as the SDK default.

The change only affects the fallback used when no model is specified. Explicit agent models, run-level model overrides, and the `OPENAI_DEFAULT_MODEL` environment variable continue to take precedence. The existing default settings of `reasoning.effort: "none"` and `text.verbosity: "low"` are unchanged.