### PR TITLE
fix: preserve free-form MCP object schemas

### DIFF
--- a/.changeset/fuzzy-mcp-objects.md
+++ b/.changeset/fuzzy-mcp-objects.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve free-form MCP object schemas

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -47,6 +47,7 @@ import {
   cachedMcpTools as _cachedTools,
 } from './mcpToolCache';
 import { getToolCallParentSpanFromDetails } from './agentToolRunConfig';
+import { assertOpenAIStrictToolSchemaPreservesOpenObjects } from './utils/strictToolSchema';
 
 export {
   BaseMCPServerSSE,
@@ -1230,17 +1231,22 @@ export function mcpToFunctionTool(
     return toolOutput;
   }
 
-  const schema: JsonObjectSchema<any> = {
-    ...mcpTool.inputSchema,
-    type: mcpTool.inputSchema?.type ?? 'object',
-    properties: mcpTool.inputSchema?.properties ?? {},
-    required: mcpTool.inputSchema?.required ?? [],
-    additionalProperties: mcpTool.inputSchema?.additionalProperties ?? false,
-  };
+  const inputSchema = mcpTool.inputSchema ?? {};
+  const inputSchemaIsEmpty = Object.keys(inputSchema).length === 0;
+  const schema = {
+    ...inputSchema,
+    type: inputSchema.type ?? 'object',
+    properties: inputSchema.properties ?? {},
+    required: inputSchema.required ?? [],
+  } as JsonObjectSchema<any>;
+  const strictSchema = (
+    inputSchemaIsEmpty ? { ...schema, additionalProperties: false } : schema
+  ) as JsonObjectSchemaStrict<any>;
+  let preserveSchemaOnFallback = false;
 
   if (convertSchemasToStrict || schema.additionalProperties === true) {
     try {
-      const strictSchema = ensureStrictJsonSchema(schema);
+      assertOpenAIStrictToolSchemaPreservesOpenObjects(strictSchema);
       return tool({
         name: toolName,
         description: mcpTool.description || '',
@@ -1263,6 +1269,7 @@ export function mcpToFunctionTool(
         },
       });
     } catch (e) {
+      preserveSchemaOnFallback = true;
       logToolActionWarning(
         globalLogger,
         'Error converting MCP schema to strict mode:',
@@ -1273,8 +1280,11 @@ export function mcpToFunctionTool(
 
   const nonStrictSchema: JsonObjectSchemaNonStrict<any> = {
     ...schema,
-    additionalProperties: true,
-  };
+    additionalProperties:
+      preserveSchemaOnFallback && 'additionalProperties' in schema
+        ? schema.additionalProperties
+        : true,
+  } as JsonObjectSchemaNonStrict<any>;
   return tool({
     name: toolName,
     description: mcpTool.description || '',
@@ -1318,20 +1328,6 @@ function cloneMcpCustomDataContextValue<T>(value: T): T {
   } catch {
     return value;
   }
-}
-
-/**
- * Ensures the given JSON schema is strict (no additional properties, required fields set).
- */
-function ensureStrictJsonSchema(
-  schema: JsonObjectSchemaNonStrict<any> | JsonObjectSchemaStrict<any>,
-): JsonObjectSchemaStrict<any> {
-  const out: JsonObjectSchemaStrict<any> = {
-    ...schema,
-    additionalProperties: false,
-  };
-  if (!out.required) out.required = [];
-  return out;
 }
 
 /**

--- a/packages/agents-core/src/utils/strictToolSchema.ts
+++ b/packages/agents-core/src/utils/strictToolSchema.ts
@@ -36,6 +36,12 @@ export function prepareOpenAIStrictToolSchema<T extends JsonObjectSchema<any>>(
   return prepareOpenAIStrictToolSchemaInternal(schema, true);
 }
 
+export function assertOpenAIStrictToolSchemaPreservesOpenObjects(
+  schema: JsonObjectSchema<any>,
+): void {
+  validateOpenAIStrictJsonSchema(schema, schema, new WeakSet(), true, true);
+}
+
 function prepareOpenAIStrictToolSchemaInternal<T extends JsonObjectSchema<any>>(
   schema: T,
   requireUnambiguousNormalization: boolean,
@@ -581,6 +587,7 @@ function validateOpenAIStrictJsonSchema(
   rootSchema: unknown,
   visitedSchemas: WeakSet<object> = new WeakSet(),
   requireUnambiguousNormalization = true,
+  rejectOpenObjects = false,
 ): void {
   if (typeof schema === 'boolean') {
     return;
@@ -615,6 +622,7 @@ function validateOpenAIStrictJsonSchema(
       rootSchema,
       visitedSchemas,
       requireUnambiguousNormalization,
+      rejectOpenObjects,
     );
   }
 
@@ -638,6 +646,7 @@ function validateOpenAIStrictJsonSchema(
         rootSchema,
         visitedSchemas,
         requireUnambiguousNormalization,
+        rejectOpenObjects,
       );
     }
     // Plain JSON Schema tools do not have a runtime validator that selects the
@@ -658,6 +667,21 @@ function validateOpenAIStrictJsonSchema(
   const properties = isRecord(schema.properties)
     ? schema.properties
     : undefined;
+  const hasObjectType =
+    schema.type === 'object' ||
+    (Array.isArray(schema.type) && schema.type.includes('object'));
+  const hasDeclaredProperties =
+    properties !== undefined && Object.keys(properties).length > 0;
+  if (
+    rejectOpenObjects &&
+    hasObjectType &&
+    schema.additionalProperties !== false &&
+    (!hasDeclaredProperties || 'additionalProperties' in schema)
+  ) {
+    throw new UserError(
+      'Cannot convert an open JSON schema object to strict mode without changing its accepted values. Set `additionalProperties: false`, declare at least one property, or disable strict mode.',
+    );
+  }
   if (schemaConvertsObjectProperties(schema) && properties) {
     const required = new Set(
       Array.isArray(schema.required) ? schema.required.map(String) : [],
@@ -668,6 +692,7 @@ function validateOpenAIStrictJsonSchema(
         rootSchema,
         visitedSchemas,
         requireUnambiguousNormalization,
+        rejectOpenObjects,
       );
       if (!required.has(key)) {
         getKnownJsonSchemaNullability(propertySchema, rootSchema);
@@ -683,6 +708,7 @@ function validateOpenAIStrictJsonSchema(
         rootSchema,
         visitedSchemas,
         requireUnambiguousNormalization,
+        rejectOpenObjects,
       );
     }
   } else if (typeof items !== 'undefined') {
@@ -691,6 +717,7 @@ function validateOpenAIStrictJsonSchema(
       rootSchema,
       visitedSchemas,
       requireUnambiguousNormalization,
+      rejectOpenObjects,
     );
   }
 
@@ -705,6 +732,7 @@ function validateOpenAIStrictJsonSchema(
         rootSchema,
         visitedSchemas,
         requireUnambiguousNormalization,
+        rejectOpenObjects,
       );
     }
   }

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -8,8 +8,24 @@ import { withTrace } from '../src/tracing';
 import { withCustomSpan } from '../src/tracing/createSpans';
 import { getCurrentSpan } from '../src/tracing';
 
+function convertExpectingStrictFallback(
+  convert: () => ReturnType<typeof mcpToFunctionTool>,
+): ReturnType<typeof mcpToFunctionTool> {
+  const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  try {
+    const functionTool = convert();
+    expect(warn).toHaveBeenCalledWith(
+      'Error converting MCP schema to strict mode:',
+      expect.anything(),
+    );
+    return functionTool;
+  } finally {
+    warn.mockRestore();
+  }
+}
+
 describe('mcpToFunctionTool', () => {
-  it('builds strict and non-strict tools based on schema settings', () => {
+  it('preserves non-strict behavior when schema conversion is disabled', () => {
     const server: MCPServer = {
       name: 'stub',
       cacheToolsList: false,
@@ -20,23 +36,25 @@ describe('mcpToFunctionTool', () => {
       invalidateToolsCache: async () => {},
     };
 
-    const strictTool = mcpToFunctionTool(
-      {
-        name: 'strict',
-        description: '',
-        inputSchema: {
-          type: 'object',
-          properties: { foo: { type: 'string' } },
-          required: [],
-          additionalProperties: true,
-        },
-      } as any,
-      server,
-      false,
+    const explicitlyOpenTool = convertExpectingStrictFallback(() =>
+      mcpToFunctionTool(
+        {
+          name: 'strict',
+          description: '',
+          inputSchema: {
+            type: 'object',
+            properties: { foo: { type: 'string' } },
+            required: [],
+            additionalProperties: true,
+          },
+        } as any,
+        server,
+        false,
+      ),
     );
 
-    expect(strictTool.strict).toBe(true);
-    expect(strictTool.parameters.additionalProperties).toBe(false);
+    expect(explicitlyOpenTool.strict).toBe(false);
+    expect(explicitlyOpenTool.parameters.additionalProperties).toBe(true);
 
     const nonStrictTool = mcpToFunctionTool(
       {
@@ -753,7 +771,6 @@ describe('mcpToFunctionTool', () => {
         inputSchema: {
           type: 'object',
           properties: { foo: { type: 'string' } },
-          additionalProperties: true,
         },
       } as any,
       server,
@@ -763,6 +780,161 @@ describe('mcpToFunctionTool', () => {
     expect(strictTool.strict).toBe(true);
     expect(strictTool.parameters.additionalProperties).toBe(false);
     expect(strictTool.parameters.required).toEqual(['foo']);
+  });
+
+  it.each([
+    ['properties omitted', { type: 'object' }],
+    ['empty properties', { type: 'object', properties: {} }],
+    [
+      'explicitly open with declared properties',
+      {
+        type: 'object',
+        properties: { known: { type: 'string' } },
+        additionalProperties: true,
+      },
+    ],
+    [
+      'schema-valued additional properties',
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: { type: 'string' },
+      },
+    ],
+  ])('falls back for free-form root schemas: %s', (_name, inputSchema) => {
+    const server: MCPServer = {
+      name: 'free-form-root-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () => [],
+      invalidateToolsCache: async () => {},
+    };
+    const inputSchemaRecord = inputSchema as Record<string, any>;
+    const originalSchema = structuredClone(inputSchema);
+
+    const functionTool = convertExpectingStrictFallback(() =>
+      mcpToFunctionTool(
+        {
+          name: 'free_form_root',
+          description: '',
+          inputSchema,
+        } as any,
+        server,
+        true,
+      ),
+    );
+
+    expect(functionTool.strict).toBe(false);
+    expect(functionTool.parameters).toEqual({
+      ...inputSchema,
+      type: 'object',
+      properties: inputSchemaRecord.properties ?? {},
+      required: [],
+      additionalProperties:
+        'additionalProperties' in inputSchema
+          ? inputSchemaRecord.additionalProperties
+          : true,
+    });
+    expect(inputSchema).toEqual(originalSchema);
+  });
+
+  it.each([
+    [
+      'object property',
+      {
+        type: 'object',
+        properties: {
+          payload: { type: 'object', properties: {} },
+        },
+        required: ['payload'],
+        additionalProperties: false,
+      },
+    ],
+    [
+      'array item',
+      {
+        type: 'object',
+        properties: {
+          payload: {
+            type: 'array',
+            items: { type: 'object' },
+          },
+        },
+        required: ['payload'],
+        additionalProperties: false,
+      },
+    ],
+  ])('preserves nested free-form schemas: %s', (_name, inputSchema) => {
+    const server: MCPServer = {
+      name: 'free-form-nested-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () => [],
+      invalidateToolsCache: async () => {},
+    };
+    const originalSchema = structuredClone(inputSchema);
+
+    const functionTool = convertExpectingStrictFallback(() =>
+      mcpToFunctionTool(
+        {
+          name: 'free_form_nested',
+          description: '',
+          inputSchema,
+        } as any,
+        server,
+        true,
+      ),
+    );
+
+    expect(functionTool.strict).toBe(false);
+    expect(functionTool.parameters).toEqual(originalSchema);
+    expect(inputSchema).toEqual(originalSchema);
+  });
+
+  it.each([
+    ['empty input schema', {}],
+    [
+      'explicitly closed empty object',
+      { type: 'object', additionalProperties: false },
+    ],
+    [
+      'declared property',
+      {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+      },
+    ],
+  ])('keeps strict-compatible MCP schemas strict: %s', (_name, inputSchema) => {
+    const server: MCPServer = {
+      name: 'strict-compatible-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool: async () => [],
+      invalidateToolsCache: async () => {},
+    };
+    const inputSchemaRecord = inputSchema as Record<string, any>;
+
+    const functionTool = mcpToFunctionTool(
+      {
+        name: 'strict_compatible',
+        description: '',
+        inputSchema,
+      } as any,
+      server,
+      true,
+    );
+
+    expect(functionTool.strict).toBe(true);
+    expect(functionTool.parameters.additionalProperties).toBe(false);
+    expect(functionTool.parameters.required).toEqual(
+      Object.keys(inputSchemaRecord.properties ?? {}),
+    );
   });
 
   it('annotates the current span when invoking the tool', async () => {


### PR DESCRIPTION
This pull request fixes MCP tool schema conversion so direct and nested free-form objects are not silently narrowed to empty closed objects. When strict conversion would change accepted values, conversion now falls back to the original normalized non-strict schema without leaking partial mutations.

Actually empty input schemas, explicitly closed objects, and ordinary strict-compatible property schemas retain their existing strict behavior.
