### PR TITLE
fix(openai): preserve apply_patch move destinations

### DIFF
--- a/.changeset/fix-apply-patch-move-to.md
+++ b/.changeset/fix-apply-patch-move-to.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix(openai): preserve apply_patch move destinations

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -2461,7 +2461,7 @@ function getInputItems(
         id: item.id ?? undefined,
         call_id: item.callId,
         status: item.status ?? 'in_progress',
-        operation: item.operation,
+        operation: serializeApplyPatchOperationForResponses(item.operation),
         ...(item.caller ? { caller: toOpenAIToolCaller(item.caller) } : {}),
       };
 
@@ -2986,13 +2986,16 @@ function convertToOutputItem(
             path: operation.path,
           };
           break;
-        case 'update_file':
+        case 'update_file': {
+          const moveTo = getApplyPatchMoveDestination(operation);
           normalizedOperation = {
             type: 'update_file',
             path: operation.path,
             diff: operation.diff,
+            ...(moveTo !== undefined ? { moveTo } : {}),
           };
           break;
+        }
         default:
           throw new UserError('Unknown apply_patch operation type');
       }
@@ -3121,6 +3124,33 @@ function convertToOutputItem(
       providerData: item,
     };
   });
+}
+
+function getApplyPatchMoveDestination(operation: unknown): string | undefined {
+  const moveTo = (operation as { move_to?: unknown }).move_to;
+  if (moveTo === undefined || moveTo === null) {
+    return undefined;
+  }
+  if (typeof moveTo !== 'string' || moveTo.length === 0) {
+    throw new UserError(
+      'apply_patch_call update_file move_to must be a non-empty string',
+    );
+  }
+  return moveTo;
+}
+
+function serializeApplyPatchOperationForResponses(
+  operation: protocol.ApplyPatchOperation,
+): OpenAI.Responses.ResponseInputItem.ApplyPatchCall['operation'] {
+  if (operation.type !== 'update_file' || operation.moveTo === undefined) {
+    return operation;
+  }
+
+  const { moveTo, ...rest } = operation;
+  return {
+    ...rest,
+    move_to: moveTo,
+  } as OpenAI.Responses.ResponseInputItem.ApplyPatchCall['operation'];
 }
 
 export { getToolChoice, convertTool, getInputItems, convertToOutputItem };

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -860,6 +860,51 @@ describe('getInputItems', () => {
     expect(items.some((entry) => entry.type === 'reasoning')).toBe(true);
   });
 
