### PR TITLE
fix: tighten sandbox mount credential exposure

### DIFF
--- a/.changeset/safe-sandbox-mount-credentials.md
+++ b/.changeset/safe-sandbox-mount-credentials.md
@@ -3,4 +3,4 @@
 '@openai/agents-extensions': patch
 ---
 
-fix: protect credentials used by sandbox mount helpers
+fix: restrict sandbox mount credentials and preserve final local process output

--- a/integration-tests/node/sandbox-storage-mounts.mjs
+++ b/integration-tests/node/sandbox-storage-mounts.mjs
@@ -252,7 +252,9 @@ async function smokeAzureBlobMount() {
         }),
       }),
     },
-  }).withInContainerMountCredentialExposureAllowed('azure');
+  })
+    .withInContainerMountCredentialExposureAcknowledged('azure')
+    .withInContainerMountBroadCredentialExposureAcknowledged('azure');
 
   const client = new DockerSandboxClient({ image: mountImage });
   const session = await client.create(manifest);
@@ -325,7 +327,7 @@ async function smokeS3Mount() {
         }),
       }),
     },
-  }).withInContainerMountCredentialExposureAllowed('s3');
+  }).withInContainerMountCredentialExposureAcknowledged('s3');
 
   const client = new DockerSandboxClient({ image: mountImage });
   const session = await client.create(manifest);

