### PR TITLE
fix(agents-openai): serialize compaction session mutations

### DIFF
--- a/.changeset/safe-compaction-mutations.md
+++ b/.changeset/safe-compaction-mutations.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: serialize OpenAI Responses compaction session mutations

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -125,6 +125,7 @@ export class OpenAIResponsesCompactionSession
   ) => boolean | Promise<boolean>;
   private compactionCandidateItems: AgentInputItem[] | undefined;
   private sessionItems: AgentInputItem[] | undefined;
+  private mutationOperation: Promise<void> = Promise.resolve();
 
   constructor(options: OpenAIResponsesCompactionSessionOptions) {
     this.client = resolveClient(options);
@@ -204,19 +205,23 @@ export class OpenAIResponsesCompactionSession
     const compacted = await this.client.responses.compact(compactRequest);
 
     const outputItems = normalizeCompactionOutputItems(compacted.output ?? []);
-    const previousItems = await this.getAllUnderlyingSessionItems();
-    await this.replaceUnderlyingSessionItems({
-      outputItems,
-      previousItems,
+    const outputCompactionCandidateItems =
+      selectCompactionCandidateItems(outputItems);
+    await this.runMutationOperation(async () => {
+      const previousItems = await this.getAllUnderlyingSessionItems();
+      await this.replaceUnderlyingSessionItems({
+        outputItems,
+        previousItems,
+      });
+      this.compactionCandidateItems = outputCompactionCandidateItems;
+      this.sessionItems = outputItems;
     });
-    this.compactionCandidateItems = selectCompactionCandidateItems(outputItems);
-    this.sessionItems = outputItems;
 
     logger.debug('compact: done %o', {
       responseId: this.responseId,
       compactionMode: resolvedMode,
       outputItemCount: outputItems.length,
-      candidateCount: this.compactionCandidateItems.length,
+      candidateCount: outputCompactionCandidateItems.length,
     });
 
     return {
@@ -237,55 +242,70 @@ export class OpenAIResponsesCompactionSession
       return;
     }
 
-    await this.underlyingSession.addItems(items);
-    if (this.compactionCandidateItems) {
-      const candidates = selectCompactionCandidateItems(items);
-      if (candidates.length > 0) {
-        this.compactionCandidateItems = [
-          ...this.compactionCandidateItems,
-          ...candidates,
-        ];
+    await this.runMutationOperation(async () => {
+      await this.underlyingSession.addItems(items);
+      if (this.compactionCandidateItems) {
+        const candidates = selectCompactionCandidateItems(items);
+        if (candidates.length > 0) {
+          this.compactionCandidateItems = [
+            ...this.compactionCandidateItems,
+            ...candidates,
+          ];
+        }
       }
-    }
-    if (this.sessionItems) {
-      this.sessionItems = [...this.sessionItems, ...items];
-    }
+      if (this.sessionItems) {
+        this.sessionItems = [...this.sessionItems, ...items];
+      }
+    });
   }
 
   async popItem() {
-    const popped = await this.underlyingSession.popItem();
-    if (!popped) {
-      return popped;
-    }
-    if (this.sessionItems) {
-      const index = this.sessionItems.lastIndexOf(popped);
-      if (index >= 0) {
-        this.sessionItems.splice(index, 1);
-      } else {
-        this.sessionItems = await this.underlyingSession.getItems();
+    return this.runMutationOperation(async () => {
+      const popped = await this.underlyingSession.popItem();
+      if (!popped) {
+        return popped;
       }
-    }
-    if (this.compactionCandidateItems) {
-      const isCandidate = selectCompactionCandidateItems([popped]).length > 0;
-      if (isCandidate) {
-        const index = this.compactionCandidateItems.indexOf(popped);
+      if (this.sessionItems) {
+        const index = this.sessionItems.lastIndexOf(popped);
         if (index >= 0) {
-          this.compactionCandidateItems.splice(index, 1);
+          this.sessionItems.splice(index, 1);
         } else {
-          // Fallback when the popped item reference differs from stored candidates.
-          this.compactionCandidateItems = selectCompactionCandidateItems(
-            await this.underlyingSession.getItems(),
-          );
+          this.sessionItems = await this.underlyingSession.getItems();
         }
       }
-    }
-    return popped;
+      if (this.compactionCandidateItems) {
+        const isCandidate = selectCompactionCandidateItems([popped]).length > 0;
+        if (isCandidate) {
+          const index = this.compactionCandidateItems.indexOf(popped);
+          if (index >= 0) {
+            this.compactionCandidateItems.splice(index, 1);
+          } else {
+            // Fallback when the popped item reference differs from stored candidates.
+            this.compactionCandidateItems = selectCompactionCandidateItems(
+              await this.underlyingSession.getItems(),
+            );
+          }
+        }
+      }
+      return popped;
+    });
   }
 
   async clearSession() {
-    await this.underlyingSession.clearSession();
-    this.compactionCandidateItems = [];
-    this.sessionItems = [];
+    await this.runMutationOperation(async () => {
+      await this.underlyingSession.clearSession();
+      this.compactionCandidateItems = [];
+      this.sessionItems = [];
+    });
+  }
+
+  private runMutationOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationOperation.then(operation);
+    this.mutationOperation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   private async getAllUnderlyingSessionItems(): Promise<AgentInputItem[]> {

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -151,6 +151,12 @@ export class OpenAIResponsesCompactionSession
   async runCompaction(
     args: OpenAIResponsesCompactionArgs = {},
   ): Promise<OpenAIResponsesCompactionResult | null> {
+    return this.runMutationOperation(() => this.runCompactionOperation(args));
+  }
+
+  private async runCompactionOperation(
+    args: OpenAIResponsesCompactionArgs,
+  ): Promise<OpenAIResponsesCompactionResult | null> {
     this.responseId = args.responseId ?? this.responseId ?? undefined;
     if (args.store !== undefined) {
       this.lastStore = args.store;
@@ -207,15 +213,13 @@ export class OpenAIResponsesCompactionSession
     const outputItems = normalizeCompactionOutputItems(compacted.output ?? []);
     const outputCompactionCandidateItems =
       selectCompactionCandidateItems(outputItems);
-    await this.runMutationOperation(async () => {
-      const previousItems = await this.getAllUnderlyingSessionItems();
-      await this.replaceUnderlyingSessionItems({
-        outputItems,
-        previousItems,
-      });
-      this.compactionCandidateItems = outputCompactionCandidateItems;
-      this.sessionItems = outputItems;
+    const previousItems = await this.getAllUnderlyingSessionItems();
+    await this.replaceUnderlyingSessionItems({
+      outputItems,
+      previousItems,
     });
+    this.compactionCandidateItems = outputCompactionCandidateItems;
+    this.sessionItems = outputItems;
 
     logger.debug('compact: done %o', {
       responseId: this.responseId,

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -9,6 +9,14 @@ import {
 import { OpenAIResponsesCompactionSession } from '../src';
 import { OPENAI_SESSION_API } from '../src/memory/openaiSessionApi';
 
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 class PartiallyFailingReplacementSession extends MemorySession {
   addCalls = 0;
   clearCalls = 0;
@@ -607,6 +615,237 @@ describe('OpenAIResponsesCompactionSession', () => {
     ]);
   });
 
+  it('restores history before a newer wrapper addItems mutation', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const history = [
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'original' }],
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'original reply' }],
+      },
+    ] as AgentInputItem[];
+    const newerItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'newer reply' }],
+    } as AgentInputItem;
+
+    class GatedRollbackSession extends MemorySession {
+      addCalls = 0;
+      clearCalls = 0;
+      readonly restoreClearStarted = createDeferred();
+      readonly allowRestoreClear = createDeferred();
+
+      async addItems(items: AgentInputItem[]): Promise<void> {
+        this.addCalls += 1;
+        if (this.addCalls === 1) {
+          await super.addItems(items.slice(0, 1));
+          throw new Error('replacement failed');
+        }
+        await super.addItems(items);
+      }
+
+      async clearSession(): Promise<void> {
+        this.clearCalls += 1;
+        if (this.clearCalls === 2) {
+          this.restoreClearStarted.resolve();
+          await this.allowRestoreClear.promise;
+        }
+        await super.clearSession();
+      }
+    }
+
+    const underlyingSession = new GatedRollbackSession({
+      initialItems: history,
+    });
+    const compact = vi.fn().mockResolvedValue({
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'compacted' }],
+        },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    });
+    const decisionSnapshots: Array<{
+      compactionCandidateItems: AgentInputItem[];
+      sessionItems: AgentInputItem[];
+    }> = [];
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+      shouldTriggerCompaction: ({ compactionCandidateItems, sessionItems }) => {
+        decisionSnapshots.push({ compactionCandidateItems, sessionItems });
+        return false;
+      },
+    });
+
+    try {
+      const compaction = session.runCompaction({ force: true });
+      await underlyingSession.restoreClearStarted.promise;
+
+      const newerWrite = session.addItems([newerItem]);
+      expect(underlyingSession.addCalls).toBe(1);
+
+      underlyingSession.allowRestoreClear.resolve();
+
+      await expect(compaction).rejects.toThrow('replacement failed');
+      await newerWrite;
+
+      const expectedItems = [...history, newerItem];
+      await expect(underlyingSession.getItems()).resolves.toEqual(
+        expectedItems,
+      );
+      expect(underlyingSession.clearCalls).toBe(2);
+      expect(underlyingSession.addCalls).toBe(3);
+
+      await expect(session.runCompaction()).resolves.toBeNull();
+      expect(decisionSnapshots).toEqual([
+        {
+          compactionCandidateItems: [history[1], newerItem],
+          sessionItems: expectedItems,
+        },
+      ]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it.each(['addItems', 'popItem', 'clearSession'] as const)(
+    'orders a concurrent wrapper %s mutation after successful compaction',
+    async (operationName) => {
+      const compactedItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'compacted' }],
+      } as AgentInputItem;
+      const newerItem = {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'newer reply' }],
+      } as AgentInputItem;
+
+      class GatedReplacementSession extends MemorySession {
+        addCalls = 0;
+        clearCalls = 0;
+        popCalls = 0;
+        readonly replacementAddStarted = createDeferred();
+        readonly allowReplacementAdd = createDeferred();
+
+        async addItems(items: AgentInputItem[]): Promise<void> {
+          this.addCalls += 1;
+          if (this.addCalls === 1) {
+            this.replacementAddStarted.resolve();
+            await this.allowReplacementAdd.promise;
+          }
+          await super.addItems(items);
+        }
+
+        async clearSession(): Promise<void> {
+          this.clearCalls += 1;
+          await super.clearSession();
+        }
+
+        async popItem(): Promise<AgentInputItem | undefined> {
+          this.popCalls += 1;
+          return super.popItem();
+        }
+      }
+
+      const underlyingSession = new GatedReplacementSession({
+        initialItems: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'original' }],
+          },
+        ] as AgentInputItem[],
+      });
+      const compact = vi.fn().mockResolvedValue({
+        output: [compactedItem],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          total_tokens: 2,
+        },
+      });
+      const decisionSnapshots: Array<{
+        compactionCandidateItems: AgentInputItem[];
+        sessionItems: AgentInputItem[];
+      }> = [];
+      const session = new OpenAIResponsesCompactionSession({
+        client: { responses: { compact } } as any,
+        underlyingSession,
+        compactionMode: 'input',
+        shouldTriggerCompaction: ({
+          compactionCandidateItems,
+          sessionItems,
+        }) => {
+          decisionSnapshots.push({ compactionCandidateItems, sessionItems });
+          return false;
+        },
+      });
+
+      const compaction = session.runCompaction({ force: true });
+      await underlyingSession.replacementAddStarted.promise;
+      const callsBeforeMutation = {
+        addCalls: underlyingSession.addCalls,
+        clearCalls: underlyingSession.clearCalls,
+        popCalls: underlyingSession.popCalls,
+      };
+
+      const mutation =
+        operationName === 'addItems'
+          ? session.addItems([newerItem])
+          : operationName === 'popItem'
+            ? session.popItem()
+            : session.clearSession();
+
+      expect({
+        addCalls: underlyingSession.addCalls,
+        clearCalls: underlyingSession.clearCalls,
+        popCalls: underlyingSession.popCalls,
+      }).toEqual(callsBeforeMutation);
+
+      underlyingSession.allowReplacementAdd.resolve();
+      await compaction;
+      const mutationResult = await mutation;
+
+      const expectedItems =
+        operationName === 'addItems' ? [compactedItem, newerItem] : [];
+      await expect(underlyingSession.getItems()).resolves.toEqual(
+        expectedItems,
+      );
+      if (operationName === 'popItem') {
+        expect(mutationResult).toEqual(compactedItem);
+      }
+
+      await expect(session.runCompaction()).resolves.toBeNull();
+      expect(decisionSnapshots).toEqual([
+        {
+          compactionCandidateItems: expectedItems,
+          sessionItems: expectedItems,
+        },
+      ]);
+    },
+  );
+
   it('restores history when replacement addItems fails', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const history = [
@@ -765,6 +1004,18 @@ describe('OpenAIResponsesCompactionSession', () => {
     expect(await underlyingSession.getItems()).toEqual(history);
     expect(underlyingSession.clearCalls).toBe(1);
     expect(underlyingSession.addCalls).toBe(0);
+
+    const newerItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'newer reply' }],
+    } as AgentInputItem;
+    await session.addItems([newerItem]);
+    await expect(underlyingSession.getItems()).resolves.toEqual([
+      ...history,
+      newerItem,
+    ]);
   });
 
   it('restores history when clearSession fails after mutation', async () => {
@@ -947,6 +1198,10 @@ describe('OpenAIResponsesCompactionSession', () => {
       );
       expect(underlyingSession.clearCalls).toBe(2);
       expect(underlyingSession.addCalls).toBe(2);
+
+      await session.clearSession();
+      await expect(underlyingSession.getItems()).resolves.toEqual([]);
+      expect(underlyingSession.clearCalls).toBe(3);
     } finally {
       warn.mockRestore();
     }

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -726,7 +726,7 @@ describe('OpenAIResponsesCompactionSession', () => {
   });
 
   it.each(['addItems', 'popItem', 'clearSession'] as const)(
-    'orders a concurrent wrapper %s mutation after successful compaction',
+    'orders a concurrent wrapper %s mutation after an in-flight compaction request',
     async (operationName) => {
       const compactedItem = {
         type: 'message',
@@ -741,19 +741,13 @@ describe('OpenAIResponsesCompactionSession', () => {
         content: [{ type: 'output_text', text: 'newer reply' }],
       } as AgentInputItem;
 
-      class GatedReplacementSession extends MemorySession {
+      class CountingSession extends MemorySession {
         addCalls = 0;
         clearCalls = 0;
         popCalls = 0;
-        readonly replacementAddStarted = createDeferred();
-        readonly allowReplacementAdd = createDeferred();
 
         async addItems(items: AgentInputItem[]): Promise<void> {
           this.addCalls += 1;
-          if (this.addCalls === 1) {
-            this.replacementAddStarted.resolve();
-            await this.allowReplacementAdd.promise;
-          }
           await super.addItems(items);
         }
 
@@ -768,7 +762,7 @@ describe('OpenAIResponsesCompactionSession', () => {
         }
       }
 
-      const underlyingSession = new GatedReplacementSession({
+      const underlyingSession = new CountingSession({
         initialItems: [
           {
             type: 'message',
@@ -777,13 +771,19 @@ describe('OpenAIResponsesCompactionSession', () => {
           },
         ] as AgentInputItem[],
       });
-      const compact = vi.fn().mockResolvedValue({
-        output: [compactedItem],
-        usage: {
-          input_tokens: 1,
-          output_tokens: 1,
-          total_tokens: 2,
-        },
+      const compactRequestStarted = createDeferred();
+      const allowCompactResponse = createDeferred();
+      const compact = vi.fn(async () => {
+        compactRequestStarted.resolve();
+        await allowCompactResponse.promise;
+        return {
+          output: [compactedItem],
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            total_tokens: 2,
+          },
+        };
       });
       const decisionSnapshots: Array<{
         compactionCandidateItems: AgentInputItem[];
@@ -803,7 +803,7 @@ describe('OpenAIResponsesCompactionSession', () => {
       });
 
       const compaction = session.runCompaction({ force: true });
-      await underlyingSession.replacementAddStarted.promise;
+      await compactRequestStarted.promise;
       const callsBeforeMutation = {
         addCalls: underlyingSession.addCalls,
         clearCalls: underlyingSession.clearCalls,
@@ -823,7 +823,7 @@ describe('OpenAIResponsesCompactionSession', () => {
         popCalls: underlyingSession.popCalls,
       }).toEqual(callsBeforeMutation);
 
-      underlyingSession.allowReplacementAdd.resolve();
+      allowCompactResponse.resolve();
       await compaction;
       const mutationResult = await mutation;
 


### PR DESCRIPTION
This pull request fixes a race between OpenAI Responses compaction history replacement and mutations issued through the session wrapper. It serializes the replacement snapshot, clear, replacement or rollback, and cache commit with `addItems()`, `popItem()`, and `clearSession()` so later mutations execute afterward and cached history remains consistent with storage.

It preserves existing clear and restore failure semantics without adding cancellation APIs or cross-instance coordination.
