### PR TITLE
fix(openai): strip placeholder IDs from Responses input

### DIFF
--- a/.changeset/strip-responses-placeholder-ids.md
+++ b/.changeset/strip-responses-placeholder-ids.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix(openai): strip placeholder item IDs from Responses input

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -45,6 +45,9 @@ import {
   shouldSynthesizeContentFilterRefusal,
 } from './openaiChatCompletionsContentFilter';
 import { snapshotRawUsage } from '@openai/agents-core/utils/internal';
+import { FAKE_ID } from './openaiItemIds';
+
+export { FAKE_ID };
 
 type ModelTracingParent = Parameters<typeof createGenerationSpan>[1];
 
@@ -56,7 +59,6 @@ function getModelTracingParent(request: ModelRequest): ModelTracingParent {
   )._internal?.tracingParent;
 }
 
-export const FAKE_ID = 'FAKE_ID';
 const GPT_56_MODEL_PATTERN =
   /^gpt-5\.6(?:-(?:sol|terra|luna)(?:-\d{4}-\d{2}-\d{2})?)?$/;
 

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -3,7 +3,7 @@ import type { CompletionUsage } from 'openai/resources/completions';
 import { protocol, UserError } from '@openai/agents-core';
 import { snapshotRawUsage } from '@openai/agents-core/utils/internal';
 import { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat';
-import { FAKE_ID } from './openaiChatCompletionsModel';
+import { FAKE_ID } from './openaiItemIds';
 import { OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
 import logger from './logger';
 import {

--- a/packages/agents-openai/src/openaiItemIds.ts
+++ b/packages/agents-openai/src/openaiItemIds.ts
@@ -1,0 +1,2 @@
+// Placeholder used when a non-Responses provider does not supply an item ID.
+export const FAKE_ID = 'FAKE_ID';

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -83,6 +83,7 @@ import {
   getInlineMediaType,
   snapshotRawUsage,
 } from '@openai/agents-core/utils/internal';
+import { FAKE_ID } from './openaiItemIds';
 
 type ModelTracingParent = Parameters<typeof createResponseSpan>[1];
 
@@ -2047,7 +2048,7 @@ function getMessageItem(
         'phase',
       ]),
     };
-    return assistantMessage;
+    return stripSdkGeneratedPlaceholderItemId(assistantMessage);
   }
 
   throw new UserError(`Unsupported item ${JSON.stringify(item)}`);
@@ -2121,6 +2122,20 @@ function getPrompt(prompt: ModelRequest['prompt']):
     version: prompt.version,
     variables: transformedVariables,
   };
+}
+
+function stripSdkGeneratedPlaceholderItemId<
+  T extends OpenAI.Responses.ResponseInputItem,
+>(item: T): T {
+  const itemWithOptionalId = item as OpenAI.Responses.ResponseInputItem & {
+    id?: unknown;
+  };
+  if (itemWithOptionalId.id !== FAKE_ID) {
+    return item;
+  }
+
+  const { id: _id, ...itemWithoutId } = itemWithOptionalId;
+  return itemWithoutId as T;
 }
 
 function getInputItems(
@@ -2256,7 +2271,7 @@ function getInputItems(
         ]),
       };
 
