### PR TITLE
fix(openai): propagate Chat Completions request IDs

### DIFF
--- a/.changeset/chat-completions-request-id.md
+++ b/.changeset/chat-completions-request-id.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: propagate Chat Completions request IDs

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -60,6 +60,26 @@ export const FAKE_ID = 'FAKE_ID';
 const GPT_56_MODEL_PATTERN =
   /^gpt-5\.6(?:-(?:sol|terra|luna)(?:-\d{4}-\d{2}-\d{2})?)?$/;
 
+type ChatCompletionStreamResult = {
+  stream: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>;
+  requestId?: string;
+};
+
+type ChatCompletionStreamWithRequestId = PromiseLike<
+  Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
+> & {
+  withResponse?: () => Promise<{
+    data: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>;
+    request_id: string | null;
+  }>;
+};
+
+function normalizeRequestId(requestId: unknown): string | undefined {
+  return typeof requestId === 'string' && requestId.length > 0
+    ? requestId
+    : undefined;
+}
+
 // Some Chat Completions API compatible providers return a reasoning property on the message
 // If that's the case we handle them separately
 type OpenAIMessageWithReasoning =
@@ -292,6 +312,9 @@ export class OpenAIChatCompletionsModel implements Model {
           : new Usage()),
       output,
       responseId: response.id,
+      requestId: normalizeRequestId(
+        (rawResponse as { _request_id?: unknown })._request_id,
+      ),
       providerData: rawResponse,
       ...(rawUsage !== undefined ? { rawUsage } : {}),
     };
@@ -325,7 +348,11 @@ export class OpenAIChatCompletionsModel implements Model {
         span.start();
         setCurrentSpan(span);
       }
-      const stream = await this.#fetchResponse(request, span, true);
+      const { stream, requestId } = await this.#fetchResponse(
+        request,
+        span,
+        true,
+      );
 
       const response: OpenAI.Chat.Completions.ChatCompletion = {
         id: FAKE_ID,
@@ -368,6 +395,9 @@ export class OpenAIChatCompletionsModel implements Model {
               ? event.response.usage.outputTokensDetails[0]
               : event.response.usage.outputTokensDetails,
           };
+        }
+        if (event.type === 'response_done' && requestId) {
+          event.response.requestId = requestId;
         }
         yield event;
       }
@@ -491,7 +521,7 @@ export class OpenAIChatCompletionsModel implements Model {
     request: ModelRequest,
     span: Span<GenerationSpanData> | undefined,
     stream: true,
-  ): Promise<Stream<OpenAI.Chat.Completions.ChatCompletionChunk>>;
+  ): Promise<ChatCompletionStreamResult>;
   async #fetchResponse(
     request: ModelRequest,
     span: Span<GenerationSpanData> | undefined,
@@ -502,8 +532,7 @@ export class OpenAIChatCompletionsModel implements Model {
     span: Span<GenerationSpanData> | undefined,
     stream: boolean,
   ): Promise<
