### PR TITLE
fix(openai): preserve streamed Chat Completions citations

### DIFF
--- a/.changeset/calm-stream-citations.md
+++ b/.changeset/calm-stream-citations.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix(openai): preserve streamed Chat Completions citations

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -14,6 +14,7 @@ import {
 type StreamingState = {
   started: boolean;
   text_content: protocol.OutputText | null;
+  annotations: ChatCompletionAnnotation[];
   messageItemId: string | undefined;
   refusal_content: protocol.Refusal | null;
   function_calls: Record<number, protocol.FunctionCallItem>;
@@ -22,6 +23,63 @@ type StreamingState = {
   finishReason: ChatCompletion['choices'][number]['finish_reason'] | null;
   hasWarnedUnsupportedChoice: boolean;
 };
+
+type ChatCompletionAnnotation = NonNullable<
+  ChatCompletion['choices'][number]['message']['annotations']
+>[number];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeUrlCitations(
+  rawAnnotations: unknown,
+): ChatCompletionAnnotation[] {
+  if (!Array.isArray(rawAnnotations)) {
+    return [];
+  }
+
+  const annotations: ChatCompletionAnnotation[] = [];
+  for (const annotation of rawAnnotations) {
+    if (
+      !isRecord(annotation) ||
+      annotation.type !== 'url_citation' ||
+      !isRecord(annotation.url_citation)
+    ) {
+      continue;
+    }
+
+    const { start_index, end_index, url, title } = annotation.url_citation;
+    if (
+      typeof start_index !== 'number' ||
+      !Number.isFinite(start_index) ||
+      typeof end_index !== 'number' ||
+      !Number.isFinite(end_index) ||
+      typeof url !== 'string' ||
+      typeof title !== 'string'
+    ) {
+      continue;
+    }
+
+    annotations.push({
+      type: 'url_citation',
+      url_citation: { start_index, end_index, url, title },
+    });
+  }
+  return annotations;
+}
+
+function isSameUrlCitation(
+  left: ChatCompletionAnnotation,
+  right: ChatCompletionAnnotation,
+): boolean {
+  return (
+    left.url_citation.start_index === right.url_citation.start_index &&
+    left.url_citation.end_index === right.url_citation.end_index &&
+    left.url_citation.url === right.url_citation.url &&
+    left.url_citation.title === right.url_citation.title
+  );
+}
 
 export async function* convertChatCompletionsStreamToResponses(
   response: ChatCompletion,
@@ -36,6 +94,7 @@ export async function* convertChatCompletionsStreamToResponses(
   const state: StreamingState = {
     started: false,
     text_content: null,
+    annotations: [],
     messageItemId: undefined,
     refusal_content: null,
     function_calls: {},
@@ -117,7 +176,7 @@ export async function* convertChatCompletionsStreamToResponses(
         state.text_content = {
           text: '',
           type: 'output_text',
-          providerData: { annotations: [] },
+          providerData: { annotations: state.annotations },
         };
         state.messageItemId =
           response.id && response.id !== FAKE_ID ? response.id : undefined;
@@ -131,6 +190,20 @@ export async function* convertChatCompletionsStreamToResponses(
         },
       };
       state.text_content.text += delta.content;
+    }
+
+    // Some providers emit URL citations with text or on a later annotation-only chunk.
+    if (state.text_content) {
+      const deltaAnnotations = (delta as { annotations?: unknown }).annotations;
+      for (const annotation of normalizeUrlCitations(deltaAnnotations)) {
+        if (
+          !state.annotations.some((existing) =>
+            isSameUrlCitation(existing, annotation),
+          )
+        ) {
+          state.annotations.push(annotation);
+        }
+      }
     }
 
     if (
@@ -308,6 +381,9 @@ function buildTraceChoice(
       role: 'assistant',
       content,
       refusal,
+      ...(state.annotations.length > 0
+        ? { annotations: [...state.annotations] }
+        : {}),
       ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
     },
   };

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -19,6 +19,23 @@ function makeChunk(delta: any, usage?: any) {
   } as any;
 }
 
+function urlCitation(
+  url = 'https://example.com/weather',
+  title = 'Weather',
+  startIndex = 0,
+  endIndex = 7,
+) {
+  return {
+    type: 'url_citation',
+    url_citation: {
+      start_index: startIndex,
+      end_index: endIndex,
+      url,
+      title,
+    },
+  };
+}
+
 describe('convertChatCompletionsStreamToResponses', () => {
   it('surfaces an empty content-filter terminal as a refusal', async () => {
     const response: ChatCompletion = {
@@ -305,6 +322,132 @@ describe('convertChatCompletionsStreamToResponses', () => {
     expect(final.response.usage.totalTokens).toBe(3);
   });
 
+  it('preserves URL citations from text and annotation-only deltas once', async () => {
+    const weatherCitation = urlCitation();
+    const forecastCitation = urlCitation(
+      'https://example.com/forecast',
+      'Forecast',
+      8,
+      16,
+    );
+
+    async function* stream(): AsyncGenerator<
+      ChatCompletionChunk,
+      void,
+      unknown
+    > {
+      yield makeChunk({
+        content: 'Weather',
+        annotations: [weatherCitation],
+      });
+      yield makeChunk({
+        annotations: [weatherCitation, forecastCitation],
+      });
+      yield makeChunk({
+        content: ' forecast',
+        annotations: [forecastCitation],
+      });
+    }
+
+    const response = { id: 'r' } as ChatCompletion;
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(
+      events
+        .filter((event) => event.type === 'output_text_delta')
+        .map((event) => event.delta),
+    ).toEqual(['Weather', ' forecast']);
+    expect(events.at(-1).response.output[0].content[0]).toEqual({
+      type: 'output_text',
+      text: 'Weather forecast',
+      providerData: {
+        annotations: [weatherCitation, forecastCitation],
+      },
+    });
+    expect(response.choices[0].message.annotations).toEqual([
+      weatherCitation,
+      forecastCitation,
+    ]);
+  });
+
+  it('ignores malformed and unsupported streamed annotations', async () => {
+    const validCitation = urlCitation();
+
+    async function* stream(): AsyncGenerator<
+      ChatCompletionChunk,
+      void,
+      unknown
+    > {
+      yield makeChunk({
+        content: 'Weather',
+        annotations: [
+          null,
+          { type: 'file_citation', file_citation: { file_id: 'file-1' } },
+          {
+            type: 'url_citation',
+            url_citation: { url: 'https://example.com/incomplete' },
+          },
+          {
+            type: 'url_citation',
+            url_citation: {
+              start_index: '0',
+              end_index: 7,
+              url: 'https://example.com/wrong-index',
+              title: 'Wrong index',
+            },
+          },
+          validCitation,
+        ],
+      });
+      yield makeChunk({ annotations: 5 });
+    }
+
+    const response = { id: 'r' } as ChatCompletion;
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events.at(-1).response.output[0].content[0].providerData).toEqual({
+      annotations: [validCitation],
+    });
+    expect(response.choices[0].message.annotations).toEqual([validCitation]);
+  });
+
+  it('ignores URL citations received before text begins', async () => {
+    async function* stream(): AsyncGenerator<
+      ChatCompletionChunk,
+      void,
+      unknown
+    > {
+      yield makeChunk({ annotations: [urlCitation()] });
+      yield makeChunk({ content: 'Weather' });
+    }
+
+    const response = { id: 'r' } as ChatCompletion;
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events.at(-1).response.output[0].content[0].providerData).toEqual({
+      annotations: [],
+    });
+    expect(response.choices[0].message.annotations).toBeUndefined();
+  });
+
   it('uses a response ID received after the first text chunk for the final message', async () => {
     const firstChunk = {
       ...makeChunk({ content: 'hello' }),
@@ -462,7 +605,15 @@ describe('convertChatCompletionsStreamToResponses', () => {
         created: 0,
         model: 'm',
         object: 'chat.completion.chunk',
-        choices: [{ index: 1, delta: { content: 'ignored-first' } }],
+        choices: [
+          {
+            index: 1,
+            delta: {
+              content: 'ignored-first',
+              annotations: [urlCitation('https://example.com/ignored')],
+            },
+          },
+        ],
       } as any,
       {
         id: 'c',
@@ -470,8 +621,17 @@ describe('convertChatCompletionsStreamToResponses', () => {
         model: 'm',
         object: 'chat.completion.chunk',
         choices: [
-          { index: 0, delta: { content: 'kept' } },
-          { index: 1, delta: { content: 'ignored-second' } },
+          {
+            index: 0,
+            delta: { content: 'kept', annotations: [urlCitation()] },
+          },
+          {
+            index: 1,
+            delta: {
+              content: 'ignored-second',
+              annotations: [urlCitation('https://example.com/ignored')],
+            },
+          },
         ],
       } as any,
       {
@@ -505,6 +665,9 @@ describe('convertChatCompletionsStreamToResponses', () => {
     ).toEqual(['kept']);
     const final = events.at(-1);
     expect(final.response.output[0].content[0].text).toBe('kept');
+    expect(
+      final.response.output[0].content[0].providerData.annotations,
+    ).toEqual([urlCitation()]);
     expect(final.response.usage.totalTokens).toBe(3);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0]?.[0]).toContain(


### PR DESCRIPTION
This pull request fixes streamed Chat Completions dropping URL citations supplied through provider annotation deltas.
It accumulates valid citations from text-bearing and later annotation-only chunks, deduplicates exact repeats, and includes them in both normalized output provider data and the terminal Chat Completion. Existing text delta behavior and unsupported-choice handling remain unchanged.