### PR TITLE
fix(openai): count requests without usage

### DIFF
--- a/.changeset/count-chat-completion-request.md
+++ b/.changeset/count-chat-completion-request.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: count completed Chat Completions requests when providers omit usage

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -289,7 +289,7 @@ export class OpenAIChatCompletionsModel implements Model {
         preservedUsage ??
         (response.usage
           ? new Usage(toResponseUsage(response.usage))
-          : new Usage()),
+          : new Usage({ requests: 1 })),
       output,
       responseId: response.id,
       providerData: rawResponse,

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -192,7 +192,7 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(result.usage.inputTokens).toBe(3);
   });
 
-  it('leaves raw usage undefined when the provider omits usage', async () => {
+  it('counts the request when the provider omits usage', async () => {
     const client = new FakeClient();
     client.chat.completions.create.mockResolvedValue({
       id: 'r',
@@ -212,6 +212,7 @@ describe('OpenAIChatCompletionsModel', () => {
     );
 
     expect(result.rawUsage).toBeUndefined();
+    expect(result.usage.requests).toBe(1);
     expect(result.usage.totalTokens).toBe(0);
   });
 


### PR DESCRIPTION
This pull request fixes Chat Completions request accounting when an OpenAI-compatible provider completes a request without returning a usage payload. The completed request now contributes one to `usage.requests`, while token counts remain zero and `rawUsage` remains absent.
