### PR TITLE
fix(openai): preserve streamed Chat Completions audio

### DIFF
--- a/.changeset/chat-completions-stream-audio.md
+++ b/.changeset/chat-completions-stream-audio.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix(openai): preserve streamed Chat Completions audio

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -1,8 +1,12 @@
 import type { Stream } from 'openai/streaming';
 import type { CompletionUsage } from 'openai/resources/completions';
-import { protocol, UserError } from '@openai/agents-core';
+import { ModelBehaviorError, protocol, UserError } from '@openai/agents-core';
 import { snapshotRawUsage } from '@openai/agents-core/utils/internal';
-import { ChatCompletion, ChatCompletionChunk } from 'openai/resources/chat';
+import {
+  ChatCompletion,
+  type ChatCompletionAudio,
+  ChatCompletionChunk,
+} from 'openai/resources/chat';
 import { FAKE_ID } from './openaiItemIds';
 import { OPENAI_CHAT_COMPLETIONS_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
 import logger from './logger';
@@ -14,6 +18,7 @@ import {
 type StreamingState = {
   started: boolean;
   text_content: protocol.OutputText | null;
+  audio: ChatCompletionAudioSnapshot | null;
   annotations: ChatCompletionAnnotation[];
   messageItemId: string | undefined;
   refusal_content: protocol.Refusal | null;
@@ -24,12 +29,56 @@ type StreamingState = {
   hasWarnedUnsupportedChoice: boolean;
 };
 
+type ChatCompletionAudioSnapshot = Partial<ChatCompletionAudio> &
+  Record<string, unknown>;
+
 type ChatCompletionAnnotation = NonNullable<
   ChatCompletion['choices'][number]['message']['annotations']
 >[number];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function appendAudioDelta(
+  snapshot: ChatCompletionAudioSnapshot | null,
+  rawAudio: unknown,
+): ChatCompletionAudioSnapshot {
+  if (!isRecord(rawAudio)) {
+    throw new ModelBehaviorError(
+      'Chat Completions stream returned malformed audio output: expected delta.audio to be an object.',
+    );
+  }
+
+  const audio = snapshot ?? {};
+  for (const [key, value] of Object.entries(rawAudio)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (key === 'data') {
+      if (typeof value !== 'string') {
+        throw new ModelBehaviorError(
+          'Chat Completions stream returned malformed audio output: expected delta.audio.data to be a string.',
+        );
+      }
+      audio.data = `${audio.data ?? ''}${value}`;
+    } else if (key === 'transcript') {
+      if (typeof value !== 'string') {
+        throw new ModelBehaviorError(
+          'Chat Completions stream returned malformed audio output: expected delta.audio.transcript to be a string.',
+        );
+      }
+      audio.transcript = `${audio.transcript ?? ''}${value}`;
+    } else {
+      Object.defineProperty(audio, key, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+  return audio;
 }
 
 function normalizeUrlCitations(
@@ -94,6 +143,7 @@ export async function* convertChatCompletionsStreamToResponses(
   const state: StreamingState = {
     started: false,
     text_content: null,
+    audio: null,
     annotations: [],
     messageItemId: undefined,
     refusal_content: null,
@@ -121,6 +171,27 @@ export async function* convertChatCompletionsStreamToResponses(
 
     if (chunk.id && (response.id === FAKE_ID || !response.id)) {
       response.id = chunk.id;
+    }
+
+    const audioDelta = chunk.choices?.find(
+      (choice) => choice.index === 0,
+    )?.delta;
+    if (
+      audioDelta &&
+      Object.prototype.hasOwnProperty.call(audioDelta, 'audio')
+    ) {
+      const rawAudio = (audioDelta as { audio?: unknown }).audio;
+      if (rawAudio !== undefined && rawAudio !== null) {
+        let audioSnapshot: unknown;
+        try {
+          audioSnapshot = structuredClone(rawAudio);
+        } catch {
+          throw new ModelBehaviorError(
+            'Chat Completions stream returned malformed audio output: expected delta.audio to be cloneable.',
+          );
+        }
+        state.audio = appendAudioDelta(state.audio, audioSnapshot);
+      }
     }
 
     if (!state.started) {
@@ -268,6 +339,7 @@ export async function* convertChatCompletionsStreamToResponses(
       finishReason: state.finishReason,
       hasOutput: Boolean(
         state.text_content?.text ||
+        state.audio !== null ||
         state.refusal_content?.refusal ||
         Object.keys(state.function_calls).length > 0 ||
         state.ignored_tool_call_indexes.size > 0,
@@ -288,6 +360,21 @@ export async function* convertChatCompletionsStreamToResponses(
     });
   }
 
+  let audioContent: protocol.AudioContent | null = null;
+  if (state.audio) {
+    const { data, ...providerData } = state.audio;
+    if (typeof data !== 'string') {
+      throw new ModelBehaviorError(
+        'Chat Completions stream ended with audio output but no audio data.',
+      );
+    }
+    audioContent = {
+      type: 'audio',
+      audio: data,
+      providerData,
+    };
+  }
+
   if (state.text_content || state.refusal_content) {
     const content: protocol.AssistantContent[] = [];
     if (state.text_content) {
@@ -299,6 +386,14 @@ export async function* convertChatCompletionsStreamToResponses(
     outputs.push({
       id: state.messageItemId ?? outputItemId,
       content,
+      role: 'assistant',
+      type: 'message',
+      status: 'completed',
+    });
+  } else if (audioContent) {
+    outputs.push({
+      id: outputItemId,
+      content: [audioContent],
       role: 'assistant',
       type: 'message',
       status: 'completed',
@@ -367,8 +462,14 @@ function buildTraceChoice(
 
   const content = state.text_content?.text ?? null;
   const refusal = state.refusal_content?.refusal ?? null;
+  const audio = state.audio;
 
-  if (content === null && refusal === null && toolCalls.length === 0) {
+  if (
+    content === null &&
+    refusal === null &&
+    audio === null &&
+    toolCalls.length === 0
+  ) {
     return undefined;
   }
 
@@ -381,6 +482,9 @@ function buildTraceChoice(
       role: 'assistant',
       content,
       refusal,
+      ...(audio
+        ? { audio: structuredClone(audio) as ChatCompletionAudio }
+        : {}),
       ...(state.annotations.length > 0
         ? { annotations: [...state.annotations] }
         : {}),

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -322,6 +322,411 @@ describe('convertChatCompletionsStreamToResponses', () => {
     expect(final.response.usage.totalTokens).toBe(3);
   });
 
+  it('accumulates streamed audio into the final assistant message', async () => {
+    const chunks = [
+      makeChunk({ audio: { transcript: 'hel' } }),
+      makeChunk({
+        role: 'assistant',
+        content: null,
+        refusal: null,
+        audio: { id: 'audio-test', data: 'abc' },
+      }),
+      makeChunk({
+        audio: { data: 'def', transcript: 'lo', format: 'pcm16' },
+      }),
+      makeChunk({ audio: { expires_at: 2 } }),
+    ];
+
+    async function* stream(): AsyncGenerator<
+      ChatCompletionChunk,
+      void,
+      unknown
+    > {
+      for (const chunk of chunks) {
+        yield chunk;
+      }
+    }
+
+    const response = { id: 'r' } as ChatCompletion;
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events.filter((event) => event.type === 'model')).toHaveLength(4);
+    expect(
+      events.filter((event) => event.type === 'output_text_delta'),
+    ).toEqual([]);
+    expect(events.at(-1)).toMatchObject({
+      type: 'response_done',
+      response: {
+        output: [
+          {
+            id: 'r',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [
+              {
+                type: 'audio',
+                audio: 'abcdef',
+                providerData: {
+                  id: 'audio-test',
+                  transcript: 'hello',
+                  format: 'pcm16',
+                  expires_at: 2,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(response.choices).toEqual([
+      {
+        index: 0,
+        logprobs: null,
+        finish_reason: 'stop',
+        message: {
+          role: 'assistant',
+          content: null,
+          refusal: null,
+          audio: {
+            id: 'audio-test',
+            data: 'abcdef',
+            transcript: 'hello',
+            format: 'pcm16',
+            expires_at: 2,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('isolates audio snapshots from mutable stream events', async () => {
+    async function* stream() {
+      yield makeChunk({
+        audio: {
+          id: 'audio-snapshot',
+          data: 'ORIGINAL',
+          transcript: 'original',
+          details: { format: 'pcm16' },
+        },
+      });
+    }
+
+    const response = { id: 'r' } as ChatCompletion;
+    const iterator = convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )[Symbol.asyncIterator]();
+
+    const started = await iterator.next();
+    const startedAudio = (started.value as any).providerData.choices[0].delta
+      .audio;
+    startedAudio.data = 'MUTATED_STARTED';
+    startedAudio.transcript = 'mutated started';
+    startedAudio.details.format = 'mutated-started';
+
+    const raw = await iterator.next();
+    const rawAudio = (raw.value as any).event.choices[0].delta.audio;
+    rawAudio.data = 'MUTATED_RAW';
+    rawAudio.transcript = 'mutated raw';
+    rawAudio.details.format = 'mutated-raw';
+
+    const completed = await iterator.next();
+    expect(completed.done).toBe(false);
+    expect((completed.value as any).response.output[0].content).toEqual([
+      {
+        type: 'audio',
+        audio: 'ORIGINAL',
+        providerData: {
+          id: 'audio-snapshot',
+          transcript: 'original',
+          details: { format: 'pcm16' },
+        },
+      },
+    ]);
+    (
+      completed.value as any
+    ).response.output[0].content[0].providerData.details.format =
+      'mutated-completed';
+
+    expect((await iterator.next()).done).toBe(true);
+    expect(response.choices[0].message.audio).toEqual({
+      id: 'audio-snapshot',
+      data: 'ORIGINAL',
+      transcript: 'original',
+      details: { format: 'pcm16' },
+    });
+  });
+
+  it('preserves audio from a content-filtered stream', async () => {
+    async function* stream(): AsyncGenerator<
+      ChatCompletionChunk,
+      void,
+      unknown
+    > {
+      yield {
+        ...makeChunk({
+          audio: {
+            id: 'audio-filtered',
+            data: 'AAA=',
+            transcript: 'hello',
+            expires_at: 2,
+          },
+        }),
+        choices: [
+          {
+            index: 0,
+            delta: {
+              audio: {
+                id: 'audio-filtered',
+                data: 'AAA=',
+                transcript: 'hello',
+                expires_at: 2,
+              },
+            },
+            finish_reason: 'content_filter',
+          },
+        ],
+      } as any;
+    }
+
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      { id: 'r' } as ChatCompletion,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events.at(-1).response.output).toEqual([
+      {
+        id: 'r',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'audio',
+            audio: 'AAA=',
+            providerData: {
+              id: 'audio-filtered',
+              transcript: 'hello',
+              expires_at: 2,
+            },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('ignores nullable streamed audio fragments', async () => {
+    async function* stream() {
+      yield makeChunk({ audio: null });
+      yield makeChunk({
+        audio: {
+          id: 'audio-nullable',
+          data: 'abc',
+          transcript: 'hel',
+        },
+      });
+      yield makeChunk({
+        audio: {
+          data: null,
+          transcript: null,
+          expires_at: 2,
+        },
+      });
+      yield makeChunk({
+        audio: {
+          data: 'def',
+          transcript: 'lo',
+        },
+      });
+    }
+
+    const response = { id: 'r' } as ChatCompletion;
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events.filter((event) => event.type === 'model')).toHaveLength(4);
+    expect(events.at(-1).response.output[0].content).toEqual([
+      {
+        type: 'audio',
+        audio: 'abcdef',
+        providerData: {
+          id: 'audio-nullable',
+          transcript: 'hello',
+          expires_at: 2,
+        },
+      },
+    ]);
+    expect(response.choices[0].message.audio).toEqual({
+      id: 'audio-nullable',
+      data: 'abcdef',
+      transcript: 'hello',
+      expires_at: 2,
+    });
+  });
+
+  it('rejects audio streams that end without audio data', async () => {
+    async function* stream() {
+      yield makeChunk({
+        audio: { id: 'audio-incomplete', transcript: 'hello' },
+      });
+    }
+
+    await expect(async () => {
+      for await (const _event of convertChatCompletionsStreamToResponses(
+        { id: 'r' } as ChatCompletion,
+        stream() as any,
+      )) {
+        // Consume the stream.
+      }
+    }).rejects.toThrow(
+      'Chat Completions stream ended with audio output but no audio data.',
+    );
+  });
+
+  it('rejects malformed audio deltas', async () => {
+    async function* stream() {
+      yield makeChunk({ audio: 'invalid' });
+    }
+
+    await expect(async () => {
+      for await (const _event of convertChatCompletionsStreamToResponses(
+        { id: 'r' } as ChatCompletion,
+        stream() as any,
+      )) {
+        // Consume the stream.
+      }
+    }).rejects.toThrow(
+      'Chat Completions stream returned malformed audio output: expected delta.audio to be an object.',
+    );
+  });
+
+  it.each([
+    {
+      name: 'numeric data',
+      audio: { data: 42 },
+      message:
+        'Chat Completions stream returned malformed audio output: expected delta.audio.data to be a string.',
+    },
+    {
+      name: 'numeric transcript',
+      audio: { transcript: 42 },
+      message:
+        'Chat Completions stream returned malformed audio output: expected delta.audio.transcript to be a string.',
+    },
+  ])('rejects malformed audio fields: $name', async ({ audio, message }) => {
+    async function* stream() {
+      yield makeChunk({ audio });
+    }
+
+    await expect(async () => {
+      for await (const _event of convertChatCompletionsStreamToResponses(
+        { id: 'r' } as ChatCompletion,
+        stream() as any,
+      )) {
+        // Consume the stream.
+      }
+    }).rejects.toThrow(message);
+  });
+
+  it('does not accept inherited audio data from provider metadata', async () => {
+    const audio = JSON.parse(
+      '{"__proto__":{"data":"forged"},"id":"audio-incomplete"}',
+    );
+
+    async function* stream() {
+      yield makeChunk({ audio });
+    }
+
+    await expect(async () => {
+      for await (const _event of convertChatCompletionsStreamToResponses(
+        { id: 'r' } as ChatCompletion,
+        stream() as any,
+      )) {
+        // Consume the stream.
+      }
+    }).rejects.toThrow(
+      'Chat Completions stream ended with audio output but no audio data.',
+    );
+  });
+
+  it('rejects non-cloneable audio metadata before emitting events', async () => {
+    async function* stream() {
+      yield makeChunk({
+        audio: {
+          data: 'AAA=',
+          unsupported: () => 'not cloneable',
+        },
+      });
+    }
+
+    const iterator = convertChatCompletionsStreamToResponses(
+      { id: 'r' } as ChatCompletion,
+      stream() as any,
+    )[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).rejects.toThrow(
+      'Chat Completions stream returned malformed audio output: expected delta.audio to be cloneable.',
+    );
+  });
+
+  it('uses text output precedence while retaining streamed audio for tracing', async () => {
+    async function* stream() {
+      yield makeChunk({
+        content: 'hello',
+        audio: {
+          id: 'audio-mixed',
+          data: 'AAA=',
+          transcript: 'hello',
+        },
+      });
+    }
+
+    const response = { id: 'r' } as ChatCompletion;
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+    )) {
+      events.push(event);
+    }
+
+    expect(events.at(-1).response.output).toEqual([
+      {
+        id: 'r',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [
+          {
+            type: 'output_text',
+            text: 'hello',
+            providerData: { annotations: [] },
+          },
+        ],
+      },
+    ]);
+    expect(response.choices[0].message.audio).toEqual({
+      id: 'audio-mixed',
+      data: 'AAA=',
+      transcript: 'hello',
+    });
+  });
+
   it('preserves URL citations from text and annotation-only deltas once', async () => {
     const weatherCitation = urlCitation();
     const forecastCitation = urlCitation(


### PR DESCRIPTION
This pull request fixes streamed Chat Completions audio being discarded during response conversion, which could leave audio-only responses with empty normalized output.

It accumulates fragmented `delta.audio` data into the existing assistant audio content shape, preserves reconstructed audio for tracing, and continues exposing source chunks through raw model events. Audio fragments are validated and snapshotted before outward events so consumer mutations cannot alter normalized output or trace data. The change also preserves existing text and refusal precedence and adds a patch changeset for `@openai/agents-openai`.
