### PR TITLE
docs: improve translation source clarity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ The OpenAI Agents JS repository is a pnpm-managed monorepo that provides:
 ### Repo Structure & Important Files
 
 - `packages/agents-core/`, `packages/agents-openai/`, `packages/agents-realtime/`, `packages/agents-extensions/`: Each has its own `package.json`, `src/`, `test/`, and build scripts.
-- `docs/`: Documentation source; develop with `pnpm docs:dev` or build with `pnpm docs:build`. Translated docs under `docs/src/content/docs/ja`, `docs/src/content/docs/ko`, and `docs/src/content/docs/zh` are generated via `pnpm docs:translate`; do not edit them manually.
+- `docs/`: Documentation source; develop with `pnpm docs:dev` or build with `pnpm docs:build`. Write and review authored English source docs for reliable translation: explicitly name actors, objects, and lifecycle subjects; avoid ambiguous pronouns and slash-compressed concepts; preserve exact API identifiers and established SDK terminology; and do not weaken or strengthen technical claims merely to simplify translation. Translated docs under `docs/src/content/docs/ja`, `docs/src/content/docs/ko`, and `docs/src/content/docs/zh` are generated via `pnpm docs:translate`; do not edit them manually.
 - `examples/`: Subdirectories (e.g. `basic`, `agent-patterns`) with their own `package.json` and start scripts.
 - `scripts/dev.mts`: Runs concurrent build-watchers and the docs dev server (`pnpm dev`).
 - `scripts/embedMeta.ts`: Generates `src/metadata.ts` for each package before build.

