### PR TITLE
feat(retry): allow applications to approve unsafe replays

### DIFF
--- a/.changeset/approve-unsafe-replays.md
+++ b/.changeset/approve-unsafe-replays.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+feat: allow applications to explicitly approve unsafe model request replays

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -128,6 +128,14 @@ export type RetryDecision =
        * Optional explanation for logging or debugging.
        */
       reason?: string;
+
+      /**
+       * Explicit application approval to repeat provider-side work that may
+       * already have happened. This only applies when the provider marks a
+       * non-streaming replay as unsafe; ordinary retry decisions never bypass
+       * replay protection.
+       */
+      approveUnsafeReplay?: boolean;
     };
 
 export type ModelRetryNormalizedError = {
@@ -181,6 +189,11 @@ export type ModelRetryAdvice = {
   replaySafety?: 'unsafe' | 'safe';
 
   /**
+   * Whether the provider had begun emitting the response when the failure occurred.
+   */
+  responseStarted?: boolean;
+
+  /**
    * Provider-supplied normalized facts that should override generic extraction when present.
    */
   normalized?: Partial<ModelRetryNormalizedError>;
@@ -216,6 +229,38 @@ export type RetryPolicyContext = {
    * Generic normalized facts extracted from the error and provider advice.
    */
   normalized: ModelRetryNormalizedError;
+
+  /**
+   * The previous response identifier carried by the failed request, when present.
+   */
+  readonly previousResponseId?: string;
+
+  /**
+   * The conversation identifier carried by the failed request, when present.
+   */
+  readonly conversationId?: string;
+
+  /**
+   * Stable provider replay classification captured before the policy runs.
+   * The runner always supplies this field; it is optional for compatibility
+   * with code that constructs policy contexts directly.
+   */
+  readonly replaySafety?: 'safe' | 'unsafe' | 'unknown';
+
+  /**
+   * Stable response-start evidence captured before the policy runs.
+   * The runner preserves `undefined` when the provider supplies no evidence.
+   * The field is optional for compatibility with code that constructs policy
+   * contexts directly.
+   */
+  readonly responseStarted?: boolean;
+
+  /**
+   * Whether the failed request carried a previous response or conversation identifier.
+   * The runner always supplies this field; it is optional for compatibility
+   * with code that constructs policy contexts directly.
+   */
+  readonly statefulRequest?: boolean;
 };
 
 export type RetryPolicy = (

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -24,15 +24,29 @@ type ResolvedRetryDecision = {
   retry: boolean;
   delayMs?: number;
   reason?: string;
+  approveUnsafeReplay?: boolean;
 };
 
-// Marks internal veto decisions that should stop retryPolicies.any() immediately.
+// Marks internal veto and approval decisions without widening the public API.
 const hardVetoSymbol = Symbol('hardRetryVeto');
+const delegableReplayVetoSymbol = Symbol('delegableReplayVeto');
 const replaySafeApprovalSymbol = Symbol('replaySafeApproval');
+const providerRetryAuthoritySymbol = Symbol('providerRetryAuthority');
+
+type ProviderRetryAuthority = Readonly<{
+  suggested?: boolean;
+  replaySafety: 'safe' | 'unsafe' | 'unknown';
+  responseStarted?: boolean;
+}>;
 
 type InternalRetryDecision = ResolvedRetryDecision & {
   [hardVetoSymbol]?: true;
+  [delegableReplayVetoSymbol]?: true;
   [replaySafeApprovalSymbol]?: true;
+};
+
+type InternalRetryPolicyContext = RetryPolicyContext & {
+  [providerRetryAuthoritySymbol]?: ProviderRetryAuthority;
 };
 
 type EvaluateRetryParams = {
@@ -43,7 +57,7 @@ type EvaluateRetryParams = {
   retryBackoff?: ModelRetryBackoffSettings;
   signal?: AbortSignal;
   stream: boolean;
-  replayUnsafeRequest: boolean;
+  request: ModelRequest;
   emittedVisibleEvent: boolean;
   emittedRawModelEvent: boolean;
   providerAdvice?: ModelRetryAdvice;
@@ -335,10 +349,71 @@ function normalizeRetryError(
     normalized.retryAfterMs = providerAdvice.retryAfterMs;
   }
 
+  const providerNormalized = providerAdvice?.normalized;
   return {
     ...normalized,
-    ...(providerAdvice?.normalized ?? {}),
+    ...(providerNormalized ?? {}),
+    // Provider normalization may add abort evidence but cannot clear evidence
+    // inferred from the signal or raw exception.
+    isAbort: normalized.isAbort || providerNormalized?.isAbort === true,
   };
+}
+
+function createProviderRetryAuthority(
+  providerAdvice: ModelRetryAdvice | undefined,
+): ProviderRetryAuthority {
+  const replaySafety = providerAdvice?.replaySafety;
+  return Object.freeze({
+    suggested: providerAdvice?.suggested,
+    replaySafety:
+      replaySafety === 'safe' || replaySafety === 'unsafe'
+        ? replaySafety
+        : 'unknown',
+    responseStarted: providerAdvice?.responseStarted,
+  });
+}
+
+function withProviderRetryAuthority(
+  context: RetryPolicyContext,
+  authority = createProviderRetryAuthority(context.providerAdvice),
+): InternalRetryPolicyContext {
+  const existing = (context as InternalRetryPolicyContext)[
+    providerRetryAuthoritySymbol
+  ];
+  if (existing) {
+    return context as InternalRetryPolicyContext;
+  }
+
+  const internalContext = { ...context } as InternalRetryPolicyContext;
+  Object.defineProperties(internalContext, {
+    replaySafety: {
+      value: authority.replaySafety,
+      enumerable: true,
+    },
+    responseStarted: {
+      value: authority.responseStarted,
+      enumerable: true,
+    },
+    statefulRequest: {
+      value:
+        context.statefulRequest ??
+        Boolean(context.previousResponseId || context.conversationId),
+      enumerable: true,
+    },
+    [providerRetryAuthoritySymbol]: {
+      value: authority,
+    },
+  });
+  return internalContext;
+}
+
+function getProviderRetryAuthority(
+  context: RetryPolicyContext,
+): ProviderRetryAuthority {
+  return (
+    (context as InternalRetryPolicyContext)[providerRetryAuthoritySymbol] ??
+    createProviderRetryAuthority(context.providerAdvice)
+  );
 }
 
 function resolveRetryDecision(decision: RetryDecision): ResolvedRetryDecision {
@@ -365,6 +440,18 @@ function withHardVeto(decision: ResolvedRetryDecision): InternalRetryDecision {
   return markInternalDecision(decision, hardVetoSymbol);
 }
 
+function withDelegableReplayVeto(
+  decision: ResolvedRetryDecision,
+): InternalRetryDecision {
+  const marked = withHardVeto(decision);
+  Object.defineProperty(marked, delegableReplayVetoSymbol, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+  return marked;
+}
+
 function withReplaySafeApproval(
   decision: ResolvedRetryDecision,
 ): InternalRetryDecision {
@@ -382,6 +469,16 @@ function isHardVeto(
   );
 }
 
+function isDelegableReplayVeto(
+  decision: ResolvedRetryDecision,
+): decision is InternalRetryDecision {
+  return (
+    isHardVeto(decision) &&
+    delegableReplayVetoSymbol in decision &&
+    decision[delegableReplayVetoSymbol] === true
+  );
+}
+
 function isReplaySafeApproval(
   decision: ResolvedRetryDecision,
 ): decision is InternalRetryDecision {
@@ -391,6 +488,42 @@ function isReplaySafeApproval(
     replaySafeApprovalSymbol in decision &&
     decision[replaySafeApprovalSymbol] === true
   );
+}
+
+function withUnsafeReplayApproval(
+  decision: ResolvedRetryDecision,
+  approveUnsafeReplay: boolean,
+): ResolvedRetryDecision {
+  if (!approveUnsafeReplay || decision.approveUnsafeReplay) {
+    return decision;
+  }
+
+  const approved = {
+    ...decision,
+    approveUnsafeReplay: true,
+  };
+  return isReplaySafeApproval(decision)
+    ? withReplaySafeApproval(approved)
+    : approved;
+}
+
+function resolveDelegableReplayVeto(
+  veto: ResolvedRetryDecision,
+  approving: ResolvedRetryDecision,
+): ResolvedRetryDecision {
+  if (!approving.retry || !approving.approveUnsafeReplay) {
+    return veto;
+  }
+
+  const resolved: ResolvedRetryDecision = {
+    retry: true,
+    delayMs: approving.delayMs,
+    reason: approving.reason ?? veto.reason,
+    approveUnsafeReplay: true,
+  };
+  return isReplaySafeApproval(approving)
+    ? withReplaySafeApproval(resolved)
+    : resolved;
 }
 
 function getDefaultDelayMs(
@@ -476,10 +609,6 @@ async function getRetryAdvice(
   return await getModelRetryAdvice.call(model, args);
 }
 
-function isStatefulConversationRequest(request: ModelRequest): boolean {
-  return Boolean(request.conversationId || request.previousResponseId);
-}
-
 async function evaluateRetry({
   error,
   attempt,
@@ -488,7 +617,7 @@ async function evaluateRetry({
   retryBackoff,
   signal,
   stream,
-  replayUnsafeRequest,
+  request,
   emittedVisibleEvent,
   emittedRawModelEvent,
   providerAdvice,
@@ -498,11 +627,28 @@ async function evaluateRetry({
   }
 
   const normalized = normalizeRetryError(error, signal, providerAdvice);
+  const authority = createProviderRetryAuthority(providerAdvice);
+  const context = withProviderRetryAuthority(
+    {
+      error,
+      attempt,
+      maxRetries,
+      stream,
+      providerAdvice,
+      normalized,
+      previousResponseId: request.previousResponseId,
+      conversationId: request.conversationId,
+    },
+    authority,
+  );
+
+  // Aborts and emitted stream events are absolute vetoes. Provider-unsafe
+  // streaming failures also remain blocked before application policy runs.
   if (
     normalized.isAbort ||
     emittedVisibleEvent ||
     emittedRawModelEvent ||
-    providerAdvice?.replaySafety === 'unsafe'
+    (stream && authority.replaySafety === 'unsafe')
   ) {
     return {
       retry: false,
@@ -514,19 +660,31 @@ async function evaluateRetry({
     return { retry: false };
   }
 
-  const context: RetryPolicyContext = {
-    error,
-    attempt,
-    maxRetries,
-    stream,
-    providerAdvice,
-    normalized,
-  };
   const decision = resolveRetryDecision(await retryPolicy(context));
   if (!decision.retry) {
     return decision;
   }
-  if (replayUnsafeRequest && !isReplaySafeApproval(decision)) {
+
+  const statefulRequest = context.statefulRequest === true;
+  const providerMarksReplaySafe = authority.replaySafety === 'safe';
+  const providerMarksReplayUnsafe = authority.replaySafety === 'unsafe';
+  if (
+    statefulRequest &&
+    !(
+      isReplaySafeApproval(decision) ||
+      providerMarksReplaySafe ||
+      (decision.approveUnsafeReplay && providerMarksReplayUnsafe)
+    )
+  ) {
+    return {
+      retry: false,
+      reason: decision.reason ?? providerAdvice?.reason,
+    };
+  }
+  if (
+    providerMarksReplayUnsafe &&
+    !(isReplaySafeApproval(decision) || decision.approveUnsafeReplay)
+  ) {
     return {
       retry: false,
       reason: decision.reason ?? providerAdvice?.reason,
@@ -540,6 +698,7 @@ async function evaluateRetry({
       normalized.retryAfterMs ??
       getDefaultDelayMs(attempt, retryBackoff),
     reason: decision.reason ?? providerAdvice?.reason,
+    approveUnsafeReplay: decision.approveUnsafeReplay,
   };
 }
 
@@ -549,22 +708,28 @@ export const retryPolicies = {
   },
 
   providerSuggested(): RetryPolicy {
-    return ({ providerAdvice, normalized }) => {
-      if (providerAdvice?.suggested === false) {
-        return withHardVeto({
+    return (inputContext) => {
+      const context = withProviderRetryAuthority(inputContext);
+      const authority = getProviderRetryAuthority(context);
+      const { providerAdvice, normalized } = context;
+      if (authority.suggested === false) {
+        const veto = {
           retry: false,
-          reason: providerAdvice.reason,
-        });
+          reason: providerAdvice?.reason,
+        };
+        return authority.replaySafety === 'unsafe'
+          ? withDelegableReplayVeto(veto)
+          : withHardVeto(veto);
       }
-      if (!providerAdvice?.suggested) {
+      if (authority.suggested !== true) {
         return false;
       }
       const decision = {
         retry: true,
-        delayMs: providerAdvice.retryAfterMs ?? normalized.retryAfterMs,
-        reason: providerAdvice.reason,
+        delayMs: providerAdvice?.retryAfterMs ?? normalized.retryAfterMs,
+        reason: providerAdvice?.reason,
       };
-      return providerAdvice.replaySafety === 'safe'
+      return authority.replaySafety === 'safe'
         ? withReplaySafeApproval(decision)
         : decision;
     };
@@ -593,17 +758,27 @@ export const retryPolicies = {
   },
 
   any(...policies: RetryPolicy[]): RetryPolicy {
-    return async (context) => {
+    return async (inputContext) => {
+      const context = withProviderRetryAuthority(inputContext);
       let firstRetryDecision: ResolvedRetryDecision | undefined;
       let lastObjectDecision: ResolvedRetryDecision | undefined;
+      let delegableReplayVeto: ResolvedRetryDecision | undefined;
 
       for (const policy of policies) {
         const rawDecision = await policy(context);
         const decision = resolveRetryDecision(rawDecision);
         if (isHardVeto(decision)) {
+          if (isDelegableReplayVeto(decision)) {
+            delegableReplayVeto ??= decision;
+            continue;
+          }
           return decision;
         }
         if (decision.retry) {
+          const approveUnsafeReplay = Boolean(
+            firstRetryDecision?.approveUnsafeReplay ||
+            decision.approveUnsafeReplay,
+          );
           if (
             firstRetryDecision === undefined ||
             (isReplaySafeApproval(decision) &&
@@ -611,11 +786,20 @@ export const retryPolicies = {
           ) {
             firstRetryDecision = decision;
           }
+          firstRetryDecision = withUnsafeReplayApproval(
+            firstRetryDecision,
+            approveUnsafeReplay,
+          );
           continue;
         }
         if (typeof rawDecision !== 'boolean') {
           lastObjectDecision = decision;
         }
+      }
+      if (delegableReplayVeto) {
+        return firstRetryDecision
+          ? resolveDelegableReplayVeto(delegableReplayVeto, firstRetryDecision)
+          : delegableReplayVeto;
       }
       if (firstRetryDecision) {
         return firstRetryDecision;
@@ -625,15 +809,21 @@ export const retryPolicies = {
   },
 
   all(...policies: RetryPolicy[]): RetryPolicy {
-    return async (context) => {
+    return async (inputContext) => {
+      const context = withProviderRetryAuthority(inputContext);
       if (policies.length === 0) {
         return false;
       }
 
       let merged: ResolvedRetryDecision = { retry: true };
+      let delegableReplayVeto: ResolvedRetryDecision | undefined;
       for (const policy of policies) {
         const decision = resolveRetryDecision(await policy(context));
         if (isHardVeto(decision)) {
+          if (isDelegableReplayVeto(decision)) {
+            delegableReplayVeto ??= decision;
+            continue;
+          }
           return decision;
         }
         if (!decision.retry) {
@@ -645,9 +835,15 @@ export const retryPolicies = {
         if (decision.reason !== undefined) {
           merged.reason = decision.reason;
         }
+        if (decision.approveUnsafeReplay) {
+          merged.approveUnsafeReplay = true;
+        }
         if (isReplaySafeApproval(decision)) {
           merged = withReplaySafeApproval(merged);
         }
+      }
+      if (delegableReplayVeto) {
+        return resolveDelegableReplayVeto(delegableReplayVeto, merged);
       }
       return merged;
     };
@@ -663,7 +859,6 @@ export async function getResponseWithRetry(
   const retryBackoff = request.modelSettings.retry?.backoff;
 
   let attempt = 1;
-  const replayUnsafeRequest = isStatefulConversationRequest(request);
   while (true) {
     const requestForAttempt = shouldDisableProviderManagedRetry(
       request,
@@ -695,7 +890,7 @@ export async function getResponseWithRetry(
         retryBackoff,
         signal: request.signal,
         stream: false,
-        replayUnsafeRequest,
+        request,
         emittedVisibleEvent: false,
         emittedRawModelEvent: false,
         providerAdvice,
@@ -720,7 +915,6 @@ export async function* getStreamedResponseWithRetry(
   const retryBackoff = request.modelSettings.retry?.backoff;
 
   let attempt = 1;
-  const replayUnsafeRequest = isStatefulConversationRequest(request);
   while (true) {
     let emittedVisibleEvent = false;
     let emittedRawModelEvent = false;
@@ -767,7 +961,7 @@ export async function* getStreamedResponseWithRetry(
         retryBackoff,
         signal: request.signal,
         stream: true,
-        replayUnsafeRequest,
+        request,
         emittedVisibleEvent,
         emittedRawModelEvent,
         providerAdvice,

--- a/packages/agents-core/test/retryPolicy.test.ts
+++ b/packages/agents-core/test/retryPolicy.test.ts
@@ -9,7 +9,12 @@ import {
   setTracingDisabled,
 } from '../src';
 import { mergeAgentToolRunConfig } from '../src/agentToolRunConfig';
-import type { Model, ModelRequest } from '../src/model';
+import type {
+  Model,
+  ModelRequest,
+  RetryPolicy,
+  RetryPolicyContext,
+} from '../src/model';
 import type { StreamEvent } from '../src/types/protocol';
 import { RequestUsage, Usage } from '../src/usage';
 import { fakeModelMessage, FakeModelProvider } from './stubs';
@@ -1054,7 +1059,7 @@ describe('retry policies', () => {
         retry: {
           maxRetries: 1,
           backoff: { initialDelayMs: 0, jitter: false },
-          policy: retryPolicies.httpStatus([503]),
+          policy: () => ({ retry: true, approveUnsafeReplay: true }),
         },
       },
     });
@@ -1100,7 +1105,7 @@ describe('retry policies', () => {
         retry: {
           maxRetries: 1,
           backoff: { initialDelayMs: 0, jitter: false },
-          policy: retryPolicies.httpStatus([503]),
+          policy: () => ({ retry: true, approveUnsafeReplay: true }),
         },
       },
     });
@@ -1198,6 +1203,491 @@ describe('retry policies', () => {
       'request may have been accepted',
     );
     expect(attempts).toBe(1);
+  });
+
+  it('retries a non-streaming unsafe replay only with explicit application approval', async () => {
+    let attempts = 0;
+    const seenContexts: Array<{
+      replaySafety?: string;
+      responseStarted?: boolean;
+      statefulRequest?: boolean;
+    }> = [];
+    const model: Model = {
+      async getResponse() {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error('request may have been accepted');
+        }
+        return {
+          usage: new Usage({ requests: 1 }),
+          output: [fakeModelMessage('Explicitly approved replay')],
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+      },
+      getRetryAdvice() {
+        return {
+          suggested: false,
+          replaySafety: 'unsafe',
+          responseStarted: true,
+          reason: 'request may have been accepted',
+        };
+      },
+    };
+
+    const result = await run(
+      new Agent({
+        name: 'ExplicitUnsafeReplayAgent',
+        model,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: (context) => {
+              seenContexts.push(context);
+              return {
+                retry: true,
+                approveUnsafeReplay: true,
+                reason: 'read-only model turn',
+              };
+            },
+          },
+        },
+      }),
+      'hello',
+    );
+
+    expect(result.finalOutput).toBe('Explicitly approved replay');
+    expect(attempts).toBe(2);
+    expect(seenContexts).toHaveLength(1);
+    expect(seenContexts[0]).toMatchObject({
+      replaySafety: 'unsafe',
+      responseStarted: true,
+      statefulRequest: false,
+    });
+  });
+
+  it('does not treat missing response-start evidence as explicit false', async () => {
+    let attempts = 0;
+    const policy = vi.fn((context: RetryPolicyContext) => {
+      expect(context.responseStarted).toBeUndefined();
+      return {
+        retry: true,
+        approveUnsafeReplay: context.responseStarted === false,
+      };
+    });
+    const model: Model = {
+      async getResponse() {
+        attempts += 1;
+        throw new Error('request may have been accepted');
+      },
+      async *getStreamedResponse() {
+        yield* [];
+      },
+      getRetryAdvice() {
+        return {
+          suggested: false,
+          replaySafety: 'unsafe',
+          reason: 'response-start state is unknown',
+        };
+      },
+    };
+
+    await expect(
+      run(
+        new Agent({
+          name: 'UnknownResponseStartAgent',
+          model,
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy,
+            },
+          },
+        }),
+        'hello',
+      ),
+    ).rejects.toThrow('request may have been accepted');
+
+    expect(attempts).toBe(1);
+    expect(policy).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows explicit unsafe replay approval for both stateful request forms', async () => {
+    const exercise = async (options: {
+      previousResponseId?: string;
+      conversationId?: string;
+    }) => {
+      let attempts = 0;
+      const seenContexts: Array<{
+        previousResponseId?: string;
+        conversationId?: string;
+        replaySafety?: string;
+        responseStarted?: boolean;
+        statefulRequest?: boolean;
+      }> = [];
+      const model: Model = {
+        async getResponse() {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error('stateful request may have been accepted');
+          }
+          return {
+            usage: new Usage({ requests: 1 }),
+            output: [fakeModelMessage('Recovered stateful request')],
+          };
+        },
+        async *getStreamedResponse() {
+          yield* [];
+        },
+        getRetryAdvice() {
+          return {
+            suggested: false,
+            replaySafety: 'unsafe',
+            reason: 'stateful request may have been accepted',
+          };
+        },
+      };
+
+      const result = await run(
+        new Agent({
+          name: 'StatefulUnsafeReplayAgent',
+          model,
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy: (context) => {
+                seenContexts.push(context);
+                return { retry: true, approveUnsafeReplay: true };
+              },
+            },
+          },
+        }),
+        'hello',
+        options,
+      );
+
+      return { attempts, finalOutput: result.finalOutput, seenContexts };
+    };
+
+    const previousResponse = await exercise({
+      previousResponseId: 'resp_unsafe',
+    });
+    expect(previousResponse).toMatchObject({
+      attempts: 2,
+      finalOutput: 'Recovered stateful request',
+      seenContexts: [
+        {
+          previousResponseId: 'resp_unsafe',
+          replaySafety: 'unsafe',
+          responseStarted: undefined,
+          statefulRequest: true,
+        },
+      ],
+    });
+
+    const conversation = await exercise({ conversationId: 'conv_unsafe' });
+    expect(conversation).toMatchObject({
+      attempts: 2,
+      finalOutput: 'Recovered stateful request',
+      seenContexts: [
+        {
+          conversationId: 'conv_unsafe',
+          replaySafety: 'unsafe',
+          responseStarted: undefined,
+          statefulRequest: true,
+        },
+      ],
+    });
+  });
+
+  it('does not apply unsafe replay approval to stateful requests with unknown safety', async () => {
+    let attempts = 0;
+    const policy = vi.fn((context) => {
+      expect(context).toMatchObject({
+        previousResponseId: 'resp_unknown',
+        replaySafety: 'unknown',
+        responseStarted: undefined,
+        statefulRequest: true,
+      });
+      return { retry: true, approveUnsafeReplay: true };
+    });
+    const model: Model = {
+      async getResponse() {
+        attempts += 1;
+        throw new Error('unknown stateful failure');
+      },
+      async *getStreamedResponse() {
+        yield* [];
+      },
+    };
+
+    await expect(
+      run(
+        new Agent({
+          name: 'UnknownStatefulReplayAgent',
+          model,
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy,
+            },
+          },
+        }),
+        'hello',
+        { previousResponseId: 'resp_unknown' },
+      ),
+    ).rejects.toThrow('unknown stateful failure');
+
+    expect(attempts).toBe(1);
+    expect(policy).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts captured provider-safe evidence for a custom stateful policy', async () => {
+    let attempts = 0;
+    const model: Model = {
+      async getResponse() {
+        attempts += 1;
+        if (attempts === 1) {
+          throw new Error('safe stateful failure');
+        }
+        return {
+          usage: new Usage({ requests: 1 }),
+          output: [fakeModelMessage('Provider-safe replay')],
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+      },
+      getRetryAdvice() {
+        return {
+          suggested: true,
+          replaySafety: 'safe',
+        };
+      },
+    };
+
+    const result = await run(
+      new Agent({
+        name: 'ProviderSafeCustomPolicyAgent',
+        model,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: () => true,
+          },
+        },
+      }),
+      'hello',
+      { previousResponseId: 'resp_safe' },
+    );
+
+    expect(result.finalOutput).toBe('Provider-safe replay');
+    expect(attempts).toBe(2);
+  });
+
+  it('does not let unsafe replay approval override provider-unsafe streaming failures', async () => {
+    let attempts = 0;
+    const policy = vi.fn(() => ({
+      retry: true,
+      approveUnsafeReplay: true,
+    }));
+    const model: Model = {
+      async getResponse() {
+        throw new Error('not used');
+      },
+      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+        attempts += 1;
+        if (attempts > 0) {
+          throw new Error('unsafe streamed failure');
+        }
+        yield* [];
+      },
+      getRetryAdvice() {
+        return {
+          suggested: false,
+          replaySafety: 'unsafe',
+          reason: 'unsafe streamed failure',
+        };
+      },
+    };
+
+    const result = await run(
+      new Agent({
+        name: 'UnsafeStreamingReplayAgent',
+        model,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy,
+          },
+        },
+      }),
+      'hello',
+      { stream: true },
+    );
+    const consume = async () => {
+      for await (const _event of result) {
+        // Consume until the stream throws.
+      }
+    };
+
+    await expect(consume()).rejects.toThrow('unsafe streamed failure');
+    expect(attempts).toBe(1);
+    expect(policy).not.toHaveBeenCalled();
+  });
+
+  it('does not let provider normalization clear raw abort evidence', async () => {
+    let attempts = 0;
+    const policy = vi.fn(() => ({
+      retry: true,
+      approveUnsafeReplay: true,
+    }));
+    const model: Model = {
+      async getResponse() {
+        attempts += 1;
+        const error = new Error('cancelled');
+        error.name = 'AbortError';
+        throw error;
+      },
+      async *getStreamedResponse() {
+        yield* [];
+      },
+      getRetryAdvice() {
+        return {
+          suggested: false,
+          replaySafety: 'unsafe',
+          normalized: { isAbort: false },
+        };
+      },
+    };
+
+    await expect(
+      run(
+        new Agent({
+          name: 'ProviderAbortOverrideAgent',
+          model,
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              backoff: { initialDelayMs: 0, jitter: false },
+              policy,
+            },
+          },
+        }),
+        'hello',
+      ),
+    ).rejects.toThrow('cancelled');
+
+    expect(attempts).toBe(1);
+    expect(policy).not.toHaveBeenCalled();
+  });
+
+  it('propagates unsafe replay approval through any() and all() in either order', async () => {
+    const createContext = () => ({
+      error: new Error('request may have been accepted'),
+      attempt: 1,
+      maxRetries: 1,
+      stream: false,
+      providerAdvice: {
+        suggested: false,
+        replaySafety: 'unsafe' as const,
+        reason: 'provider veto',
+      },
+      normalized: {
+        isAbort: false,
+        isNetworkError: true,
+      },
+    });
+    const approving = () => ({
+      retry: true,
+      approveUnsafeReplay: true,
+      reason: 'application approval',
+    });
+
+    for (const combinator of ['any', 'all'] as const) {
+      for (const providerFirst of [false, true]) {
+        const providerPolicy = retryPolicies.providerSuggested();
+        const policies = providerFirst
+          ? [providerPolicy, approving]
+          : [approving, providerPolicy];
+        const combined =
+          combinator === 'any'
+            ? retryPolicies.any(...policies)
+            : retryPolicies.all(...policies);
+
+        await expect(combined(createContext())).resolves.toMatchObject({
+          retry: true,
+          approveUnsafeReplay: true,
+          reason: 'application approval',
+        });
+      }
+    }
+  });
+
+  it('keeps provider replay authority stable across composed policy mutation', async () => {
+    for (const combinator of ['any', 'all'] as const) {
+      const providerAdvice = {
+        suggested: false,
+        replaySafety: 'unsafe' as 'safe' | 'unsafe',
+        responseStarted: true,
+        reason: 'provider veto',
+      };
+      const mutateAdvice = (context: RetryPolicyContext) => {
+        expect(context.replaySafety).toBe('unsafe');
+        expect(context.responseStarted).toBe(true);
+        const authority = Object.getOwnPropertySymbols(context)
+          .map(
+            (symbol) => (context as unknown as Record<symbol, unknown>)[symbol],
+          )
+          .find(
+            (value): value is Record<string, unknown> =>
+              typeof value === 'object' &&
+              value !== null &&
+              'replaySafety' in value,
+          );
+        expect(authority).toBeDefined();
+        expect(Object.isFrozen(authority)).toBe(true);
+        expect(Reflect.set(authority!, 'replaySafety', 'safe')).toBe(false);
+        context.providerAdvice!.suggested = true;
+        context.providerAdvice!.replaySafety = 'safe';
+        context.providerAdvice!.responseStarted = false;
+        expect(context.replaySafety).toBe('unsafe');
+        expect(context.responseStarted).toBe(true);
+        return true;
+      };
+      const policies: RetryPolicy[] = [
+        mutateAdvice,
+        retryPolicies.providerSuggested(),
+      ];
+      const combined =
+        combinator === 'any'
+          ? retryPolicies.any(...policies)
+          : retryPolicies.all(...policies);
+
+      await expect(
+        combined({
+          error: new Error('request may have been accepted'),
+          attempt: 1,
+          maxRetries: 1,
+          stream: false,
+          providerAdvice,
+          normalized: {
+            isAbort: false,
+            isNetworkError: true,
+          },
+        }),
+      ).resolves.toMatchObject({
+        retry: false,
+        reason: 'provider veto',
+      });
+    }
   });
 
   it('retries stateful follow-up requests when providerSuggested() approves replay', async () => {
@@ -1418,8 +1908,7 @@ describe('retry policies', () => {
   it('deep merges retry settings between runner and agent configs', async () => {
     const policy = () => true;
     let capturedRetrySettings:
-      | ModelRequest['modelSettings']['retry']
-      | undefined;
+      ModelRequest['modelSettings']['retry'] | undefined;
 
     const model: Model = {
       async getResponse(request: ModelRequest) {
@@ -1474,8 +1963,7 @@ describe('retry policies', () => {
   it('inherits runner retry policy when an agent overrides only backoff', async () => {
     const policy = () => true;
     let capturedRetrySettings:
-      | ModelRequest['modelSettings']['retry']
-      | undefined;
+      ModelRequest['modelSettings']['retry'] | undefined;
 
     const model: Model = {
       async getResponse(request: ModelRequest) {

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -722,11 +722,14 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     } catch (error) {
       threwError = true;
       if (requestMayHaveReachedServer && error instanceof Error) {
-        (
-          error as Error & {
-            unsafeToReplay?: boolean;
-          }
-        ).unsafeToReplay = true;
+        const replayError = error as Error & {
+          unsafeToReplay?: boolean;
+          responseStarted?: boolean;
+        };
+        replayError.unsafeToReplay = true;
+        if (receivedServerMessage) {
+          replayError.responseStarted = true;
+        }
       }
       if (hadActiveResponse && sentFrameWasReturnedUnsent) {
         const transportOverridesKey = this.#webSocketTransportOverridesKey;

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -333,6 +333,24 @@ function isAmbiguousWebSocketReplayError(error: unknown): boolean {
   );
 }
 
+function markUnsafeWebSocketReplayError(
+  error: unknown,
+  responseStarted: boolean,
+): void {
+  if (!(error instanceof Error)) {
+    return;
+  }
+
+  const replayError = error as Error & {
+    unsafeToReplay?: boolean;
+    responseStarted?: boolean;
+  };
+  replayError.unsafeToReplay = true;
+  if (responseStarted) {
+    replayError.responseStarted = true;
+  }
+}
+
 function hasSerializedComputerDisplayMetadata(
   tool: SerializedComputerTool,
 ): tool is SerializedComputerTool & {
@@ -3814,11 +3832,13 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
     }
 
     if (isAmbiguousWebSocketReplayError(args.error)) {
-      return {
-        suggested: false,
-        replaySafety: 'unsafe',
-        reason: args.error instanceof Error ? args.error.message : undefined,
-      };
+      return (
+        super.getRetryAdvice(args) ?? {
+          suggested: false,
+          replaySafety: 'unsafe',
+          reason: args.error instanceof Error ? args.error.message : undefined,
+        }
+      );
     }
 
     return super.getRetryAdvice(args);
@@ -3850,37 +3870,33 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       return this.#iterWebSocketResponseEvents(builtRequest);
     }
 
-    let finalResponse: OpenAI.Responses.Response | undefined;
-    let receivedAnyEvent = false;
+    let receivedResponseEvent = false;
     try {
+      let finalResponse: OpenAI.Responses.Response | undefined;
       for await (const event of this.#iterWebSocketResponseEvents(
         builtRequest,
       )) {
-        receivedAnyEvent = true;
+        receivedResponseEvent = true;
         const eventType = (event as { type?: string }).type;
         if (isTerminalResponsesStreamEventType(eventType)) {
           finalResponse = (event as { response: OpenAI.Responses.Response })
             .response;
         }
       }
+
+      if (!finalResponse) {
+        throw new Error(
+          'Responses websocket stream ended without a terminal response event.',
+        );
+      }
+
+      return finalResponse;
     } catch (error) {
-      if (receivedAnyEvent && error instanceof Error) {
-        (
-          error as Error & {
-            unsafeToReplay?: boolean;
-          }
-        ).unsafeToReplay = true;
+      if (receivedResponseEvent) {
+        markUnsafeWebSocketReplayError(error, true);
       }
       throw error;
     }
-
-    if (!finalResponse) {
-      throw new Error(
-        'Responses websocket stream ended without a terminal response event.',
-      );
-    }
-
-    return finalResponse;
   }
 
   async close(): Promise<void> {
@@ -3897,7 +3913,8 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       requestTimeoutDeadline,
     );
 
-    let receivedAnyEvent = false;
+    let replayMayBeUnsafe = false;
+    let receivedServerFrame = false;
     let sawTerminalResponseEvent = false;
     try {
       throwIfAborted(builtRequest.signal);
@@ -3951,12 +3968,12 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
           requestTimeoutDeadline,
         );
         if (rawFrame === null) {
-          if (!receivedAnyEvent && reusedConnectionForCurrentAttempt) {
+          if (!receivedServerFrame && reusedConnectionForCurrentAttempt) {
             // The request frame was already sent on a reused socket. If the
             // socket closes before the first response event arrives, the server
             // may still be processing the request, so replaying `response.create`
             // can duplicate model work and tool side effects.
-            receivedAnyEvent = true;
+            replayMayBeUnsafe = true;
             throw new Error(
               'Responses websocket connection closed after sending a request on a reused connection before any response events were received. The request may have been accepted, so the SDK will not automatically retry this websocket request.',
             );
@@ -3966,6 +3983,8 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
           );
         }
 
+        replayMayBeUnsafe = true;
+        receivedServerFrame = true;
         const payloadText = await webSocketFrameToText(rawFrame);
         const payload = JSON.parse(payloadText);
         const eventType =
@@ -3974,7 +3993,6 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
             : undefined;
 
         if (eventType === 'error') {
-          receivedAnyEvent = true;
           throw new Error(
             `Responses websocket error: ${JSON.stringify(payload)}`,
           );
@@ -3985,7 +4003,6 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
           isTerminalResponsesStreamEventType(eventType);
         // Successful websocket responses do not currently expose a transport
         // request ID analogous to the HTTP x-request-id header.
-        receivedAnyEvent = true;
         if (isTerminalResponseEvent) {
           sawTerminalResponseEvent = true;
         }
@@ -3996,8 +4013,11 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
         }
       }
     } catch (error) {
+      if (replayMayBeUnsafe) {
+        markUnsafeWebSocketReplayError(error, receivedServerFrame);
+      }
       if (
-        !receivedAnyEvent &&
+        !replayMayBeUnsafe &&
         !(error instanceof OpenAI.APIUserAbortError) &&
         shouldWrapNoEventWebSocketError(error)
       ) {

--- a/packages/agents-openai/src/retryAdvice.ts
+++ b/packages/agents-openai/src/retryAdvice.ts
@@ -11,6 +11,10 @@ function isUnsafeToReplayError(error: unknown): boolean {
   return isRecord(error) && error.unsafeToReplay === true;
 }
 
+function didResponseStart(error: unknown): boolean {
+  return isRecord(error) && error.responseStarted === true;
+}
+
 function getHeaderValue(error: unknown, key: string): string | undefined {
   if (!isRecord(error)) {
     return undefined;
@@ -73,6 +77,7 @@ export function getOpenAIRetryAdvice(
       suggested: false,
       replaySafety: 'unsafe',
       reason: error instanceof Error ? error.message : undefined,
+      ...(didResponseStart(error) ? { responseStarted: true } : {}),
     };
   }
 

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1705,15 +1705,21 @@ describe('OpenAIHostedMultiAgentModel', () => {
     ]);
     const model = new TestHostedMultiAgentModel(fakeWebSocket);
 
-    let error: (Error & { unsafeToReplay?: boolean }) | undefined;
+    let error:
+      | (Error & { unsafeToReplay?: boolean; responseStarted?: boolean })
+      | undefined;
     try {
       await withTestTrace(() => model.getResponse(request()));
     } catch (caught) {
-      error = caught as Error & { unsafeToReplay?: boolean };
+      error = caught as Error & {
+        unsafeToReplay?: boolean;
+        responseStarted?: boolean;
+      };
     }
 
     expect(error).toBe(socketError);
     expect(error?.unsafeToReplay).toBe(true);
+    expect(error?.responseStarted).toBe(true);
     expect(
       model.getRetryAdvice({
         error,
@@ -1721,7 +1727,11 @@ describe('OpenAIHostedMultiAgentModel', () => {
         stream: false,
         attempt: 1,
       }),
-    ).toMatchObject({ suggested: false, replaySafety: 'unsafe' });
+    ).toMatchObject({
+      suggested: false,
+      replaySafety: 'unsafe',
+      responseStarted: true,
+    });
     expect(fakeWebSocket.close).toHaveBeenCalledOnce();
   });
 

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -1384,6 +1384,7 @@ describe('OpenAIResponsesModel', () => {
       ),
       {
         unsafeToReplay: true,
+        responseStarted: true,
       },
     );
 
@@ -1406,6 +1407,7 @@ describe('OpenAIResponsesModel', () => {
       replaySafety: 'unsafe',
       reason:
         'Responses websocket connection closed before a terminal response event.',
+      responseStarted: true,
     });
   });
 

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -99,6 +99,10 @@ class TestWebSocket {
     this.emit('message', { data: JSON.stringify(payload) });
   }
 
+  queueRaw(data: unknown) {
+    this.emit('message', { data });
+  }
+
   onSend(handler: (data: string) => void) {
     this.addEventListener('send', (event) => {
       handler(String(event.data));
@@ -965,6 +969,59 @@ describe('OpenAIResponsesWSModel', () => {
     },
   );
 
+  it('marks post-consumption terminal response validation failures as unsafe', async () => {
+    const fakeClient = createFakeClient();
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.completed',
+          sequence_number: 0,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch(
+        (err: unknown) =>
+          err as Error & {
+            unsafeToReplay?: boolean;
+            responseStarted?: boolean;
+          },
+      );
+
+    expect(error.message).toBe(
+      'Responses websocket stream ended without a terminal response event.',
+    );
+    expect(error.unsafeToReplay).toBe(true);
+    expect(error.responseStarted).toBe(true);
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: false,
+      replaySafety: 'unsafe',
+      responseStarted: true,
+    });
+  });
+
   it('surfaces first-frame websocket error payloads without feature-disabled wrapping', async () => {
     const fakeClient = createFakeClient();
 
@@ -993,12 +1050,80 @@ describe('OpenAIResponsesWSModel', () => {
 
     const error = await (model as any)
       ._fetchResponse(request as any, false)
-      .catch((err: unknown) => err as Error);
+      .catch(
+        (err: unknown) =>
+          err as Error & {
+            unsafeToReplay?: boolean;
+            responseStarted?: boolean;
+          },
+      );
 
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toContain('Responses websocket error:');
     expect(error.message).toContain('invalid request');
     expect(error.message).not.toContain('feature may not be enabled');
+    expect(error.unsafeToReplay).toBe(true);
+    expect(error.responseStarted).toBe(true);
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: false,
+      replaySafety: 'unsafe',
+      responseStarted: true,
+    });
+  });
+
+  it('marks a consumed websocket frame unsafe before payload parsing', async () => {
+    const fakeClient = createFakeClient();
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        socket.queueRaw('{invalid json');
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch(
+        (err: unknown) =>
+          err as Error & {
+            unsafeToReplay?: boolean;
+            responseStarted?: boolean;
+          },
+      );
+
+    expect(error).toBeInstanceOf(SyntaxError);
+    expect(error.unsafeToReplay).toBe(true);
+    expect(error.responseStarted).toBe(true);
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: false,
+      replaySafety: 'unsafe',
+      responseStarted: true,
+    });
   });
 
   it('marks non-streaming websocket failures as unsafe to replay after any response event', async () => {
@@ -1031,12 +1156,19 @@ describe('OpenAIResponsesWSModel', () => {
 
     const error = await (model as any)
       ._fetchResponse(request as any, false)
-      .catch((err: unknown) => err as Error & { unsafeToReplay?: boolean });
+      .catch(
+        (err: unknown) =>
+          err as Error & {
+            unsafeToReplay?: boolean;
+            responseStarted?: boolean;
+          },
+      );
 
     expect(error.message).toBe(
       'Responses websocket connection closed before a terminal response event.',
     );
     expect(error.unsafeToReplay).toBe(true);
+    expect(error.responseStarted).toBe(true);
   });
 
   it('preserves local websocket setup errors before first event', async () => {
@@ -1824,11 +1956,44 @@ describe('OpenAIResponsesWSModel', () => {
     };
 
     const first = await consumeStream();
-    await expect(consumeStream()).rejects.toThrow(
-      'The request may have been accepted, so the SDK will not automatically retry this websocket request.',
-    );
+    let error:
+      | (Error & { unsafeToReplay?: boolean; responseStarted?: boolean })
+      | undefined;
+    try {
+      await consumeStream();
+    } catch (caught) {
+      error = caught as Error & {
+        unsafeToReplay?: boolean;
+        responseStarted?: boolean;
+      };
+    }
 
     expect(first).toBe('resp_done_1');
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toContain(
+      'The request may have been accepted, so the SDK will not automatically retry this websocket request.',
+    );
+    expect(error?.unsafeToReplay).toBe(true);
+    expect(error?.responseStarted).toBeUndefined();
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: true,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: false,
+      replaySafety: 'unsafe',
+    });
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: true,
+        attempt: 1,
+      })?.responseStarted,
+    ).toBeUndefined();
     expect(TestWebSocket.instances).toHaveLength(1);
     expect(TestWebSocket.instances[0]?.sent).toHaveLength(2);
   });


### PR DESCRIPTION
This pull request adds an explicit `approveUnsafeReplay` retry decision for applications that deliberately accept duplicate provider-side work on non-streaming failures. It exposes stable replay-safety and stateful-request context, propagates approval through `retryPolicies.any()` and `retryPolicies.all()`, and preserves non-overridable abort, streaming, emitted-event, and unknown-stateful vetoes.

It also records OpenAI Responses WebSocket response-start evidence across regular and hosted transport failure boundaries so provider advice reaches the shared retry evaluator without losing authority. Existing behavior remains unchanged unless applications explicitly opt in. Documentation is intentionally deferred until the behavior is released.