-      return entry;
+      return stripSdkGeneratedPlaceholderItemId(entry);
     }
 
     if (item.type === 'function_call_result') {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -20,6 +20,13 @@ import {
   Span,
 } from '@openai/agents-core';
 import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
+import { FAKE_ID } from '../src/openaiItemIds';
+
+class TestableOpenAIResponsesModel extends OpenAIResponsesModel {
+  buildRequest(request: any, stream: boolean) {
+    return this._buildResponsesCreateRequest(request, stream);
+  }
+}
 
 describe('OpenAIResponsesModel', () => {
   beforeAll(() => {
@@ -34,6 +41,180 @@ describe('OpenAIResponsesModel', () => {
     setTracingDisabled(true);
     setTraceProcessors([]);
   });
+
+  it.each([
+    { label: 'without providerData', stream: false, providerData: undefined },
+    {
+      label: 'with providerData',
+      stream: false,
+      providerData: { customMarker: 'keep' },
+    },
+    { label: 'without providerData', stream: true, providerData: undefined },
+    {
+      label: 'with providerData',
+      stream: true,
+      providerData: { customMarker: 'keep' },
+    },
+  ])(
+    'strips Chat Completions placeholder item IDs $label when stream=$stream',
+    ({ stream, providerData }) => {
+      const model = new TestableOpenAIResponsesModel(
+        { responses: { create: vi.fn() } } as unknown as OpenAI,
+        'gpt-test',
+      );
+      const providerMetadata = providerData ? { providerData } : {};
+      const history = [
+        {
+          id: FAKE_ID,
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'hello' }],
+          status: 'completed',
+          ...providerMetadata,
+        },
+        {
+          id: FAKE_ID,
+          type: 'function_call',
+          callId: 'call_1',
+          name: 'lookup',
+          arguments: '{}',
+          status: 'completed',
+          ...providerMetadata,
+        },
+      ];
+      const originalHistory = structuredClone(history);
+
+      const request = model.buildRequest(
+        {
+          input: history,
+          modelSettings: {},
+          tools: [],
+          handoffs: [],
+          outputType: 'text',
+          tracing: false,
+        },
+        stream,
+      );
+      const input = request.requestData.input as Array<Record<string, unknown>>;
+
+      expect(input[0]).not.toHaveProperty('id');
+      expect(input[1]).not.toHaveProperty('id');
+      expect(input[1]).toMatchObject({
+        type: 'function_call',
+        call_id: 'call_1',
+      });
+      if (providerData) {
+        expect(input[0]).toHaveProperty('custom_marker', 'keep');
+        expect(input[1]).toHaveProperty('custom_marker', 'keep');
+      }
+      expect(history).toEqual(originalHistory);
+    },
+  );
+
+  it('preserves provider item IDs and tool correlation IDs in Responses input', () => {
+    const model = new TestableOpenAIResponsesModel(
+      { responses: { create: vi.fn() } } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    const request = model.buildRequest(
+      {
+        input: [
+          {
+            id: 'msg_real',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'hello' }],
+            status: 'completed',
+          },
+          {
+            id: 'fc_real',
+            type: 'function_call',
+            callId: 'call_real',
+            name: 'lookup',
+            arguments: '{}',
+            status: 'completed',
+          },
+          {
+            id: 'fco_real',
+            type: 'function_call_result',
+            callId: 'call_real',
+            output: 'result',
+            status: 'completed',
+          },
+          {
+            id: FAKE_ID,
+            type: 'reasoning',
+            content: [],
+          },
+          {
+            id: FAKE_ID,
+            type: 'program',
+            callId: 'program_call_real',
+            code: 'return 1;',
+            fingerprint: 'fingerprint_real',
+          },
+          {
+            id: FAKE_ID,
+            type: 'program_output',
+            callId: 'program_call_real',
+            output: '1',
+            status: 'completed',
+          },
+          {
+            id: FAKE_ID,
+            type: 'computer_call',
+            callId: 'computer_call_real',
+            action: { type: 'wait' },
+            status: 'completed',
+          },
+          {
+            id: FAKE_ID,
+            type: 'unknown',
+            providerData: {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'provider message' }],
+              status: 'completed',
+            },
+          },
+          {
+            id: `${FAKE_ID}-but-not-the-placeholder`,
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'near match' }],
+            status: 'completed',
+          },
+        ],
+        modelSettings: {},
+        tools: [],
+        handoffs: [],
+        outputType: 'text',
+        tracing: false,
+      },
+      false,
+    );
+    const input = request.requestData.input as Array<Record<string, unknown>>;
+
+    expect(input.map((item) => item.id)).toEqual([
+      'msg_real',
+      'fc_real',
+      'fco_real',
+      FAKE_ID,
+      FAKE_ID,
+      FAKE_ID,
+      FAKE_ID,
+      FAKE_ID,
+      `${FAKE_ID}-but-not-the-placeholder`,
+    ]);
+    expect(input[1]).toHaveProperty('call_id', 'call_real');
+    expect(input[2]).toHaveProperty('call_id', 'call_real');
+    expect(input[4]).toHaveProperty('call_id', 'program_call_real');
+    expect(input[5]).toHaveProperty('call_id', 'program_call_real');
+    expect(input[6]).toHaveProperty('call_id', 'computer_call_real');
+    expect(input[7]).toHaveProperty('type', 'message');
+  });
+
   it('getResponse returns correct ModelResponse and calls client with right parameters', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {


### PR DESCRIPTION
This pull request fixes cross-model history replay when Chat Completions streaming does not provide a usable item ID. It centralizes the SDK-owned placeholder and removes only that exact top-level ID while building Responses input, regardless of `providerData`, while preserving valid provider IDs, tool correlation IDs, metadata, and persisted history.

It also adds coverage for streaming and non-streaming requests, history with and without `providerData`, valid reasoning and program item IDs, near-match IDs, and input non-mutation.