--- a/docs/src/content/docs/guides/agents.mdx
+++ b/docs/src/content/docs/guides/agents.mdx
@@ -60,12 +60,12 @@ The `Agent` constructor takes a single configuration object. The most commonlyâ€
 | `model` | no | Model name **or** a custom [`Model`](/openai-agents-js/openai/agents/interfaces/model/) implementation. |
 | `modelSettings` | no | Tuning parameters (temperature, top_p, etc.). See [Models](/openai-agents-js/guides/models#modelsettings). If the properties you need arenâ€™t at the top level, you can include them under `providerData`. |
 | `tools` | no | Array of [`Tool`](/openai-agents-js/openai/agents/type-aliases/tool/) instances the model can call. See [Tools](/openai-agents-js/guides/tools). |
-| `mcpServers` | no | MCP-backed tools for the agent. See the [MCP guide](/openai-agents-js/guides/mcp). |
+| `mcpServers` | no | MCP servers that provide tools to the agent. See the [MCP guide](/openai-agents-js/guides/mcp). |
 | `mcpConfig` | no | Options for local MCP tools, such as strict schemas, error handling, and server-prefixed tool names. See [Agent-level MCP configuration](/openai-agents-js/guides/mcp#agent-level-mcp-configuration). |
 | `inputGuardrails` | no | Guardrails applied to the first user input for this agent chain. See [Guardrails](/openai-agents-js/guides/guardrails). |
 | `outputGuardrails` | no | Guardrails applied to the final output for this agent. See [Guardrails](/openai-agents-js/guides/guardrails). |
 | `outputType` | no | Return structured output instead of plain text. See [Output types](#output-types) and [Results](/openai-agents-js/guides/results#final-output). |
-| `toolUseBehavior` | no | Control whether function-tool results loop back to the model or finish the run. See [Forcing tool use](#forcing-tool-use). |
+| `toolUseBehavior` | no | Control whether the SDK sends function-tool results back to the model or uses a function-tool result as the run's final output. See [Forcing tool use](#forcing-tool-use). |
 | `resetToolChoice` | no | Reset `toolChoice` to the default after a tool call (default: `true`) to prevent tool-use loops. See [Forcing tool use](#forcing-tool-use). |
 | `handoffOutputTypeWarningEnabled` | no | Emit a warning when handoff output types differ (default: `true`). See [Results](/openai-agents-js/guides/results#final-output). |
 

--- a/docs/src/content/docs/guides/context.mdx
+++ b/docs/src/content/docs/guides/context.mdx
@@ -9,7 +9,7 @@ import localContextExample from '../../../../../examples/docs/context/localConte
 Context is an overloaded term. There are two main classes of context you might care about:
 
 1. **Local context** that your code can access during a run: dependencies or data needed by tools, callbacks like `onHandoff`, and lifecycle hooks.
-2. **Agent/LLM context** that the language model can see when generating a response.
+2. **LLM-visible context** that the language model can see when generating a response.
 
 ## Local context
 
@@ -60,11 +60,11 @@ If you later serialize a [`RunState`](/openai-agents-js/guides/results#interrupt
 
 If you subclass `RunContext`, verify that nested or derived runs still preserve any subclass-specific instance state you rely on. The SDK creates forked contexts internally during nested runs.
 
-## Agent/LLM context
+## LLM-visible context
 
 When the LLM is called, the only data it can see comes from the conversation history. To make additional information available you have a few options:
 
 1. Add it to the Agent `instructions` – also known as a system or developer message. This can be a static string or a function that receives the context and returns a string.
 2. Include it in the `input` when calling `Runner.run()`. This is similar to the instructions technique but lets you place the message lower in the [chain of command](https://cdn.openai.com/spec/model-spec-2024-05-08.html#follow-the-chain-of-command).
-3. Expose it via function tools so the LLM can fetch data on demand.
+3. Expose the additional information through function tools so the LLM can fetch that information on demand.
 4. Use retrieval or web search tools to ground responses in relevant data from files, databases, or the web.

--- a/docs/src/content/docs/guides/guardrails.mdx
+++ b/docs/src/content/docs/guides/guardrails.mdx
@@ -23,7 +23,7 @@ Guardrails are attached to agents, but they do not necessarily run on every agen
 - **Output guardrails** run only for the agent that produces the final output.
 - **Tool guardrails** run on every function-tool invocation, with input guardrails before execution and output guardrails after execution.
 
-If you need checks around each custom function-tool call in a workflow that includes managers or handoffs, use **tool guardrails** instead of agent-level input/output guardrails.
+If you need checks around each custom function-tool call in a workflow that includes managers or handoffs, use **tool guardrails** instead of agent-level input guardrails and output guardrails.
 
 ## Input guardrails
 
@@ -37,7 +37,7 @@ Input guardrails run in three steps:
 
 ### Execution modes
 
-- `runInParallel: true` (default) starts guardrails alongside the LLM/tool calls. This minimizes latency but the model may already have consumed tokens or run tools if the guardrail later triggers.
+- `runInParallel: true` (default) starts input guardrails concurrently with agent execution. Concurrent execution minimizes latency, but the model may already have consumed tokens or run tools if the guardrail later triggers.
 - `runInParallel: false` runs the guardrail **before** calling the model, preventing token spend and tool execution when the guardrail blocks the request. Use this when you prefer safety and cost over latency.
 
 ## Output guardrails
@@ -56,7 +56,7 @@ Output guardrail functions also receive an optional `details` object with the un
 
 Tool guardrails wrap **function tools** and let you validate or block tool calls before and after execution. They are configured on the tool itself (via `tool()` options) and run for every invocation of that tool.
 
-In practice, this means custom function tools where you set `inputGuardrails` and/or `outputGuardrails` on `tool({...})`.
+In practice, this means custom function tools where you set `inputGuardrails`, `outputGuardrails`, or both on `tool({...})`.
 
 - **Input tool guardrails** run before the tool executes and can reject the call with a message or throw a tripwire.
 - **Output tool guardrails** run after the tool executes and can replace the output with a rejection message or throw a tripwire.
@@ -93,7 +93,7 @@ Output guardrails work the same way.
   title="Output guardrail example"
 />
 
-Tool input/output guardrails look like this:
+Tool input guardrails and tool output guardrails look like this:
 
 <Code lang="typescript" code={toolGuardrailsExample} title="Tool guardrails" />
 

--- a/docs/src/content/docs/guides/mcp.mdx
+++ b/docs/src/content/docs/guides/mcp.mdx
@@ -302,7 +302,7 @@ const agent = new Agent({
 
 With this setting, a `search` tool from a `docs` server is exposed to the model as `mcp_docs__search`, while a `search` tool from a `calendar` server is exposed as `mcp_calendar__search`. The SDK still invokes the original MCP tool name on the original server.
 
-Generated names are ASCII-safe, stay within the function-tool name limit, and avoid local function tool names and enabled handoff names on the same agent. The setting only affects local Streamable HTTP and stdio MCP tools; hosted MCP tools keep their hosted server labels and tool metadata.
+Generated names are ASCII-safe, stay within the name-length limit for `FunctionTool` instances, and do not collide with names of local `FunctionTool` instances or enabled handoffs on the same agent. The setting only affects local Streamable HTTP and stdio MCP tools; hosted MCP tools keep their hosted server labels and tool metadata.
 
 ### Tool filtering
 

--- a/docs/src/content/docs/guides/quickstart.mdx
+++ b/docs/src/content/docs/guides/quickstart.mdx
@@ -71,7 +71,7 @@ You can give an agent tools to use to look up information or perform actions.
 
 ## Add a few more agents
 
-Additional agents can be defined similarly to break down problems into smaller parts and have your agent be more focused on the task at hand. It also allows you to use different models for different problems by defining the model on the agent.
+Define additional specialist agents to break down problems into smaller parts, keep each specialist focused on one task, and use different models for different problems.
 
 <Code
   lang="typescript"
@@ -81,7 +81,7 @@ Additional agents can be defined similarly to break down problems into smaller p
 
 ## Define your handoffs
 
-In order to orchestrate between multiple agents, you can define `handoffs` for an agent. This will enable the agent to pass the conversation on to the next agent. This will happen automatically during the course of a run.
+To orchestrate multiple agents, define an agent's `handoffs`. When a handoff is selected during a run, the runner automatically transfers the conversation to the target agent.
 
 <Code lang="typescript" code={defineHandoffsExample} title="Define handoffs" />
 
@@ -105,7 +105,7 @@ Let's put it all together into one full example. Place this into your `index.js`
 
 ## View your traces
 
-The Agents SDK will automatically generate traces for you. This allows you to review how your agents are operating, what tools they called or which agent they handed off to.
+The Agents SDK automatically generates traces. You can use these traces to review how your agents are operating, what tools they called, and which agents received handoffs.
 
 To review what happened during your agent run, navigate to the [Trace viewer in the OpenAI Dashboard](https://platform.openai.com/traces).
 

--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -78,7 +78,7 @@ The additional options are:
 
 ### Streaming
 
-Streaming allows you to additionally receive streaming events as the LLM runs. Once the stream is started, the `StreamedRunResult` will contain the complete information about the run, including all the new outputs produced. You can iterate over the streaming events using a `for await` loop. Read more in the [streaming guide](/openai-agents-js/guides/streaming).
+Streaming additionally exposes events while the LLM runs. A `StreamedRunResult` accumulates information as the run proceeds. After the result's `completed` promise resolves, the result's summary properties include all newly produced outputs. You can iterate over the streaming events using a `for await` loop. Read more in the [streaming guide](/openai-agents-js/guides/streaming).
 
 ### Run config
 

--- a/docs/src/content/docs/guides/sandbox-agents/concepts.mdx
+++ b/docs/src/content/docs/guides/sandbox-agents/concepts.mdx
@@ -19,7 +19,7 @@ import sdkOwnedLifecycleExample from '../../../../../../examples/docs/sandbox-ag
 
 Modern agents work best when they can operate on real files in a filesystem. **Sandbox Agents** can make use of specialized tools and shell commands to search over and manipulate large document sets, edit files, generate artifacts, and run commands. The sandbox provides the model with a persistent workspace that the agent can use to do work on your behalf. Sandbox Agents in the Agents SDK help you run agents paired with a sandbox environment, making it easy to get the right files on the filesystem and orchestrate sandboxes to start, stop, and resume tasks at scale.
 
-You define the workspace around the data the agent needs. It can start from GitHub repos, local files and directories, synthetic task files, remote filesystems such as S3 or Azure Blob Storage, and other sandbox inputs you provide.
+You define the workspace around the data the agent needs. A fresh workspace can be populated from GitHub repos, local files and directories, synthetic task files, remote filesystems such as S3 or Azure Blob Storage, and other sandbox inputs you provide.
 
 <figure class="sandbox-harness-image">
   <img src={harnessWithCompute.src} alt="Sandbox agent harness with compute" />
@@ -153,7 +153,7 @@ Sandbox client choice, sandbox-session reuse, manifest override, and snapshot se
 
 `defaultManifest` is the default workspace used when the runner creates a fresh sandbox session for this agent. Pass either a `Manifest` instance or the same init object you would pass to `new Manifest(...)`. Use it for the files, repos, helper material, output directories, and mounts the agent should usually start with.
 
-This is only the default. A run can override it with `sandbox.manifest`, and a reused or resumed sandbox session keeps its existing workspace state.
+`defaultManifest` provides only the default workspace. A run can override `defaultManifest` with `sandbox.manifest`, and a reused or resumed sandbox session keeps its existing workspace state.
 
 <Code lang="typescript" code={manifestExample} title="Define a manifest" />
 

--- a/docs/src/content/docs/guides/tools.mdx
+++ b/docs/src/content/docs/guides/tools.mdx
@@ -235,7 +235,7 @@ When an agent runs as a tool, the Agents SDK creates a `Runner` and uses that ru
 
 You can also set `needsApproval` and `isEnabled` on the agent tool via `asTool()` options to integrate with human‑in‑the‑loop flows and conditional tool availability.
 
-Inside `customOutputExtractor`, use `result.agentToolInvocation` to inspect the current `Agent.asTool()` invocation. In that callback the result always comes from `Agent.asTool()`, so `agentToolInvocation` is always defined and exposes `toolName`, `toolCallId`, and `toolArguments`. Use `result.runContext.context` for the application context and `result.runContext.toolInput` for the nested invocation's tool input. The `agentToolInvocation` metadata is scoped to the current nested invocation and is not serialized into `RunState`.
+Inside `customOutputExtractor`, use `result.agentToolInvocation` to inspect the current `Agent.asTool()` invocation. In that callback the result always comes from `Agent.asTool()`, so `agentToolInvocation` is always defined and exposes `toolName`, `toolCallId`, and `toolArguments`. Use `result.runContext.context` for the application context. With the default single-`input` schema, `result.runContext.toolInput` is undefined; use `result.agentToolInvocation.toolArguments` to read the invocation arguments instead. When you configure custom `parameters` or an `inputBuilder`, `result.runContext.toolInput` contains the captured structured arguments. The `agentToolInvocation` metadata is scoped to the current nested invocation and is not serialized into `RunState`.
 
 <Code
   lang="typescript"

--- a/docs/src/content/docs/guides/tools.mdx
+++ b/docs/src/content/docs/guides/tools.mdx
@@ -231,11 +231,11 @@ Under the hood the SDK:
 - Runs the sub‑agent with that input when the tool is called.
 - Returns either the last message or the output extracted by `customOutputExtractor`.
 
-When you run an agent as a tool, Agents SDK creates a runner with the default settings and run the agent with it within the function execution. If you want to provide any properties of `runConfig` or `runOptions`, you can pass them to the `asTool()` method to customize the runner's behavior.
+When an agent runs as a tool, the Agents SDK creates a `Runner` and uses that runner to execute the agent within the function-tool call. Pass `runConfig` to configure the nested runner and `runOptions` to configure the nested run.
 
 You can also set `needsApproval` and `isEnabled` on the agent tool via `asTool()` options to integrate with human‑in‑the‑loop flows and conditional tool availability.
 
-Inside `customOutputExtractor`, use `result.agentToolInvocation` to inspect the current `Agent.asTool()` invocation. In that callback the result always comes from `Agent.asTool()`, so `agentToolInvocation` is always defined and exposes `toolName`, `toolCallId`, and `toolArguments`. Use `result.runContext` for the regular app context and `toolInput`. This metadata is scoped to the current nested invocation and is not serialized into `RunState`.
+Inside `customOutputExtractor`, use `result.agentToolInvocation` to inspect the current `Agent.asTool()` invocation. In that callback the result always comes from `Agent.asTool()`, so `agentToolInvocation` is always defined and exposes `toolName`, `toolCallId`, and `toolArguments`. Use `result.runContext.context` for the application context and `result.runContext.toolInput` for the nested invocation's tool input. The `agentToolInvocation` metadata is scoped to the current nested invocation and is not serialized into `RunState`.
 
 <Code
   lang="typescript"

--- a/docs/src/content/docs/guides/voice-agents/build.mdx
+++ b/docs/src/content/docs/guides/voice-agents/build.mdx
@@ -97,7 +97,7 @@ The underlying API behavior still matters:
 
 At the SDK layer, `await session.connect()` means "the transport is ready enough to start the conversation", but the exact point differs by transport:
 
-- In the default browser WebRTC transport, the SDK sends the initial `session.update` as soon as the data channel opens and tries to wait for the corresponding `session.updated` event before resolving `connect()`. This is there to avoid audio reaching the server before your instructions, tools, and modalities are applied. If that acknowledgement never arrives, `connect()` falls back to resolving after a short timeout.
+- In the default browser WebRTC transport, the SDK sends the initial `session.update` as soon as the data channel opens and tries to wait for the corresponding `session.updated` event before resolving `connect()`. The WebRTC transport waits for this acknowledgement to avoid audio reaching the server before your instructions, tools, and modalities are applied. If that acknowledgement never arrives, `connect()` falls back to resolving after a short timeout.
 - In the default server-side WebSocket transport, `connect()` resolves once the socket is open and the initial config has been sent. The matching `session.updated` event can therefore arrive after `connect()` has already resolved.
 
 If you need the raw event model, read the official [Realtime conversations guide](https://developers.openai.com/api/docs/guides/realtime-conversations/) alongside this page.
@@ -156,7 +156,7 @@ There are two common cases:
 1. If you disable VAD entirely with `audio.input.turnDetection = null`, you are responsible for committing audio turns and then sending `response.create`.
 2. If you keep VAD enabled but set `turnDetection.interruptResponse = false` and `turnDetection.createResponse = false`, the API still detects turns but leaves response creation up to you.
 
-That second pattern is useful when you want to inspect or moderate user input before the model responds. It matches the official [Realtime conversations guidance on disabling automatic responses](https://developers.openai.com/api/docs/guides/realtime-conversations/#keep-vad-but-disable-automatic-responses).
+Keeping VAD enabled while setting both `turnDetection.interruptResponse` and `turnDetection.createResponse` to `false` is useful when you want to inspect or moderate user input before the model responds. This configuration matches the official [Realtime conversations guidance on disabling automatic responses](https://developers.openai.com/api/docs/guides/realtime-conversations/#keep-vad-but-disable-automatic-responses).
 
 ## Agent capabilities
 
@@ -192,7 +192,7 @@ The current filtered MCP tool list is also available as `session.availableMcpToo
 
 Hosted MCP setup is easiest to reason about if you treat secure server selection, headers, and approvals as pre-connect configuration. Before `RealtimeSession.connect()` opens the transport, the SDK resolves the active agent's hosted MCP tool definitions and includes the supported MCP fields in the initial session config it sends to the Realtime API.
 
-That timing matters most in browser WebRTC apps. The ephemeral client secret is always minted on your server, so any hosted MCP credentials or custom `headers` that must stay secret should be attached in that server-side `POST /v1/realtime/client_secrets` request as part of the initial `session` payload. Do not put long-lived credentials in browser code and plan to add them later after `connect()` starts.
+Providing secure hosted MCP configuration before `connect()` matters most in browser WebRTC apps. The ephemeral client secret is always minted on your server, so any hosted MCP credentials or custom `headers` that must stay secret should be attached in that server-side `POST /v1/realtime/client_secrets` request as part of the initial `session` payload. Do not put long-lived credentials in browser code and plan to add them later after `connect()` starts.
 
 At the Realtime API level, later `session.update` calls can still change tools and other mutable session fields, and the SDK itself sends `session.update` when the active agent changes. In browser apps, though, you should treat secure Hosted MCP initialization as a server-side, pre-connect concern and keep the browser-side `RealtimeSession` config aligned with what your server minted.
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -25,7 +25,7 @@ The [OpenAI Agents SDK for TypeScript](https://github.com/openai/openai-agents-j
 - **Agents**, which are LLMs equipped with instructions and tools
 - **Sandbox agents**, which pair agents with isolated filesystem workspaces, shell commands, file editing, snapshots, and sandbox session state
 - **Realtime agents**, which support low-latency spoken interactions with tools, guardrails, handoffs, and conversation history
-- **Agents as tools / Handoffs**, which allow agents to delegate to other agents for specific tasks
+- **Agents as tools and handoffs**, which allow agents to delegate to other agents for specific tasks
 - **Guardrails**, which enable the inputs to agents to be validated
 
 In combination with TypeScript, these primitives are powerful enough to express complex relationships between tools and agents, give agents a real workspace when they need one, and allow you to build real-world applications without a steep learning curve. In addition, the SDK comes with built-in **tracing** that lets you visualize and debug your agentic flows, as well as evaluate them and even fine-tune models for your application.
@@ -43,10 +43,10 @@ Here are the main features of the SDK:
 - **Sandbox execution**: Run agents with isolated filesystem workspaces, shell commands, file editing, snapshots, and sandbox session state when the work needs a workspace.
 - **Realtime Agents**: Build low-latency spoken interactions with features such as automatic interruption detection, context management, guardrails, and more.
 - **TypeScript-first**: Orchestrate and chain agents using native TypeScript language features, without needing to learn new abstractions.
-- **Agents as tools / Handoffs**: A powerful mechanism for coordinating and delegating work across multiple agents.
+- **Agents as tools and handoffs**: A powerful mechanism for coordinating and delegating work across multiple agents.
 - **Guardrails**: Run input validation and safety checks in parallel with agent execution, and fail fast when checks do not pass.
 - **Function tools**: Turn any TypeScript function into a tool with automatic schema generation and Zod-powered validation.
-- **MCP server tool calling**: Built-in MCP server tool integration that works the same way as function tools.
+- **MCP server tool calling**: Built-in integration that exposes tools from MCP servers to agents alongside function tools.
 - **Sessions**: A persistent memory layer for maintaining working context within an agent loop.
 - **Human in the loop**: Built-in mechanisms for involving humans across agent runs.
 - **Tracing**: Built-in tracing for visualizing, debugging, and monitoring workflows, with support for the OpenAI suite of evaluation, fine-tuning, and distillation tools.


### PR DESCRIPTION
This pull request updates the English source documentation to reduce concrete translation ambiguity while preserving technical meaning and claim strength.

It explicitly names actors, objects, and lifecycle subjects; expands slash-compressed concepts; and preserves exact API identifiers across ten documentation pages. It also adds durable contributor guidance for translation-friendly English and reiterates that generated Japanese, Korean, and Chinese documentation must not be edited manually.