--- a/packages/agents-core/src/sandbox/internal.ts
+++ b/packages/agents-core/src/sandbox/internal.ts
@@ -24,15 +24,18 @@ export {
   captureLiveMountCredentialAuthority,
   captureLiveMountCredentialAuthorityIfAbsent,
   captureLiveMountEnvironmentAuthority,
+  captureLiveMountRuntimeAuthority,
   copyValidatedMountEffectivePaths,
   copyTrustedMountCredentialRebindProvenance,
   configuredMountCredentialFields,
   liveMountCredentialAuthorityMatches,
   liveMountEnvironmentAuthorityMatches,
+  liveMountRuntimeAuthorityMatches,
   manifestHasNonResumableMountAuthority,
   isSandboxSessionStateUnsafe,
   isMountCredentialFileEnvironmentName,
   manifestHasInContainerMounts,
+  mountCredentialEnvironmentForEntry,
   mountCredentialFileReferences,
   NON_RESUMABLE_MOUNT_AUTHORITY_KEY,
   markSandboxSessionStateUnsafe,
@@ -48,6 +51,7 @@ export {
 } from './mountSecurity';
 export type {
   EffectiveManifestEntryPath,
+  MountCredentialExposureDecision,
   MountCredentialFileReference,
 } from './mountSecurity';
 export { stableJsonStringify } from './shared/stableJson';

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -180,12 +180,9 @@ export class Manifest<
 
   constructor(init: ManifestInit<TEntries, TEnvironment> = {}) {
     if (
-      [
-        'in_container_mount_credential_exposure_allowed_paths',
-        '_in_container_mount_credential_exposure_allowed_paths',
-        'inContainerMountCredentialExposureAllowedPaths',
-        '_inContainerMountCredentialExposureAllowedPaths',
-      ].some((key) => key in (init as Record<string, unknown>))
+      MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS.some(
+        (key) => key in (init as Record<string, unknown>),
+      )
     ) {
       throw new TypeError(
         'In-container mount credential exposure must be configured on a trusted Manifest instance, not in a manifest init object.',
@@ -217,27 +214,39 @@ export class Manifest<
   }
 
   /**
-   * Returns a trusted manifest that acknowledges credential exposure for exact
-   * in-container mount paths.
+   * Returns a trusted manifest that acknowledges exposure of mount-scoped
+   * credentials for exact in-container mount paths.
    *
    * This application-side policy is runtime-only. It is not accepted from
    * manifest init objects and is never serialized into sandbox session state.
    */
-  withInContainerMountCredentialExposureAllowed(
+  withInContainerMountCredentialExposureAcknowledged(
     ...mountPaths: string[]
   ): Manifest<TEntries, TEnvironment> {
-    if (mountPaths.length === 0) {
-      throw new TypeError('At least one in-container mount path is required.');
-    }
-    const trusted = cloneManifest(this) as Manifest<TEntries, TEnvironment>;
-    const allowed = new Set(
-      inContainerMountCredentialExposureAllowedPaths.get(this) ?? [],
+    return withInContainerMountCredentialExposureAcknowledgement(
+      this,
+      'mount_scoped',
+      mountPaths,
     );
-    for (const mountPath of mountPaths) {
-      allowed.add(normalizeManifestMountPolicyPath(this.root, mountPath));
-    }
-    inContainerMountCredentialExposureAllowedPaths.set(trusted, allowed);
-    return trusted;
+  }
+
+  /**
+   * Returns a trusted manifest that acknowledges exposure of broad credential
+   * authority for exact in-container mount paths.
+   *
+   * Broad authority includes ambient credentials, workload or managed
+   * identity, and external credential files. This application-side policy is
+   * runtime-only. It is not accepted from manifest init objects and is never
+   * serialized into sandbox session state.
+   */
+  withInContainerMountBroadCredentialExposureAcknowledged(
+    ...mountPaths: string[]
+  ): Manifest<TEntries, TEnvironment> {
+    return withInContainerMountCredentialExposureAcknowledgement(
+      this,
+      'broad',
+      mountPaths,
+    );
   }
 
   validatedEntries(): Record<string, Entry> {
@@ -548,24 +557,48 @@ export type ManifestInput<
   TEnvironment extends ManifestEnvironment = ManifestEnvironment,
 > = Manifest<TEntries, TEnvironment> | ManifestInit<TEntries, TEnvironment>;
 
-const inContainerMountCredentialExposureAllowedPaths = new WeakMap<
+export const MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS = [
+  'in_container_mount_credential_exposure_allowed_paths',
+  '_in_container_mount_credential_exposure_allowed_paths',
+  'inContainerMountCredentialExposureAllowedPaths',
+  '_inContainerMountCredentialExposureAllowedPaths',
+  'in_container_mount_credential_exposure_acknowledged_paths',
+  '_in_container_mount_credential_exposure_acknowledged_paths',
+  'inContainerMountCredentialExposureAcknowledgedPaths',
+  '_inContainerMountCredentialExposureAcknowledgedPaths',
+  'in_container_mount_broad_credential_exposure_acknowledged_paths',
+  '_in_container_mount_broad_credential_exposure_acknowledged_paths',
+  'inContainerMountBroadCredentialExposureAcknowledgedPaths',
+  '_inContainerMountBroadCredentialExposureAcknowledgedPaths',
+] as const;
+
+export type InContainerMountCredentialExposureAuthority =
+  'mount_scoped' | 'broad';
+
+type InContainerMountCredentialExposurePolicy = Readonly<
+  Record<InContainerMountCredentialExposureAuthority, ReadonlySet<string>>
+>;
+
+const inContainerMountCredentialExposurePolicy = new WeakMap<
   Manifest,
-  ReadonlySet<string>
+  InContainerMountCredentialExposurePolicy
 >();
 
-export function manifestAllowsInContainerMountCredentialExposure(
+export function manifestAcknowledgesInContainerMountCredentialExposure(
   manifest: Manifest,
   mountPath: string,
+  authority: InContainerMountCredentialExposureAuthority,
 ): boolean {
-  const allowed = inContainerMountCredentialExposureAllowedPaths.get(manifest);
-  if (!allowed) {
+  const acknowledged =
+    inContainerMountCredentialExposurePolicy.get(manifest)?.[authority];
+  if (!acknowledged) {
     return false;
   }
   const normalized = normalizeRoot(mountPath);
   const relative = relativePathWithinRoot(manifest.root, normalized);
   return (
-    (relative !== null && allowed.has(`relative:${relative}`)) ||
-    allowed.has(`absolute:${normalized}`)
+    (relative !== null && acknowledged.has(`relative:${relative}`)) ||
+    acknowledged.has(`absolute:${normalized}`)
   );
 }
 
@@ -573,16 +606,23 @@ export function copyManifestMountCredentialExposurePolicy(
   target: Manifest,
   ...sources: Manifest[]
 ): void {
-  const allowed = new Set<string>();
+  const policy: Record<
+    InContainerMountCredentialExposureAuthority,
+    Set<string>
+  > = {
+    mount_scoped: new Set<string>(),
+    broad: new Set<string>(),
+  };
   for (const source of sources) {
-    for (const path of inContainerMountCredentialExposureAllowedPaths.get(
-      source,
-    ) ?? []) {
-      allowed.add(path);
+    const sourcePolicy = inContainerMountCredentialExposurePolicy.get(source);
+    for (const authority of ['mount_scoped', 'broad'] as const) {
+      for (const path of sourcePolicy?.[authority] ?? []) {
+        policy[authority].add(path);
+      }
     }
   }
-  if (allowed.size > 0) {
-    inContainerMountCredentialExposureAllowedPaths.set(target, allowed);
+  if (policy.mount_scoped.size > 0 || policy.broad.size > 0) {
+    inContainerMountCredentialExposurePolicy.set(target, policy);
   }
 }
 
@@ -590,12 +630,15 @@ export function replaceManifestMountCredentialExposurePolicy(
   target: Manifest,
   source: Manifest,
 ): void {
-  const allowed = inContainerMountCredentialExposureAllowedPaths.get(source);
-  if (!allowed || allowed.size === 0) {
-    inContainerMountCredentialExposureAllowedPaths.delete(target);
+  const policy = inContainerMountCredentialExposurePolicy.get(source);
+  if (!policy || (policy.mount_scoped.size === 0 && policy.broad.size === 0)) {
+    inContainerMountCredentialExposurePolicy.delete(target);
     return;
   }
-  inContainerMountCredentialExposureAllowedPaths.set(target, new Set(allowed));
+  inContainerMountCredentialExposurePolicy.set(target, {
+    mount_scoped: new Set(policy.mount_scoped),
+    broad: new Set(policy.broad),
+  });
 }
 
 export function cloneManifest(manifest: ManifestInput): Manifest {
@@ -642,6 +685,35 @@ function normalizeManifestMountPolicyPath(root: string, path: string): string {
   }
   const relative = relativePathWithinRoot(root, normalized);
   return relative === null ? `absolute:${normalized}` : `relative:${relative}`;
+}
+
+function withInContainerMountCredentialExposureAcknowledgement<
+  TEntries extends ManifestEntries,
+  TEnvironment extends ManifestEnvironment,
+>(
+  manifest: Manifest<TEntries, TEnvironment>,
+  authority: InContainerMountCredentialExposureAuthority,
+  mountPaths: string[],
+): Manifest<TEntries, TEnvironment> {
+  if (mountPaths.length === 0) {
+    throw new TypeError('At least one in-container mount path is required.');
+  }
+  const trusted = cloneManifest(manifest) as Manifest<TEntries, TEnvironment>;
+  const current = inContainerMountCredentialExposurePolicy.get(manifest);
+  const policy: Record<
+    InContainerMountCredentialExposureAuthority,
+    Set<string>
+  > = {
+    mount_scoped: new Set(current?.mount_scoped ?? []),
+    broad: new Set(current?.broad ?? []),
+  };
+  for (const mountPath of mountPaths) {
+    policy[authority].add(
+      normalizeManifestMountPolicyPath(manifest.root, mountPath),
+    );
+  }
+  inContainerMountCredentialExposurePolicy.set(trusted, policy);
+  return trusted;
 }
 
 export function normalizeRelativePath(path: string): string {

--- a/packages/agents-core/src/sandbox/mountSecurity.ts
+++ b/packages/agents-core/src/sandbox/mountSecurity.ts
@@ -4,10 +4,12 @@ import { isMount, type Entry, type Mount, type TypedMount } from './entries';
 import {
   cloneManifest,
   Environment,
-  manifestAllowsInContainerMountCredentialExposure,
+  manifestAcknowledgesInContainerMountCredentialExposure,
   Manifest,
+  MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS,
   normalizeRelativePath,
   replaceManifestMountCredentialExposurePolicy,
+  type InContainerMountCredentialExposureAuthority,
 } from './manifest';
 import { stableJsonStringify } from './shared/stableJson';
 import { validateCredentialPair } from './shared/credentials';
@@ -29,12 +31,10 @@ export type EffectiveManifestEntryPath = {
   recursive: boolean;
 };
 
-const POLICY_KEYS = new Set([
-  'in_container_mount_credential_exposure_allowed_paths',
-  '_in_container_mount_credential_exposure_allowed_paths',
-  'inContainerMountCredentialExposureAllowedPaths',
-  '_inContainerMountCredentialExposureAllowedPaths',
-]);
+export type MountCredentialExposureDecision = {
+  credentialExposureAcknowledged: boolean;
+  broadCredentialExposureAcknowledged: boolean;
+};
 
 const CREDENTIAL_FIELDS_BY_MOUNT_TYPE: Readonly<
   Record<string, readonly string[]>
@@ -97,6 +97,176 @@ const OUTSIDE_SANDBOX_STRATEGIES = new Set([
   'blaxel_drive',
 ]);
 
+type InContainerMountCredentialCapability = {
+  strategyTypes: readonly string[];
+  provider: string;
+  patternType?: string;
+  mountScopedCredentialFields: readonly string[];
+  broadCredentialFields: readonly string[];
+  enablesBroadCredentialDiscovery?: boolean;
+};
+
+const RCLONE_STRATEGY_TYPES = [
+  'in_container',
+  'e2b_cloud_bucket',
+  'daytona_cloud_bucket',
+  'runloop_cloud_bucket',
+] as const;
+
+const IN_CONTAINER_MOUNT_CREDENTIAL_CAPABILITIES: readonly InContainerMountCredentialCapability[] =
+  [
+    {
+      strategyTypes: RCLONE_STRATEGY_TYPES,
+      provider: 's3',
+      patternType: 'rclone',
+      mountScopedCredentialFields: [
+        'accessKeyId',
+        'secretAccessKey',
+        'sessionToken',
+      ],
+      broadCredentialFields: [
+        'mountStrategy.credentialEnvironment',
+        'mountStrategy.pattern.configFilePath',
+      ],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: RCLONE_STRATEGY_TYPES,
+      provider: 'r2',
+      patternType: 'rclone',
+      mountScopedCredentialFields: ['accessKeyId', 'secretAccessKey'],
+      broadCredentialFields: [
+        'mountStrategy.credentialEnvironment',
+        'mountStrategy.pattern.configFilePath',
+      ],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: RCLONE_STRATEGY_TYPES,
+      provider: 'gcs',
+      patternType: 'rclone',
+      mountScopedCredentialFields: [
+        'accessId',
+        'secretAccessKey',
+        'serviceAccountCredentials',
+        'accessToken',
+      ],
+      broadCredentialFields: [
+        'serviceAccountFile',
+        'mountStrategy.credentialEnvironment',
+        'mountStrategy.pattern.configFilePath',
+      ],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: RCLONE_STRATEGY_TYPES,
+      provider: 'azure_blob',
+      patternType: 'rclone',
+      mountScopedCredentialFields: ['accountKey'],
+      broadCredentialFields: [
+        'identityClientId',
+        'managedIdentity',
+        'mountStrategy.credentialEnvironment',
+        'mountStrategy.pattern.configFilePath',
+      ],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: RCLONE_STRATEGY_TYPES,
+      provider: 'box',
+      patternType: 'rclone',
+      mountScopedCredentialFields: [
+        'clientSecret',
+        'accessToken',
+        'token',
+        'configCredentials',
+      ],
+      broadCredentialFields: [
+        'boxConfigFile',
+        'mountStrategy.credentialEnvironment',
+        'mountStrategy.pattern.configFilePath',
+      ],
+    },
+    {
+      strategyTypes: ['in_container'],
+      provider: 's3',
+      patternType: 'mountpoint',
+      mountScopedCredentialFields: [
+        'accessKeyId',
+        'secretAccessKey',
+        'sessionToken',
+      ],
+      broadCredentialFields: ['mountStrategy.credentialEnvironment'],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: ['in_container'],
+      provider: 'gcs',
+      patternType: 'mountpoint',
+      mountScopedCredentialFields: ['accessId', 'secretAccessKey'],
+      broadCredentialFields: [],
+    },
+    {
+      strategyTypes: ['in_container'],
+      provider: 'azure_blob',
+      patternType: 'fuse',
+      mountScopedCredentialFields: ['accountKey'],
+      broadCredentialFields: ['identityClientId', 'managedIdentity'],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: ['in_container'],
+      provider: 's3_files',
+      patternType: 's3files',
+      mountScopedCredentialFields: [],
+      broadCredentialFields: [
+        'workloadIdentity',
+        'extraOptions',
+        'config.extraOptions',
+        'mountStrategy.pattern.options.extraOptions',
+      ],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: ['vercel_cloud_bucket'],
+      provider: 's3',
+      mountScopedCredentialFields: [
+        'accessKeyId',
+        'secretAccessKey',
+        'sessionToken',
+      ],
+      broadCredentialFields: ['mountStrategy.credentialEnvironment'],
+      enablesBroadCredentialDiscovery: true,
+    },
+    {
+      strategyTypes: ['blaxel_cloud_bucket'],
+      provider: 's3',
+      mountScopedCredentialFields: [
+        'accessKeyId',
+        'secretAccessKey',
+        'sessionToken',
+      ],
+      broadCredentialFields: [],
+    },
+    {
+      strategyTypes: ['blaxel_cloud_bucket'],
+      provider: 'r2',
+      mountScopedCredentialFields: ['accessKeyId', 'secretAccessKey'],
+      broadCredentialFields: [],
+    },
+    {
+      strategyTypes: ['blaxel_cloud_bucket'],
+      provider: 'gcs',
+      mountScopedCredentialFields: [
+        'accessId',
+        'secretAccessKey',
+        'serviceAccountCredentials',
+        'accessToken',
+      ],
+      broadCredentialFields: ['serviceAccountFile'],
+    },
+  ];
+
 const S3_MOUNT_ENVIRONMENT_NAMES = [
   'AWS_ACCESS_KEY_ID',
   'AWS_SECRET_ACCESS_KEY',
@@ -127,6 +297,20 @@ const S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES = [
   'AWS_CONFIG_FILE',
   'AWS_ROLE_ARN',
   'AWS_WEB_IDENTITY_TOKEN_FILE',
+  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
+  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN',
+  'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
+] as const;
+
+const S3_MOUNT_BROAD_CREDENTIAL_ENVIRONMENT_NAMES = [
+  'AWS_PROFILE',
+  'AWS_SHARED_CREDENTIALS_FILE',
+  'AWS_CONFIG_FILE',
+  'AWS_SDK_LOAD_CONFIG',
+  'AWS_ROLE_ARN',
+  'AWS_WEB_IDENTITY_TOKEN_FILE',
+  'AWS_ROLE_SESSION_NAME',
   'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
   'AWS_CONTAINER_CREDENTIALS_FULL_URI',
   'AWS_CONTAINER_AUTHORIZATION_TOKEN',
@@ -164,6 +348,10 @@ const validatedMountEffectivePaths = new WeakMap<
   ReadonlyMap<string, string>
 >();
 const liveMountEnvironmentAuthority = new WeakMap<Manifest, string>();
+const liveMountRuntimeAuthority = new WeakMap<
+  Manifest,
+  ReadonlyMap<symbol, string>
+>();
 const trustedCredentialReboundManifests = new WeakSet<Manifest>();
 const unsafeManifestTransitionStates = new WeakSet<object>();
 const pendingManifestMutationCounts = new WeakMap<object, number>();
@@ -272,14 +460,9 @@ export function configuredMountCredentialFields(
   entry: Mount | TypedMount,
 ): string[] {
   const entryRecord = entry as Record<string, unknown>;
-  const fields =
-    CREDENTIAL_FIELDS_BY_MOUNT_TYPE[entry.type] ?? ALL_CREDENTIAL_FIELDS;
-  const configured: string[] = fields
-    .filter(
-      (field) =>
-        entryRecord[field] !== undefined && entryRecord[field] !== null,
-    )
-    .sort();
+  const configured: string[] = ALL_CREDENTIAL_FIELDS.filter(
+    (field) => entryRecord[field] !== undefined && entryRecord[field] !== null,
+  ).sort();
   for (const field of STRATEGY_CREDENTIAL_FIELDS) {
     const value = readNestedField(entryRecord, field);
     if (
@@ -429,43 +612,208 @@ export function validateMountCredentialBoundaries(manifest: Manifest): void {
       ...configuredMountCredentialFields(entry),
       ...implicitWorkloadIdentityCredentialFields(entry),
     ];
-    if (credentialFields.length === 0) {
-      continue;
-    }
-
-    assertMountCredentialFilesAreNotSerializedManifestEntries(
-      manifest,
-      entry,
-      mountPath,
-    );
-
     const strategyType = mountStrategyType(entry);
     if (OUTSIDE_SANDBOX_STRATEGIES.has(strategyType)) {
-      continue;
-    }
-    if (manifestAllowsInContainerMountCredentialExposure(manifest, mountPath)) {
+      if (credentialFields.length > 0) {
+        assertMountCredentialFilesAreNotSerializedManifestEntries(
+          manifest,
+          entry,
+          mountPath,
+        );
+      }
       continue;
     }
 
-    const details = {
+    const acknowledgement = mountCredentialExposureAcknowledgement(
+      manifest,
+      mountPath,
+    );
+    if (
+      credentialFields.length === 0 &&
+      !acknowledgement.mount_scoped &&
+      !acknowledgement.broad
+    ) {
+      continue;
+    }
+
+    const capability = inContainerMountCredentialCapability(entry);
+    const details: Record<string, unknown> = {
       mountPath,
       mountType: entry.type,
       mountStrategy: strategyType,
+      mountProvider: sdkOwnedMountProvider(entry),
+      mountPattern: resolvedInContainerMountPatternType(entry),
       credentialFields,
     };
-    if (INSIDE_SANDBOX_STRATEGIES.has(strategyType)) {
+    if (!capability) {
       throw new SandboxMountError(
-        'Mount credentials cannot be passed to a helper inside a model-controlled sandbox by default. Use an external or provider-native mount strategy, or explicitly acknowledge exposure for this exact path on a trusted Manifest instance.',
+        'Credential-bearing in-container mounts require an SDK-supported strategy, provider, mount type, and pattern combination before exposure can be acknowledged. Use a supported typed mount and strategy, a credentialless helper, or an external or provider-native mount strategy.',
         details,
         'mount_config_invalid',
       );
     }
+
+    const requiredAuthorities = classifyMountCredentialAuthorities(
+      capability,
+      credentialFields,
+      details,
+    );
+    validateAcknowledgementSupportedByCapability(
+      capability,
+      acknowledgement,
+      details,
+    );
+
+    if (credentialFields.length > 0) {
+      assertMountCredentialFilesAreNotSerializedManifestEntries(
+        manifest,
+        entry,
+        mountPath,
+      );
+    }
+    for (const authority of requiredAuthorities) {
+      if (acknowledgement[authority]) {
+        continue;
+      }
+      const broad = authority === 'broad';
+      throw new SandboxMountError(
+        broad
+          ? 'Broad credential authority cannot be exposed to a helper inside a model-controlled sandbox by default. Use a credentialless or external/provider-native strategy, or explicitly acknowledge broad credential exposure for this exact path with Manifest.withInContainerMountBroadCredentialExposureAcknowledged().'
+          : 'Mount-scoped credentials cannot be exposed to a helper inside a model-controlled sandbox by default. Use a credentialless or external/provider-native strategy, or explicitly acknowledge credential exposure for this exact path with Manifest.withInContainerMountCredentialExposureAcknowledged().',
+        details,
+        'mount_config_invalid',
+      );
+    }
+  }
+}
+
+function inContainerMountCredentialCapability(
+  entry: Mount | TypedMount,
+): InContainerMountCredentialCapability | undefined {
+  const strategyType = mountStrategyType(entry);
+  const provider = sdkOwnedMountProvider(entry);
+  if (!provider) {
+    return undefined;
+  }
+  const patternType = resolvedInContainerMountPatternType(entry);
+  return IN_CONTAINER_MOUNT_CREDENTIAL_CAPABILITIES.find(
+    (capability) =>
+      capability.strategyTypes.includes(strategyType) &&
+      capability.provider === provider &&
+      capability.patternType === patternType,
+  );
+}
+
+function sdkOwnedMountProvider(entry: Mount | TypedMount): string | undefined {
+  if (entry.type === 'mount') {
+    return undefined;
+  }
+  const provider = typedMountProviderConfig(entry).provider;
+  return entry.provider === undefined || entry.provider === provider
+    ? provider
+    : undefined;
+}
+
+function resolvedInContainerMountPatternType(
+  entry: Mount | TypedMount,
+): string | undefined {
+  const patternType = mountStrategyPattern(entry.mountStrategy)?.type;
+  if (patternType !== undefined) {
+    return typeof patternType === 'string' ? patternType : undefined;
+  }
+  const strategyType = mountStrategyType(entry);
+  if (
+    strategyType === 'e2b_cloud_bucket' ||
+    strategyType === 'daytona_cloud_bucket' ||
+    strategyType === 'runloop_cloud_bucket'
+  ) {
+    return 'rclone';
+  }
+  if (strategyType !== 'in_container') {
+    return undefined;
+  }
+  return entry.type === 's3_files_mount'
+    ? 's3files'
+    : entry.type === 's3_mount' ||
+        entry.type === 'r2_mount' ||
+        entry.type === 'gcs_mount' ||
+        entry.type === 'azure_blob_mount' ||
+        entry.type === 'box_mount'
+      ? 'rclone'
+      : undefined;
+}
+
+function classifyMountCredentialAuthorities(
+  capability: InContainerMountCredentialCapability,
+  credentialFields: readonly string[],
+  details: Record<string, unknown>,
+): Set<InContainerMountCredentialExposureAuthority> {
+  const mountScopedFields = new Set(capability.mountScopedCredentialFields);
+  const broadFields = new Set(capability.broadCredentialFields);
+  const unsupportedCredentialFields = credentialFields.filter(
+    (field) => !mountScopedFields.has(field) && !broadFields.has(field),
+  );
+  if (unsupportedCredentialFields.length > 0) {
     throw new SandboxMountError(
-      'Mount strategy must declare a trusted credential boundary before it can be used with explicit credentials.',
+      'The selected in-container mount capability does not support exposing these credential fields. Use the credential fields supported by this typed mount and strategy, or choose a credentialless or external/provider-native strategy.',
+      { ...details, unsupportedCredentialFields },
+      'mount_config_invalid',
+    );
+  }
+  const authorities = new Set<InContainerMountCredentialExposureAuthority>();
+  if (credentialFields.some((field) => mountScopedFields.has(field))) {
+    authorities.add('mount_scoped');
+  }
+  if (credentialFields.some((field) => broadFields.has(field))) {
+    authorities.add('broad');
+  }
+  return authorities;
+}
+
+function validateAcknowledgementSupportedByCapability(
+  capability: InContainerMountCredentialCapability,
+  acknowledgement: Record<InContainerMountCredentialExposureAuthority, boolean>,
+  details: Record<string, unknown>,
+): void {
+  if (
+    acknowledgement.mount_scoped &&
+    capability.mountScopedCredentialFields.length === 0
+  ) {
+    throw new SandboxMountError(
+      'The selected in-container mount capability does not support mount-scoped credential exposure acknowledgement.',
       details,
       'mount_config_invalid',
     );
   }
+  if (
+    acknowledgement.broad &&
+    capability.broadCredentialFields.length === 0 &&
+    capability.enablesBroadCredentialDiscovery !== true
+  ) {
+    throw new SandboxMountError(
+      'The selected in-container mount capability does not support broad credential exposure acknowledgement.',
+      details,
+      'mount_config_invalid',
+    );
+  }
+}
+
+function mountCredentialExposureAcknowledgement(
+  manifest: Manifest,
+  mountPath: string,
+): Record<InContainerMountCredentialExposureAuthority, boolean> {
+  return {
+    mount_scoped: manifestAcknowledgesInContainerMountCredentialExposure(
+      manifest,
+      mountPath,
+      'mount_scoped',
+    ),
+    broad: manifestAcknowledgesInContainerMountCredentialExposure(
+      manifest,
+      mountPath,
+      'broad',
+    ),
+  };
 }
 
 function validateRclonePatternArguments(
@@ -564,29 +912,35 @@ function validateMountCredentialEnvironmentPairs(
     entry.type === 'r2_mount' ||
     entry.type === 's3_files_mount'
   ) {
-    const accessKeyId = optionalCredentialString(environment.AWS_ACCESS_KEY_ID);
-    const secretAccessKey = optionalCredentialString(
-      environment.AWS_SECRET_ACCESS_KEY,
-    );
-    validateCredentialPair({
-      accessKeyId,
-      secretAccessKey,
-      message:
-        'S3 mount environment credentials require both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY when either is provided.',
-      details: { mountType: entry.type },
-      code: 'mount_config_invalid',
-    });
-    if (
-      (optionalCredentialString(environment.AWS_SESSION_TOKEN) !== undefined ||
-        optionalCredentialString(environment.AWS_SECURITY_TOKEN) !==
-          undefined) &&
-      (!accessKeyId || !secretAccessKey)
-    ) {
-      throw new SandboxMountError(
-        'S3 mount environment credentials require a complete AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY pair when a session token is provided.',
-        { mountType: entry.type },
-        'mount_config_invalid',
+    const entryRecord = entry as Record<string, unknown>;
+    if (!(entryRecord.accessKeyId && entryRecord.secretAccessKey)) {
+      const accessKeyId = optionalCredentialString(
+        environment.AWS_ACCESS_KEY_ID,
       );
+      const secretAccessKey = optionalCredentialString(
+        environment.AWS_SECRET_ACCESS_KEY,
+      );
+      validateCredentialPair({
+        accessKeyId,
+        secretAccessKey,
+        message:
+          'S3 mount environment credentials require both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY when either is provided.',
+        details: { mountType: entry.type },
+        code: 'mount_config_invalid',
+      });
+      if (
+        (optionalCredentialString(environment.AWS_SESSION_TOKEN) !==
+          undefined ||
+          optionalCredentialString(environment.AWS_SECURITY_TOKEN) !==
+            undefined) &&
+        (!accessKeyId || !secretAccessKey)
+      ) {
+        throw new SandboxMountError(
+          'S3 mount environment credentials require a complete AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY pair when a session token is provided.',
+          { mountType: entry.type },
+          'mount_config_invalid',
+        );
+      }
     }
   }
 
@@ -714,26 +1068,56 @@ export function validateMountCredentialBoundariesAtEffectivePath(
   logicalPath: string,
   entry: Mount | TypedMount,
   effectivePath: string,
-): boolean {
-  const effectivePathAllowed = manifestAllowsInContainerMountCredentialExposure(
+): MountCredentialExposureDecision {
+  const effectiveAcknowledgement = mountCredentialExposureAcknowledgement(
     manifest,
     effectivePath,
   );
   const declaredPath = manifest
     .mountTargets()
     .find((target) => target.logicalPath === logicalPath)?.mountPath;
-  if (
-    declaredPath &&
-    manifestAllowsInContainerMountCredentialExposure(manifest, declaredPath) &&
-    !effectivePathAllowed
-  ) {
-    throw new SandboxMountError(
-      'Mount credentials cannot be passed to a helper inside a model-controlled sandbox because the effective mount path does not match the trusted exact-path opt-in.',
+  const declaredAcknowledgement = declaredPath
+    ? mountCredentialExposureAcknowledgement(manifest, declaredPath)
+    : { mount_scoped: false, broad: false };
+  for (const authority of ['mount_scoped', 'broad'] as const) {
+    if (
+      declaredAcknowledgement[authority] &&
+      !effectiveAcknowledgement[authority]
+    ) {
+      throw new SandboxMountError(
+        'Mount credentials cannot be exposed to a helper inside a model-controlled sandbox because the effective mount path does not match the trusted exact-path acknowledgement.',
+        {
+          mountType: entry.type,
+          mountStrategy: mountStrategyType(entry),
+          credentialAuthority: authority,
+        },
+        'mount_config_invalid',
+      );
+    }
+  }
+  if (effectiveAcknowledgement.mount_scoped || effectiveAcknowledgement.broad) {
+    const capability = inContainerMountCredentialCapability(entry);
+    if (!capability) {
+      throw new SandboxMountError(
+        'Credential-bearing in-container mounts require an SDK-supported strategy, provider, mount type, and pattern combination before exposure can be acknowledged.',
+        {
+          mountType: entry.type,
+          mountStrategy: mountStrategyType(entry),
+          mountProvider: sdkOwnedMountProvider(entry),
+          mountPattern: resolvedInContainerMountPatternType(entry),
+        },
+        'mount_config_invalid',
+      );
+    }
+    validateAcknowledgementSupportedByCapability(
+      capability,
+      effectiveAcknowledgement,
       {
         mountType: entry.type,
         mountStrategy: mountStrategyType(entry),
+        mountProvider: sdkOwnedMountProvider(entry),
+        mountPattern: resolvedInContainerMountPatternType(entry),
       },
-      'mount_config_invalid',
     );
   }
   const effectivePaths = new Map(
@@ -741,7 +1125,11 @@ export function validateMountCredentialBoundariesAtEffectivePath(
   );
   effectivePaths.set(logicalPath, normalizePosixPath(effectivePath));
   validatedMountEffectivePaths.set(manifest, effectivePaths);
-  return effectivePathAllowed;
+  return {
+    credentialExposureAcknowledged:
+      effectiveAcknowledgement.mount_scoped || effectiveAcknowledgement.broad,
+    broadCredentialExposureAcknowledged: effectiveAcknowledgement.broad,
+  };
 }
 
 export function copyValidatedMountEffectivePaths(
@@ -766,13 +1154,9 @@ export function sanitizeMountCredentialEnvironmentForPersistence(state: {
   environment?: Record<string, string>;
 }): { manifest: Manifest; environment: Record<string, string> } {
   const environment = state.environment ?? {};
-  const effectiveEnvironment = mountEffectiveEnvironment(
+  const credentialNames = mountCredentialEnvironmentNamesForPersistence(
     state.manifest,
     environment,
-  );
-  const credentialNames = mountCredentialEnvironmentNames(
-    state.manifest,
-    effectiveEnvironment,
   );
   const sanitizedManifest = cloneManifest(state.manifest);
   const sanitizedEnvironment = { ...environment };
@@ -844,7 +1228,7 @@ export function deserializeMountCredentialRedactionMetadata(
 export function sanitizePersistedManifestRecord(
   value: Record<string, unknown>,
 ): { record: Record<string, unknown>; credentialPaths: string[] } {
-  if ([...POLICY_KEYS].some((key) => key in value)) {
+  if (MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS.some((key) => key in value)) {
     throw new TypeError(
       'Persisted sandbox manifest cannot configure mount credential exposure policy.',
     );
@@ -968,6 +1352,28 @@ export function recordLiveMountCredentialAuthority(
   if (environmentAuthority !== undefined) {
     liveMountEnvironmentAuthority.set(target, environmentAuthority);
   }
+  const runtimeAuthority = liveMountRuntimeAuthority.get(source);
+  if (runtimeAuthority !== undefined) {
+    liveMountRuntimeAuthority.set(target, new Map(runtimeAuthority));
+  }
+}
+
+export function captureLiveMountRuntimeAuthority(
+  manifest: Manifest,
+  key: symbol,
+  signature: string,
+): void {
+  const authority = new Map(liveMountRuntimeAuthority.get(manifest) ?? []);
+  authority.set(key, signature);
+  liveMountRuntimeAuthority.set(manifest, authority);
+}
+
+export function liveMountRuntimeAuthorityMatches(
+  manifest: Manifest,
+  key: symbol,
+  signature: string,
+): boolean {
+  return liveMountRuntimeAuthority.get(manifest)?.get(key) === signature;
 }
 
 export function captureLiveMountCredentialAuthority(
@@ -1477,11 +1883,8 @@ function mountCredentialAuthoritySignature(
           path: logicalPath,
           effectivePath,
           credentials,
-          inContainerExposureAllowed:
-            manifestAllowsInContainerMountCredentialExposure(
-              manifest,
-              effectivePath,
-            ),
+          inContainerExposureAcknowledgement:
+            mountCredentialExposureAcknowledgement(manifest, effectivePath),
         };
       }),
   );
@@ -1594,25 +1997,61 @@ function entryIsRecursiveSource(entry: { type?: unknown }): boolean {
   return entry.type === 'local_dir' || entry.type === 'git_repo';
 }
 
-function mountCredentialEnvironmentNames(
+function mountCredentialEnvironmentNamesForPersistence(
   manifest: Manifest,
   environment: Record<string, string>,
 ): Set<string> {
   const names = new Set<string>();
+  const configuredNames = new Set([
+    ...Object.keys(manifest.environment),
+    ...Object.keys(environment),
+  ]);
   for (const { entry } of manifest.mountTargets()) {
-    for (const name of Object.keys(
-      mountCredentialEnvironmentForEntry(entry, environment),
-    )) {
-      names.add(name);
+    if (
+      !isMount(entry) ||
+      !ENVIRONMENT_CREDENTIAL_STRATEGIES.has(mountStrategyType(entry))
+    ) {
+      continue;
+    }
+    if (mountUsesRcloneEnvironment(entry)) {
+      for (const name of configuredNames) {
+        if (name === 'RCLONE_CONFIG' || name.startsWith('RCLONE_CONFIG_')) {
+          names.add(name);
+        }
+      }
+    }
+    if (
+      entry.type === 's3_mount' ||
+      entry.type === 'r2_mount' ||
+      entry.type === 's3_files_mount'
+    ) {
+      for (const name of [
+        ...S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES,
+        ...S3_MOUNT_BROAD_CREDENTIAL_ENVIRONMENT_NAMES,
+      ]) {
+        if (configuredNames.has(name)) {
+          names.add(name);
+        }
+      }
+    }
+    if (entry.type === 'gcs_mount') {
+      for (const name of GCS_MOUNT_ENVIRONMENT_NAMES) {
+        if (configuredNames.has(name)) {
+          names.add(name);
+        }
+      }
     }
   }
   return names;
 }
 
-function mountCredentialEnvironmentForEntry(
-  entry: Mount | TypedMount,
+export function mountCredentialEnvironmentForEntry(
+  entry: Entry,
   environment: Record<string, string>,
 ): Record<string, string> {
+  if (!isMount(entry)) {
+    return {};
+  }
   if (!ENVIRONMENT_CREDENTIAL_STRATEGIES.has(mountStrategyType(entry))) {
     return {};
   }
@@ -1625,28 +2064,42 @@ function mountCredentialEnvironmentForEntry(
     }
   }
   const entryRecord = entry as Record<string, unknown>;
-  const usesEntryCredentialPair = Boolean(
+  const usesS3EntryCredentialPair = Boolean(
     entryRecord.accessKeyId && entryRecord.secretAccessKey,
   );
+  const exposesShadowedCredentialEnvironment =
+    mountUsesRcloneEnvironment(entry);
+  const usesS3CredentialEnvironment =
+    ((!usesS3EntryCredentialPair || exposesShadowedCredentialEnvironment) &&
+      S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES.some(
+        (name) => environment[name] !== undefined,
+      )) ||
+    S3_MOUNT_BROAD_CREDENTIAL_ENVIRONMENT_NAMES.some(
+      (name) => environment[name] !== undefined,
+    );
   if (
     (entry.type === 's3_mount' ||
       entry.type === 'r2_mount' ||
       entry.type === 's3_files_mount') &&
-    !usesEntryCredentialPair &&
-    S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES.some(
-      (name) => environment[name] !== undefined,
-    )
+    usesS3CredentialEnvironment
   ) {
-    for (const name of S3_MOUNT_ENVIRONMENT_NAMES) {
+    const environmentNames =
+      usesS3EntryCredentialPair && !exposesShadowedCredentialEnvironment
+        ? S3_MOUNT_BROAD_CREDENTIAL_ENVIRONMENT_NAMES
+        : S3_MOUNT_ENVIRONMENT_NAMES;
+    for (const name of environmentNames) {
       names.add(name);
     }
   }
+  const usesGcsEntryCredentials = Boolean(
+    (entryRecord.accessId && entryRecord.secretAccessKey) ||
+    entryRecord.serviceAccountCredentials ||
+    entryRecord.serviceAccountFile ||
+    entryRecord.accessToken,
+  );
   if (
     entry.type === 'gcs_mount' &&
-    !usesEntryCredentialPair &&
-    !entryRecord.serviceAccountCredentials &&
-    !entryRecord.serviceAccountFile &&
-    !entryRecord.accessToken &&
+    (!usesGcsEntryCredentials || exposesShadowedCredentialEnvironment) &&
     environment.GOOGLE_APPLICATION_CREDENTIALS !== undefined
   ) {
     for (const name of GCS_MOUNT_ENVIRONMENT_NAMES) {
@@ -1697,16 +2150,16 @@ function mountUsesRcloneEnvironment(entry: Mount | TypedMount): boolean {
   if (strategyType === 'vercel_cloud_bucket') {
     return false;
   }
-  const patternType = mountStrategyPattern(entry.mountStrategy)?.type;
-  if (patternType !== undefined) {
-    return patternType === 'rclone';
-  }
   if (
     strategyType === 'e2b_cloud_bucket' ||
     strategyType === 'daytona_cloud_bucket' ||
     strategyType === 'runloop_cloud_bucket'
   ) {
     return true;
+  }
+  const patternType = mountStrategyPattern(entry.mountStrategy)?.type;
+  if (patternType !== undefined) {
+    return patternType === 'rclone';
   }
   return (
     strategyType === 'in_container' &&

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -2562,6 +2562,7 @@ type PreparedDockerInContainerMount = {
   entry: Mount | TypedMount;
   effectiveMountPath: string;
   pattern: MountPattern;
+  credentialExposureAcknowledged: boolean;
   allowAmbientCredentials: boolean;
   environment: Record<string, string>;
   revalidateMountAuthority: () => Promise<void>;
@@ -2587,13 +2588,12 @@ async function prepareDockerInContainerMount(
       entry,
       mountPath,
     );
-    const allowAmbientCredentials =
-      validateMountCredentialBoundariesAtEffectivePath(
-        manifest,
-        logicalPath,
-        entry,
-        effectiveMountPath,
-      );
+    const credentialExposure = validateMountCredentialBoundariesAtEffectivePath(
+      manifest,
+      logicalPath,
+      entry,
+      effectiveMountPath,
+    );
     const preparedCredentialFiles = await prepareDockerMountCredentialFiles(
       session,
       credentialBoundaryManifest,
@@ -2605,7 +2605,10 @@ async function prepareDockerInContainerMount(
       entry: preparedCredentialFiles.entry,
       effectiveMountPath,
       pattern: dockerInContainerMountPattern(preparedCredentialFiles.entry),
-      allowAmbientCredentials,
+      credentialExposureAcknowledged:
+        credentialExposure.credentialExposureAcknowledged,
+      allowAmbientCredentials:
+        credentialExposure.broadCredentialExposureAcknowledged,
       environment: preparedCredentialFiles.environment,
     };
   };
@@ -2614,12 +2617,14 @@ async function prepareDockerInContainerMount(
     logicalPath,
     ...candidate,
     revalidateMountAuthority: async () => {
-      if (!candidate.allowAmbientCredentials) {
+      if (!candidate.credentialExposureAcknowledged) {
         return;
       }
       const current = await prepareCandidate();
       if (
         current.effectiveMountPath !== candidate.effectiveMountPath ||
+        current.credentialExposureAcknowledged !==
+          candidate.credentialExposureAcknowledged ||
         current.allowAmbientCredentials !== candidate.allowAmbientCredentials ||
         stableJsonStringify(current.entry) !==
           stableJsonStringify(candidate.entry) ||
@@ -3286,15 +3291,21 @@ async function applyDockerMountpointMount(
   )}`;
   const envPath = `${envDir}/credentials.env`;
   const cleanupEnvCommand = `rm -rf -- ${shellQuote(envDir)}`;
-  const clearInheritedAwsAuthorityCommand =
-    DOCKER_AWS_CREDENTIAL_AUTHORITY_NAMES.join(' ');
+  const clearedInheritedCredentialAuthorityNames = [
+    ...DOCKER_AWS_CREDENTIAL_AUTHORITY_NAMES,
+    ...(entry.type === 'gcs_mount'
+      ? DOCKER_GCS_CREDENTIAL_AUTHORITY_NAMES
+      : []),
+  ];
+  const clearInheritedCredentialAuthorityCommand =
+    clearedInheritedCredentialAuthorityNames.join(' ');
   const command = envText
     ? [
         `trap ${shellQuote(cleanupEnvCommand)} EXIT HUP INT TERM`,
         cleanupEnvCommand,
         `install -d -m 700 -- ${shellQuote(envDir)}`,
         `(umask 077 && cat > ${shellQuote(envPath)})`,
-        `unset ${clearInheritedAwsAuthorityCommand}`,
+        `unset ${clearInheritedCredentialAuthorityCommand}`,
         `set -a && . ${shellQuote(envPath)} && set +a`,
         cleanupEnvCommand,
         shellCommand(mountArgs),
@@ -3309,7 +3320,7 @@ async function applyDockerMountpointMount(
           input: envText,
           environment: Object.fromEntries([
             ...Object.entries(environment),
-            ...DOCKER_AWS_CREDENTIAL_AUTHORITY_NAMES.map(
+            ...clearedInheritedCredentialAuthorityNames.map(
               (name) => [name, ''] as const,
             ),
           ]),
@@ -3332,6 +3343,10 @@ const DOCKER_AWS_CREDENTIAL_AUTHORITY_NAMES = [
   'AWS_CONTAINER_CREDENTIALS_FULL_URI',
   'AWS_CONTAINER_AUTHORIZATION_TOKEN',
   'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
+] as const;
+
+const DOCKER_GCS_CREDENTIAL_AUTHORITY_NAMES = [
+  'GOOGLE_APPLICATION_CREDENTIALS',
 ] as const;
 
 async function applyDockerS3FilesMount(

--- a/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
@@ -1490,6 +1490,7 @@ async function waitForProcessOrTimeout(
   timeoutMs: number,
 ): Promise<void> {
   if (activeProcess.done) {
+    await activeProcess.outputClosedPromise;
     return;
   }
 

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -60,9 +60,10 @@ describe('index.ts', () => {
     expect(typeof Sandbox.Capabilities.default).toBe('function');
     expect(typeof Sandbox.filesystem).toBe('function');
     expect(typeof Sandbox.shell).toBe('function');
-    expect('manifestAllowsInContainerMountCredentialExposure' in Sandbox).toBe(
-      false,
-    );
+    expect(
+      'manifestAcknowledgesInContainerMountCredentialExposure' in Sandbox,
+    ).toBe(false);
+    expect('MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS' in Sandbox).toBe(false);
     expect('copyManifestMountCredentialExposurePolicy' in Sandbox).toBe(false);
     expect('replaceManifestMountCredentialExposurePolicy' in Sandbox).toBe(
       false,

--- a/packages/agents-core/test/sandboxMountSecurity.test.ts
+++ b/packages/agents-core/test/sandboxMountSecurity.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  boxMount,
   dockerVolumeMountStrategy,
   file,
   gcsMount,
@@ -30,7 +31,10 @@ import {
   validateMountCredentialBoundaries,
   validateMountEnvironmentCredentialBoundaries,
 } from '../src/sandbox/internal';
-import { assertMountCredentialsRebound } from '../src/sandbox/mountSecurity';
+import {
+  assertMountCredentialsRebound,
+  redactMountCredentialsForPersistence,
+} from '../src/sandbox/mountSecurity';
 import {
   sanitizeSerializedSandboxState,
   toSessionStateEnvelope,
@@ -108,7 +112,7 @@ describe('sandbox mount credential boundaries', () => {
     );
   });
 
-  it('treats an Azure managed identity selector as explicit mount authority', () => {
+  it('requires broad acknowledgement for an Azure managed identity selector', () => {
     const manifest = new Manifest({
       entries: {
         remote: {
@@ -126,7 +130,14 @@ describe('sandbox mount credential boundaries', () => {
     );
     expect(() =>
       validateMountCredentialBoundaries(
-        manifest.withInContainerMountCredentialExposureAllowed('remote'),
+        manifest.withInContainerMountCredentialExposureAcknowledged('remote'),
+      ),
+    ).toThrow(/broad credential authority/iu);
+    expect(() =>
+      validateMountCredentialBoundaries(
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+          'remote',
+        ),
       ),
     ).not.toThrow();
   });
@@ -162,7 +173,7 @@ describe('sandbox mount credential boundaries', () => {
   ])('rejects $label before mount path resolution', ({ entry }) => {
     const manifest = new Manifest({
       entries: { remote: entry },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
 
     expect(() => validateMountCredentialBoundaries(manifest)).toThrow(
       /complete|both/u,
@@ -195,14 +206,14 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     expect(() =>
       validateMountEnvironmentCredentialBoundaries(manifest, environment),
     ).toThrow(/complete|both/u);
   });
 
-  it('preserves ambient AWS profile credentials without static keys', () => {
+  it('requires separate broad acknowledgement for ambient AWS profiles', () => {
     const manifest = new Manifest({
       entries: {
         remote: s3Mount({
@@ -210,14 +221,110 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    });
 
     expect(() =>
       validateMountEnvironmentCredentialBoundaries(manifest, {
         AWS_PROFILE: 'trusted-profile',
       }),
+    ).toThrow(/broad credential authority/iu);
+    expect(() =>
+      validateMountEnvironmentCredentialBoundaries(
+        manifest.withInContainerMountCredentialExposureAcknowledged('remote'),
+        { AWS_PROFILE: 'trusted-profile' },
+      ),
+    ).toThrow(/broad credential authority/iu);
+    expect(() =>
+      validateMountEnvironmentCredentialBoundaries(
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+          'remote',
+        ),
+        { AWS_PROFILE: 'trusted-profile' },
+      ),
     ).not.toThrow();
   });
+
+  it('requires separate broad acknowledgement for ambient AWS credentials shadowed by inline credentials', () => {
+    const manifest = new Manifest({
+      entries: {
+        remote: s3Mount({
+          bucket: 'private',
+          accessKeyId: 'inline-access-key',
+          secretAccessKey: 'inline-secret-key',
+          mountStrategy: {
+            type: 'e2b_cloud_bucket',
+          } as MountStrategy,
+        }),
+      },
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
+    const environment = {
+      AWS_ACCESS_KEY_ID: 'ambient-access-key',
+      AWS_SECRET_ACCESS_KEY: 'ambient-secret-key',
+      AWS_SESSION_TOKEN: 'ambient-session-token',
+    };
+
+    expect(() =>
+      validateMountEnvironmentCredentialBoundaries(manifest, environment),
+    ).toThrow(/broad credential authority/iu);
+    expect(() =>
+      validateMountEnvironmentCredentialBoundaries(
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+          'remote',
+        ),
+        environment,
+      ),
+    ).not.toThrow();
+  });
+
+  it.each([
+    {
+      label: 'an HMAC key pair',
+      credentials: {
+        accessId: 'inline-access-id',
+        secretAccessKey: 'inline-secret-key',
+      },
+    },
+    {
+      label: 'service account credentials',
+      credentials: {
+        serviceAccountCredentials: 'inline-service-account-credentials',
+      },
+    },
+    {
+      label: 'an access token',
+      credentials: { accessToken: 'inline-access-token' },
+    },
+  ])(
+    'requires separate broad acknowledgement for ambient GCS credentials shadowed by $label',
+    ({ credentials }) => {
+      const manifest = new Manifest({
+        entries: {
+          remote: gcsMount({
+            bucket: 'private',
+            ...credentials,
+            mountStrategy: {
+              type: 'e2b_cloud_bucket',
+            } as MountStrategy,
+          }),
+        },
+      }).withInContainerMountCredentialExposureAcknowledged('remote');
+      const environment = {
+        GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/gcp.json',
+      };
+
+      expect(() =>
+        validateMountEnvironmentCredentialBoundaries(manifest, environment),
+      ).toThrow(/broad credential authority/iu);
+      expect(() =>
+        validateMountEnvironmentCredentialBoundaries(
+          manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+            'remote',
+          ),
+          environment,
+        ),
+      ).not.toThrow();
+    },
+  );
 
   it('requires exact opt-in for implicit workload identity mount patterns', () => {
     const manifests = [
@@ -251,31 +358,36 @@ describe('sandbox mount credential boundaries', () => {
       );
       expect(() =>
         validateMountCredentialBoundaries(
-          manifest.withInContainerMountCredentialExposureAllowed('remote'),
+          manifest.withInContainerMountCredentialExposureAcknowledged('remote'),
+        ),
+      ).toThrow(/broad credential|does not support mount-scoped/u);
+      expect(() =>
+        validateMountCredentialBoundaries(
+          manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+            'remote',
+          ),
         ),
       ).not.toThrow();
     }
   });
 
-  it('requires a trusted exact effective mount path opt-in', () => {
+  it('requires a trusted exact effective mount path acknowledgement', () => {
     const manifest = credentialedS3Manifest(inContainerMountStrategy(), {
       mountPath: '/workspace/data',
     });
     const trusted =
-      manifest.withInContainerMountCredentialExposureAllowed('data');
+      manifest.withInContainerMountCredentialExposureAcknowledged('data');
 
     validateMountCredentialBoundaries(trusted);
     expect(() =>
-      manifest.withInContainerMountCredentialExposureAllowed('other'),
+      manifest.withInContainerMountCredentialExposureAcknowledged('other'),
     ).not.toThrow();
     expect(() =>
       validateMountCredentialBoundaries(
-        manifest.withInContainerMountCredentialExposureAllowed('other'),
+        manifest.withInContainerMountCredentialExposureAcknowledged('other'),
       ),
     ).toThrow(/exact path/u);
-    expect(JSON.stringify(trusted)).not.toContain(
-      'inContainerMountCredentialExposureAllowedPaths',
-    );
+    expect(JSON.stringify(trusted)).not.toContain('CredentialExposure');
   });
 
   it('rejects empty and workspace-root exposure paths', () => {
@@ -283,7 +395,10 @@ describe('sandbox mount credential boundaries', () => {
 
     for (const path of ['', ' ', '.', '/', '/workspace']) {
       expect(() =>
-        manifest.withInContainerMountCredentialExposureAllowed(path),
+        manifest.withInContainerMountCredentialExposureAcknowledged(path),
+      ).toThrow(/non-root path/u);
+      expect(() =>
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(path),
       ).toThrow(/non-root path/u);
     }
   });
@@ -291,19 +406,29 @@ describe('sandbox mount credential boundaries', () => {
   it('supports trusted exact absolute mount paths outside the workspace root', () => {
     const trusted = credentialedS3Manifest(inContainerMountStrategy(), {
       mountPath: '/mnt/private',
-    }).withInContainerMountCredentialExposureAllowed('/mnt/private');
+    }).withInContainerMountCredentialExposureAcknowledged('/mnt/private');
 
     expect(() => validateMountCredentialBoundaries(trusted)).not.toThrow();
   });
 
-  it('does not accept exposure policy from manifest init objects', () => {
-    expect(
-      () =>
-        new Manifest({
-          inContainerMountCredentialExposureAllowedPaths: ['remote'],
-        } as never),
-    ).toThrow(/credential exposure/u);
-  });
+  it.each([
+    'inContainerMountCredentialExposureAllowedPaths',
+    'inContainerMountCredentialExposureAcknowledgedPaths',
+    'inContainerMountBroadCredentialExposureAcknowledgedPaths',
+  ])(
+    'does not accept %s from manifest init objects or persisted records',
+    (key) => {
+      expect(() => new Manifest({ [key]: ['remote'] } as never)).toThrow(
+        /credential exposure/u,
+      );
+      expect(() =>
+        deserializeManifest({
+          ...serializeManifestRecord(new Manifest()),
+          [key]: ['remote'],
+        }),
+      ).toThrow(/credential exposure policy/u);
+    },
+  );
 
   it('rejects rclone credential config stored in a serialized entry', () => {
     const manifest = new Manifest({
@@ -318,14 +443,14 @@ describe('sandbox mount credential boundaries', () => {
           }),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
 
     expect(() => validateMountCredentialBoundaries(manifest)).toThrow(
       /serialized manifest entry/u,
     );
   });
 
-  it('allows a trusted external rclone config path', () => {
+  it('requires broad acknowledgement for a trusted external rclone config', () => {
     const manifest = new Manifest({
       extraPathGrants: [
         {
@@ -352,7 +477,14 @@ describe('sandbox mount credential boundaries', () => {
     );
     expect(() =>
       validateMountCredentialBoundaries(
-        manifest.withInContainerMountCredentialExposureAllowed('remote'),
+        manifest.withInContainerMountCredentialExposureAcknowledged('remote'),
+      ),
+    ).toThrow(/broad credential authority/iu);
+    expect(() =>
+      validateMountCredentialBoundaries(
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+          'remote',
+        ),
       ),
     ).not.toThrow();
   });
@@ -368,7 +500,7 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     expect(() => validateMountCredentialBoundaries(explicit)).toThrow(
       /credential files cannot come from a serialized manifest entry/u,
     );
@@ -388,7 +520,7 @@ describe('sandbox mount credential boundaries', () => {
       environment: {
         GOOGLE_APPLICATION_CREDENTIALS: '/workspace/gcp.json',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     expect(() =>
       validateMountEnvironmentCredentialBoundaries(ambient, {
         GOOGLE_APPLICATION_CREDENTIALS: '/workspace/gcp.json',
@@ -405,7 +537,7 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     expect(() => validateMountCredentialBoundaries(recursiveExplicit)).toThrow(
       /credential files cannot come from a serialized manifest entry/u,
     );
@@ -422,7 +554,7 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     expect(() =>
       validateMountEnvironmentCredentialBoundaries(recursiveAmbient, {
         GOOGLE_APPLICATION_CREDENTIALS:
@@ -486,7 +618,7 @@ describe('sandbox mount credential boundaries', () => {
         AWS_SECRET_ACCESS_KEY: 'AMBIENT_SECRET_SENTINEL',
         SAFE: 'visible',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const environment = {
       AWS_ACCESS_KEY_ID: 'AMBIENT_ACCESS_SENTINEL',
       AWS_SECRET_ACCESS_KEY: 'AMBIENT_SECRET_SENTINEL',
@@ -514,6 +646,42 @@ describe('sandbox mount credential boundaries', () => {
     ).toBe(false);
   });
 
+  it('redacts shadowed credential environment beside inline credentials', () => {
+    const manifest = new Manifest({
+      entries: {
+        remote: s3Mount({
+          bucket: 'private',
+          accessKeyId: 'INLINE_ACCESS_SENTINEL',
+          secretAccessKey: 'INLINE_SECRET_SENTINEL',
+          mountStrategy: inContainerMountStrategy(),
+        }),
+      },
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
+    const environment = {
+      AWS_ACCESS_KEY_ID: 'SHADOWED_ACCESS_SENTINEL',
+      AWS_SECRET_ACCESS_KEY: 'SHADOWED_SECRET_SENTINEL',
+      AWS_SESSION_TOKEN: 'SHADOWED_SESSION_SENTINEL',
+      SAFE: 'visible',
+    };
+
+    const sanitized = sanitizeMountCredentialEnvironmentForPersistence({
+      manifest,
+      environment,
+    });
+
+    expect(JSON.stringify(sanitized)).not.toContain('SHADOWED_ACCESS_SENTINEL');
+    expect(JSON.stringify(sanitized)).not.toContain('SHADOWED_SECRET_SENTINEL');
+    expect(JSON.stringify(sanitized)).not.toContain(
+      'SHADOWED_SESSION_SENTINEL',
+    );
+    expect(sanitized.environment).toEqual({ SAFE: 'visible' });
+    expect(environment).toMatchObject({
+      AWS_ACCESS_KEY_ID: 'SHADOWED_ACCESS_SENTINEL',
+      AWS_SECRET_ACCESS_KEY: 'SHADOWED_SECRET_SENTINEL',
+      AWS_SESSION_TOKEN: 'SHADOWED_SESSION_SENTINEL',
+    });
+  });
+
   it('redacts manifest-sourced mount credentials from RunState envelopes', () => {
     const manifest = new Manifest({
       environment: {
@@ -526,7 +694,7 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     const envelope = toSessionStateEnvelope(
       'probe',
@@ -545,6 +713,43 @@ describe('sandbox mount credential boundaries', () => {
     expect(serialized).not.toContain('ENVELOPE_SECRET_SENTINEL');
   });
 
+  it('redacts manifest credentials hidden by an undefined runtime override', () => {
+    const manifest = new Manifest({
+      environment: {
+        AWS_ACCESS_KEY_ID: 'MANIFEST_ACCESS_SENTINEL',
+        AWS_SECRET_ACCESS_KEY: 'MANIFEST_SECRET_SENTINEL',
+      },
+      entries: {
+        remote: s3Mount({
+          bucket: 'private',
+          accessKeyId: 'INLINE_ACCESS_SENTINEL',
+          secretAccessKey: 'INLINE_SECRET_SENTINEL',
+          mountStrategy: inContainerMountStrategy(),
+        }),
+      },
+    })
+      .withInContainerMountCredentialExposureAcknowledged('remote')
+      .withInContainerMountBroadCredentialExposureAcknowledged('remote');
+    const environment = {
+      AWS_ACCESS_KEY_ID: undefined,
+    } as unknown as Record<string, string>;
+
+    const sanitized = sanitizeMountCredentialEnvironmentForPersistence({
+      manifest,
+      environment,
+    });
+    const envelope = toSessionStateEnvelope(
+      'probe',
+      { manifest, environment },
+      {},
+    );
+
+    expect(JSON.stringify(sanitized)).not.toContain('MANIFEST_ACCESS_SENTINEL');
+    expect(JSON.stringify(sanitized)).not.toContain('MANIFEST_SECRET_SENTINEL');
+    expect(JSON.stringify(envelope)).not.toContain('MANIFEST_ACCESS_SENTINEL');
+    expect(JSON.stringify(envelope)).not.toContain('MANIFEST_SECRET_SENTINEL');
+  });
+
   it('rejects resolved credential files before RunState envelope persistence', () => {
     const manifest = new Manifest({
       environment: {
@@ -557,7 +762,7 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
 
     expect(() =>
       toSessionStateEnvelope(
@@ -576,7 +781,7 @@ describe('sandbox mount credential boundaries', () => {
   it('strips persisted credentials and rebinds only matching trusted topology', () => {
     const trusted = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const serializedManifest = serializeManifestRecord(trusted);
     const metadata = serializeMountCredentialRedactionMetadata({
       manifest: trusted,
@@ -603,7 +808,7 @@ describe('sandbox mount credential boundaries', () => {
 
     const mismatched = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     (mismatched.entries.remote as { bucket: string }).bucket = 'different';
     expect(() =>
       rebindPersistedMountCredentials(persistedState, mismatched),
@@ -616,16 +821,18 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     expect(() =>
       rebindPersistedMountCredentials(persistedState, credentialless),
     ).toThrow(/no longer provides credential authority/u);
   });
 
-  it('strips and rebinds opaque generic in-container mount sources', () => {
-    const source =
-      'https://mount-user:SOURCE_SECRET_SENTINEL@example.test/private';
-    const trusted = new Manifest({
+  it('rejects opaque generic in-container mount sources despite acknowledgement', () => {
+    const source = [
+      'https://mount-user',
+      'fixture-value@example.test/private',
+    ].join(':');
+    const manifest = new Manifest({
       entries: {
         remote: {
           type: 'mount',
@@ -633,28 +840,51 @@ describe('sandbox mount credential boundaries', () => {
           mountStrategy: inContainerMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
-    const serializedManifest = serializeManifestRecord(trusted);
-    const metadata = serializeMountCredentialRedactionMetadata({
-      manifest: trusted,
     });
+    for (const trusted of [
+      manifest.withInContainerMountCredentialExposureAcknowledged('remote'),
+      manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+        'remote',
+      ),
+    ]) {
+      expect(() => validateMountCredentialBoundaries(trusted)).toThrow(
+        /SDK-supported strategy, provider, mount type, and pattern/u,
+      );
+      expect(() => serializeManifestRecord(trusted)).toThrow(
+        /SDK-supported strategy, provider, mount type, and pattern/u,
+      );
+    }
+  });
 
-    expect(JSON.stringify({ serializedManifest, metadata })).not.toContain(
-      'SOURCE_SECRET_SENTINEL',
-    );
-    expect(
-      (serializedManifest.entries as Record<string, unknown>).remote,
-    ).not.toHaveProperty('source');
-
-    const rebound = rebindPersistedMountCredentials(
-      {
-        manifest: deserializeManifest(serializedManifest),
-        ...deserializeMountCredentialRedactionMetadata(metadata),
+  it('supports mount-scoped Box credentials only for a closed capability', () => {
+    const manifest = new Manifest({
+      entries: {
+        remote: boxMount({
+          accessToken: 'BOX_TOKEN_SENTINEL',
+          mountStrategy: inContainerMountStrategy(),
+        }),
       },
-      trusted,
+    });
+    expect(() => validateMountCredentialBoundaries(manifest)).toThrow(
+      /mount-scoped credentials/iu,
     );
-    expect(rebound.manifest.entries.remote).toMatchObject({ source });
-    validateMountCredentialBoundaries(rebound.manifest);
+    expect(() =>
+      validateMountCredentialBoundaries(
+        manifest.withInContainerMountCredentialExposureAcknowledged('remote'),
+      ),
+    ).not.toThrow();
+
+    const custom = new Manifest({
+      entries: {
+        remote: boxMount({
+          accessToken: 'BOX_TOKEN_SENTINEL',
+          mountStrategy: { type: 'custom' },
+        }),
+      },
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
+    expect(() => validateMountCredentialBoundaries(custom)).toThrow(
+      /SDK-supported strategy, provider, mount type, and pattern/u,
+    );
   });
 
   it('treats arbitrary command and external config mount authority as non-resumable', () => {
@@ -669,7 +899,7 @@ describe('sandbox mount credential boundaries', () => {
             mountStrategy: inContainerMountStrategy({ pattern }),
           }),
         },
-      }).withInContainerMountCredentialExposureAllowed('remote');
+      }).withInContainerMountCredentialExposureAcknowledged('remote');
       expect(manifestHasNonResumableMountAuthority(manifest)).toBe(true);
     }
   });
@@ -685,7 +915,7 @@ describe('sandbox mount credential boundaries', () => {
           }),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sessionState = {
       version: 2 as const,
       backendId: 'fake',
@@ -713,7 +943,7 @@ describe('sandbox mount credential boundaries', () => {
   it('rejects credential rebind when the persisted manifest root changed', () => {
     const trusted = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const serializedManifest = serializeManifestRecord(trusted);
     serializedManifest.root = '/attacker/workspace';
     const persistedState = {
@@ -731,7 +961,7 @@ describe('sandbox mount credential boundaries', () => {
   it('detects live mount credential, policy, and topology changes', () => {
     const original = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const liveManifest = deserializeManifest(serializeManifestRecord(original));
     recordLiveMountCredentialAuthority(liveManifest, original);
 
@@ -745,7 +975,7 @@ describe('sandbox mount credential boundaries', () => {
     expect(
       liveMountCredentialAuthorityMatches(
         liveManifest,
-        rotated.withInContainerMountCredentialExposureAllowed('remote'),
+        rotated.withInContainerMountCredentialExposureAcknowledged('remote'),
       ),
     ).toBe(false);
 
@@ -774,10 +1004,10 @@ describe('sandbox mount credential boundaries', () => {
   it('rejects removing or replacing active mount topology', () => {
     const current = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const sameTopologyWithRotatedCredentials = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     (
       sameTopologyWithRotatedCredentials.entries.remote as {
         accessKeyId: string;
@@ -804,7 +1034,7 @@ describe('sandbox mount credential boundaries', () => {
   it('preserves provider-recorded authority during manager registration', () => {
     const trusted = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const sanitized = deserializeManifest(serializeManifestRecord(trusted));
     recordLiveMountCredentialAuthority(sanitized, trusted);
 
@@ -816,7 +1046,7 @@ describe('sandbox mount credential boundaries', () => {
   it('does not retain stale exposure trust during credential rebind', () => {
     const stale = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const currentWithoutTrust = credentialedS3Manifest(
       inContainerMountStrategy(),
     );
@@ -844,7 +1074,7 @@ describe('sandbox mount credential boundaries', () => {
       /Unsupported rclone mount args/u,
     );
     const trusted =
-      untrusted.withInContainerMountCredentialExposureAllowed('rclone');
+      untrusted.withInContainerMountCredentialExposureAcknowledged('rclone');
     expect(() => validateMountCredentialBoundaries(trusted)).toThrow(
       /Unsupported rclone mount args/u,
     );
@@ -869,7 +1099,7 @@ describe('sandbox mount credential boundaries', () => {
             mountStrategy: inContainerMountStrategy({ pattern }),
           }),
         },
-      }).withInContainerMountCredentialExposureAllowed('remote');
+      }).withInContainerMountCredentialExposureAcknowledged('remote');
 
       expect(() => validateMountCredentialBoundaries(manifest)).toThrow(
         /configFilePath/u,
@@ -1021,23 +1251,22 @@ describe('sandbox mount credential boundaries', () => {
     });
 
     expect(() => validateMountCredentialBoundaries(generic)).toThrow(
-      /model-controlled sandbox/u,
+      /SDK-supported strategy, provider, mount type, and pattern/u,
     );
     expect(() => validateMountCredentialBoundaries(s3Files)).toThrow(
-      /model-controlled sandbox/u,
+      /broad credential authority/iu,
     );
 
-    const trusted = new Manifest({
-      entries: {
-        generic: generic.entries.remote!,
-        s3Files: s3Files.entries.remote!,
-      },
-    })
-      .withInContainerMountCredentialExposureAllowed('generic')
-      .withInContainerMountCredentialExposureAllowed('s3Files');
+    expect(() =>
+      validateMountCredentialBoundaries(
+        generic.withInContainerMountCredentialExposureAcknowledged('remote'),
+      ),
+    ).toThrow(/SDK-supported strategy, provider, mount type, and pattern/u);
+
+    const trusted =
+      s3Files.withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const serializedManifest = serializeManifestRecord(trusted);
     const serialized = JSON.stringify(serializedManifest);
-    expect(serialized).not.toContain('GENERIC_CONFIG_SENTINEL');
     expect(serialized).not.toContain('S3_FILES_OPTION_SENTINEL');
 
     const metadata = serializeMountCredentialRedactionMetadata({
@@ -1061,21 +1290,19 @@ describe('sandbox mount credential boundaries', () => {
     );
     const rotated = new Manifest({
       entries: {
-        generic: {
-          ...(trusted.entries.generic as Record<string, unknown>),
-          config: { token: 'ROTATED_GENERIC_CONFIG' },
-        } as never,
-        s3Files: trusted.entries.s3Files!,
+        remote: s3FilesMount({
+          fileSystemId: 'fs-123',
+          extraOptions: { password: 'ROTATED_S3_FILES_OPTION' },
+          mountStrategy: inContainerMountStrategy(),
+        }),
       },
-    })
-      .withInContainerMountCredentialExposureAllowed('generic')
-      .withInContainerMountCredentialExposureAllowed('s3Files');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     expect(liveMountCredentialAuthorityMatches(liveManifest, rotated)).toBe(
       false,
     );
   });
 
-  it('default-denies residual config on typed mounts as non-resumable', () => {
+  it('rejects residual config on typed mounts despite acknowledgement', () => {
     const manifest = new Manifest({
       entries: {
         remote: {
@@ -1088,29 +1315,40 @@ describe('sandbox mount credential boundaries', () => {
     });
 
     expect(() => validateMountCredentialBoundaries(manifest)).toThrow(
-      /model-controlled sandbox/u,
+      /does not support exposing these credential fields/u,
     );
 
     const trusted =
-      manifest.withInContainerMountCredentialExposureAllowed('remote');
-    const serializedManifest = serializeManifestRecord(trusted);
-    expect(JSON.stringify(serializedManifest)).not.toContain(
-      'TYPED_CONFIG_SENTINEL',
+      manifest.withInContainerMountCredentialExposureAcknowledged('remote');
+    expect(() => validateMountCredentialBoundaries(trusted)).toThrow(
+      /does not support exposing these credential fields/u,
     );
+    expect(() => serializeManifestRecord(trusted)).toThrow(
+      /does not support exposing these credential fields/u,
+    );
+  });
 
-    const metadata = serializeMountCredentialRedactionMetadata({
-      manifest: trusted,
-    });
-    expect(metadata[NON_RESUMABLE_MOUNT_AUTHORITY_KEY]).toBe(true);
-    expect(() =>
-      rebindPersistedMountCredentials(
-        {
-          manifest: deserializeManifest(serializedManifest),
-          ...deserializeMountCredentialRedactionMetadata(metadata),
-        },
-        trusted,
-      ),
-    ).toThrow(/opaque mount authority/u);
+  it('rejects and defensively redacts cross-provider credential fields', () => {
+    const entry = {
+      ...s3Mount({
+        bucket: 'example',
+        mountStrategy: inContainerMountStrategy(),
+      }),
+      serviceAccountCredentials: 'CROSS_PROVIDER_SECRET_SENTINEL',
+    };
+    const trusted = new Manifest({
+      entries: { remote: entry },
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
+
+    expect(() => validateMountCredentialBoundaries(trusted)).toThrow(
+      /does not support exposing these credential fields/u,
+    );
+    expect(() => serializeManifestRecord(trusted)).toThrow(
+      /does not support exposing these credential fields/u,
+    );
+    expect(
+      JSON.stringify(redactMountCredentialsForPersistence(entry)),
+    ).not.toContain('CROSS_PROVIDER_SECRET_SENTINEL');
   });
 
   it('requires trusted rebind provenance for credential-bearing resume state', () => {
@@ -1143,7 +1381,7 @@ describe('sandbox mount credential boundaries', () => {
 
     const trustedInside = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const reboundInside = rebindPersistedMountCredentials(
       { manifest: deserializeManifest(serializeManifestRecord(trustedInside)) },
       trustedInside,
@@ -1156,7 +1394,7 @@ describe('sandbox mount credential boundaries', () => {
   it('preserves exact-path trust across host path grant rebinding', () => {
     const trusted = credentialedS3Manifest(
       inContainerMountStrategy(),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     const persistedState = {
       manifest: deserializeManifest(serializeManifestRecord(trusted)),
       ...deserializeMountCredentialRedactionMetadata(
@@ -1179,7 +1417,7 @@ describe('sandbox mount credential boundaries', () => {
     const raw = serializeManifestRecord(
       credentialedS3Manifest(
         inContainerMountStrategy(),
-      ).withInContainerMountCredentialExposureAllowed('remote'),
+      ).withInContainerMountCredentialExposureAcknowledged('remote'),
     );
     const rawEntry = (raw.entries as Record<string, Record<string, unknown>>)
       .remote;

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -2842,7 +2842,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([
@@ -2908,7 +2908,7 @@ describe('sandbox runner integration', () => {
         environment: {
           GOOGLE_APPLICATION_CREDENTIALS: async () => '/workspace/gcp.json',
         },
-      }).withInContainerMountCredentialExposureAllowed('remote'),
+      }).withInContainerMountCredentialExposureAcknowledged('remote'),
       error: /serialized manifest entry/u,
     },
   ])(
@@ -4153,7 +4153,7 @@ describe('sandbox runner integration', () => {
           AWS_ACCESS_KEY_ID: 'TRUSTED_ENV_AK',
           AWS_SECRET_ACCESS_KEY: 'TRUSTED_ENV_SK',
         },
-      }).withInContainerMountCredentialExposureAllowed('remote');
+      }).withInContainerMountCredentialExposureAcknowledged('remote');
 
       await expect(
         deserializeSandboxSessionStateEntry(
@@ -4392,7 +4392,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     captureLiveMountCredentialAuthority(originalManifest);
     const client = new FakeSandboxClient();
     const session = client.makeSession({
@@ -4440,7 +4440,7 @@ describe('sandbox runner integration', () => {
           }),
         },
       }),
-    ).withInContainerMountCredentialExposureAllowed('remote');
+    ).withInContainerMountCredentialExposureAcknowledged('remote');
     await withExclusiveSandboxManifestMutation(session.state, async () => {
       captureLiveMountCredentialAuthority(rotatedManifest);
       session.state.manifest = rotatedManifest;
@@ -7189,7 +7189,7 @@ describe('sandbox runner integration', () => {
               mountStrategy: inContainerMountStrategy(),
             }),
           },
-        }).withInContainerMountCredentialExposureAllowed('remote'),
+        }).withInContainerMountBroadCredentialExposureAcknowledged('remote'),
       targetManifest: (live: Manifest) => live,
       liveEnvironment: {
         AWS_ACCESS_KEY_ID: 'old-access',
@@ -7211,7 +7211,7 @@ describe('sandbox runner integration', () => {
               mountStrategy: inContainerMountStrategy(),
             }),
           },
-        }).withInContainerMountCredentialExposureAllowed('remote');
+        }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
         accessKey = 'new-access';
         return manifest;
       },
@@ -7327,6 +7327,7 @@ describe('sandbox runner integration', () => {
         },
       }),
       environment: {},
+      expectedError: /model-controlled sandbox/u,
     },
     {
       label: 'ambient',
@@ -7342,6 +7343,7 @@ describe('sandbox runner integration', () => {
         AWS_ACCESS_KEY_ID: 'ambient-access',
         AWS_SECRET_ACCESS_KEY: 'ambient-secret',
       },
+      expectedError: /model-controlled sandbox/u,
     },
     {
       label: 'typed opaque config',
@@ -7356,10 +7358,11 @@ describe('sandbox runner integration', () => {
         },
       }),
       environment: {},
+      expectedError: /does not support exposing these credential fields/u,
     },
   ])(
     'rejects $label credentials on provided live sessions',
-    async ({ manifest, environment }) => {
+    async ({ manifest, environment, expectedError }) => {
       const applyManifest = vi.fn();
       const sandboxAgent = new SandboxAgent({
         name: 'SandboxWorker',
@@ -7393,7 +7396,7 @@ describe('sandbox runner integration', () => {
           currentAgent: sandboxAgent as Agent<unknown, any>,
           turnInput: [],
         }),
-      ).rejects.toThrow(/model-controlled sandbox/u);
+      ).rejects.toThrow(expectedError);
       expect(applyManifest).not.toHaveBeenCalled();
     },
   );
@@ -7411,7 +7414,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -7454,7 +7457,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -7498,7 +7501,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const liveManifest = new Manifest({
       entries: {
         remote: s3Mount({
@@ -8126,7 +8129,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -8192,7 +8195,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -8269,7 +8272,7 @@ describe('sandbox runner integration', () => {
             mountStrategy: inContainerMountStrategy(),
           }),
         },
-      }).withInContainerMountCredentialExposureAllowed('remote');
+      }).withInContainerMountCredentialExposureAcknowledged('remote');
       const firstAgent = new SandboxAgent({
         name: 'SandboxWorker',
         model: new RecordingFakeModel([]),
@@ -8289,7 +8292,7 @@ describe('sandbox runner integration', () => {
       const sharedSession = client.makeSession({
         manifest: new Manifest(
           trustedManifest,
-        ).withInContainerMountCredentialExposureAllowed('remote'),
+        ).withInContainerMountCredentialExposureAcknowledged('remote'),
         sessionId: 'shared-session',
       });
       captureLiveMountCredentialAuthority(sharedSession.state.manifest);
@@ -8400,14 +8403,14 @@ describe('sandbox runner integration', () => {
           REMOVED_TOKEN: new LiveSecretReference('removed'),
           REPLACED_TOKEN: new LiveSecretReference('replaced'),
         },
-      }).withInContainerMountCredentialExposureAllowed('remote');
+      }).withInContainerMountCredentialExposureAcknowledged('remote');
       const trustedManifest = new Manifest({
         entries: structuredClone(manifest.entries),
         environment: {
           ROTATING_TOKEN: new LiveSecretReference('rotating'),
           REPLACED_TOKEN: 'configured-value',
         },
-      }).withInContainerMountCredentialExposureAllowed('remote');
+      }).withInContainerMountCredentialExposureAcknowledged('remote');
       const sandboxAgent = new SandboxAgent({
         name: 'SandboxWorker',
         model: new RecordingFakeModel([]),
@@ -8629,7 +8632,7 @@ describe('sandbox runner integration', () => {
         AWS_ACCESS_KEY_ID: 'ambient-access',
         AWS_SECRET_ACCESS_KEY: 'ambient-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -8685,14 +8688,14 @@ describe('sandbox runner integration', () => {
         AWS_ACCESS_KEY_ID: 'initial-access',
         AWS_SECRET_ACCESS_KEY: 'initial-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const currentManifest = new Manifest({
       entries: structuredClone(initialManifest.entries),
       environment: {
         AWS_ACCESS_KEY_ID: 'rotated-access',
         AWS_SECRET_ACCESS_KEY: 'rotated-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -9666,7 +9669,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
@@ -9708,7 +9711,7 @@ describe('sandbox runner integration', () => {
     expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
   });
 
-  it('recreates live sessions with opaque command environment authority', async () => {
+  it('rejects opaque command authority before session creation', async () => {
     const client = new FakeSandboxClient();
     const manifest = new Manifest({
       entries: {
@@ -9721,45 +9724,23 @@ describe('sandbox runner integration', () => {
         },
       },
       environment: { CUSTOM_SECRET: 'original-secret' },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),
       defaultManifest: manifest,
     });
-    const state = new RunState<unknown, Agent<unknown, any>>(
-      new RunContext(),
-      'Hello',
-      sandboxAgent as Agent<unknown, any>,
-      1,
-    );
-    const firstManager = new SandboxRuntimeManager({
+    const manager = new SandboxRuntimeManager({
       startingAgent: sandboxAgent as Agent<unknown, any>,
       sandboxConfig: { client },
-      runState: state,
     });
-    await firstManager.prepareAgent({
-      currentAgent: sandboxAgent as Agent<unknown, any>,
-      turnInput: [],
-    });
-    const firstSession = client.createdSessions[0];
-    await firstManager.cleanup(state, { preserveOwnedSessions: true });
-
-    const secondManager = new SandboxRuntimeManager({
-      startingAgent: sandboxAgent as Agent<unknown, any>,
-      sandboxConfig: { client },
-      runState: state,
-    });
-    await secondManager.adoptPreservedOwnedSessions();
-    await secondManager.prepareAgent({
-      currentAgent: sandboxAgent as Agent<unknown, any>,
-      turnInput: [],
-    });
-
-    expect(client.createdSessions).toHaveLength(2);
-    expect(client.resumeCalls).toHaveLength(0);
-    expect(client.closeCalls).toContain(firstSession?.state.sessionId);
-    await secondManager.cleanup(state);
+    await expect(
+      manager.prepareAgent({
+        currentAgent: sandboxAgent as Agent<unknown, any>,
+        turnInput: [],
+      }),
+    ).rejects.toThrow(/SDK-supported strategy/u);
+    expect(client.createdSessions).toHaveLength(0);
   });
 
   it('recreates serialized sessions with in-container mounts instead of resuming them', async () => {
@@ -9773,7 +9754,7 @@ describe('sandbox runner integration', () => {
           mountStrategy: inContainerMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: new RecordingFakeModel([]),

--- a/packages/agents-core/test/sandboxes/docker.test.ts
+++ b/packages/agents-core/test/sandboxes/docker.test.ts
@@ -40,8 +40,8 @@ describe('DockerSandboxClient', () => {
     }
   });
 
-  itIfDocker(
-    'applies in-container command mounts inside Docker',
+  it(
+    'rejects custom command mount credential exposure before Docker side effects',
     async () => {
       rootDir = await mkdtemp(
         join(tmpdir(), 'agents-core-docker-sandbox-test-'),
@@ -50,52 +50,24 @@ describe('DockerSandboxClient', () => {
         workspaceBaseDir: rootDir,
         image: DOCKER_TEST_IMAGE,
       });
-      const session = await client.create(
-        new Manifest({
-          entries: {
-            mounted: {
-              type: 'mount',
-              source: 'memory://initial',
-              mountStrategy: inContainerMountStrategy({
-                pattern: {
-                  type: 'fuse',
-                  command:
-                    'printf initial > "$OPENAI_AGENTS_MOUNT_PATH/marker.txt"',
-                },
-              }),
+      await expect(
+        client.create(
+          new Manifest({
+            entries: {
+              mounted: {
+                type: 'mount',
+                source: 'memory://initial',
+                mountStrategy: inContainerMountStrategy({
+                  pattern: {
+                    type: 'fuse',
+                    command: 'custom-mount',
+                  },
+                }),
+              },
             },
-          },
-        }).withInContainerMountCredentialExposureAllowed('mounted'),
-      );
-      cleanupContainerIds.add(session.state.containerId);
-
-      const initialOutput = await session.execCommand({
-        cmd: 'cat mounted/marker.txt',
-      });
-      expect(initialOutput).toContain('initial');
-
-      await session.applyManifest(
-        new Manifest({
-          entries: {
-            applied: {
-              type: 'mount',
-              source: 'memory://applied',
-              mountStrategy: inContainerMountStrategy({
-                pattern: {
-                  type: 'fuse',
-                  command:
-                    'printf applied > "$OPENAI_AGENTS_MOUNT_PATH/marker.txt"',
-                },
-              }),
-            },
-          },
-        }).withInContainerMountCredentialExposureAllowed('mounted', 'applied'),
-      );
-
-      const appliedOutput = await session.execCommand({
-        cmd: 'cat applied/marker.txt',
-      });
-      expect(appliedOutput).toContain('applied');
+          }).withInContainerMountCredentialExposureAcknowledged('mounted'),
+        ),
+      ).rejects.toThrow(/SDK-supported strategy/u);
     },
     DOCKER_TEST_TIMEOUT_MS,
   );

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -64,6 +64,7 @@ import {
   NoopSnapshotSpec,
   registerEnvValueReference,
   SandboxMountError,
+  s3Mount,
   skills,
 } from '../../src/sandbox/local';
 
@@ -556,7 +557,7 @@ describe('DockerSandboxClient unit behavior', () => {
     );
   });
 
-  it('starts Docker with fuse privileges and applies in-container command mounts', async () => {
+  it('rejects custom in-container command mounts before Docker effects', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
@@ -583,38 +584,23 @@ describe('DockerSandboxClient unit behavior', () => {
       workspaceBaseDir: rootDir,
     });
 
-    await client.create(
-      new Manifest({
-        entries: {
-          mounted: {
-            type: 'mount',
-            source: 'memory://fixture',
-            mountStrategy: inContainerMountStrategy({
-              pattern: {
-                type: 'fuse',
-                command:
-                  'printf mounted > "$OPENAI_AGENTS_MOUNT_PATH/marker.txt"',
-              },
-            }),
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            mounted: {
+              type: 'mount',
+              source: 'memory://fixture',
+              mountStrategy: inContainerMountStrategy({
+                pattern: { type: 'fuse', command: 'custom-mount' },
+              }),
+            },
           },
-        },
-      }).withInContainerMountCredentialExposureAllowed('mounted'),
-    );
-
-    const runCall = processMocks.runSandboxProcess.mock.calls.find(
-      ([, args]) => args[0] === 'run',
-    );
-    expect(runCall?.[1]).toEqual(
-      expect.arrayContaining([
-        '--device',
-        '/dev/fuse',
-        '--cap-add',
-        'SYS_ADMIN',
-        '--security-opt',
-        'apparmor:unconfined',
-      ]),
-    );
-    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+        }).withInContainerMountCredentialExposureAcknowledged('mounted'),
+      ),
+    ).rejects.toThrow(/SDK-supported strategy/u);
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
   });
 
   it('validates credential opt-ins against symlink-resolved mount paths', async () => {
@@ -648,7 +634,7 @@ describe('DockerSandboxClient unit behavior', () => {
           mountStrategy: inContainerMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
 
     await expect(session.applyManifest(update)).rejects.toThrow(
       /model-controlled sandbox/u,
@@ -700,7 +686,7 @@ describe('DockerSandboxClient unit behavior', () => {
               mountStrategy: inContainerMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('/mnt/data'),
+        }).withInContainerMountCredentialExposureAcknowledged('/mnt/data'),
       ),
     ).rejects.toThrow(/model-controlled sandbox/u);
 
@@ -748,7 +734,10 @@ describe('DockerSandboxClient unit behavior', () => {
           mountStrategy: inContainerMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('remote', 'redirected');
+    }).withInContainerMountCredentialExposureAcknowledged(
+      'remote',
+      'redirected',
+    );
 
     await session.applyManifest(update);
 
@@ -770,7 +759,7 @@ describe('DockerSandboxClient unit behavior', () => {
 
     const currentWithoutEffectivePathTrust = new Manifest({
       entries: structuredClone(session.state.manifest.entries),
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountCredentialExposureAcknowledged('remote');
     expect(
       liveMountCredentialAuthorityMatches(
         session.state.manifest,
@@ -820,18 +809,14 @@ describe('DockerSandboxClient unit behavior', () => {
     const session = await client.create(
       new Manifest({
         entries: {
-          mounted: {
-            type: 'mount',
-            source: 'memory://fixture',
-            mountStrategy: inContainerMountStrategy({
-              pattern: {
-                type: 'fuse',
-                command: 'true',
-              },
-            }),
-          },
+          mounted: s3Mount({
+            bucket: 'fixture',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountStrategy: inContainerMountStrategy(),
+          }),
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted'),
     );
 
     await expect(session.pathExists('mounted/file.txt')).resolves.toBe(true);
@@ -895,17 +880,15 @@ describe('DockerSandboxClient unit behavior', () => {
         new Manifest({
           entries: {
             mounted: {
-              type: 'mount',
-              source: 'memory://fixture',
-              mountStrategy: inContainerMountStrategy({
-                pattern: {
-                  type: 'fuse',
-                  command: 'false',
-                },
+              ...s3Mount({
+                bucket: 'fixture',
+                accessKeyId: 'access-key',
+                secretAccessKey: 'secret-key',
+                mountStrategy: inContainerMountStrategy(),
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted'),
       )
       .then(
         () => undefined,
@@ -960,17 +943,15 @@ describe('DockerSandboxClient unit behavior', () => {
         new Manifest({
           entries: {
             mounted: {
-              type: 'mount',
-              source: 'memory://fixture',
-              mountStrategy: inContainerMountStrategy({
-                pattern: {
-                  type: 'fuse',
-                  command: 'false',
-                },
+              ...s3Mount({
+                bucket: 'fixture',
+                accessKeyId: 'access-key',
+                secretAccessKey: 'secret-key',
+                mountStrategy: inContainerMountStrategy(),
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted'),
       ),
     ).rejects.toThrow(
       'Docker sandbox creation failed and cleanup could not complete.',
@@ -1100,7 +1081,7 @@ describe('DockerSandboxClient unit behavior', () => {
             }),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('azure'),
+      }).withInContainerMountCredentialExposureAcknowledged('azure'),
     );
 
     const configInput = dockerStdinWrites.join('\n');
@@ -1162,6 +1143,7 @@ describe('DockerSandboxClient unit behavior', () => {
               type: 'azure_blob_mount',
               account: 'account-name',
               container: 'container-name',
+              accountKey: 'account-key',
               mountPath: 'azure',
               mountStrategy: inContainerMountStrategy({
                 pattern: {
@@ -1171,7 +1153,7 @@ describe('DockerSandboxClient unit behavior', () => {
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('azure'),
+        }).withInContainerMountCredentialExposureAcknowledged('azure'),
       ),
     ).rejects.toThrow(/cachePath must be outside the mount path/);
     expect(
@@ -1251,6 +1233,7 @@ describe('DockerSandboxClient unit behavior', () => {
               type: 'azure_blob_mount',
               account: 'account-name',
               container: 'container-name',
+              accountKey: 'account-key',
               mountStrategy: inContainerMountStrategy({
                 pattern: {
                   type: 'fuse',
@@ -1259,7 +1242,7 @@ describe('DockerSandboxClient unit behavior', () => {
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('azure'),
+        }).withInContainerMountCredentialExposureAcknowledged('azure'),
       ),
     ).rejects.toThrow(/cachePath must be relative/);
     expect(
@@ -1317,7 +1300,7 @@ describe('DockerSandboxClient unit behavior', () => {
             }),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('s3files'),
+      }).withInContainerMountBroadCredentialExposureAcknowledged('s3files'),
     );
 
     const runCall = processMocks.runSandboxProcess.mock.calls.find(
@@ -1398,7 +1381,7 @@ describe('DockerSandboxClient unit behavior', () => {
           AWS_SESSION_TOKEN: 'inherited-session-token',
           AWS_SECURITY_TOKEN: 'inherited-security-token',
         },
-      }).withInContainerMountCredentialExposureAllowed('s3'),
+      }).withInContainerMountCredentialExposureAcknowledged('s3'),
     );
 
     const runCall = processMocks.runSandboxProcess.mock.calls.find(
@@ -1442,7 +1425,7 @@ describe('DockerSandboxClient unit behavior', () => {
                 mountStrategy: inContainerMountStrategy({ pattern }),
               },
             },
-          }).withInContainerMountCredentialExposureAllowed('s3'),
+          }).withInContainerMountCredentialExposureAcknowledged('s3'),
         ),
       ).rejects.toThrow(/both accessKeyId and secretAccessKey/u);
 
@@ -1498,6 +1481,58 @@ describe('DockerSandboxClient unit behavior', () => {
     expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
   });
 
+  it('removes shadowed GCS credential files from Docker mountpoint helpers', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-123\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
+      const command = args.join(' ');
+      expect(command).toContain('mount-s3');
+      expect(command).toContain('unset AWS_ACCESS_KEY_ID');
+      expect(command).toContain('GOOGLE_APPLICATION_CREDENTIALS');
+      expect(command).toContain('-e GOOGLE_APPLICATION_CREDENTIALS=');
+      expect(command).not.toContain('/run/secrets/gcp.json');
+      return dockerSpawnResult({ status: 0 });
+    });
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await client.create(
+      new Manifest({
+        entries: {
+          gcs: {
+            type: 'gcs_mount',
+            bucket: 'gcs-logs',
+            accessId: 'inline-access-id',
+            secretAccessKey: 'inline-secret-key',
+            mountStrategy: inContainerMountStrategy({
+              pattern: {
+                type: 'mountpoint',
+              },
+            }),
+          },
+        },
+        environment: {
+          GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/gcp.json',
+        },
+      }).withInContainerMountCredentialExposureAcknowledged('gcs'),
+    );
+
+    expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+  });
+
   it('rejects rclone credential config stored in manifest entries', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
@@ -1538,7 +1573,7 @@ describe('DockerSandboxClient unit behavior', () => {
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('s3'),
+        }).withInContainerMountCredentialExposureAcknowledged('s3'),
       ),
     ).rejects.toThrow(/serialized manifest entry/u);
     expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
@@ -1599,7 +1634,7 @@ describe('DockerSandboxClient unit behavior', () => {
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('data'),
+        }).withInContainerMountBroadCredentialExposureAcknowledged('data'),
       ),
     ).rejects.toThrow(/resolve to a serialized manifest entry/u);
 
@@ -1661,6 +1696,58 @@ describe('DockerSandboxClient unit behavior', () => {
     expect(childProcessMocks.spawn).not.toHaveBeenCalled();
   });
 
+  it('requires broad acknowledgement for ambient credentials exposed beside inline rclone credentials', async () => {
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            s3: {
+              type: 's3_mount',
+              bucket: 'agent-logs',
+              accessKeyId: 'inline-access-key',
+              secretAccessKey: 'inline-secret-key',
+              mountStrategy: inContainerMountStrategy({
+                pattern: { type: 'rclone' },
+              }),
+            },
+          },
+          environment: {
+            AWS_ACCESS_KEY_ID: 'ambient-access-key',
+            AWS_SECRET_ACCESS_KEY: 'ambient-secret-key',
+            AWS_SESSION_TOKEN: 'ambient-session-token',
+          },
+        }).withInContainerMountCredentialExposureAcknowledged('s3'),
+      ),
+    ).rejects.toThrow(/broad credential authority/iu);
+
+    await expect(
+      client.create(
+        new Manifest({
+          entries: {
+            gcs: {
+              type: 'gcs_mount',
+              bucket: 'agent-logs',
+              accessToken: 'inline-access-token',
+              mountStrategy: inContainerMountStrategy({
+                pattern: { type: 'rclone' },
+              }),
+            },
+          },
+          environment: {
+            GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/gcp.json',
+          },
+        }).withInContainerMountCredentialExposureAcknowledged('gcs'),
+      ),
+    ).rejects.toThrow(/broad credential authority/iu);
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+  });
+
   it('honors R2 prefixes in Docker in-container rclone mounts', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
@@ -1704,7 +1791,7 @@ describe('DockerSandboxClient unit behavior', () => {
             }),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('r2logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('r2logs'),
     );
 
     expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
@@ -1746,7 +1833,7 @@ describe('DockerSandboxClient unit behavior', () => {
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('s3'),
+        }).withInContainerMountBroadCredentialExposureAcknowledged('s3'),
       )
       .then(
         () => undefined,
@@ -1862,7 +1949,7 @@ describe('DockerSandboxClient unit behavior', () => {
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('s3'),
+        }).withInContainerMountCredentialExposureAcknowledged('s3'),
       )
       .then(
         () => undefined,
@@ -2018,7 +2105,7 @@ describe('DockerSandboxClient unit behavior', () => {
             }),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('gcs'),
+      }).withInContainerMountBroadCredentialExposureAcknowledged('gcs'),
     );
 
     expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
@@ -4192,7 +4279,7 @@ describe('DockerSandboxClient unit behavior', () => {
               }),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('s3files'),
+        }).withInContainerMountBroadCredentialExposureAcknowledged('s3files'),
       ),
     ).rejects.toThrow(/requires Docker privileges/);
   });
@@ -4218,18 +4305,14 @@ describe('DockerSandboxClient unit behavior', () => {
     const session = await client.create(
       new Manifest({
         entries: {
-          bootstrap: {
-            type: 'mount',
-            source: 'memory://fixture',
-            mountStrategy: inContainerMountStrategy({
-              pattern: {
-                type: 'fuse',
-                command: 'true',
-              },
-            }),
-          },
+          bootstrap: s3Mount({
+            bucket: 'bootstrap',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountStrategy: inContainerMountStrategy(),
+          }),
         },
-      }).withInContainerMountCredentialExposureAllowed('bootstrap'),
+      }).withInContainerMountCredentialExposureAcknowledged('bootstrap'),
     );
     childProcessMocks.spawn.mockClear();
     childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
@@ -4246,19 +4329,15 @@ describe('DockerSandboxClient unit behavior', () => {
     await session.applyManifest(
       new Manifest({
         entries: {
-          mounted: {
-            type: 'mount',
-            source: 'memory://fixture',
+          mounted: s3Mount({
+            bucket: 'mounted',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
             mountPath: '/mnt/absolute',
-            mountStrategy: inContainerMountStrategy({
-              pattern: {
-                type: 'fuse',
-                command: 'true',
-              },
-            }),
-          },
+            mountStrategy: inContainerMountStrategy(),
+          }),
         },
-      }).withInContainerMountCredentialExposureAllowed(
+      }).withInContainerMountCredentialExposureAcknowledged(
         'bootstrap',
         '/mnt/absolute',
         '/mnt/resolved',
@@ -4275,17 +4354,18 @@ describe('DockerSandboxClient unit behavior', () => {
     const chownIndex = commands.findIndex((command) =>
       command.includes("chown -R 'node':'node' -- '/mnt/resolved'"),
     );
-    const mountIndex = commands.findIndex((command) =>
-      command.includes("OPENAI_AGENTS_MOUNT_PATH='/mnt/resolved'"),
+    const mountIndex = commands.findIndex(
+      (command) =>
+        command.includes('/mnt/resolved') && command.includes('rclone'),
     );
     expect(mkdirIndex).toBeGreaterThanOrEqual(0);
     expect(chownIndex).toBeGreaterThan(mkdirIndex);
     expect(mountIndex).toBeGreaterThan(chownIndex);
 
     const mounted = session.state.manifest.entries.mounted as unknown as {
-      mountStrategy: { pattern: { command: string } };
+      accessKeyId: string;
     };
-    mounted.mountStrategy.pattern.command = 'rotated-command';
+    mounted.accessKeyId = 'rotated-access-key';
     expect(
       liveMountCredentialAuthorityMatches(
         session.state.manifest,
@@ -4311,7 +4391,7 @@ describe('DockerSandboxClient unit behavior', () => {
     );
     childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
       const command = args.join(' ');
-      if (command.includes("OPENAI_AGENTS_MOUNT_PATH='/workspace/second'")) {
+      if (command.includes('/workspace/second') && command.includes('rclone')) {
         return dockerSpawnResult({ stderr: 'second failed', status: 1 });
       }
       return dockerSpawnResult({ status: 0 });
@@ -4322,18 +4402,14 @@ describe('DockerSandboxClient unit behavior', () => {
     const session = await client.create(
       new Manifest({
         entries: {
-          bootstrap: {
-            type: 'mount',
-            source: 'memory://fixture',
-            mountStrategy: inContainerMountStrategy({
-              pattern: {
-                type: 'fuse',
-                command: 'true',
-              },
-            }),
-          },
+          bootstrap: s3Mount({
+            bucket: 'bootstrap',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountStrategy: inContainerMountStrategy(),
+          }),
         },
-      }).withInContainerMountCredentialExposureAllowed('bootstrap'),
+      }).withInContainerMountCredentialExposureAcknowledged('bootstrap'),
     );
     childProcessMocks.spawn.mockClear();
 
@@ -4341,28 +4417,20 @@ describe('DockerSandboxClient unit behavior', () => {
       session.applyManifest(
         new Manifest({
           entries: {
-            first: {
-              type: 'mount',
-              source: 'memory://fixture',
-              mountStrategy: inContainerMountStrategy({
-                pattern: {
-                  type: 'fuse',
-                  command: 'true',
-                },
-              }),
-            },
-            second: {
-              type: 'mount',
-              source: 'memory://fixture',
-              mountStrategy: inContainerMountStrategy({
-                pattern: {
-                  type: 'fuse',
-                  command: 'false',
-                },
-              }),
-            },
+            first: s3Mount({
+              bucket: 'first',
+              accessKeyId: 'access-key',
+              secretAccessKey: 'secret-key',
+              mountStrategy: inContainerMountStrategy(),
+            }),
+            second: s3Mount({
+              bucket: 'second',
+              accessKeyId: 'access-key',
+              secretAccessKey: 'secret-key',
+              mountStrategy: inContainerMountStrategy(),
+            }),
           },
-        }).withInContainerMountCredentialExposureAllowed(
+        }).withInContainerMountCredentialExposureAcknowledged(
           'bootstrap',
           'first',
           'second',
@@ -4424,23 +4492,19 @@ describe('DockerSandboxClient unit behavior', () => {
           KEEP: 'old',
         },
         entries: {
-          bootstrap: {
-            type: 'mount',
-            source: 'memory://fixture',
-            mountStrategy: inContainerMountStrategy({
-              pattern: {
-                type: 'fuse',
-                command: 'true',
-              },
-            }),
-          },
+          bootstrap: s3Mount({
+            bucket: 'bootstrap',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+            mountStrategy: inContainerMountStrategy(),
+          }),
         },
-      }).withInContainerMountCredentialExposureAllowed('bootstrap'),
+      }).withInContainerMountCredentialExposureAcknowledged('bootstrap'),
     );
     childProcessMocks.spawn.mockClear();
     childProcessMocks.spawn.mockImplementation((_command, args: string[]) => {
       const command = (args as string[]).join(' ');
-      if (command.includes("OPENAI_AGENTS_MOUNT_PATH='/workspace/failed'")) {
+      if (command.includes('/workspace/failed') && command.includes('rclone')) {
         return dockerSpawnResult({ stderr: 'mount failed', status: 1 });
       }
       return dockerSpawnResult({ status: 0 });
@@ -4456,18 +4520,17 @@ describe('DockerSandboxClient unit behavior', () => {
             },
           },
           entries: {
-            failed: {
-              type: 'mount',
-              source: 'memory://fixture',
-              mountStrategy: inContainerMountStrategy({
-                pattern: {
-                  type: 'fuse',
-                  command: 'false',
-                },
-              }),
-            },
+            failed: s3Mount({
+              bucket: 'failed',
+              accessKeyId: 'access-key',
+              secretAccessKey: 'secret-key',
+              mountStrategy: inContainerMountStrategy(),
+            }),
           },
-        }).withInContainerMountCredentialExposureAllowed('bootstrap', 'failed'),
+        }).withInContainerMountCredentialExposureAcknowledged(
+          'bootstrap',
+          'failed',
+        ),
       ),
     ).rejects.toThrow(/exit status 1/u);
 
@@ -4613,6 +4676,7 @@ describe('DockerSandboxClient unit behavior', () => {
             type: 'azure_blob_mount',
             account: 'account-name',
             container: 'container-name',
+            accountKey: 'account-key',
             mountStrategy: inContainerMountStrategy({
               pattern: {
                 type: 'fuse',
@@ -4621,7 +4685,7 @@ describe('DockerSandboxClient unit behavior', () => {
             }),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('azure'),
+      }).withInContainerMountCredentialExposureAcknowledged('azure'),
     );
     await mkdir(
       join(session.state.workspaceRootPath, '.sandbox-blobfuse-config'),
@@ -5469,7 +5533,7 @@ describe('DockerSandboxClient unit behavior', () => {
         AWS_SECRET_ACCESS_KEY: 'AMBIENT_SECRET_SENTINEL',
         SAFE_ENV: 'visible',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     const session = await client.create(manifest);
     const serialized = await client.serializeSessionState(session.state);

--- a/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
@@ -1,10 +1,19 @@
-import { execFile } from 'node:child_process';
+import {
+  execFile,
+  type ChildProcessWithoutNullStreams,
+} from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { mkdtemp, rm, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
 import { promisify } from 'node:util';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { Manifest, UnixLocalSandboxClient } from '../../src/sandbox/local';
+import {
+  Manifest,
+  UnixLocalSandboxClient,
+  UnixLocalSandboxSession,
+} from '../../src/sandbox/local';
 
 const execFileAsync = promisify(execFile);
 const ACTIVE_PROCESS_POLL_MS = 50;
@@ -156,6 +165,59 @@ describe('UnixLocalSandboxClient process sessions', () => {
     expect(started).toContain('Process running with session ID');
     expect(finished).toContain('Process exited with code 0');
     expect(finished).toContain('hello stdin');
+  });
+
+  it('waits for final output after observing process completion', async () => {
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const baseSession = await client.create(new Manifest());
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdin,
+      stdout,
+      stderr,
+      kill: () => true,
+    }) as unknown as ChildProcessWithoutNullStreams;
+    class ControlledUnixLocalSandboxSession extends UnixLocalSandboxSession {
+      protected override async spawnShellCommand(): Promise<ChildProcessWithoutNullStreams> {
+        return child;
+      }
+    }
+    const session = new ControlledUnixLocalSandboxSession({
+      state: baseSession.state,
+    });
+
+    const started = await session.execCommand({
+      cmd: 'ignored',
+      tty: true,
+      yieldTimeMs: 0,
+    });
+    const sessionId = Number(
+      started.match(/Process running with session ID (\d+)/)?.[1],
+    );
+    expect(Number.isFinite(sessionId)).toBe(true);
+
+    child.emit('close', 0, null);
+    let settled = false;
+    const finishedPromise = session
+      .writeStdin({ sessionId, yieldTimeMs: 0 })
+      .then((output) => {
+        settled = true;
+        return output;
+      });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    stdout.emit('data', 'late stdout\n');
+    stdout.emit('close');
+    stderr.emit('close');
+
+    const finished = await finishedPromise;
+    expect(finished).toContain('Process exited with code 0');
+    expect(finished).toContain('late stdout');
   });
 
   it('returns buffered PTY output when yielding an active session', async () => {

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -639,9 +639,9 @@ describe('UnixLocalSandboxClient', () => {
               mountStrategy: { type: 'in_container' },
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('data'),
+        }).withInContainerMountCredentialExposureAcknowledged('data'),
       ),
-    ).rejects.toThrow(/does not support this mount entry: data/);
+    ).rejects.toThrow(/SDK-supported strategy/u);
 
     const session = await client.create(new Manifest());
     await expect(
@@ -1663,11 +1663,10 @@ describe('UnixLocalSandboxClient', () => {
       entries: {
         data: {
           type: 'mount',
-          source: 's3://bucket/data',
           mountStrategy: { type: 'in_container' },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    });
 
     await materializeLocalWorkspaceManifestMounts(manifest, workspaceRootPath, {
       supportsMount: () => true,
@@ -1679,9 +1678,7 @@ describe('UnixLocalSandboxClient', () => {
       },
     });
 
-    expect(calls).toEqual([
-      { logicalPath: 'data', source: 's3://bucket/data' },
-    ]);
+    expect(calls).toEqual([{ logicalPath: 'data', source: undefined }]);
   });
 
   it('materializes parent mount targets before nested targets', async () => {
@@ -1692,27 +1689,20 @@ describe('UnixLocalSandboxClient', () => {
       entries: {
         parent: {
           type: 'mount',
-          source: 's3://bucket/parent',
           mountPath: 'mounted',
           mountStrategy: { type: 'in_container' },
         },
         child: {
           type: 'mount',
-          source: 's3://bucket/child',
           mountPath: 'mounted/cache',
           mountStrategy: { type: 'in_container' },
         },
         other: {
           type: 'mount',
-          source: 's3://bucket/other',
           mountStrategy: { type: 'in_container' },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed(
-      'mounted',
-      'mounted/cache',
-      'other',
-    );
+    });
 
     await materializeLocalWorkspaceManifestMounts(manifest, workspaceRootPath, {
       supportsMount: () => true,
@@ -1731,7 +1721,6 @@ describe('UnixLocalSandboxClient', () => {
       entries: {
         child: {
           type: 'mount',
-          source: 's3://bucket/child',
           mountPath: 'mounted/cache',
           mountStrategy: { type: 'in_container' },
         },
@@ -1741,15 +1730,11 @@ describe('UnixLocalSandboxClient', () => {
         },
         parent: {
           type: 'mount',
-          source: 's3://bucket/parent',
           mountPath: 'mounted',
           mountStrategy: { type: 'in_container' },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed(
-      'mounted',
-      'mounted/cache',
-    );
+    });
 
     await materializeLocalWorkspaceManifest(manifest, workspaceRootPath, {
       supportsMount: () => true,

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -770,14 +770,14 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
       for (const {
         absolutePath,
         entry,
-        allowMountCredentialExposure,
+        broadCredentialExposureAcknowledged,
         environment,
         revalidateMountAuthority,
       } of targets) {
         await revalidateMountAuthority();
         await this.materializeMountEntry(absolutePath, entry, {
           environment: environment ?? this.state.environment,
-          allowAmbientCredentials: allowMountCredentialExposure,
+          allowAmbientCredentials: broadCredentialExposureAcknowledged,
           revalidateMountAuthority,
         });
       }

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -1247,14 +1247,14 @@ export class RunloopSandboxSession extends RemoteSandboxSessionBase<RunloopSandb
         for (const {
           absolutePath,
           entry,
-          allowMountCredentialExposure,
+          broadCredentialExposureAcknowledged,
           environment,
           revalidateMountAuthority,
         } of resolvedMounts) {
           await revalidateMountAuthority();
           await this.materializeMountEntry(absolutePath, entry, {
             environment: environment ?? this.state.environment,
-            allowAmbientCredentials: allowMountCredentialExposure,
+            allowAmbientCredentials: broadCredentialExposureAcknowledged,
             revalidateMountAuthority,
           });
         }

--- a/packages/agents-extensions/src/sandbox/shared/inContainerMounts.ts
+++ b/packages/agents-extensions/src/sandbox/shared/inContainerMounts.ts
@@ -19,6 +19,7 @@ import { readOptionalString } from './typeGuards';
 import {
   validateCredentialPair as validateSandboxCredentialPair,
   stableJsonStringify,
+  mountCredentialEnvironmentForEntry,
   validateMountCredentialBoundaries,
   validateMountEnvironmentCredentialBoundaries,
 } from '@openai/agents-core/sandbox/internal';
@@ -85,48 +86,6 @@ const RCLONE_CHECKSUM_MISMATCH_STATUS = 86;
 const RCLONE_INSTALL_PATH = '/usr/local/bin/rclone';
 const RCLONE_ON_PATH_CHECK_COMMAND = 'command -v rclone >/dev/null 2>&1';
 const RCLONE_AVAILABLE_CHECK_COMMAND = `${RCLONE_ON_PATH_CHECK_COMMAND} || test -x ${RCLONE_INSTALL_PATH}`;
-
-export const RCLONE_S3_MOUNT_ENVIRONMENT_NAMES = [
-  'AWS_ACCESS_KEY_ID',
-  'AWS_SECRET_ACCESS_KEY',
-  'AWS_SESSION_TOKEN',
-  'AWS_SECURITY_TOKEN',
-  'AWS_REGION',
-  'AWS_DEFAULT_REGION',
-  'AWS_PROFILE',
-  'AWS_SHARED_CREDENTIALS_FILE',
-  'AWS_CONFIG_FILE',
-  'AWS_SDK_LOAD_CONFIG',
-  'AWS_ROLE_ARN',
-  'AWS_WEB_IDENTITY_TOKEN_FILE',
-  'AWS_ROLE_SESSION_NAME',
-  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
-  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
-  'AWS_CONTAINER_AUTHORIZATION_TOKEN',
-  'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
-] as const;
-
-export const RCLONE_S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES = [
-  'AWS_ACCESS_KEY_ID',
-  'AWS_SECRET_ACCESS_KEY',
-  'AWS_SESSION_TOKEN',
-  'AWS_SECURITY_TOKEN',
-  'AWS_PROFILE',
-  'AWS_SHARED_CREDENTIALS_FILE',
-  'AWS_CONFIG_FILE',
-  'AWS_ROLE_ARN',
-  'AWS_WEB_IDENTITY_TOKEN_FILE',
-  'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI',
-  'AWS_CONTAINER_CREDENTIALS_FULL_URI',
-  'AWS_CONTAINER_AUTHORIZATION_TOKEN',
-  'AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE',
-] as const;
-
-const RCLONE_GCS_MOUNT_ENVIRONMENT_NAMES = [
-  'GOOGLE_APPLICATION_CREDENTIALS',
-  'GOOGLE_CLOUD_PROJECT',
-  'CLOUDSDK_CORE_PROJECT',
-] as const;
 
 const rcloneMountEnvironmentAuthority = Symbol(
   'openaiAgentsRcloneMountEnvironmentAuthority',
@@ -402,43 +361,7 @@ export function rcloneCredentialEnvironmentForEntry(
   if (!isSharedRcloneMount(entry)) {
     return {};
   }
-  const names = new Set(
-    Object.keys(environment).filter(
-      (name) => name === 'RCLONE_CONFIG' || name.startsWith('RCLONE_CONFIG_'),
-    ),
-  );
-  const usesEntryCredentialPair = Boolean(
-    readOptionalString(entry, 'accessKeyId') &&
-    readOptionalString(entry, 'secretAccessKey'),
-  );
-  if (
-    (entry.type === 's3_mount' || entry.type === 'r2_mount') &&
-    !usesEntryCredentialPair &&
-    RCLONE_S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES.some(
-      (name) => environment[name] !== undefined,
-    )
-  ) {
-    for (const name of RCLONE_S3_MOUNT_ENVIRONMENT_NAMES) {
-      names.add(name);
-    }
-  }
-  if (
-    entry.type === 'gcs_mount' &&
-    !usesEntryCredentialPair &&
-    !readOptionalString(entry, 'serviceAccountCredentials') &&
-    !readOptionalString(entry, 'serviceAccountFile') &&
-    !readOptionalString(entry, 'accessToken') &&
-    environment.GOOGLE_APPLICATION_CREDENTIALS !== undefined
-  ) {
-    for (const name of RCLONE_GCS_MOUNT_ENVIRONMENT_NAMES) {
-      names.add(name);
-    }
-  }
-  return Object.fromEntries(
-    [...names].flatMap((name) =>
-      environment[name] === undefined ? [] : [[name, environment[name]]],
-    ),
-  );
+  return mountCredentialEnvironmentForEntry(entry, environment);
 }
 
 export async function mountRcloneCloudBucket(

--- a/packages/agents-extensions/src/sandbox/shared/manifest.ts
+++ b/packages/agents-extensions/src/sandbox/shared/manifest.ts
@@ -223,7 +223,8 @@ export type PreparedManifestMount = {
   logicalPath: string;
   absolutePath: string;
   entry: Mount | TypedMount;
-  allowMountCredentialExposure: boolean;
+  credentialExposureAcknowledged: boolean;
+  broadCredentialExposureAcknowledged: boolean;
   environment?: Readonly<Record<string, string>>;
   revalidateMountAuthority: () => Promise<void>;
 };
@@ -238,7 +239,7 @@ type DeferredMountMaterializationOptions = ManifestMaterializationOptions & {
   skipMountEntries?: boolean;
   materializationEnvironment?: Readonly<Record<string, string>>;
   preparedMountEnvironment?: Readonly<Record<string, string>>;
-  allowMountCredentialExposure?: boolean;
+  broadCredentialExposureAcknowledged?: boolean;
   revalidateMountAuthority?: () => Promise<void>;
 };
 
@@ -509,13 +510,12 @@ export async function prepareManifestMounts(
       return {
         absolutePath,
         entry: preparedCredentialFiles.entry,
-        allowMountCredentialExposure:
-          validateMountCredentialBoundariesAtEffectivePath(
-            manifest,
-            logicalPath,
-            entry,
-            absolutePath,
-          ),
+        ...validateMountCredentialBoundariesAtEffectivePath(
+          manifest,
+          logicalPath,
+          entry,
+          absolutePath,
+        ),
         environment: preparedCredentialFiles.environment,
       };
     };
@@ -524,14 +524,16 @@ export async function prepareManifestMounts(
       logicalPath,
       ...candidate,
       revalidateMountAuthority: async () => {
-        if (!candidate.allowMountCredentialExposure) {
+        if (!candidate.credentialExposureAcknowledged) {
           return;
         }
         const current = await prepareCandidate();
         if (
           current.absolutePath !== candidate.absolutePath ||
-          current.allowMountCredentialExposure !==
-            candidate.allowMountCredentialExposure ||
+          current.credentialExposureAcknowledged !==
+            candidate.credentialExposureAcknowledged ||
+          current.broadCredentialExposureAcknowledged !==
+            candidate.broadCredentialExposureAcknowledged ||
           stableJsonStringify(current.entry) !==
             stableJsonStringify(candidate.entry) ||
           stableJsonStringify(current.environment) !==
@@ -695,14 +697,14 @@ export async function materializeManifestEntries<TOptions extends object>(
   for (const {
     absolutePath,
     entry,
-    allowMountCredentialExposure,
+    broadCredentialExposureAcknowledged,
     environment,
     revalidateMountAuthority,
   } of resolvedMounts) {
     await revalidateMountAuthority();
     await materializeEntry(writer, absolutePath, entry, providerLabel, {
       ...options,
-      allowMountCredentialExposure,
+      broadCredentialExposureAcknowledged,
       preparedMountEnvironment: environment,
       revalidateMountAuthority,
     });
@@ -743,13 +745,12 @@ async function preparedMountsForManifest(
     }
     return {
       ...prepared,
-      allowMountCredentialExposure:
-        validateMountCredentialBoundariesAtEffectivePath(
-          manifest,
-          target.logicalPath,
-          target.entry,
-          prepared.absolutePath,
-        ),
+      ...validateMountCredentialBoundariesAtEffectivePath(
+        manifest,
+        target.logicalPath,
+        target.entry,
+        prepared.absolutePath,
+      ),
     };
   });
 }
@@ -821,7 +822,7 @@ export async function materializeInlineManifestEntry(
             .materializationEnvironment,
         allowAmbientCredentials: (
           options as DeferredMountMaterializationOptions
-        ).allowMountCredentialExposure,
+        ).broadCredentialExposureAcknowledged,
         revalidateMountAuthority: (
           options as DeferredMountMaterializationOptions
         ).revalidateMountAuthority,

--- a/packages/agents-extensions/src/sandbox/vercel/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/mounts.ts
@@ -30,6 +30,11 @@ export const VERCEL_S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES = [
   'AWS_WEB_IDENTITY_TOKEN_FILE',
 ] as const;
 
+export const VERCEL_S3_MOUNT_ROUTING_ENVIRONMENT_NAMES = [
+  'AWS_REGION',
+  'AWS_DEFAULT_REGION',
+] as const;
+
 /**
  * Selects Vercel's create-time-only application of the remote mount policy.
  *
@@ -93,6 +98,23 @@ export function validateVercelCloudBucketMountEntry(entry: Entry): void {
   resolveVercelS3MountConfig(entry);
 }
 
+export function vercelS3MountRoutingEnvironment(
+  entry: Entry,
+  configuredEnvironment: Record<string, string> = {},
+): Record<string, string> {
+  const environment =
+    mountEnvironment(
+      resolveVercelS3MountConfig(entry),
+      configuredEnvironment,
+      false,
+    ) ?? {};
+  return Object.fromEntries(
+    VERCEL_S3_MOUNT_ROUTING_ENVIRONMENT_NAMES.flatMap((name) =>
+      environment[name] === undefined ? [] : [[name, environment[name]]],
+    ),
+  );
+}
+
 export async function mountVercelCloudBucket(args: {
   entry: Entry;
   mountPath: string;
@@ -137,7 +159,11 @@ export async function mountVercelCloudBucket(args: {
       args.allowAmbientCredentials === true,
     ),
     options: {
-      env: mountEnvironment(config, args.environment),
+      env: mountEnvironment(
+        config,
+        args.environment,
+        args.allowAmbientCredentials === true,
+      ),
       sudo: true,
       timeoutMs: MOUNTPOINT_COMMAND_TIMEOUT_MS,
     },
@@ -377,9 +403,13 @@ function isSupportedMountpointVersion(
 function mountEnvironment(
   config: VercelS3MountConfig,
   configuredEnvironment: Record<string, string> = {},
+  allowAmbientCredentials: boolean = false,
 ): Record<string, string> | undefined {
+  const allowedConfiguredNames = allowAmbientCredentials
+    ? VERCEL_S3_MOUNT_ENVIRONMENT_NAMES
+    : VERCEL_S3_MOUNT_ROUTING_ENVIRONMENT_NAMES;
   const environment = Object.fromEntries(
-    VERCEL_S3_MOUNT_ENVIRONMENT_NAMES.flatMap((name) => {
+    allowedConfiguredNames.flatMap((name) => {
       const value = configuredEnvironment[name];
       return typeof value === 'string' ? [[name, value]] : [];
     }),

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -70,20 +70,28 @@ import {
   assertLiveMountCredentialAuthorityMatches,
   assertLiveMountEnvironmentAuthorityMatches,
   assertSandboxStateGenerationUnchanged,
+  captureLiveMountRuntimeAuthority,
   captureSandboxStateGeneration,
   captureLiveMountCredentialAuthority,
   captureLiveMountCredentialAuthorityIfAbsent,
+  liveMountCredentialAuthorityMatches,
+  liveMountEnvironmentAuthorityMatches,
+  liveMountRuntimeAuthorityMatches,
   recordLiveMountCredentialAuthority,
+  sanitizeMountCredentialEnvironmentForPersistence,
+  stableJsonStringify,
   validateMountCredentialBoundaries,
+  validateMountEnvironmentCredentialBoundaries,
   withExclusiveSandboxManifestMutation,
 } from '@openai/agents-core/sandbox/internal';
 import {
+  hasVercelS3Credentials,
   isVercelCloudBucketMountEntry,
   mountVercelCloudBucket,
   unmountVercelCloudBucket,
   validateVercelCloudBucketMountEntry,
-  VERCEL_S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES,
   VERCEL_S3_MOUNT_ENVIRONMENT_NAMES,
+  vercelS3MountRoutingEnvironment,
   type VercelMountCommand,
 } from './mounts';
 
@@ -259,7 +267,7 @@ export interface VercelSandboxClientOptions extends SandboxClientOptions {
   snapshotExpirationMs?: number;
   env?: Record<string, string>;
   /**
-   * @deprecated Use Manifest.withInContainerMountCredentialExposureAllowed()
+   * @deprecated Use Manifest.withInContainerMountCredentialExposureAcknowledged()
    * with each exact Vercel mount path instead.
    */
   allowS3CredentialExposure?: boolean;
@@ -289,6 +297,10 @@ export interface VercelSandboxSessionState extends SandboxSessionState {
   snapshotSupported?: boolean;
 }
 
+const VERCEL_MOUNT_ROUTING_AUTHORITY = Symbol(
+  'openaiAgentsVercelMountRoutingAuthority',
+);
+
 export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandboxSessionState> {
   private sandbox: VercelSandboxInstance;
   private readonly knownDirs: Set<string>;
@@ -307,6 +319,10 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
    * makes those transitions unambiguous.
    */
   private readonly activeMounts = new Map<string, VercelActiveMount>();
+  readonly #activeMountRoutingEnvironment = new Map<
+    string,
+    Readonly<Record<string, string>>
+  >();
   private readonly credentials: Pick<
     VercelSandboxClientOptions,
     'projectId' | 'teamId' | 'token'
@@ -720,19 +736,28 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
       logicalPath: preparedMount.logicalPath,
       entry,
     });
+    const environment = {
+      ...(preparedMount.environment ?? this.state.environment),
+    };
     await mountVercelCloudBucket({
       entry,
       mountPath,
       runCommand: this.mountCommand,
-      environment: preparedMount.environment
-        ? { ...preparedMount.environment }
-        : this.state.environment,
-      allowAmbientCredentials: preparedMount.allowMountCredentialExposure,
+      environment,
+      allowAmbientCredentials:
+        preparedMount.broadCredentialExposureAcknowledged,
       validateMountPath: async () => {
         await this.assertCanonicalMountPath(mountPath);
       },
       revalidateMountAuthority: preparedMount.revalidateMountAuthority,
     });
+    captureVercelMountRoutingAuthority(
+      this.state.manifest,
+      this.#activeMountRoutingEnvironment,
+      mountPath,
+      entry,
+      environment,
+    );
   }
 
   private async assertCanonicalMountPath(mountPath: string): Promise<void> {
@@ -777,6 +802,7 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
           runCommand: this.mountCommand,
         });
         this.activeMounts.delete(mountPath);
+        this.#activeMountRoutingEnvironment.delete(mountPath);
       } catch {
         failureCount += 1;
       }
@@ -931,14 +957,16 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
         );
       }
       await this.assertCanonicalMountPathDuringTransition(mountPath);
+      const environment = {
+        ...(preparedMount.environment ?? this.state.environment),
+      };
       await mountVercelCloudBucket({
         entry: preparedMount.entry,
         mountPath,
         runCommand: this.mountCommand,
-        environment: preparedMount.environment
-          ? { ...preparedMount.environment }
-          : this.state.environment,
-        allowAmbientCredentials: preparedMount.allowMountCredentialExposure,
+        environment,
+        allowAmbientCredentials:
+          preparedMount.broadCredentialExposureAcknowledged,
         validateMountPath: async () => {
           await this.assertCanonicalMountPathDuringTransition(mountPath);
         },
@@ -948,6 +976,13 @@ export class VercelSandboxSession extends RemoteSandboxSessionBase<VercelSandbox
         logicalPath: preparedMount.logicalPath,
         entry: preparedMount.entry,
       });
+      captureVercelMountRoutingAuthority(
+        this.state.manifest,
+        this.#activeMountRoutingEnvironment,
+        mountPath,
+        preparedMount.entry,
+        environment,
+      );
     }
   }
 
@@ -1519,22 +1554,43 @@ export class VercelSandboxClient implements SandboxClient<
     this.options = options;
   }
 
-  resolveTrustedManifestForResume(manifest: Manifest): Manifest {
-    return resolveManifestRoot(manifest);
+  resolveTrustedManifestForResume(
+    manifest: Manifest,
+    options?: VercelSandboxClientOptions,
+  ): Manifest {
+    const resolvedOptions = resolveVercelOptions(this.options, options);
+    return withReleasedVercelS3CredentialExposureCompatibility(
+      resolveManifestRoot(manifest),
+      resolvedOptions.allowS3CredentialExposure === true,
+    );
   }
 
   async create(
     args?: SandboxClientCreateArgs<VercelSandboxClientOptions> | Manifest,
     manifestOptions?: VercelSandboxClientOptions,
   ): Promise<VercelSandboxSession> {
-    const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
-    assertCoreSnapshotUnsupported('VercelSandboxClient', createArgs.snapshot);
-    const manifest = createArgs.manifest;
+    const requestedOptions =
+      args instanceof Manifest ? manifestOptions : args?.options;
     const resolvedOptions = resolveVercelOptions(
       this.options,
-      createArgs.options,
+      requestedOptions,
     );
-    const resolvedManifest = resolveManifestRoot(manifest);
+    const requestedManifest = cloneManifest(
+      args instanceof Manifest ? args : (args?.manifest ?? new Manifest()),
+    );
+    const compatibilityManifest =
+      withReleasedVercelS3CredentialExposureCompatibility(
+        requestedManifest,
+        resolvedOptions.allowS3CredentialExposure === true,
+      );
+    const createArgs = normalizeSandboxClientCreateArgs(
+      args instanceof Manifest
+        ? compatibilityManifest
+        : { ...(args ?? {}), manifest: compatibilityManifest },
+      manifestOptions,
+    );
+    assertCoreSnapshotUnsupported('VercelSandboxClient', createArgs.snapshot);
+    const resolvedManifest = resolveManifestRoot(createArgs.manifest);
     assertSandboxManifestMetadataSupported(
       'VercelSandboxClient',
       resolvedManifest,
@@ -1643,7 +1699,14 @@ export class VercelSandboxClient implements SandboxClient<
     options?: SandboxSessionSerializationOptions,
   ): Promise<Record<string, unknown>> {
     const stateGeneration = captureSandboxStateGeneration(state);
-    state.manifest = sanitizeVercelMountManifest(state.manifest);
+    const liveManifest = state.manifest;
+    const sanitizedMountEnvironment =
+      sanitizeMountCredentialEnvironmentForPersistence(state);
+    const sanitizedManifest = sanitizeVercelMountManifest(
+      sanitizedMountEnvironment.manifest,
+    );
+    recordLiveMountCredentialAuthority(sanitizedManifest, liveManifest);
+    state.manifest = sanitizedManifest;
     const credentials = selectVercelSessionCredentials(state, this.options);
     applyVercelCredentials(state, credentials);
     if (
@@ -1662,9 +1725,7 @@ export class VercelSandboxClient implements SandboxClient<
     const serialized = serializeRemoteSandboxSessionState(
       {
         ...state,
-        environment: hasVercelMounts(state.manifest)
-          ? omitVercelS3CredentialEnvironment(state.environment)
-          : state.environment,
+        environment: sanitizedMountEnvironment.environment,
       },
       state,
     );
@@ -1703,17 +1764,34 @@ export class VercelSandboxClient implements SandboxClient<
     if (!options.trustedManifest) {
       return false;
     }
+    const resolvedOptions = resolveVercelOptions(
+      this.options,
+      options.clientOptions,
+    );
+    const trustedManifest = withReleasedVercelS3CredentialExposureCompatibility(
+      resolveManifestRoot(options.trustedManifest),
+      resolvedOptions.allowS3CredentialExposure === true,
+    );
     const trustedEnvironment = await materializeEnvironment(
-      options.trustedManifest,
-      resolveVercelOptions(this.options, options.clientOptions).env,
+      trustedManifest,
+      resolvedOptions.env,
     );
     validateVercelMountEnvironmentCredentialExposure(
-      options.trustedManifest,
+      trustedManifest,
       trustedEnvironment,
     );
-    return vercelMountEnvironmentAuthorityMatches(
-      state.environment,
-      trustedEnvironment,
+    return (
+      liveMountCredentialAuthorityMatches(state.manifest, trustedManifest) &&
+      liveMountEnvironmentAuthorityMatches(
+        state.manifest,
+        trustedManifest,
+        trustedEnvironment,
+      ) &&
+      vercelMountRoutingAuthorityMatches(
+        state.manifest,
+        trustedManifest,
+        trustedEnvironment,
+      )
     );
   }
 
@@ -1959,6 +2037,27 @@ function adaptVercelCommand(
   };
 }
 
+function withReleasedVercelS3CredentialExposureCompatibility(
+  manifest: Manifest,
+  allowS3CredentialExposure: boolean,
+): Manifest {
+  if (!allowS3CredentialExposure) {
+    return manifest;
+  }
+  const credentialedMountPaths = manifest
+    .mountTargetsForMaterialization()
+    .filter(
+      ({ entry }) =>
+        isVercelCloudBucketMountEntry(entry) && hasVercelS3Credentials(entry),
+    )
+    .map(({ mountPath }) => mountPath);
+  return credentialedMountPaths.length > 0
+    ? manifest.withInContainerMountCredentialExposureAcknowledged(
+        ...credentialedMountPaths,
+      )
+    : manifest;
+}
+
 function assertVercelMountManifest(manifest: Manifest): void {
   const mountPaths: string[] = [];
   for (const {
@@ -2023,49 +2122,58 @@ function hasVercelMounts(manifest: Manifest): boolean {
   return manifest.mountTargetsForMaterialization().length > 0;
 }
 
-function omitVercelS3CredentialEnvironment(
+function captureVercelMountRoutingAuthority(
+  manifest: Manifest,
+  activeRoutingEnvironment: Map<string, Readonly<Record<string, string>>>,
+  mountPath: string,
+  entry: S3Mount,
   environment: Record<string, string>,
-): Record<string, string> {
-  const serializedEnvironment = { ...environment };
-  for (const name of VERCEL_S3_MOUNT_ENVIRONMENT_NAMES) {
-    delete serializedEnvironment[name];
-  }
-  return serializedEnvironment;
+): void {
+  activeRoutingEnvironment.set(
+    mountPath,
+    vercelS3MountRoutingEnvironment(entry, environment),
+  );
+  captureLiveMountRuntimeAuthority(
+    manifest,
+    VERCEL_MOUNT_ROUTING_AUTHORITY,
+    stableJsonStringify(
+      [...activeRoutingEnvironment]
+        .map(([path, routingEnvironment]) => ({
+          path,
+          environment: routingEnvironment,
+        }))
+        .sort(({ path: left }, { path: right }) => left.localeCompare(right)),
+    ),
+  );
+}
+
+function vercelMountRoutingAuthorityMatches(
+  liveManifest: Manifest,
+  trustedManifest: Manifest,
+  trustedEnvironment: Record<string, string>,
+): boolean {
+  const trustedSignature = stableJsonStringify(
+    trustedManifest
+      .mountTargetsForMaterialization()
+      .filter(({ entry }) => isVercelCloudBucketMountEntry(entry))
+      .map(({ absolutePath, entry }) => ({
+        path: absolutePath,
+        environment: vercelS3MountRoutingEnvironment(entry, trustedEnvironment),
+      }))
+      .sort(({ path: left }, { path: right }) => left.localeCompare(right)),
+  );
+  return liveMountRuntimeAuthorityMatches(
+    liveManifest,
+    VERCEL_MOUNT_ROUTING_AUTHORITY,
+    trustedSignature,
+  );
 }
 
 function validateVercelMountEnvironmentCredentialExposure(
   manifest: Manifest,
   environment: Record<string, string>,
 ): void {
-  const credentialEnvironment = Object.fromEntries(
-    VERCEL_S3_MOUNT_ENVIRONMENT_NAMES.flatMap((name) =>
-      environment[name] === undefined ? [] : [[name, environment[name]]],
-    ),
-  );
-  const candidate = cloneManifestWithRoot(manifest, manifest.root);
-  if (
-    VERCEL_S3_MOUNT_CREDENTIAL_ENVIRONMENT_NAMES.some(
-      (name) => environment[name] !== undefined,
-    )
-  ) {
-    for (const { entry } of candidate.mountTargetsForMaterialization()) {
-      if (!isVercelCloudBucketMountEntry(entry)) {
-        continue;
-      }
-      (entry.mountStrategy as Record<string, unknown>).credentialEnvironment =
-        credentialEnvironment;
-    }
-  }
-  validateMountCredentialBoundaries(candidate);
-}
-
-function vercelMountEnvironmentAuthorityMatches(
-  live: Record<string, string>,
-  trusted: Record<string, string>,
-): boolean {
-  return VERCEL_S3_MOUNT_ENVIRONMENT_NAMES.every(
-    (name) => live[name] === trusted[name],
-  );
+  validateMountEnvironmentCredentialBoundaries(manifest, environment);
 }
 
 function assertNoOverlappingMountPath(

--- a/packages/agents-extensions/test/sandbox/blaxel.test.ts
+++ b/packages/agents-extensions/test/sandbox/blaxel.test.ts
@@ -959,7 +959,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelDriveMountStrategy(),
           }),
         },
-      }).withInContainerMountCredentialExposureAllowed(
+      }).withInContainerMountCredentialExposureAcknowledged(
         'mounted/gcs-a',
         'mounted/gcs-b',
       ),
@@ -1415,7 +1415,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('data'),
+        }).withInContainerMountCredentialExposureAcknowledged('data'),
       ),
     ).rejects.toThrow(/reused sandbox it does not own/u);
 
@@ -1601,7 +1601,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
 
     expect(
@@ -1685,7 +1685,7 @@ describe('BlaxelSandboxClient', () => {
         .create(
           new Manifest({
             entries: { data: entry },
-          }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+          }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
         )
         .then(
           () => undefined,
@@ -1745,7 +1745,7 @@ describe('BlaxelSandboxClient', () => {
           mountStrategy: new BlaxelCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
 
     const error = await client.create(manifest).then(
       () => undefined,
@@ -1804,7 +1804,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/gcs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/gcs'),
       )
       .then(
         () => undefined,
@@ -1843,7 +1843,7 @@ describe('BlaxelSandboxClient', () => {
           mountStrategy: new BlaxelCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
     const client = new BlaxelSandboxClient({
       name: 'shared-sandbox',
     } satisfies BlaxelSandboxClientOptions);
@@ -1878,7 +1878,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
 
     const mountCommand = processExecMock.mock.calls
@@ -1911,7 +1911,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
     session.state.environment['INVALID-NAME'] = 'env-value';
     processExecMock.mockClear();
@@ -1941,7 +1941,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
     await session.close();
 
@@ -1990,7 +1990,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
       )
       .then(
         () => undefined,
@@ -2044,7 +2044,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
       )
       .then(
         () => undefined,
@@ -2109,7 +2109,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
       )
       .then(
         () => undefined,
@@ -2153,7 +2153,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
       ),
     ).rejects.toThrow(/both accessKeyId and secretAccessKey/u);
 
@@ -2180,7 +2180,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/gcs'),
+      }).withInContainerMountBroadCredentialExposureAcknowledged('mounted/gcs'),
     );
 
     const mountCommand = processExecMock.mock.calls
@@ -2214,7 +2214,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/gcs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/gcs'),
     );
 
     const mountCommand = processExecMock.mock.calls
@@ -2243,7 +2243,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/gcs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/gcs'),
     );
 
     const mountCommand = processExecMock.mock.calls
@@ -2311,7 +2311,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/gcs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/gcs'),
       ),
     ).rejects.toThrow('Blaxel cloud bucket mount failed.');
 
@@ -2365,7 +2365,7 @@ describe('BlaxelSandboxClient', () => {
               mountStrategy: new BlaxelCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/gcs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/gcs'),
       )
       .then(
         () => undefined,
@@ -2416,7 +2416,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed(
+      }).withInContainerMountCredentialExposureAcknowledged(
         'mounted/gcs-a',
         'mounted/gcs-b',
       ),
@@ -2460,7 +2460,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/gcs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/gcs'),
     );
     processExecMock.mockClear();
     processExecMock.mockResolvedValue({
@@ -2505,7 +2505,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('a+b', 'a/b'),
+      }).withInContainerMountCredentialExposureAcknowledged('a+b', 'a/b'),
     );
 
     const mountCommands = processExecMock.mock.calls
@@ -2542,7 +2542,7 @@ describe('BlaxelSandboxClient', () => {
             mountStrategy: new BlaxelCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed(longMountPath),
+      }).withInContainerMountCredentialExposureAcknowledged(longMountPath),
     );
 
     const socketPaths = processExecMock.mock.calls.flatMap(([params]) =>

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -1,4 +1,5 @@
 import {
+  boxMount,
   Manifest,
   SandboxMountError,
   SandboxProviderError,
@@ -722,6 +723,60 @@ describe('DaytonaSandboxClient', () => {
     expect(startMock).not.toHaveBeenCalled();
   });
 
+  test('requires broad acknowledgement for ambient credentials shadowed by inline credentials', async () => {
+    const client = new DaytonaSandboxClient({
+      env: {
+        AWS_ACCESS_KEY_ID: 'ambient-access-key',
+        AWS_SECRET_ACCESS_KEY: 'ambient-secret-key',
+      },
+    });
+    const manifest = new Manifest({
+      entries: {
+        data: {
+          type: 's3_mount',
+          bucket: 'agent-logs',
+          accessKeyId: 'inline-access-key',
+          secretAccessKey: 'inline-secret-key',
+          mountStrategy: new DaytonaCloudBucketMountStrategy(),
+        },
+      },
+    }).withInContainerMountCredentialExposureAcknowledged('data');
+
+    await expect(client.create(manifest)).rejects.toThrow(
+      /broad credential authority/iu,
+    );
+    await expect(
+      new DaytonaSandboxClient({
+        env: {
+          GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/gcp.json',
+        },
+      }).create(
+        new Manifest({
+          entries: {
+            data: {
+              type: 'gcs_mount',
+              bucket: 'agent-logs',
+              accessToken: 'inline-access-token',
+              mountStrategy: new DaytonaCloudBucketMountStrategy(),
+            },
+          },
+        }).withInContainerMountCredentialExposureAcknowledged('data'),
+      ),
+    ).rejects.toThrow(/broad credential authority/iu);
+    await expect(
+      new DaytonaSandboxClient({
+        env: {
+          RCLONE_CONFIG_REMOTE_ACCESS_KEY_ID: 'partial-access-key',
+        },
+      }).create(
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+          'data',
+        ),
+      ),
+    ).rejects.toThrow(/both ACCESS_KEY_ID and SECRET_ACCESS_KEY/iu);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('keeps the sandbox usable after dynamic mount validation rejects', async () => {
     const client = new DaytonaSandboxClient();
     const session = await client.create(new Manifest());
@@ -760,6 +815,80 @@ describe('DaytonaSandboxClient', () => {
     await expect(session.execCommand({ cmd: 'pwd' })).resolves.toContain(
       'Process exited with code 0',
     );
+  });
+
+  test('enforces mount-scoped Box credentials through the provider client', async () => {
+    const client = new DaytonaSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        box: boxMount({
+          path: '/Shared/Docs',
+          clientId: 'box-client-id',
+          clientSecret: 'BOX_CLIENT_SECRET_SENTINEL',
+          accessToken: 'BOX_ACCESS_TOKEN_SENTINEL',
+          mountStrategy: new DaytonaCloudBucketMountStrategy(),
+        }),
+      },
+    });
+
+    await expect(client.create(manifest)).rejects.toThrow(
+      /Mount-scoped credentials/u,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+
+    await client.create(
+      manifest.withInContainerMountCredentialExposureAcknowledged('box'),
+    );
+
+    const commandText = executeCommandMock.mock.calls
+      .map(([command]) => String(command))
+      .join('\n');
+    const uploadedText = uploadFileMock.mock.calls
+      .map(([content]) =>
+        Buffer.isBuffer(content) ? content.toString('utf8') : String(content),
+      )
+      .join('\n');
+    expect(commandText).toContain("'rclone' 'mount'");
+    expect(commandText).toMatch(/rm -f -- '\/tmp\/openai-agents-.*\.conf'/u);
+    expect(commandText).not.toContain('BOX_CLIENT_SECRET_SENTINEL');
+    expect(commandText).not.toContain('BOX_ACCESS_TOKEN_SENTINEL');
+    expect(uploadedText).toContain(
+      'client_secret = BOX_CLIENT_SECRET_SENTINEL',
+    );
+    expect(uploadedText).toContain('access_token = BOX_ACCESS_TOKEN_SENTINEL');
+  });
+
+  test('requires broad acknowledgement for a Box credential file', async () => {
+    const client = new DaytonaSandboxClient();
+    const manifest = new Manifest({
+      entries: {
+        box: boxMount({
+          path: '/Shared/Docs',
+          boxConfigFile: '/run/secrets/BOX_CONFIG_PATH_SENTINEL.json',
+          mountStrategy: new DaytonaCloudBucketMountStrategy(),
+        }),
+      },
+    }).withInContainerMountCredentialExposureAcknowledged('box');
+
+    let error: unknown;
+    try {
+      await client.create(manifest);
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(SandboxMountError);
+    expect((error as Error).message).toMatch(/Broad credential authority/u);
+    expect(JSON.stringify(error)).not.toContain('BOX_CONFIG_PATH_SENTINEL');
+    expect(createMock).not.toHaveBeenCalled();
+
+    await client.create(
+      manifest.withInContainerMountBroadCredentialExposureAcknowledged('box'),
+    );
+    const commandText = executeCommandMock.mock.calls
+      .map(([command]) => String(command))
+      .join('\n');
+    expect(commandText).toContain("'rclone' 'mount'");
+    expect(commandText).toMatch(/rm -f -- '\/tmp\/openai-agents-.*\.conf'/u);
   });
 
   test('rejects active mount replacement without deleting the sandbox', async () => {
@@ -834,7 +963,7 @@ describe('DaytonaSandboxClient', () => {
         AWS_ACCESS_KEY_ID: 'original-access',
         AWS_SECRET_ACCESS_KEY: 'original-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const client = new DaytonaSandboxClient();
     const session = await client.create(manifest);
     executeCommandMock.mockClear();
@@ -862,7 +991,7 @@ describe('DaytonaSandboxClient', () => {
           mountStrategy: new DaytonaCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed(
+    }).withInContainerMountCredentialExposureAcknowledged(
       'mounted/logs',
       'redirected/logs',
     );
@@ -903,7 +1032,7 @@ describe('DaytonaSandboxClient', () => {
     const trustedWithoutRedirect = new Manifest({
       root: session.state.manifest.root,
       entries: structuredClone(session.state.manifest.entries),
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
     expect(
       liveMountCredentialAuthorityMatches(
         session.state.manifest,
@@ -940,7 +1069,7 @@ describe('DaytonaSandboxClient', () => {
           mountStrategy: new DaytonaCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed(
+    }).withInContainerMountCredentialExposureAcknowledged(
       'mounted/logs',
       'redirected/logs',
     );
@@ -949,7 +1078,7 @@ describe('DaytonaSandboxClient', () => {
     const trustedWithoutRedirect = new Manifest({
       root: session.state.manifest.root,
       entries: structuredClone(session.state.manifest.entries),
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
 
     expect(
       liveMountCredentialAuthorityMatches(
@@ -968,7 +1097,7 @@ describe('DaytonaSandboxClient', () => {
           mountStrategy: new DaytonaCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountCredentialExposureAcknowledged('data');
     const client = new DaytonaSandboxClient();
     const session = await client.create(manifest);
     const defaultExecute = executeCommandMock.getMockImplementation()!;
@@ -1008,7 +1137,7 @@ describe('DaytonaSandboxClient', () => {
           mountStrategy: new DaytonaCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountCredentialExposureAcknowledged('data');
     const client = new DaytonaSandboxClient();
     const session = await client.create(manifest);
     const defaultExecute = executeCommandMock.getMockImplementation()!;
@@ -1052,8 +1181,8 @@ describe('DaytonaSandboxClient', () => {
       },
     });
     manifest = manifest
-      .withInContainerMountCredentialExposureAllowed('first')
-      .withInContainerMountCredentialExposureAllowed('second');
+      .withInContainerMountCredentialExposureAcknowledged('first')
+      .withInContainerMountCredentialExposureAcknowledged('second');
     const client = new DaytonaSandboxClient();
     const session = await client.create(manifest);
     const defaultExecute = executeCommandMock.getMockImplementation();
@@ -1091,7 +1220,7 @@ describe('DaytonaSandboxClient', () => {
     async (_pathKind, path) => {
       const client = new DaytonaSandboxClient();
       const baseManifest =
-        new Manifest().withInContainerMountCredentialExposureAllowed(
+        new Manifest().withInContainerMountCredentialExposureAcknowledged(
           'mounted/logs',
         );
       const session = await client.create(baseManifest);
@@ -1110,7 +1239,7 @@ describe('DaytonaSandboxClient', () => {
 
       const trustedManifest = new Manifest({
         entries: { data: entry },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
       await expect(
         client.canReusePreservedOwnedSession(session.state, {
           trustedManifest,
@@ -1134,7 +1263,7 @@ describe('DaytonaSandboxClient', () => {
           mountStrategy: new DaytonaCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
     const session = await client.create(manifest, {
       autoStopInterval: 10,
     });
@@ -1501,7 +1630,7 @@ describe('DaytonaSandboxClient', () => {
             mountStrategy: new DaytonaCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
     await session.close();
 
@@ -1538,7 +1667,9 @@ describe('DaytonaSandboxClient', () => {
     });
 
     const session = await client.create(
-      new Manifest().withInContainerMountCredentialExposureAllowed('data'),
+      new Manifest().withInContainerMountBroadCredentialExposureAcknowledged(
+        'data',
+      ),
     );
     executeCommandMock.mockClear();
 
@@ -1577,7 +1708,7 @@ describe('DaytonaSandboxClient', () => {
           mountStrategy: new DaytonaCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
 
     const session = await client.create(manifest, {
       pauseOnExit: true,

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -1261,7 +1261,7 @@ describe('E2BSandboxClient', () => {
             mountStrategy: new E2BCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
     await session.close();
 
@@ -1314,7 +1314,7 @@ describe('E2BSandboxClient', () => {
               mountStrategy: new E2BCloudBucketMountStrategy(),
             },
           },
-        }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+        }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
       ),
     ).rejects.toThrow(/model-controlled sandbox/u);
 
@@ -1347,6 +1347,82 @@ describe('E2BSandboxClient', () => {
         }),
       ),
     ).rejects.toThrow(/model-controlled sandbox/u);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('requires broad acknowledgement for ambient credentials shadowed by inline credentials', async () => {
+    const client = new E2BSandboxClient({
+      env: {
+        AWS_ACCESS_KEY_ID: 'ambient-access-key',
+        AWS_SECRET_ACCESS_KEY: 'ambient-secret-key',
+      },
+    });
+    const manifest = new Manifest({
+      entries: {
+        data: {
+          type: 's3_mount',
+          bucket: 'agent-logs',
+          accessKeyId: 'inline-access-key',
+          secretAccessKey: 'inline-secret-key',
+          mountStrategy: new E2BCloudBucketMountStrategy(),
+        },
+      },
+    }).withInContainerMountCredentialExposureAcknowledged('data');
+
+    await expect(client.create(manifest)).rejects.toThrow(
+      /broad credential authority/iu,
+    );
+    await expect(
+      new E2BSandboxClient({
+        env: {
+          GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/gcp.json',
+        },
+      }).create(
+        new Manifest({
+          entries: {
+            data: {
+              type: 'gcs_mount',
+              bucket: 'agent-logs',
+              serviceAccountCredentials: 'inline-service-account-credentials',
+              mountStrategy: new E2BCloudBucketMountStrategy(),
+            },
+          },
+        }).withInContainerMountCredentialExposureAcknowledged('data'),
+      ),
+    ).rejects.toThrow(/broad credential authority/iu);
+    await expect(
+      new E2BSandboxClient({
+        env: {
+          GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/gcp.json',
+        },
+      }).create(
+        new Manifest({
+          entries: {
+            data: {
+              type: 'gcs_mount',
+              bucket: 'agent-logs',
+              mountStrategy: {
+                type: 'e2b_cloud_bucket',
+                pattern: { type: 'mountpoint' },
+              },
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(
+      /SDK-supported strategy, provider, mount type, and pattern/iu,
+    );
+    await expect(
+      new E2BSandboxClient({
+        env: {
+          RCLONE_CONFIG_REMOTE_ACCESS_KEY_ID: 'partial-access-key',
+        },
+      }).create(
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+          'data',
+        ),
+      ),
+    ).rejects.toThrow(/both ACCESS_KEY_ID and SECRET_ACCESS_KEY/iu);
     expect(createMock).not.toHaveBeenCalled();
   });
 
@@ -1395,7 +1471,7 @@ describe('E2BSandboxClient', () => {
           mountStrategy: new E2BCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const client = new E2BSandboxClient({ env: environment });
     const session = await client.create(manifest);
 
@@ -1433,7 +1509,7 @@ describe('E2BSandboxClient', () => {
           mountStrategy: new E2BCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const client = new E2BSandboxClient({ env: environment });
     const session = await client.create(manifest);
 
@@ -1506,7 +1582,7 @@ describe('E2BSandboxClient', () => {
             mountStrategy: new E2BCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
 
     expect(
@@ -1534,7 +1610,9 @@ describe('E2BSandboxClient', () => {
       },
     });
     const session = await client.create(
-      new Manifest().withInContainerMountCredentialExposureAllowed('data'),
+      new Manifest().withInContainerMountBroadCredentialExposureAcknowledged(
+        'data',
+      ),
     );
     runMock.mockClear();
 

--- a/packages/agents-extensions/test/sandbox/mountSecurity.test.ts
+++ b/packages/agents-extensions/test/sandbox/mountSecurity.test.ts
@@ -47,7 +47,9 @@ describe('remote mount credential boundaries', () => {
       ).toThrow(/model-controlled sandbox/u);
       expect(() =>
         validateRcloneMountEnvironmentCredentialExposure(
-          manifest.withInContainerMountCredentialExposureAllowed('remote'),
+          manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+            'remote',
+          ),
           environment,
         ),
       ).not.toThrow();
@@ -67,7 +69,7 @@ describe('remote mount credential boundaries', () => {
         AWS_SECRET_ACCESS_KEY: 'secret-key',
         KEEP: 'safe',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     const serialized = serializeRemoteSandboxSessionState({
       manifest,
@@ -98,8 +100,8 @@ describe('remote mount credential boundaries', () => {
         }),
       },
     })
-      .withInContainerMountCredentialExposureAllowed('first')
-      .withInContainerMountCredentialExposureAllowed('second');
+      .withInContainerMountBroadCredentialExposureAcknowledged('first')
+      .withInContainerMountBroadCredentialExposureAcknowledged('second');
     const state = {
       manifest,
       environment: {
@@ -136,7 +138,7 @@ describe('remote mount credential boundaries', () => {
     ).toBe(false);
   });
 
-  it('ignores ambient AWS values for inline credentials but tracks rclone overrides', () => {
+  it('tracks ambient AWS values exposed beside inline credentials', () => {
     const manifest = new Manifest({
       entries: {
         remote: s3Mount({
@@ -146,7 +148,9 @@ describe('remote mount credential boundaries', () => {
           mountStrategy: { type: 'e2b_cloud_bucket' },
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    })
+      .withInContainerMountCredentialExposureAcknowledged('remote')
+      .withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const state = {
       manifest,
       environment: { AWS_ACCESS_KEY_ID: 'ambient-key' },
@@ -161,10 +165,58 @@ describe('remote mount credential boundaries', () => {
       rcloneMountEnvironmentAuthorityMatches(state, manifest, {
         AWS_ACCESS_KEY_ID: 'rotated-ambient-key',
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       rcloneMountEnvironmentAuthorityMatches(state, manifest, {
         RCLONE_CONFIG_PASS: 'new-password',
+      }),
+    ).toBe(false);
+  });
+
+  it('redacts and compares broad AWS authority beside inline credentials', () => {
+    const manifest = new Manifest({
+      entries: {
+        remote: s3Mount({
+          bucket: 'example',
+          accessKeyId: 'inline-key',
+          secretAccessKey: 'inline-secret',
+          mountStrategy: { type: 'daytona_cloud_bucket' },
+        }),
+      },
+    })
+      .withInContainerMountCredentialExposureAcknowledged('remote')
+      .withInContainerMountBroadCredentialExposureAcknowledged('remote');
+    const state = {
+      manifest,
+      environment: {
+        AWS_CONTAINER_CREDENTIALS_FULL_URI: 'http://169.254.170.2/credentials',
+        AWS_CONTAINER_AUTHORIZATION_TOKEN: 'CONTAINER_TOKEN_SENTINEL_A',
+        KEEP: 'safe',
+      },
+    };
+    captureRcloneMountEnvironmentAuthority(
+      state,
+      '/workspace/remote',
+      manifest.entries.remote!,
+    );
+
+    const serialized = serializeRemoteSandboxSessionState(state);
+    expect(serialized.environment).toEqual({ KEEP: 'safe' });
+    expect(JSON.stringify(serialized)).not.toContain(
+      'CONTAINER_TOKEN_SENTINEL_A',
+    );
+    expect(
+      rcloneMountEnvironmentAuthorityMatches(state, manifest, {
+        AWS_CONTAINER_CREDENTIALS_FULL_URI: 'http://169.254.170.2/credentials',
+        AWS_CONTAINER_AUTHORIZATION_TOKEN: 'CONTAINER_TOKEN_SENTINEL_A',
+        KEEP: 'safe',
+      }),
+    ).toBe(true);
+    expect(
+      rcloneMountEnvironmentAuthorityMatches(state, manifest, {
+        AWS_CONTAINER_CREDENTIALS_FULL_URI: 'http://169.254.170.2/credentials',
+        AWS_CONTAINER_AUTHORIZATION_TOKEN: 'CONTAINER_TOKEN_SENTINEL_B',
+        KEEP: 'safe',
       }),
     ).toBe(false);
   });

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -95,7 +95,7 @@ function runloopCloudBucketManifest(
         ...entryOverrides,
       },
     },
-  }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+  }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
 }
 
 function execResult(args: {
@@ -1010,6 +1010,65 @@ describe('RunloopSandboxClient', () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 
+  test('requires broad acknowledgement for managed credentials shadowed by inline credentials', async () => {
+    const client = new RunloopSandboxClient();
+    const manifest = runloopManifest({
+      entries: {
+        data: {
+          type: 's3_mount',
+          bucket: 'private',
+          accessKeyId: 'inline-access-key',
+          secretAccessKey: 'inline-secret-key',
+          mountStrategy: new RunloopCloudBucketMountStrategy(),
+        },
+      },
+    }).withInContainerMountCredentialExposureAcknowledged('data');
+
+    await expect(
+      client.create(manifest, {
+        managedSecrets: {
+          AWS_ACCESS_KEY_ID: 'managed-access-key',
+          AWS_SECRET_ACCESS_KEY: 'managed-secret-key',
+        },
+      }),
+    ).rejects.toThrow(/broad credential authority/iu);
+    await expect(
+      client.create(
+        runloopManifest({
+          entries: {
+            data: {
+              type: 'gcs_mount',
+              bucket: 'private',
+              accessToken: 'inline-access-token',
+              mountStrategy: new RunloopCloudBucketMountStrategy(),
+            },
+          },
+        }).withInContainerMountCredentialExposureAcknowledged('data'),
+        {
+          managedSecrets: {
+            GOOGLE_APPLICATION_CREDENTIALS: '/run/secrets/gcp.json',
+          },
+        },
+      ),
+    ).rejects.toThrow(/broad credential authority/iu);
+    await expect(
+      client.create(
+        manifest.withInContainerMountBroadCredentialExposureAcknowledged(
+          'data',
+        ),
+        {
+          managedSecrets: {
+            RCLONE_CONFIG_REMOTE_ACCESS_KEY_ID: 'partial-access-key',
+          },
+        },
+      ),
+    ).rejects.toThrow(/both ACCESS_KEY_ID and SECRET_ACCESS_KEY/iu);
+
+    expect(runloopSdkConstructorMock).not.toHaveBeenCalled();
+    expect(secretCreateMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('rejects partial managed mount credentials before Runloop provider effects', async () => {
     const client = new RunloopSandboxClient();
     const manifest = runloopManifest({
@@ -1020,7 +1079,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
     await expect(
       client.create(manifest, {
@@ -1046,7 +1105,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
     await expect(
       client.create(manifest, {
@@ -1071,7 +1130,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
     await expect(
       client.create(manifest, {
@@ -1096,7 +1155,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const defaultExec = execMock.getMockImplementation()!;
     execMock.mockImplementation(async (command, ...args) => {
       if (
@@ -1145,7 +1204,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('mounted/logs');
     const session = await client.create(manifest, {
       managedSecrets: {
         AWS_ACCESS_KEY_ID: 'managed-access',
@@ -1245,7 +1304,7 @@ describe('RunloopSandboxClient', () => {
             mountStrategy: new RunloopCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('data');
+      }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
       await expect(session.applyManifest(manifest)).rejects.toThrow(
         /cannot be validated before an in-container mount/u,
@@ -1275,7 +1334,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
     await expect(session.applyManifest(manifest)).rejects.toThrow(
       /cannot be validated before an in-container mount/u,
@@ -1304,7 +1363,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
     await expect(session.applyManifest(manifest)).rejects.toThrow(
       /ambient credential authority cannot be verified/u,
@@ -1323,7 +1382,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const state = await client.deserializeSessionState({
       manifest,
       devboxId: 'devbox_test',
@@ -1385,7 +1444,7 @@ describe('RunloopSandboxClient', () => {
             mountStrategy: new RunloopCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('data');
+      }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
       await expect(session.applyManifest(manifest)).rejects.toThrow(
         /ambient credential authority cannot be verified/u,
@@ -1405,7 +1464,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const defaultExec = execMock.getMockImplementation()!;
     execMock.mockImplementation(async (command, ...args) => {
       if (
@@ -1500,7 +1559,7 @@ describe('RunloopSandboxClient', () => {
             mountStrategy: new RunloopCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('data');
+      }).withInContainerMountBroadCredentialExposureAcknowledged('data');
       const client = new RunloopSandboxClient();
       const session = await client.create(manifest, options);
 
@@ -1527,8 +1586,8 @@ describe('RunloopSandboxClient', () => {
     const originalPath = '/home/user/mounted/logs';
     const redirectedPath = '/home/user/redirected/logs';
     const manifest = runloopCloudBucketManifest()
-      .withInContainerMountCredentialExposureAllowed('mounted/logs')
-      .withInContainerMountCredentialExposureAllowed('redirected/logs');
+      .withInContainerMountCredentialExposureAcknowledged('mounted/logs')
+      .withInContainerMountCredentialExposureAcknowledged('redirected/logs');
     const client = new RunloopSandboxClient();
     const session = await client.create(manifest);
     const defaultExec = execMock.getMockImplementation()!;
@@ -1559,7 +1618,7 @@ describe('RunloopSandboxClient', () => {
 
     const trustedWithoutRedirect = runloopManifest({
       entries: structuredClone(session.state.manifest.entries),
-    }).withInContainerMountCredentialExposureAllowed('mounted/logs');
+    }).withInContainerMountCredentialExposureAcknowledged('mounted/logs');
     expect(
       liveMountCredentialAuthorityMatches(
         session.state.manifest,
@@ -1577,7 +1636,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const client = new RunloopSandboxClient();
     const session = await client.create(manifest, {
       managedSecrets: {
@@ -1608,7 +1667,7 @@ describe('RunloopSandboxClient', () => {
           mountStrategy: new RunloopCloudBucketMountStrategy(),
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     const defaultExec = execMock.getMockImplementation()!;
     execMock.mockImplementation(async (command, ...args) => {
       if (
@@ -1633,7 +1692,7 @@ describe('RunloopSandboxClient', () => {
         ...structuredClone(baseManifest.entries),
         'gcp.json': { type: 'file', content: '{"private_key":"secret"}' },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
     execMock.mockClear();
 
     await expect(
@@ -1691,8 +1750,8 @@ describe('RunloopSandboxClient', () => {
       },
     });
     manifest = manifest
-      .withInContainerMountCredentialExposureAllowed('first')
-      .withInContainerMountCredentialExposureAllowed('second');
+      .withInContainerMountCredentialExposureAcknowledged('first')
+      .withInContainerMountCredentialExposureAcknowledged('second');
     const client = new RunloopSandboxClient();
     const session = await client.create(manifest);
     const defaultExec = execMock.getMockImplementation();
@@ -2317,7 +2376,7 @@ describe('RunloopSandboxClient', () => {
           },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('dir/data');
+    }).withInContainerMountCredentialExposureAcknowledged('dir/data');
     const session = await client.create(manifest, { pauseOnExit: true });
     await session.close();
     execMock.mockClear();
@@ -3103,7 +3162,7 @@ describe('RunloopSandboxClient', () => {
             mountStrategy: new RunloopCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
 
     const rootMountCommands = execMock.mock.calls
@@ -3145,7 +3204,7 @@ describe('RunloopSandboxClient', () => {
             mountStrategy: new RunloopCloudBucketMountStrategy(),
           },
         },
-      }).withInContainerMountCredentialExposureAllowed('mounted/logs'),
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
     );
 
     const defaultRootMountCommands = execMock.mock.calls

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -570,7 +570,7 @@ describe('remote sandbox path helpers', () => {
           type: 's3_mount',
           bucket: 'agent-logs',
           mountStrategy: {
-            type: 'test_cloud_bucket',
+            type: 'daytona_cloud_bucket',
             pattern: {
               type: 'rclone',
               remoteName: 'custom',
@@ -579,7 +579,7 @@ describe('remote sandbox path helpers', () => {
           },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
     await expect(
       prepareManifestMounts(manifest, async (path) => `/workspace/${path}`, {
@@ -598,7 +598,7 @@ describe('remote sandbox path helpers', () => {
           type: 's3_mount',
           bucket: 'agent-logs',
           mountStrategy: {
-            type: 'test_cloud_bucket',
+            type: 'daytona_cloud_bucket',
             pattern: {
               type: 'rclone',
               remoteName: 'custom',
@@ -607,7 +607,7 @@ describe('remote sandbox path helpers', () => {
           },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
 
     await expect(
       materializeInlineManifest(
@@ -3788,7 +3788,7 @@ describe('remote sandbox path helpers', () => {
             },
           },
         },
-      }).withInContainerMountCredentialExposureAllowed(
+      }).withInContainerMountCredentialExposureAcknowledged(
         'mounted',
         'mounted/cache',
         'mounted/cache/nested',
@@ -3806,7 +3806,7 @@ describe('remote sandbox path helpers', () => {
             src: sourceFile,
           },
         },
-      }).withInContainerMountCredentialExposureAllowed(
+      }).withInContainerMountCredentialExposureAcknowledged(
         'mounted',
         'mounted/cache',
       ),
@@ -3883,7 +3883,6 @@ describe('remote sandbox path helpers', () => {
       new Manifest({
         entries: {
           child: mount({
-            source: 's3://bucket/child',
             mountPath: 'mounted/cache',
             mountStrategy: { type: 'in_container' },
           }),
@@ -3892,23 +3891,17 @@ describe('remote sandbox path helpers', () => {
             children: {
               'note.txt': file({ content: 'note' }),
               nested: mount({
-                source: 's3://bucket/nested',
                 mountPath: 'mounted/cache/nested',
                 mountStrategy: { type: 'in_container' },
               }),
             },
           },
           parent: mount({
-            source: 's3://bucket/parent',
             mountPath: 'mounted',
             mountStrategy: { type: 'in_container' },
           }),
         },
-      }).withInContainerMountCredentialExposureAllowed(
-        'mounted',
-        'mounted/cache',
-        'mounted/cache/nested',
-      ),
+      }),
       'test',
       async (path) => {
         resolvedPaths.push(path);
@@ -3935,9 +3928,6 @@ describe('remote sandbox path helpers', () => {
       'app',
       'app/note.txt',
       'app/nested',
-      'mounted',
-      'mounted/cache',
-      'mounted/cache/nested',
     ]);
   });
 
@@ -3965,7 +3955,7 @@ describe('remote sandbox path helpers', () => {
           mountStrategy: { type: 'in_container' },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('first', 'second');
+    }).withInContainerMountCredentialExposureAcknowledged('first', 'second');
 
     await expect(
       materializeInlineManifest(
@@ -3996,7 +3986,7 @@ describe('remote sandbox path helpers', () => {
           mountStrategy: { type: 'in_container' },
         },
       },
-    }).withInContainerMountCredentialExposureAllowed('data');
+    }).withInContainerMountCredentialExposureAcknowledged('data');
 
     await expect(
       materializeInlineManifest(
@@ -4042,7 +4032,6 @@ describe('remote sandbox path helpers', () => {
         extraPathGrants: [{ path: dirname(sourceFile), readOnly: true }],
         entries: {
           child: mount({
-            source: 's3://bucket/child',
             mountPath: 'mounted/cache',
             mountStrategy: { type: 'in_container' },
           }),
@@ -4051,15 +4040,11 @@ describe('remote sandbox path helpers', () => {
             src: sourceFile,
           },
           parent: mount({
-            source: 's3://bucket/parent',
             mountPath: 'mounted',
             mountStrategy: { type: 'in_container' },
           }),
         },
-      }).withInContainerMountCredentialExposureAllowed(
-        'mounted',
-        'mounted/cache',
-      ),
+      }),
       'test',
       async (path) => {
         resolvedPaths.push(path);
@@ -4081,8 +4066,6 @@ describe('remote sandbox path helpers', () => {
       'mounted',
       'mounted/cache',
       'copied/source.txt',
-      'mounted',
-      'mounted/cache',
     ]);
   });
 
@@ -4090,12 +4073,7 @@ describe('remote sandbox path helpers', () => {
     const state = {
       manifest: new Manifest({
         root: '/workspace',
-      }).withInContainerMountCredentialExposureAllowed(
-        'project/mounted',
-        'project/mounted/cache',
-        '/remote/project/mounted',
-        '/remote/project/mounted/cache',
-      ),
+      }),
     };
     const operations: string[] = [];
     const resolvedPaths: string[] = [];
@@ -4115,13 +4093,11 @@ describe('remote sandbox path helpers', () => {
         type: 'dir',
         children: {
           child: mount({
-            source: 's3://bucket/child',
             mountPath: 'project/mounted/cache',
             mountStrategy: { type: 'in_container' },
           }),
           'note.txt': file({ content: 'note' }),
           parent: mount({
-            source: 's3://bucket/parent',
             mountPath: 'project/mounted',
             mountStrategy: { type: 'in_container' },
           }),
@@ -4153,8 +4129,6 @@ describe('remote sandbox path helpers', () => {
       'project/child',
       'project/note.txt',
       'project/parent',
-      'project/mounted',
-      'project/mounted/cache',
     ]);
     expect(state.manifest.entries.project).toMatchObject({
       type: 'dir',

--- a/packages/agents-extensions/test/sandbox/sharedSession.test.ts
+++ b/packages/agents-extensions/test/sandbox/sharedSession.test.ts
@@ -281,7 +281,7 @@ describe('shared sandbox session helpers', () => {
         AWS_ACCESS_KEY_ID: 'rotated-key',
         AWS_SECRET_ACCESS_KEY: 'rotated-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     await session.applyManifest(update);
 
@@ -303,7 +303,7 @@ describe('shared sandbox session helpers', () => {
         AWS_ACCESS_KEY_ID: 'trusted-key',
         AWS_SECRET_ACCESS_KEY: 'trusted-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     await session.applyManifest(mounted);
 
     await expect(
@@ -337,7 +337,7 @@ describe('shared sandbox session helpers', () => {
         AWS_ACCESS_KEY_ID: 'trusted-key',
         AWS_SECRET_ACCESS_KEY: 'trusted-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     const applying = session.applyManifest(manifest);
     await vi.waitFor(() => expect(session.beforeApplyCalls).toBe(1));
@@ -371,7 +371,7 @@ describe('shared sandbox session helpers', () => {
         AWS_ACCESS_KEY_ID: 'first-key',
         AWS_SECRET_ACCESS_KEY: 'first-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('first');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('first');
     const second = new Manifest({
       entries: {
         second: s3Mount({
@@ -383,7 +383,7 @@ describe('shared sandbox session helpers', () => {
         AWS_ACCESS_KEY_ID: 'second-key',
         AWS_SECRET_ACCESS_KEY: 'second-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('second');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('second');
 
     const applyingFirst = session.applyManifest(first);
     await vi.waitFor(() =>
@@ -409,7 +409,7 @@ describe('shared sandbox session helpers', () => {
           mountStrategy: { type: 'e2b_cloud_bucket' },
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     await expect(session.applyManifest(manifest)).rejects.toThrow(
       /model-controlled sandbox/u,
@@ -461,7 +461,7 @@ describe('shared sandbox session helpers', () => {
         AWS_ACCESS_KEY_ID: 'old-key',
         AWS_SECRET_ACCESS_KEY: 'old-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     await session.applyManifest(mounted);
 
     await session.applyManifest(
@@ -493,7 +493,7 @@ describe('shared sandbox session helpers', () => {
         AWS_ACCESS_KEY_ID: 'trusted-key',
         AWS_SECRET_ACCESS_KEY: 'trusted-secret',
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     await expect(session.applyManifest(update)).rejects.toThrow('mount failed');
     expect(session.deleteCalls).toBe(1);
@@ -555,7 +555,7 @@ describe('shared sandbox session helpers', () => {
           mountStrategy: { type: 'e2b_cloud_bucket' },
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('remote');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
 
     expect(() =>
       serializeRemoteSandboxSessionState({

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -20,6 +20,7 @@ import {
   liveMountCredentialAuthorityMatches,
   recordLiveMountCredentialAuthority,
   serializeManifestRecord,
+  validateMountCredentialBoundaries,
   withExclusiveSandboxManifestMutation,
 } from '@openai/agents-core/sandbox/internal';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
@@ -345,7 +346,7 @@ describe('VercelSandboxClient', () => {
           mountStrategy: new VercelCloudBucketMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('bucket');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('bucket');
 
     await expect(
       new VercelSandboxClient({
@@ -384,7 +385,7 @@ describe('VercelSandboxClient', () => {
           mountStrategy: new VercelCloudBucketMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('bucket');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('bucket');
     const session = await new VercelSandboxClient({
       env: { AWS_WEB_IDENTITY_TOKEN_FILE: credentialPath },
     }).create(manifest);
@@ -449,7 +450,7 @@ describe('VercelSandboxClient', () => {
           mountStrategy: new VercelCloudBucketMountStrategy(),
         }),
       },
-    }).withInContainerMountCredentialExposureAllowed('bucket');
+    }).withInContainerMountBroadCredentialExposureAcknowledged('bucket');
 
     await expect(
       new VercelSandboxClient({
@@ -467,14 +468,13 @@ describe('VercelSandboxClient', () => {
 
   test('mounts a fixed S3 manifest without persisting its credentials', async () => {
     const client = new VercelSandboxClient();
-    const session = await client.create(
-      vercelS3Manifest('bucket', {
-        accessKeyId: 'access-key',
-        secretAccessKey: 'secret-key',
-        sessionToken: 'session-token',
-        region: 'us-east-1',
-      }).withInContainerMountCredentialExposureAllowed('bucket'),
-    );
+    const trustedManifest = vercelS3Manifest('bucket', {
+      accessKeyId: 'access-key',
+      secretAccessKey: 'secret-key',
+      sessionToken: 'session-token',
+      region: 'us-east-1',
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
+    const session = await client.create(trustedManifest);
 
     const mountCall = runCommandMock.mock.calls.find(([params]) => {
       return isolatedMountCommand(params)?.command === 'mount-s3';
@@ -512,6 +512,84 @@ describe('VercelSandboxClient', () => {
     expect(JSON.stringify(serialized)).not.toContain('access-key');
     expect(JSON.stringify(serialized)).not.toContain('secret-key');
     expect(JSON.stringify(serialized)).not.toContain('session-token');
+    expect(
+      liveMountCredentialAuthorityMatches(
+        session.state.manifest,
+        client.resolveTrustedManifestForResume(trustedManifest),
+      ),
+    ).toBe(true);
+    expect(
+      liveMountCredentialAuthorityMatches(
+        session.state.manifest,
+        client.resolveTrustedManifestForResume(
+          vercelS3Manifest('bucket', {
+            accessKeyId: 'rotated-access-key',
+            secretAccessKey: 'rotated-secret-key',
+            sessionToken: 'rotated-session-token',
+            region: 'us-east-1',
+          }).withInContainerMountCredentialExposureAcknowledged('bucket'),
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  test('preserves the released Vercel option for explicit S3 mount credentials', async () => {
+    const client = new VercelSandboxClient({
+      allowS3CredentialExposure: true,
+    });
+
+    await client.create(
+      vercelS3Manifest('bucket', {
+        accessKeyId: 'released-access-key',
+        secretAccessKey: 'released-secret-key',
+      }),
+    );
+
+    const mountCall = runCommandMock.mock.calls.find(([params]) => {
+      return isolatedMountCommand(params)?.command === 'mount-s3';
+    });
+    expect(mountCall?.[0].args).toEqual(
+      expect.arrayContaining([
+        'AWS_ACCESS_KEY_ID=released-access-key',
+        'AWS_SECRET_ACCESS_KEY=released-secret-key',
+      ]),
+    );
+  });
+
+  test('uses the per-call released Vercel option for trusted resume manifests', () => {
+    const client = new VercelSandboxClient();
+    const manifest = vercelS3Manifest('bucket', {
+      accessKeyId: 'released-access-key',
+      secretAccessKey: 'released-secret-key',
+    });
+
+    expect(() =>
+      validateMountCredentialBoundaries(
+        client.resolveTrustedManifestForResume(manifest, {
+          allowS3CredentialExposure: true,
+        }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      validateMountCredentialBoundaries(
+        client.resolveTrustedManifestForResume(manifest),
+      ),
+    ).toThrow(/Mount-scoped credentials/u);
+  });
+
+  test('does not let the released Vercel option authorize ambient credentials', async () => {
+    const client = new VercelSandboxClient({
+      allowS3CredentialExposure: true,
+      env: {
+        AWS_ACCESS_KEY_ID: 'ambient-access-key',
+        AWS_SECRET_ACCESS_KEY: 'ambient-secret-key',
+      },
+    });
+
+    await expect(client.create(vercelS3Manifest())).rejects.toThrow(
+      /Broad credential authority/u,
+    );
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   test('retains an owned mount entry when the caller mutates its manifest', async () => {
@@ -574,7 +652,7 @@ describe('VercelSandboxClient', () => {
     });
 
     const trustedManifest =
-      vercelS3Manifest().withInContainerMountCredentialExposureAllowed(
+      vercelS3Manifest().withInContainerMountBroadCredentialExposureAcknowledged(
         'bucket',
       );
     const session = await client.create(trustedManifest);
@@ -629,7 +707,7 @@ describe('VercelSandboxClient', () => {
           AWS_REGION: 'us-east-1',
           UNRELATED_ENV: 'keep-me',
         },
-      }).withInContainerMountCredentialExposureAllowed('bucket'),
+      }).withInContainerMountBroadCredentialExposureAcknowledged('bucket'),
     );
 
     const providerState = await client.serializeSessionState(session.state);
@@ -653,6 +731,102 @@ describe('VercelSandboxClient', () => {
     });
   });
 
+  test('does not persist broad AWS authority from client options with inline keys', async () => {
+    const client = new VercelSandboxClient({
+      env: {
+        AWS_ACCESS_KEY_ID: 'shadowed-access-key',
+        AWS_SECRET_ACCESS_KEY: 'shadowed-secret-key',
+        AWS_SESSION_TOKEN: 'shadowed-session-token',
+        AWS_CONTAINER_CREDENTIALS_FULL_URI:
+          'http://169.254.170.2/v2/credentials',
+        AWS_CONTAINER_AUTHORIZATION_TOKEN: 'options-token-sentinel',
+        UNRELATED_ENV: 'keep-me',
+      },
+    });
+    const trustedManifest = vercelS3Manifest('bucket', {
+      accessKeyId: 'inline-access-key',
+      secretAccessKey: 'inline-secret-key',
+    })
+      .withInContainerMountCredentialExposureAcknowledged('bucket')
+      .withInContainerMountBroadCredentialExposureAcknowledged('bucket');
+    const session = await client.create(trustedManifest);
+
+    const serialized = await client.serializeSessionState(session.state);
+
+    expect(serialized.environment).toEqual({ UNRELATED_ENV: 'keep-me' });
+    expect(JSON.stringify(serialized)).not.toContain('shadowed-access-key');
+    expect(JSON.stringify(serialized)).not.toContain('shadowed-secret-key');
+    expect(JSON.stringify(serialized)).not.toContain('shadowed-session-token');
+    expect(JSON.stringify(serialized)).not.toContain('options-token-sentinel');
+    expect(session.state.environment).toMatchObject({
+      AWS_ACCESS_KEY_ID: 'shadowed-access-key',
+      AWS_SECRET_ACCESS_KEY: 'shadowed-secret-key',
+      AWS_SESSION_TOKEN: 'shadowed-session-token',
+      AWS_CONTAINER_AUTHORIZATION_TOKEN: 'options-token-sentinel',
+    });
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        trustedManifest,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        trustedManifest,
+        clientOptions: {
+          env: {
+            AWS_CONTAINER_CREDENTIALS_FULL_URI:
+              'http://169.254.170.2/v2/credentials',
+            AWS_CONTAINER_AUTHORIZATION_TOKEN: 'rotated-token-sentinel',
+            UNRELATED_ENV: 'keep-me',
+          },
+        },
+      }),
+    ).resolves.toBe(false);
+  });
+
+  test('does not persist broad AWS authority from Manifest.environment', async () => {
+    const client = new VercelSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          bucket: s3Mount({
+            bucket: 'example-bucket',
+            accessKeyId: 'inline-access-key',
+            secretAccessKey: 'inline-secret-key',
+            mountStrategy: new VercelCloudBucketMountStrategy(),
+          }),
+        },
+        environment: {
+          AWS_PROFILE: 'manifest-profile-sentinel',
+          AWS_SHARED_CREDENTIALS_FILE:
+            '/run/secrets/manifest-credentials-sentinel',
+          AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE:
+            '/run/secrets/manifest-token-file-sentinel',
+          UNRELATED_ENV: 'keep-me',
+        },
+      })
+        .withInContainerMountCredentialExposureAcknowledged('bucket')
+        .withInContainerMountBroadCredentialExposureAcknowledged('bucket'),
+    );
+
+    const serialized = await client.serializeSessionState(session.state);
+    const envelopeManifest = serializeManifestRecord(session.state.manifest);
+    const serializedJson = JSON.stringify({ envelopeManifest, serialized });
+
+    expect(serializedJson).not.toContain('manifest-profile-sentinel');
+    expect(serializedJson).not.toContain('manifest-credentials-sentinel');
+    expect(serializedJson).not.toContain('manifest-token-file-sentinel');
+    expect(envelopeManifest.environment).toMatchObject({
+      UNRELATED_ENV: { value: 'keep-me' },
+    });
+    expect(session.state.environment).toMatchObject({
+      AWS_PROFILE: 'manifest-profile-sentinel',
+      AWS_SHARED_CREDENTIALS_FILE: '/run/secrets/manifest-credentials-sentinel',
+      AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE:
+        '/run/secrets/manifest-token-file-sentinel',
+    });
+  });
+
   test('does not combine inline static keys with an inherited session token', async () => {
     const client = new VercelSandboxClient({
       env: {
@@ -666,7 +840,7 @@ describe('VercelSandboxClient', () => {
       vercelS3Manifest('bucket', {
         accessKeyId: 'inline-access-key',
         secretAccessKey: 'inline-secret-key',
-      }).withInContainerMountCredentialExposureAllowed('bucket'),
+      }).withInContainerMountCredentialExposureAcknowledged('bucket'),
     );
 
     const mountCall = runCommandMock.mock.calls.find(([params]) => {
@@ -680,6 +854,45 @@ describe('VercelSandboxClient', () => {
     );
     expect(mountCall?.[0].args).not.toContain(
       'AWS_SESSION_TOKEN=environment-session-token',
+    );
+  });
+
+  test('requires broad acknowledgement for workload identity with inline keys', async () => {
+    const client = new VercelSandboxClient({
+      env: {
+        AWS_ROLE_ARN: 'arn:aws:iam::123456789012:role/sandbox',
+        AWS_WEB_IDENTITY_TOKEN_FILE: '/var/run/secrets/aws/token',
+        UNRELATED_SECRET: 'do-not-forward',
+      },
+    });
+    const narrowManifest = vercelS3Manifest('bucket', {
+      accessKeyId: 'inline-access-key',
+      secretAccessKey: 'inline-secret-key',
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
+
+    await expect(client.create(narrowManifest)).rejects.toThrow(
+      /Broad credential authority/u,
+    );
+    expect(createMock).not.toHaveBeenCalled();
+
+    await client.create(
+      narrowManifest.withInContainerMountBroadCredentialExposureAcknowledged(
+        'bucket',
+      ),
+    );
+    const mountCall = runCommandMock.mock.calls.find(([params]) => {
+      return isolatedMountCommand(params)?.command === 'mount-s3';
+    });
+    expect(mountCall?.[0].args).toEqual(
+      expect.arrayContaining([
+        'AWS_ACCESS_KEY_ID=inline-access-key',
+        'AWS_SECRET_ACCESS_KEY=inline-secret-key',
+        'AWS_ROLE_ARN=arn:aws:iam::123456789012:role/sandbox',
+        'AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/aws/token',
+      ]),
+    );
+    expect(mountCall?.[0].args).not.toContain(
+      'UNRELATED_SECRET=do-not-forward',
     );
   });
 
@@ -697,7 +910,7 @@ describe('VercelSandboxClient', () => {
         accessKeyId: 'inline-access-key',
         secretAccessKey: 'inline-secret-key',
         sessionToken: 'inline-session-token',
-      }).withInContainerMountCredentialExposureAllowed('bucket'),
+      }).withInContainerMountCredentialExposureAcknowledged('bucket'),
     );
 
     const mountCall = runCommandMock.mock.calls.find(([params]) => {
@@ -963,7 +1176,7 @@ describe('VercelSandboxClient', () => {
 
   test('rejects direct initial materialization after mount environment authority changes', async () => {
     const trustedManifest =
-      vercelS3Manifest().withInContainerMountCredentialExposureAllowed(
+      vercelS3Manifest().withInContainerMountBroadCredentialExposureAcknowledged(
         'bucket',
       );
     const client = new VercelSandboxClient({
@@ -981,7 +1194,7 @@ describe('VercelSandboxClient', () => {
         new Manifest({
           root: session.state.manifest.root,
           entries: trustedManifest.entries,
-        }).withInContainerMountCredentialExposureAllowed('bucket'),
+        }).withInContainerMountBroadCredentialExposureAcknowledged('bucket'),
       ),
     ).rejects.toThrow(
       /environment authority does not match the active session/u,
@@ -1008,8 +1221,8 @@ describe('VercelSandboxClient', () => {
       },
     });
     trustedManifest = trustedManifest
-      .withInContainerMountCredentialExposureAllowed('first')
-      .withInContainerMountCredentialExposureAllowed('second');
+      .withInContainerMountCredentialExposureAcknowledged('first')
+      .withInContainerMountCredentialExposureAcknowledged('second');
     const liveManifest = new Manifest({
       root: session.state.manifest.root,
       entries: structuredClone(trustedManifest.entries),
@@ -1089,6 +1302,56 @@ describe('VercelSandboxClient', () => {
       commandNames.indexOf('tar'),
     );
     expect(snapshotMock).not.toHaveBeenCalled();
+  });
+
+  test('captures the routing snapshot passed to a pending remount', async () => {
+    const archive = makeTarArchive([
+      { name: 'README.md', content: 'persisted' },
+    ]);
+    readFileToBufferMock.mockResolvedValue(archive);
+    const trustedManifest = vercelS3Manifest('bucket', {
+      accessKeyId: 'inline-access-key',
+      secretAccessKey: 'inline-secret-key',
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
+    const client = new VercelSandboxClient({
+      env: { AWS_REGION: 'us-east-1' },
+    });
+    const session = await client.create(trustedManifest);
+    const remountStarted = deferred();
+    const releaseRemount = deferred();
+    let remountCall: MockRunCommandParams | undefined;
+    runCommandMock.mockImplementation(
+      async (params: MockRunCommandParams = {}) => {
+        if (
+          remountCall === undefined &&
+          isolatedMountCommand(params)?.command === 'mount-s3'
+        ) {
+          remountCall = params;
+          remountStarted.resolve();
+          await releaseRemount.promise;
+        }
+        return await defaultRunCommand(params);
+      },
+    );
+
+    const persistence = session.persistWorkspace();
+    await remountStarted.promise;
+    session.state.environment.AWS_REGION = 'us-west-2';
+    releaseRemount.resolve();
+    await expect(persistence).resolves.toEqual(archive);
+
+    expect(remountCall?.args).toContain('AWS_REGION=us-east-1');
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        trustedManifest,
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        trustedManifest,
+        clientOptions: { env: { AWS_REGION: 'us-west-2' } },
+      }),
+    ).resolves.toBe(false);
   });
 
   test('serializes mount-detaching persistence and session I/O', async () => {
@@ -3240,15 +3503,17 @@ describe('VercelSandboxClient', () => {
   });
 
   test('revalidates AWS mount environment before live reuse', async () => {
-    const trustedManifest =
-      vercelS3Manifest().withInContainerMountCredentialExposureAllowed(
-        'bucket',
-      );
+    const trustedManifest = vercelS3Manifest('bucket', {
+      accessKeyId: 'inline-access-key',
+      secretAccessKey: 'inline-secret-key',
+    })
+      .withInContainerMountCredentialExposureAcknowledged('bucket')
+      .withInContainerMountBroadCredentialExposureAcknowledged('bucket');
     const client = new VercelSandboxClient({
       env: {
-        AWS_ACCESS_KEY_ID: 'old-access-key',
-        AWS_SECRET_ACCESS_KEY: 'old-secret-key',
-        AWS_WEB_IDENTITY_TOKEN_FILE: '/var/run/secrets/aws/old-token',
+        AWS_CONTAINER_CREDENTIALS_FULL_URI:
+          'http://169.254.170.2/v2/credentials',
+        AWS_CONTAINER_AUTHORIZATION_TOKEN: 'old-authorization-token',
       },
     });
     const session = await client.create(trustedManifest, {
@@ -3265,9 +3530,9 @@ describe('VercelSandboxClient', () => {
         trustedManifest,
         clientOptions: {
           env: {
-            AWS_ACCESS_KEY_ID: 'new-access-key',
-            AWS_SECRET_ACCESS_KEY: 'new-secret-key',
-            AWS_WEB_IDENTITY_TOKEN_FILE: '/var/run/secrets/aws/new-token',
+            AWS_CONTAINER_CREDENTIALS_FULL_URI:
+              'http://169.254.170.2/v2/credentials',
+            AWS_CONTAINER_AUTHORIZATION_TOKEN: 'new-authorization-token',
           },
         },
       }),
@@ -3286,11 +3551,78 @@ describe('VercelSandboxClient', () => {
     ).resolves.toBe(false);
   });
 
+  test('revalidates AWS mount routing after session serialization', async () => {
+    const trustedManifest = vercelS3Manifest('bucket', {
+      accessKeyId: 'inline-access-key',
+      secretAccessKey: 'inline-secret-key',
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
+    const initialEnvironment = {
+      AWS_REGION: 'us-east-1',
+      AWS_DEFAULT_REGION: 'us-east-1',
+    };
+    const client = new VercelSandboxClient({ env: initialEnvironment });
+    const session = await client.create(trustedManifest, {
+      workspacePersistence: 'snapshot',
+    });
+
+    const serialized = await client.serializeSessionState(session.state);
+
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        trustedManifest,
+      }),
+    ).resolves.toBe(true);
+    const rotatedCredentials = vercelS3Manifest('bucket', {
+      accessKeyId: 'rotated-access-key',
+      secretAccessKey: 'rotated-secret-key',
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        trustedManifest: rotatedCredentials,
+      }),
+    ).resolves.toBe(false);
+    for (const name of ['AWS_REGION', 'AWS_DEFAULT_REGION'] as const) {
+      await expect(
+        client.canReusePreservedOwnedSession(session.state, {
+          trustedManifest,
+          clientOptions: {
+            env: { ...initialEnvironment, [name]: 'us-west-2' },
+          },
+        }),
+      ).resolves.toBe(false);
+      session.state.environment[name] = 'us-west-2';
+      const publicState = session.state as unknown as Record<
+        PropertyKey,
+        unknown
+      >;
+      for (const symbol of Object.getOwnPropertySymbols(publicState)) {
+        const value = publicState[symbol];
+        if (value instanceof Map) {
+          value.clear();
+          value.set('/vercel/sandbox/bucket', {
+            ...initialEnvironment,
+            [name]: 'us-west-2',
+          });
+        }
+      }
+      await expect(
+        client.canReusePreservedOwnedSession(session.state, {
+          trustedManifest,
+          clientOptions: {
+            env: { ...initialEnvironment, [name]: 'us-west-2' },
+          },
+        }),
+      ).resolves.toBe(false);
+      session.state.environment[name] = initialEnvironment[name];
+    }
+    expect(Object.getOwnPropertySymbols(serialized)).toEqual([]);
+  });
+
   test('preserves an unchanged mounted session through Runner interruption', async () => {
     const trustedManifest = vercelS3Manifest(
       'bucket',
       {},
-    ).withInContainerMountCredentialExposureAllowed('bucket');
+    ).withInContainerMountCredentialExposureAcknowledged('bucket');
     const approvalTool = tool({
       name: 'needs_approval',
       description: 'requires approval',
@@ -3367,7 +3699,7 @@ describe('VercelSandboxClient', () => {
     const original = vercelS3Manifest('bucket', {
       accessKeyId: 'old-access-key',
       secretAccessKey: 'old-secret-key',
-    }).withInContainerMountCredentialExposureAllowed('bucket');
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
     const session = await client.create(original, {
       workspacePersistence: 'snapshot',
     });
@@ -3375,7 +3707,7 @@ describe('VercelSandboxClient', () => {
     const same = vercelS3Manifest('bucket', {
       accessKeyId: 'old-access-key',
       secretAccessKey: 'old-secret-key',
-    }).withInContainerMountCredentialExposureAllowed('bucket');
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
     expect(
       liveMountCredentialAuthorityMatches(
         session.state.manifest,
@@ -3393,7 +3725,7 @@ describe('VercelSandboxClient', () => {
     const rotated = vercelS3Manifest('bucket', {
       accessKeyId: 'new-access-key',
       secretAccessKey: 'new-secret-key',
-    }).withInContainerMountCredentialExposureAllowed('bucket');
+    }).withInContainerMountCredentialExposureAcknowledged('bucket');
     expect(
       liveMountCredentialAuthorityMatches(
         session.state.manifest,


### PR DESCRIPTION
This pull request follows up on the unreleased in-container mount credential support introduced in #1602. Before v0.15.0, it replaces the generic credential-exposure acknowledgement with a narrower contract: exposure is allowed only when both the exact effective path is acknowledged and the strategy, provider, mount type, and credential pattern form an SDK-owned capability.

- Rejects unknown and custom strategies before provider or filesystem side effects, even when the requested path is acknowledged.
- Separates explicit mount-scoped credentials from ambient credentials, workload or managed identity, external credential files, and full-environment rclone helpers, which require a distinct broad-exposure acknowledgement.
- Requires broad acknowledgement for ambient AWS credentials passed to privileged rclone helpers, even when inline mount credentials shadow them for authentication.
- Preserves credentialless and provider-native alternatives, released v0.14.3 behavior, credential stripping during serialization, trusted configuration rebinding, and fresh sandbox creation for persisted in-container mounts.
- Adds regression coverage for supported credentialed mounts, unsupported strategies, broad credential authority, provider execution, serialization and resume, and live-session reuse.
- Also fixes a Unix-local PTY completion race that could drop final process output observed after process exit.

Documentation and the support matrix are intentionally excluded from this change and will be handled separately before v0.15.0.