-    | Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
-    | OpenAI.Chat.Completions.ChatCompletion
+    ChatCompletionStreamResult | OpenAI.Chat.Completions.ChatCompletion
   > {
     const tools: OpenAI.Chat.Completions.ChatCompletionTool[] = [];
     if (request.tools) {
@@ -664,17 +693,44 @@ export class OpenAIChatCompletionsModel implements Model {
       requestOptions.maxRetries = 0;
     }
 
-    const completion = await this.#client.chat.completions.create(
+    const completionPromise = this.#client.chat.completions.create(
       requestData,
       requestOptions,
     );
+
+    let completion:
+      | Stream<OpenAI.Chat.Completions.ChatCompletionChunk>
+      | OpenAI.Chat.Completions.ChatCompletion;
+    let requestId: string | undefined;
+    if (stream) {
+      const withResponse = (
+        completionPromise as ChatCompletionStreamWithRequestId
+      ).withResponse;
+      if (typeof withResponse === 'function') {
+        const streamedResponse = await withResponse.call(completionPromise);
+        completion = streamedResponse.data;
+        requestId = normalizeRequestId(streamedResponse.request_id);
+      } else {
+        completion =
+          (await completionPromise) as Stream<OpenAI.Chat.Completions.ChatCompletionChunk>;
+      }
+    } else {
+      completion =
+        (await completionPromise) as OpenAI.Chat.Completions.ChatCompletion;
+    }
 
     if (logger.dontLogModelData) {
       logger.debug('Response received');
     } else {
       logger.debug(`Response received: ${JSON.stringify(completion, null, 2)}`);
     }
-    return completion;
+    return stream
+      ? {
+          stream:
+            completion as Stream<OpenAI.Chat.Completions.ChatCompletionChunk>,
+          ...(requestId ? { requestId } : {}),
+        }
+      : (completion as OpenAI.Chat.Completions.ChatCompletion);
   }
 }
 

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -106,6 +106,36 @@ describe('OpenAIChatCompletionsModel', () => {
       },
     ]);
     expect(result.rawUsage).toBeUndefined();
+    expect(result.requestId).toBeUndefined();
+  });
+
+  it('propagates the request ID in a non-streamed response', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: 'hi' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    Object.defineProperty(response, '_request_id', {
+      value: 'req_nonstreamed_123',
+      enumerable: false,
+    });
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const result = await withTrace('t', () => model.getResponse(req));
+
+    expect(result.requestId).toBe('req_nonstreamed_123');
+    expect(result.providerData).toBe(response);
   });
 
   it('preserves raw usage field presence before normalization when enabled', async () => {
@@ -1763,6 +1793,56 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(events).toEqual([{ type: 'first' }, { type: 'second' }]);
   });
 
+  it('propagates the request ID in a streamed response', async () => {
+    vi.mocked(convertChatCompletionsStreamToResponses).mockImplementationOnce(
+      async function* () {
+        yield {
+          type: 'response_done',
+          response: {
+            id: 'r',
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            output: [],
+          },
+        } as any;
+      },
+    );
+
+    const client = new FakeClient();
+    async function* fakeStream() {
+      yield { id: 'c' } as any;
+    }
+    const stream = fakeStream();
+    const completionPromise = Promise.resolve(stream);
+    const withResponse = vi.fn().mockResolvedValue({
+      data: stream,
+      request_id: 'req_streamed_456',
+    });
+    Object.assign(completionPromise, { withResponse });
+    client.chat.completions.create.mockReturnValue(completionPromise);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'hi',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+    const events: any[] = [];
+
+    await withTrace('t', async () => {
+      for await (const event of model.getStreamedResponse(req)) {
+        events.push(event);
+      }
+    });
+
+    expect(client.chat.completions.create).toHaveBeenCalledTimes(1);
+    expect(withResponse).toHaveBeenCalledTimes(1);
+    const responseDone = events.find((event) => event.type === 'response_done');
+    expect(responseDone?.response.requestId).toBe('req_streamed_456');
+  });
+
   it('passes strict feature validation to the stream converter', async () => {
     const client = new FakeClient();
     async function* fakeStream() {
@@ -1907,5 +1987,7 @@ describe('OpenAIChatCompletionsModel', () => {
     const responseDone = events.find((e) => e.type === 'response_done');
     expect(responseDone).toBeDefined();
     expect(responseDone.response.usage.totalTokens).toBe(15);
+    expect(responseDone.response.requestId).toBeUndefined();
+    expect(client.chat.completions.create).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This pull request fixes Chat Completions request ID propagation so both non-streamed and streamed model responses expose the transport request ID through `ModelResponse.requestId`.

It uses the OpenAI Node SDK's parsed-response metadata and `withResponse()` stream metadata while preserving fallback behavior for compatible clients that do not expose `withResponse()`.