+  it('serializes apply_patch update move destinations for Responses input', () => {
+    const [item, inPlaceItem] = getInputItems([
+      {
+        type: 'apply_patch_call',
+        id: 'ap-move',
+        callId: 'p-move',
+        status: 'completed',
+        operation: {
+          type: 'update_file',
+          path: 'old.txt',
+          diff: '@@\n-old\n+new\n',
+          moveTo: 'renamed/new.txt',
+        },
+      },
+      {
+        type: 'apply_patch_call',
+        id: 'ap-in-place',
+        callId: 'p-in-place',
+        status: 'completed',
+        operation: {
+          type: 'update_file',
+          path: 'keep.txt',
+          diff: '@@\n-old\n+new\n',
+        },
+      },
+    ] as any);
+
+    expect(item).toMatchObject({
+      type: 'apply_patch_call',
+      call_id: 'p-move',
+      operation: {
+        type: 'update_file',
+        path: 'old.txt',
+        diff: '@@\n-old\n+new\n',
+        move_to: 'renamed/new.txt',
+      },
+    });
+    expect((item as any).operation).not.toHaveProperty('moveTo');
+    expect((inPlaceItem as any).operation).toEqual({
+      type: 'update_file',
+      path: 'keep.txt',
+      diff: '@@\n-old\n+new\n',
+    });
+  });
+
   it('preserves replay-only Responses fields when rebuilding input items', () => {
     const items = getInputItems([
       {
@@ -2973,4 +3018,141 @@ describe('convertToOutputItem', () => {
       output: 'conflict',
     });
   });
+
+  it('preserves apply_patch update move destinations from Responses output', () => {
+    const [output] = convertToOutputItem([
+      {
+        type: 'apply_patch_call',
+        id: 'ap-move',
+        call_id: 'p-move',
+        status: 'in_progress',
+        operation: {
+          type: 'update_file',
+          path: 'old.txt',
+          diff: '@@\n-old\n+new\n',
+          move_to: 'renamed/new.txt',
+        },
+      } as any,
+    ]);
+
+    expect(output).toMatchObject({
+      type: 'apply_patch_call',
+      callId: 'p-move',
+      operation: {
+        type: 'update_file',
+        path: 'old.txt',
+        diff: '@@\n-old\n+new\n',
+        moveTo: 'renamed/new.txt',
+      },
+    });
+  });
+
+  it.each([undefined, null])(
+    'keeps apply_patch updates in place when move_to is %s',
+    (moveTo) => {
+      const operation = {
+        type: 'update_file',
+        path: 'keep.txt',
+        diff: '@@\n-old\n+new\n',
+        ...(moveTo !== undefined ? { move_to: moveTo } : {}),
+      };
+      const [output] = convertToOutputItem([
+        {
+          type: 'apply_patch_call',
+          id: 'ap-in-place',
+          call_id: 'p-in-place',
+          status: 'in_progress',
+          operation,
+        } as any,
+      ]);
+
+      expect((output as any).operation).toEqual({
+        type: 'update_file',
+        path: 'keep.txt',
+        diff: '@@\n-old\n+new\n',
+      });
+    },
+  );
+
+  it.each([5, ''])(
+    'rejects malformed apply_patch move destinations: %j',
+    (moveTo) => {
+      expect(() =>
+        convertToOutputItem([
+          {
+            type: 'apply_patch_call',
+            id: 'ap-invalid-move',
+            call_id: 'p-invalid-move',
+            status: 'in_progress',
+            operation: {
+              type: 'update_file',
+              path: 'old.txt',
+              diff: '@@\n-old\n+new\n',
+              move_to: moveTo,
+            },
+          } as any,
+        ]),
+      ).toThrowError(
+        'apply_patch_call update_file move_to must be a non-empty string',
+      );
+    },
+  );
+
+  it.each([
+    [
+      'camelCase moveTo on update_file',
+      {
+        type: 'update_file',
+        path: 'old.txt',
+        diff: '@@\n-old\n+new\n',
+        moveTo: 'unsupported.txt',
+      },
+      {
+        type: 'update_file',
+        path: 'old.txt',
+        diff: '@@\n-old\n+new\n',
+      },
+    ],
+    [
+      'move_to on create_file',
+      {
+        type: 'create_file',
+        path: 'created.txt',
+        diff: '+created\n',
+        move_to: 'unsupported.txt',
+      },
+      {
+        type: 'create_file',
+        path: 'created.txt',
+        diff: '+created\n',
+      },
+    ],
+    [
+      'move_to on delete_file',
+      {
+        type: 'delete_file',
+        path: 'deleted.txt',
+        move_to: 'unsupported.txt',
+      },
+      {
+        type: 'delete_file',
+        path: 'deleted.txt',
+      },
+    ],
+  ])(
+    'ignores unsupported apply_patch destinations: %s',
+    (_, operation, expected) => {
+      const [output] = convertToOutputItem([
+        {
+          type: 'apply_patch_call',
+          id: 'ap-unsupported-move',
+          call_id: 'p-unsupported-move',
+          status: 'in_progress',
+          operation,
+        } as any,
+      ]);
+
+      expect((output as any).operation).toEqual(expected);
+    },
+  );
 });


### PR DESCRIPTION
This pull request fixes Responses `apply_patch_call` conversion so update-file move destinations are preserved between the OpenAI wire field `move_to` and the normalized SDK field `moveTo`.

It also ensures replayed operations serialize `moveTo` back to `move_to`, keeps omitted or null destinations as in-place updates, and rejects malformed update-file destinations without broadening support to other operation types.
