### PR TITLE
feat: add durable pending input to RunState

### DIFF
--- a/.changeset/durable-pending-input.md
+++ b/.changeset/durable-pending-input.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents': patch
+---
+
+feat: add durable pending input to resumable run state

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -97,6 +97,7 @@ export { assistant, system, user } from './helpers/message';
 export {
   extractAllTextOutput,
   RunCompactionItem,
+  RunInputItem,
   RunHandoffCallItem,
   RunHandoffOutputItem,
   RunItem,

--- a/packages/agents-core/src/items.ts
+++ b/packages/agents-core/src/items.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from '@openai/agents-core/_shims';
 import { Agent } from './agent';
 import { toSmartString } from './utils/smartString';
 import * as protocol from './types/protocol';
@@ -15,6 +16,29 @@ export class RunItemBase {
     return {
       type: this.type,
       rawItem: this.rawItem,
+    };
+  }
+}
+
+/**
+ * An input item admitted while resuming a run.
+ */
+export class RunInputItem extends RunItemBase {
+  public readonly type = 'input_item' as const;
+
+  constructor(
+    public rawItem: protocol.ModelItem,
+    public agent: Agent<any, any>,
+    public inputId: string = randomUUID(),
+  ) {
+    super();
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      agent: this.agent.toJSON(),
+      inputId: this.inputId,
     };
   }
 }
@@ -310,6 +334,7 @@ function getStringProperty(item: object, key: string): string | undefined {
 }
 
 export type RunItem =
+  | RunInputItem
   | RunMessageOutputItem
   | RunToolCallItem
   | RunToolSearchCallItem

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -16,7 +16,7 @@ import {
 } from '@openai/agents-core/_shims';
 import { ReadableStream } from './shims/interface';
 import { RunStreamEvent } from './events';
-import { getTurnInput } from './runner/items';
+import { getRunOutput, getTurnInput } from './runner/items';
 import { RunState } from './runState';
 import { RunContext } from './runContext';
 import type { AgentToolInvocation } from './agentToolInvocation';
@@ -159,7 +159,7 @@ class RunResultBase<
    * For the output including the agents, use the `newItems` property.
    */
   get output(): AgentOutputItem[] {
-    return getTurnInput([], this.newItems, this.state._reasoningItemIdPolicy);
+    return getRunOutput(this.newItems, this.state._reasoningItemIdPolicy);
   }
 
   /**

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -14,7 +14,6 @@ import {
 } from './guardrail';
 import type {
   InputGuardrailDefinition,
-  InputGuardrailResult,
   OutputGuardrailDefinition,
   OutputGuardrailMetadata,
 } from './guardrail';
@@ -58,6 +57,7 @@ import type { AgentInputItem } from './types';
 import {
   ServerConversationTracker,
   applyCallModelInputFilter,
+  getServerConversationOwner,
 } from './runner/conversation';
 import {
   createGuardrailTracker,
@@ -100,10 +100,22 @@ import {
 } from './runner/turnResolution';
 import { hasBlockedOutputExecutionEffect } from './runner/blockedOutputPersistence';
 import { prepareTurn } from './runner/turnPreparation';
+import type { NextStep } from './runner/steps';
+import {
+  commitPendingInput,
+  hasUnpersistedRunInput,
+  mapPendingInputAfterContextProcessing,
+  selectPendingInputForAdmission,
+} from './runner/pendingInput';
 import { prepareAgentArtifacts } from './runner/modelPreparation';
 import {
   applyTurnResult,
+  assertAcceptedResponseContinuationAuthority,
   handleInterruptedOutcome,
+  isAcceptedResponseCheckpoint,
+  markAcceptedResponseProcessingStarted,
+  markAcceptedResponseFinalizationStarted,
+  resumeAcceptedModelResponse,
   resumeInterruptedTurn,
 } from './runner/runLoop';
 import {
@@ -143,6 +155,7 @@ import type {
 } from './runner/types';
 import {
   attachRunStateToError,
+  invalidateAcceptedResponseReplayEvidence,
   prepareRunErrorFinalOutput,
 } from './runner/errorHandlers';
 import type { RunErrorHandlers } from './runner/errorHandlers';
@@ -477,6 +490,27 @@ function rollbackUnstartedTurn(
   return true;
 }
 
+function assertPendingInputServerOwnership(
+  state: RunState<any, any>,
+  conversationId: string | undefined,
+  previousResponseId: string | undefined,
+): void {
+  const serverManagesConversation = Boolean(
+    conversationId || previousResponseId,
+  );
+  if (
+    state._pendingInput.length === 0 ||
+    !serverManagesConversation ||
+    getServerConversationOwner(conversationId, previousResponseId)
+  ) {
+    return;
+  }
+  throw new UserError(
+    'Pending RunState input requires exactly one server-managed conversation owner',
+    state,
+  );
+}
+
 // --------------------------------------------------------------
 //  Runner
 // --------------------------------------------------------------
@@ -724,6 +758,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       AgentInputItem[] | undefined;
     if (resumingFromState) {
       const resumedState = input as RunState<TContext, TAgent>;
+      assertAcceptedResponseContinuationAuthority(
+        resumedState,
+        effectiveOptions.conversationId,
+        effectiveOptions.previousResponseId,
+      );
       const hadSessionBinding =
         resumedState._currentTurnSessionHistoryTransactionSessionId !==
         undefined;
@@ -1097,12 +1136,18 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       const resolvedPreviousResponseId =
         options.previousResponseId ??
         (isResumedState ? state._previousResponseId : undefined);
+      const serverManagesConversation = Boolean(
+        resolvedConversationId || resolvedPreviousResponseId,
+      );
+      assertPendingInputServerOwnership(
+        state,
+        resolvedConversationId,
+        resolvedPreviousResponseId,
+      );
 
       if (!isResumedState) {
         await prepareSessionHistoryTransactionsForRun(options.session, state, {
-          serverManagesConversation: Boolean(
-            resolvedConversationId || resolvedPreviousResponseId,
-          ),
+          serverManagesConversation,
         });
       }
 
@@ -1113,14 +1158,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         );
       }
 
-      const serverConversationTracker =
-        resolvedConversationId || resolvedPreviousResponseId
-          ? new ServerConversationTracker({
-              conversationId: resolvedConversationId,
-              previousResponseId: resolvedPreviousResponseId,
-              reasoningItemIdPolicy: resolvedReasoningItemIdPolicy,
-            })
-          : undefined;
+      const serverConversationTracker = serverManagesConversation
+        ? new ServerConversationTracker({
+            conversationId: resolvedConversationId,
+            previousResponseId: resolvedPreviousResponseId,
+            reasoningItemIdPolicy: resolvedReasoningItemIdPolicy,
+          })
+        : undefined;
 
       if (serverConversationTracker && isResumedState) {
         serverConversationTracker.primeFromState({
@@ -1172,8 +1216,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
       let continuingInterruptedTurn = false;
       let runError: unknown;
+      const attemptedRunErrorHandlers = new WeakSet<object>();
       let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
       let turnPendingModelRequest: TurnPreparationSnapshot | undefined;
+      let guardrailTracker = createGuardrailTracker();
       const parentUsageRecorder = getRunnerParentUsageRecorder(this);
       const recordUsage = (usage: Usage) => {
         recordRunnerSpanUsage(taskSpan, usage);
@@ -1244,6 +1290,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             state,
           );
         }
+        markAcceptedResponseFinalizationStarted(state);
         try {
           await runOutputGuardrails(
             state,
@@ -1320,6 +1367,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           state._currentStep = state._currentStep ?? {
             type: 'next_step_run_again',
           };
+
+          if (isAcceptedResponseCheckpoint(state)) {
+            await resumeAcceptedModelResponse({
+              state,
+              runner: this,
+              toolErrorFormatter,
+              agentToolParentRunConfig,
+              signal: options.signal,
+            });
+          }
 
           if (state._currentStep.type === 'next_step_interruption') {
             await prepareSandboxInterruptedTurnResume({
@@ -1403,7 +1460,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
             const wasContinuingInterruptedTurn = continuingInterruptedTurn;
             continuingInterruptedTurn = false;
-            const guardrailTracker = createGuardrailTracker();
+            guardrailTracker = createGuardrailTracker();
             const previousTurn = state._currentTurn;
             turnPendingModelRequest = {
               currentTurn: previousTurn,
@@ -1411,35 +1468,36 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             };
             const previousPersistedCount = state._currentTurnPersistedItemCount;
             const previousGeneratedCount = state._generatedItems.length;
-            const { turnInput, parallelGuardrailPromise } = await prepareTurn({
-              state,
-              input: state._originalInput,
-              generatedItems: state._generatedItems,
-              isResumedState,
-              preserveTurnPersistenceOnResume,
-              continuingInterruptedTurn: wasContinuingInterruptedTurn,
-              serverConversationTracker,
-              inputGuardrailDefs: this.inputGuardrailDefs,
-              guardrailHandlers: {
-                onParallelStart: guardrailTracker.markPending,
-                onParallelError: guardrailTracker.setError,
-              },
-              emitAgentStart: (context, agent, inputItems) => {
-                this.emit('agent_start', context, agent, inputItems);
-              },
-              onAgentSpanReady: useTaskAndTurnSpans
-                ? (turn, agentName) => {
-                    currentTurnSpan = ensureTurnSpan(
-                      currentTurnSpan,
-                      turn,
-                      agentName,
-                      state._currentAgentSpan,
-                    );
-                    setRunStateTurnSpanParent(state, currentTurnSpan.span);
-                  }
-                : undefined,
-              agentSpanParent: taskSpan?.span ?? invocationSpanParent,
-            });
+            const { turnInput, pendingInputItems, pendingInputSourceItems } =
+              await prepareTurn({
+                state,
+                input: state._originalInput,
+                generatedItems: state._generatedItems,
+                isResumedState,
+                preserveTurnPersistenceOnResume,
+                continuingInterruptedTurn: wasContinuingInterruptedTurn,
+                serverConversationTracker,
+                inputGuardrailDefs: this.inputGuardrailDefs,
+                guardrailHandlers: {
+                  onParallelPromise: guardrailTracker.setPromise,
+                  onParallelError: guardrailTracker.setError,
+                },
+                emitAgentStart: (context, agent, inputItems) => {
+                  this.emit('agent_start', context, agent, inputItems);
+                },
+                onAgentSpanReady: useTaskAndTurnSpans
+                  ? (turn, agentName) => {
+                      currentTurnSpan = ensureTurnSpan(
+                        currentTurnSpan,
+                        turn,
+                        agentName,
+                        state._currentAgentSpan,
+                      );
+                      setRunStateTurnSpanParent(state, currentTurnSpan.span);
+                    }
+                  : undefined,
+                agentSpanParent: taskSpan?.span ?? invocationSpanParent,
+              });
             if (
               preserveTurnPersistenceOnResume &&
               state._currentTurn > previousTurn &&
@@ -1449,7 +1507,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               state._currentTurnPersistedItemCount = previousPersistedCount;
             }
 
-            guardrailTracker.setPromise(parallelGuardrailPromise);
             const sessionPreparedTurnInput = [...turnInput];
             const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
               currentAgent: state._currentAgent,
@@ -1463,6 +1520,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               sessionPreparedTurnInput,
               preparedSandboxAgent.turnInput,
             );
+            const processedPendingInputItems =
+              mapPendingInputAfterContextProcessing(
+                pendingInputItems,
+                sessionPreparedTurnInput,
+                preparedSandboxAgent.turnInput,
+              );
             const artifacts = await prepareAgentArtifacts(
               state,
               preparedSandboxAgent.executionAgent,
@@ -1484,6 +1547,48 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             );
 
             await guardrailTracker.throwIfError();
+
+            const requiresPendingInputAdmissionCheckpoint =
+              pendingInputItems.length > 0 ||
+              (!serverConversationTracker && hasUnpersistedRunInput(state));
+            if (requiresPendingInputAdmissionCheckpoint) {
+              options.signal?.throwIfAborted();
+            }
+            const admittedPendingInput = selectPendingInputForAdmission(
+              processedPendingInputItems,
+              preparedCall,
+            );
+            let localPendingInputCommitted = false;
+            const commitLocalPendingInput = async () => {
+              if (serverConversationTracker || localPendingInputCommitted) {
+                return;
+              }
+              localPendingInputCommitted = true;
+              commitPendingInput(
+                state,
+                pendingInputItems,
+                admittedPendingInput,
+                pendingInputSourceItems,
+              );
+              if (hasUnpersistedRunInput(state)) {
+                await saveToSession(
+                  options.session,
+                  undefined,
+                  new RunResult<TContext, TAgent>(state),
+                  { runCompaction: false },
+                );
+              }
+              if (requiresPendingInputAdmissionCheckpoint) {
+                options.signal?.throwIfAborted();
+              }
+            };
+            const deferLocalPendingInputAdmission =
+              !serverConversationTracker &&
+              pendingInputItems.length > 0 &&
+              guardrailTracker.pending;
+            if (!deferLocalPendingInputAdmission) {
+              await commitLocalPendingInput();
+            }
 
             const modelRequest: ModelRequest = {
               systemInstructions: preparedCall.modelInput.instructions,
@@ -1510,11 +1615,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               signal: options.signal,
             };
             turnPendingModelRequest = undefined;
-            state._lastTurnResponse = await getResponseWithRetry(
-              preparedCall.model,
-              modelRequest,
-            );
-            if (serverConversationTracker) {
+            let serverInputMarked = false;
+            const markServerInputAccepted = (responseAvailable = true) => {
+              if (serverInputMarked || !serverConversationTracker) {
+                return;
+              }
               serverConversationTracker.markInputAsSent(
                 preparedCall.filterApplied
                   ? preparedCall.sourceItems
@@ -1524,6 +1629,63 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   allTurnItems: preparedCall.turnInput,
                 },
               );
+              commitPendingInput(
+                state,
+                pendingInputItems,
+                admittedPendingInput,
+                pendingInputSourceItems,
+              );
+              if (pendingInputItems.length > 0) {
+                if (admittedPendingInput.length > 0) {
+                  serverConversationTracker.markInputAsSent(
+                    admittedPendingInput.map((item) => item.rawItem),
+                  );
+                }
+                if (!responseAvailable) {
+                  state._lastTurnResponse = undefined;
+                }
+                state._lastProcessedResponse = undefined;
+                state._currentStep = {
+                  type: 'next_step_interruption',
+                  data: { interruptions: [], responseAccepted: true },
+                };
+              }
+              serverInputMarked = true;
+            };
+            const pendingModelResponse = getResponseWithRetry(
+              preparedCall.model,
+              modelRequest,
+              serverConversationTracker && pendingInputItems.length > 0
+                ? {
+                    onPossiblyAcceptedRequestFailure: () =>
+                      markServerInputAccepted(false),
+                  }
+                : undefined,
+            );
+            if (deferLocalPendingInputAdmission) {
+              const modelResponseOutcome = pendingModelResponse.then(
+                (response) => ({ status: 'fulfilled' as const, response }),
+                (error: unknown) => ({ status: 'rejected' as const, error }),
+              );
+              try {
+                await guardrailTracker.awaitCompletion();
+                await commitLocalPendingInput();
+              } catch (error) {
+                // The request already started in parallel, so drain it before
+                // surfacing a guardrail or persistence failure.
+                await modelResponseOutcome;
+                throw error;
+              }
+              const outcome = await modelResponseOutcome;
+              if (outcome.status === 'rejected') {
+                throw outcome.error;
+              }
+              state._lastTurnResponse = outcome.response;
+            } else {
+              state._lastTurnResponse = await pendingModelResponse;
+            }
+            if (serverConversationTracker) {
+              markServerInputAccepted();
             }
             state._modelResponses.push(state._lastTurnResponse);
             state._context.usage.add(state._lastTurnResponse.usage);
@@ -1572,6 +1734,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
             await guardrailTracker.awaitCompletion();
 
+            markAcceptedResponseProcessingStarted(state);
+
             const turnResult = await resolveTurnAfterModelResponse(
               state._currentAgent,
               state._originalInput,
@@ -1585,6 +1749,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               options.errorHandlers,
               options.signal,
               suppressedToolCalls,
+              attemptedRunErrorHandlers,
             );
 
             applyTurnResult({
@@ -1605,7 +1770,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
           }
 
-          const currentStep = state._currentStep;
+          const currentStep = state._currentStep as NextStep | undefined;
           if (!currentStep) {
             logger.debug('Running next loop');
             continue;
@@ -1646,7 +1811,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               logger.debug('Running next loop');
           }
         }
-      } catch (err) {
+      } catch (caughtError) {
+        if (guardrailTracker.pending) {
+          await guardrailTracker.awaitCompletion({ suppressErrors: true });
+        }
+        const err = guardrailTracker.failed
+          ? guardrailTracker.error
+          : caughtError;
+        if (guardrailTracker.failed) {
+          invalidateAcceptedResponseReplayEvidence(state);
+        }
         const restoredPendingTurn = rollbackUnstartedTurn(
           state,
           turnPendingModelRequest,
@@ -1661,6 +1835,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           error: err,
           state,
           errorHandlers: options.errorHandlers,
+          responseAccepted: isAcceptedResponseCheckpoint(state),
+          attemptedErrors: attemptedRunErrorHandlers,
         });
         if (errorHandled) {
           try {
@@ -1766,6 +1942,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       options.previousResponseId ?? result.state._previousResponseId;
     const serverManagesConversation =
       Boolean(resolvedConversationId) || Boolean(resolvedPreviousResponseId);
+    assertPendingInputServerOwnership(
+      result.state,
+      resolvedConversationId,
+      resolvedPreviousResponseId,
+    );
     const serverConversationTracker = serverManagesConversation
       ? new ServerConversationTracker({
           conversationId: resolvedConversationId,
@@ -1792,7 +1973,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       streamInputPersisted = true;
       markSessionHistoryTransactionInputPersisted(result.state);
     };
-    let parallelGuardrailPromise: Promise<InputGuardrailResult[]> | undefined;
     const awaitInputGuardrails = async () => {
       await guardrailTracker.awaitCompletion();
       if (guardrailTracker.failed) {
@@ -1820,6 +2000,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
     let continuingInterruptedTurn = false;
     let runError: unknown;
+    const attemptedRunErrorHandlers = new WeakSet<object>();
     let suppressStreamInputPersistence = false;
     let approvedToolCheckpointCompacted = false;
     let approvedToolCheckpointRequiresLocalInputCompaction =
@@ -1827,6 +2008,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     let approvedToolCheckpointModelResponseCount = result.rawResponses.length;
     let currentTurnSpan: ReturnType<typeof startTurnSpan> | undefined;
     let turnPendingModelRequest: TurnPreparationSnapshot | undefined;
+    let commitDeferredLocalPendingInput: (() => Promise<void>) | undefined;
     const parentUsageRecorder = getRunnerParentUsageRecorder(this);
     const recordUsage = (usage: Usage) => {
       recordRunnerSpanUsage(taskSpan, usage);
@@ -1895,6 +2077,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           result.state,
         );
       }
+      markAcceptedResponseFinalizationStarted(result.state);
       result._hideFinalOutput();
       try {
         await runOutputGuardrails(
@@ -1990,6 +2173,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           type: 'next_step_run_again',
         };
 
+        if (isAcceptedResponseCheckpoint(result.state)) {
+          await resumeAcceptedModelResponse({
+            state: result.state,
+            runner: this,
+            toolErrorFormatter,
+            agentToolParentRunConfig,
+            signal: options.signal,
+            onStepItems: (turnResult) => {
+              addStepToRunResult(result, turnResult);
+            },
+          });
+        }
+
         if (result.state._currentStep.type === 'next_step_interruption') {
           await prepareSandboxInterruptedTurnResume({
             startingAgent,
@@ -2063,6 +2259,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         }
 
         if (result.state._currentStep.type === 'next_step_run_again') {
+          commitDeferredLocalPendingInput = undefined;
           if (
             approvedToolCheckpointCompacted &&
             result.state._currentTurnSessionHistoryTransactionSessionId ===
@@ -2074,7 +2271,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               { serverManagesConversation: false },
             );
           }
-          parallelGuardrailPromise = undefined;
           guardrailTracker = createGuardrailTracker();
           const wasContinuingInterruptedTurn = continuingInterruptedTurn;
           continuingInterruptedTurn = false;
@@ -2096,9 +2292,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             serverConversationTracker,
             inputGuardrailDefs: this.inputGuardrailDefs,
             guardrailHandlers: {
-              onParallelStart: () => {
-                guardrailTracker.markPending();
-              },
+              onParallelPromise: guardrailTracker.setPromise,
               onParallelError: (err) => {
                 guardrailTracker.setError(err);
               },
@@ -2128,9 +2322,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             result.state._currentTurnPersistedItemCount =
               previousPersistedCount;
           }
-          const { turnInput } = preparedTurn;
-          parallelGuardrailPromise = preparedTurn.parallelGuardrailPromise;
-          guardrailTracker.setPromise(parallelGuardrailPromise);
+          const { turnInput, pendingInputItems, pendingInputSourceItems } =
+            preparedTurn;
           // If guardrails are still running, defer input persistence until they finish.
           const sessionPreparedTurnInput = [...turnInput];
           const preparedSandboxAgent = await sandboxRuntime.prepareAgent({
@@ -2146,6 +2339,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             sessionPreparedTurnInput,
             preparedSandboxAgent.turnInput,
           );
+          const processedPendingInputItems =
+            mapPendingInputAfterContextProcessing(
+              pendingInputItems,
+              sessionPreparedTurnInput,
+              preparedSandboxAgent.turnInput,
+            );
           const artifacts = await prepareAgentArtifacts(
             result.state,
             preparedSandboxAgent.executionAgent,
@@ -2169,7 +2368,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
           await guardrailTracker.throwIfError();
 
-          // Initial request and session-persistence ordering remain unchanged.
           // Once a logical turn is established, do not start another model
           // request if cancellation arrives during asynchronous preparation.
           if ((sentInputToModel || isResumedState) && result.cancelled) {
@@ -2178,18 +2376,57 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             return;
           }
 
+          const admittedPendingInput = selectPendingInputForAdmission(
+            processedPendingInputItems,
+            preparedCall,
+          );
+          let localPendingInputCommitted = false;
+          const commitLocalPendingInput = async () => {
+            if (serverConversationTracker || localPendingInputCommitted) {
+              return;
+            }
+            localPendingInputCommitted = true;
+            commitPendingInput(
+              result.state,
+              pendingInputItems,
+              admittedPendingInput,
+              pendingInputSourceItems,
+            );
+            if (hasUnpersistedRunInput(result.state)) {
+              await saveStreamResultToSession(options.session, result, {
+                runCompaction: false,
+              });
+            }
+          };
+          const deferLocalPendingInputAdmission =
+            !serverConversationTracker &&
+            pendingInputItems.length > 0 &&
+            guardrailTracker.pending;
+          if (deferLocalPendingInputAdmission) {
+            commitDeferredLocalPendingInput = async () => {
+              commitDeferredLocalPendingInput = undefined;
+              await commitLocalPendingInput();
+            };
+          } else {
+            await commitLocalPendingInput();
+            if ((sentInputToModel || isResumedState) && result.cancelled) {
+              rollbackUnstartedTurn(result.state, turnPendingModelRequest);
+              turnPendingModelRequest = undefined;
+              return;
+            }
+          }
+
           let finalResponse: ModelResponse | undefined = undefined;
           const abortReconciliationState =
             createStreamAbortReconciliationState();
           let inputMarked = false;
-          const markInputOnce = () => {
+          const markServerInputAccepted = () => {
             if (inputMarked || !serverConversationTracker) {
               return;
             }
-            // We only mark inputs as sent after receiving the first stream event,
-            // which is the earliest reliable confirmation that the server accepted
-            // the request. If the stream fails before any events, leave inputs
-            // unmarked so a retry can resend safely.
+            // Mark inputs after the first stream event, an explicit abort after
+            // request start, or provider advice that the failed request may have
+            // been accepted.
             // Record the exact input that was sent so the server tracker can advance safely.
             serverConversationTracker.markInputAsSent(
               preparedCall.filterApplied
@@ -2200,6 +2437,25 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 allTurnItems: preparedCall.turnInput,
               },
             );
+            commitPendingInput(
+              result.state,
+              pendingInputItems,
+              admittedPendingInput,
+              pendingInputSourceItems,
+            );
+            if (pendingInputItems.length > 0) {
+              if (admittedPendingInput.length > 0) {
+                serverConversationTracker.markInputAsSent(
+                  admittedPendingInput.map((item) => item.rawItem),
+                );
+              }
+              result.state._lastTurnResponse = undefined;
+              result.state._lastProcessedResponse = undefined;
+              result.state._currentStep = {
+                type: 'next_step_interruption',
+                data: { interruptions: [], responseAccepted: true },
+              };
+            }
             inputMarked = true;
           };
           const reconcileStreamAbortIfNeeded = async () => {
@@ -2298,9 +2554,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             for await (const event of getStreamedResponseWithRetry(
               preparedCall.model,
               modelRequest,
+              serverConversationTracker && pendingInputItems.length > 0
+                ? {
+                    onPossiblyAcceptedRequestFailure: markServerInputAccepted,
+                  }
+                : undefined,
             )) {
+              markServerInputAccepted();
               await guardrailTracker.throwIfError();
-              markInputOnce();
               recordStreamEventForAbortReconciliation(
                 abortReconciliationState,
                 event,
@@ -2338,6 +2599,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   requestId: parsed.response.requestId,
                   ...(rawUsage !== undefined ? { rawUsage } : {}),
                 };
+                result.state._lastTurnResponse = finalResponse;
                 result.state._context.usage.add(finalResponse.usage);
                 recordUsage(finalResponse.usage);
               }
@@ -2345,6 +2607,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 // When the user's code exits a loop to consume the stream, we need to break
                 // this loop to prevent internal false errors and unnecessary processing
                 await awaitInputGuardrails();
+                await commitDeferredLocalPendingInput?.();
                 await reconcileStreamAbortIfNeeded();
                 return;
               }
@@ -2353,9 +2616,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           } catch (error) {
             if (isAbortError(error)) {
               if (sentInputToModel) {
-                markInputOnce();
+                markServerInputAccepted();
               }
               await awaitInputGuardrails();
+              await commitDeferredLocalPendingInput?.();
               await reconcileStreamAbortIfNeeded();
               return;
             }
@@ -2363,10 +2627,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           }
 
           if (finalResponse) {
-            markInputOnce();
+            markServerInputAccepted();
           }
 
           await awaitInputGuardrails();
+          await commitDeferredLocalPendingInput?.();
 
           if (result.cancelled) {
             return;
@@ -2430,6 +2695,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             streamStepItemsToRunResult(result, streamableItems);
           }
 
+          markAcceptedResponseProcessingStarted(result.state);
+
           const turnResult = await resolveTurnAfterModelResponse(
             currentAgent,
             result.state._originalInput,
@@ -2443,6 +2710,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             options.errorHandlers,
             options.signal,
             suppressedToolCalls,
+            attemptedRunErrorHandlers,
           );
 
           applyTurnResult({
@@ -2499,7 +2767,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             logger.debug('Running next loop');
         }
       }
-    } catch (error) {
+    } catch (caughtError) {
+      if (guardrailTracker.pending) {
+        await guardrailTracker.awaitCompletion({ suppressErrors: true });
+      }
+      if (!guardrailTracker.failed) {
+        await commitDeferredLocalPendingInput?.();
+      }
+      const error = guardrailTracker.failed
+        ? guardrailTracker.error
+        : caughtError;
       const restoredPendingTurn = rollbackUnstartedTurn(
         result.state,
         turnPendingModelRequest,
@@ -2512,14 +2789,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       releaseUnusedSessionHistoryTransactionBinding(result.state);
       suppressStreamInputPersistence =
         error instanceof CompactionItemValidationError;
-      if (guardrailTracker.pending) {
-        await guardrailTracker.awaitCompletion({ suppressErrors: true });
-      }
       const errorHandled = await prepareRunErrorFinalOutput({
         error,
         state: result.state,
         errorHandlers: options.errorHandlers,
         streamResult: result,
+        responseAccepted: isAcceptedResponseCheckpoint(result.state),
+        attemptedErrors: attemptedRunErrorHandlers,
       });
       if (errorHandled) {
         try {
@@ -2820,14 +3096,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         artifacts.serializedHandoffs.length === 0
       );
 
-    const { modelInput, sourceItems, persistedItems, filterApplied } =
-      await applyCallModelInputFilter(
-        state._currentAgent,
-        options.callModelInputFilter,
-        state._context,
-        turnInput,
-        systemInstructions,
-      );
+    const {
+      modelInput,
+      sourceItems,
+      persistedItems,
+      sourceMatchKinds,
+      filterApplied,
+    } = await applyCallModelInputFilter(
+      state._currentAgent,
+      options.callModelInputFilter,
+      state._context,
+      turnInput,
+      systemInstructions,
+    );
 
     // Persist normalized clones so session history mirrors the exact model payload. An empty array
     // is intentional when a filter removes everything.
@@ -2851,6 +3132,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       previousResponseId,
       conversationId,
       sourceItems,
+      persistedItems,
+      sourceMatchKinds,
       filterApplied,
       turnInput,
     };

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -7,6 +7,7 @@ import { buildAgentIdentityMap } from './runStateIdentity';
 export { buildAgentIdentityMap } from './runStateIdentity';
 import {
   RunMessageOutputItem,
+  RunInputItem,
   RunItem,
   RunToolApprovalItem,
   RunToolCallItem,
@@ -23,8 +24,10 @@ import { RunContext } from './runContext';
 import {
   extractOutputItemsFromRunItems,
   getTurnInput,
+  toAgentInputList,
   type ReasoningItemIdPolicy,
 } from './runner/items';
+import { getServerConversationOwner } from './runner/conversation';
 import { AgentToolUseTracker } from './runner/toolUseTracker';
 import { nextStepSchema, NextStep } from './runner/steps';
 import { createToolRunFunction, type ProcessedResponse } from './runner/types';
@@ -70,6 +73,7 @@ import {
   getFunctionToolStateKeys,
   getHostedMcpApprovalRequestIdentity,
   getHostedMcpApprovalRequestKey,
+  getToolCallName,
   getToolCallNamespace,
   getToolCallDisplayName,
   resolveFunctionToolCall,
@@ -150,8 +154,9 @@ import {
  * - 1.18: Adds sandbox session-state envelope version 3 so credential-redacted
  *   mount authority cannot be consumed by older SDKs, and binds per-call approvals
  *   and committed local tool results to canonical invocation fingerprints. It also
- *   scopes persistent hosted MCP approvals by server label and tool name, and preserves
- *   JSON-compatible tool outputs as structured data.
+ *   scopes persistent hosted MCP approvals by server label and tool name, preserves
+ *   JSON-compatible tool outputs as structured data, and adds durable pending input
+ *   and accepted-response resume state.
  */
 export const CURRENT_SCHEMA_VERSION = '1.18' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
@@ -1231,6 +1236,12 @@ const jsonCompatibleValueSchema = z.preprocess(
 
 const itemSchema = z.discriminatedUnion('type', [
   z.object({
+    type: z.literal('input_item'),
+    rawItem: protocol.ModelItem,
+    agent: serializedAgentSchema,
+    inputId: z.string().min(1),
+  }),
+  z.object({
     type: z.literal('message_output_item'),
     rawItem: protocol.AssistantMessageItem,
     agent: serializedAgentSchema,
@@ -1636,6 +1647,7 @@ export const SerializedRunState = z.object({
   currentTurn: z.number(),
   currentAgent: serializedAgentSchema,
   originalInput: z.string().or(z.array(protocol.ModelItem)),
+  pendingInput: z.array(protocol.ModelItem).optional(),
   modelResponses: z.array(modelResponseSchema),
   context: z.object({
     usage: usageSchema,
@@ -1774,6 +1786,10 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    * Original user input prior to any processing.
    */
   public _originalInput: string | AgentInputItem[];
+  /**
+   * Input staged for admission immediately before the next resumed model call.
+   */
+  public _pendingInput: AgentInputItem[];
   /**
    * Responses from the model so far.
    */
@@ -1978,6 +1994,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     this._context = context;
     this._agentToolInvocation = undefined;
     this._originalInput = structuredClone(originalInput);
+    this._pendingInput = [];
     this._modelResponses = [];
     this._currentAgentSpan = undefined;
     this._currentAgent = startingAgent;
@@ -2330,6 +2347,75 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
   }
 
   /**
+   * Returns a copy of input staged for the next resumed model call.
+   */
+  get pendingInput(): AgentInputItem[] {
+    return structuredClone(this._pendingInput);
+  }
+
+  /**
+   * Stages input for admission immediately before the next resumed model call.
+   */
+  addInput(input: string | AgentInputItem[]): void {
+    const currentStep = this._currentStep;
+    if (
+      currentStep?.type !== 'next_step_interruption' &&
+      currentStep?.type !== 'next_step_run_again'
+    ) {
+      throw new UserError('Cannot add input to a terminal RunState', this);
+    }
+    if (
+      this._maxTurns !== null &&
+      this._currentTurn >= this._maxTurns &&
+      !this._currentTurnInProgress
+    ) {
+      throw new UserError(
+        'Cannot add input to a RunState with no remaining model turns',
+        this,
+      );
+    }
+    if (currentStep.type === 'next_step_interruption') {
+      if (currentStep.data?.responseAccepted === true) {
+        throw new UserError(
+          'Cannot add input while an accepted model response is awaiting local processing',
+          this,
+        );
+      }
+      const toolUseBehavior = this._currentAgent.toolUseBehavior;
+      const interruptions = this.getInterruptions();
+      const stopsBeforeNextModel =
+        toolUseBehavior === 'stop_on_first_tool' ||
+        (typeof toolUseBehavior === 'object' &&
+          toolUseBehavior.stopAtToolNames.some((toolName) =>
+            interruptions.some(
+              (item) =>
+                item.name === toolName ||
+                (item.rawItem.type === 'function_call' &&
+                  getToolCallName(item.rawItem) === toolName),
+            ),
+          ));
+      if (stopsBeforeNextModel || typeof toolUseBehavior === 'function') {
+        throw new UserError(
+          'Cannot add input to an interrupted RunState whose tool result may end the run',
+          this,
+        );
+      }
+    }
+
+    const normalized = toAgentInputList(input).map((item) =>
+      protocol.ModelItem.parse(item),
+    );
+    this._pendingInput.push(...structuredClone(normalized));
+  }
+
+  /**
+   * Removes all input staged for the next resumed model call.
+   */
+  clearPendingInput(): void {
+    this._pendingInput = [];
+  }
+
+  /**
    * Returns all interruptions if the current step is an interruption otherwise returns an empty array.
    */
   getInterruptions(): RunToolApprovalItem[] {
@@ -2582,6 +2668,8 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
         agentIdentity.byAgent,
       ),
       originalInput: this._originalInput as any,
+      pendingInput:
+        this._pendingInput.length > 0 ? this._pendingInput : undefined,
       modelResponses: this._modelResponses.map((response) => {
         return {
           usage: {
@@ -2781,6 +2869,10 @@ async function buildRunStateFromString<
     currentSchemaVersion as SupportedSchemaVersion,
     jsonResult,
   );
+  const hasPendingInputField =
+    jsonResult !== null &&
+    typeof jsonResult === 'object' &&
+    hasOwnProperty(jsonResult, 'pendingInput');
   const stateJson = SerializedRunState.parse(jsonResult);
   assertSchemaVersionSupportsStructuredToolOutputs(
     currentSchemaVersion as SupportedSchemaVersion,
@@ -2809,6 +2901,11 @@ async function buildRunStateFromString<
   assertSchemaVersionSupportsOutputGuardrailSessionPersistence(
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
+  );
+  assertSchemaVersionSupportsPendingInput(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+    hasPendingInputField,
   );
   const normalizedState = rehydrateLegacyCompactionRunItems(
     currentSchemaVersion as SupportedSchemaVersion,
@@ -3095,6 +3192,93 @@ function assertSchemaVersionSupportsOutputGuardrailSessionPersistence(
   throw new UserError(
     `Run state schema version ${schemaVersion} does not support output guardrail session persistence state. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
   );
+}
+
+function assertSchemaVersionSupportsPendingInput(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+  hasPendingInputField: boolean,
+): void {
+  if (schemaVersionSupportsV118State(schemaVersion)) {
+    validateAcceptedResponseState(stateJson);
+    return;
+  }
+  const hasInputItems = [
+    ...stateJson.generatedItems,
+    ...(stateJson.lastProcessedResponse?.newItems ?? []),
+  ].some((item) => item.type === 'input_item');
+  const hasAcceptedResponseState = hasAcceptedResponseStepFields(
+    stateJson.currentStep,
+  );
+  if (
+    !hasPendingInputField &&
+    (stateJson.pendingInput?.length ?? 0) === 0 &&
+    !hasInputItems &&
+    !hasAcceptedResponseState
+  ) {
+    return;
+  }
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support pending input. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function hasAcceptedResponseStepFields(
+  currentStep: z.infer<typeof nextStepSchema> | undefined,
+): boolean {
+  if (currentStep?.type === 'next_step_interruption') {
+    return (
+      hasOwnProperty(currentStep.data, 'responseAccepted') ||
+      hasOwnProperty(currentStep.data, 'localProcessingStarted')
+    );
+  }
+  return (
+    currentStep?.type === 'next_step_final_output' &&
+    (currentStep.responseAccepted !== undefined ||
+      currentStep.localFinalizationStarted !== undefined)
+  );
+}
+
+function hasOwnProperty(record: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function validateAcceptedResponseState(
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  const currentStep = stateJson.currentStep;
+  let responseAccepted = false;
+  let invalidProgress = false;
+  if (currentStep?.type === 'next_step_interruption') {
+    const hasAccepted = hasOwnProperty(currentStep.data, 'responseAccepted');
+    const hasStarted = hasOwnProperty(
+      currentStep.data,
+      'localProcessingStarted',
+    );
+    responseAccepted = currentStep.data.responseAccepted === true;
+    invalidProgress =
+      (hasAccepted && !responseAccepted) ||
+      (hasStarted && currentStep.data.localProcessingStarted !== true) ||
+      (hasStarted && !responseAccepted);
+  } else if (currentStep?.type === 'next_step_final_output') {
+    responseAccepted = currentStep.responseAccepted === true;
+    invalidProgress =
+      currentStep.localFinalizationStarted === true && !responseAccepted;
+  }
+  if (invalidProgress) {
+    throw new UserError('RunState accepted response progress is invalid.');
+  }
+  if (
+    responseAccepted &&
+    !getServerConversationOwner(
+      stateJson.conversationId,
+      stateJson.previousResponseId,
+    )
+  ) {
+    throw new UserError(
+      'Accepted model response state requires exactly one server-managed conversation owner.',
+    );
+  }
 }
 
 function validateOutputGuardrailSessionPersistenceState(
@@ -5297,6 +5481,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   state._currentStep = stateJson.currentStep;
 
   state._originalInput = stateJson.originalInput;
+  state._pendingInput = structuredClone(stateJson.pendingInput ?? []);
   state._modelResponses = stateJson.modelResponses.map(
     deserializeModelResponse,
   );
@@ -5753,6 +5938,12 @@ export function deserializeItem(
   agentMap: Map<string, Agent<any, any>>,
 ): RunItem {
   switch (serializedItem.type) {
+    case 'input_item':
+      return new RunInputItem(
+        serializedItem.rawItem,
+        resolveSerializedAgent(serializedItem.agent, agentMap),
+        serializedItem.inputId,
+      );
     case 'message_output_item':
       return new RunMessageOutputItem(
         serializedItem.rawItem,

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -1,6 +1,6 @@
 import { Agent, AgentOutputType } from '../agent';
 import { UserError } from '../errors';
-import { RunItem } from '../items';
+import { RunInputItem, RunItem } from '../items';
 import { ModelResponse } from '../model';
 import { RunContext } from '../runContext';
 import { AgentInputItem } from '../types';
@@ -53,8 +53,37 @@ export type FilterApplicationResult = {
   modelInput: { input: AgentInputItem[]; instructions?: string };
   sourceItems: (AgentInputItem | undefined)[];
   persistedItems: AgentInputItem[];
+  sourceMatchKinds: Array<'identity' | 'content' | 'fallback' | 'injected'>;
   filterApplied: boolean;
 };
+
+export type ServerConversationOwner =
+  | { type: 'conversation'; id: string }
+  | { type: 'previous_response'; id: string };
+
+/**
+ * Resolves the single server-side continuation owner for an accepted response.
+ */
+export function getServerConversationOwner(
+  conversationId: string | undefined,
+  previousResponseId: string | undefined,
+): ServerConversationOwner | undefined {
+  if (
+    typeof conversationId === 'string' &&
+    conversationId.length > 0 &&
+    previousResponseId === undefined
+  ) {
+    return { type: 'conversation', id: conversationId };
+  }
+  if (
+    typeof previousResponseId === 'string' &&
+    previousResponseId.length > 0 &&
+    conversationId === undefined
+  ) {
+    return { type: 'previous_response', id: previousResponseId };
+  }
+  return undefined;
+}
 
 /**
  * Applies the optional callModelInputFilter and returns the filtered input alongside the original
@@ -98,6 +127,7 @@ export async function applyCallModelInputFilter<TContext>(
         (item) => cloneMap.get(item as object) ?? item,
       ),
       persistedItems: cloneInputItems(normalizedInput),
+      sourceMatchKinds: normalizedInput.map(() => 'identity'),
       filterApplied: false,
     };
   }
@@ -168,6 +198,10 @@ export async function applyCallModelInputFilter<TContext>(
         return original;
       },
     );
+    const sourceMatchKinds: FilterApplicationResult['sourceMatchKinds'] =
+      sourceItems.map((source) =>
+        source === undefined ? 'injected' : 'identity',
+      );
 
     // Reserve all exact clone matches before considering equal-content items. A prepended clone
     // that happens to equal a later unchanged item must remain an injected item.
@@ -187,6 +221,7 @@ export async function applyCallModelInputFilter<TContext>(
       if (matchedByContent) {
         removeFromFallback(matchedByContent);
         sourceItems[index] = matchedByContent;
+        sourceMatchKinds[index] = 'content';
       }
     }
 
@@ -205,6 +240,7 @@ export async function applyCallModelInputFilter<TContext>(
       const fallback = takeFallbackOriginal();
       if (fallback) {
         sourceItems[index] = fallback;
+        sourceMatchKinds[index] = 'fallback';
       }
     }
 
@@ -219,6 +255,7 @@ export async function applyCallModelInputFilter<TContext>(
       },
       sourceItems,
       persistedItems: clonedFilteredInput.map((item) => structuredClone(item)),
+      sourceMatchKinds,
       filterApplied: true,
     };
   } catch (error) {
@@ -379,6 +416,10 @@ export class ServerConversationTracker {
           continue;
         }
         const rawItemKey = getAgentInputItemKey(rawItem as AgentInputItem);
+        if (item instanceof RunInputItem) {
+          this.sentItems.add(rawItem);
+          continue;
+        }
         if (this.serverItems.has(rawItem) || serverItemKeys.has(rawItemKey)) {
           this.sentItems.add(rawItem);
           continue;

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -20,7 +20,7 @@ import type {
   AgentOutputItem,
   ResolvedAgentOutput,
 } from '../types';
-import { getTurnInput } from './items';
+import { getRunOutput, getTurnInput } from './items';
 import { streamStepItemsToRunResult } from './streaming';
 import { createRedactedErrorDetailsError } from '../utils/finalOutputError';
 
@@ -81,6 +81,8 @@ type TryHandleRunErrorArgs<TContext, TAgent extends Agent<any, any>> = {
   state: RunState<TContext, TAgent>;
   errorHandlers?: RunErrorHandlers<TContext, TAgent>;
   streamResult?: StreamedRunResult<TContext, TAgent>;
+  responseAccepted: boolean;
+  attemptedErrors?: WeakSet<object>;
 };
 
 type ResolveRunErrorHandlerArgs<TContext, TAgent extends Agent<any, any>> = {
@@ -89,6 +91,7 @@ type ResolveRunErrorHandlerArgs<TContext, TAgent extends Agent<any, any>> = {
   errorHandlers?: RunErrorHandlers<TContext, TAgent>;
   context: RunContext<TContext>;
   runData: RunErrorData<TContext, TAgent>;
+  attemptedErrors?: WeakSet<object>;
 };
 
 export async function preserveInvalidFinalOutputRedaction<T>(
@@ -136,7 +139,7 @@ const buildRunData = <TContext, TAgent extends Agent<any, any>>(
     state._generatedItems,
     state._reasoningItemIdPolicy,
   ),
-  output: getTurnInput([], state._generatedItems, state._reasoningItemIdPolicy),
+  output: getRunOutput(state._generatedItems, state._reasoningItemIdPolicy),
   rawResponses: state._modelResponses,
   lastAgent: state._currentAgent,
   state,
@@ -182,6 +185,17 @@ export const formatRunErrorFinalOutput = formatFinalOutput;
 export const createRunErrorFinalOutputItem = createFinalOutputItem;
 export const validateRunErrorHandlerFinalOutput = validateRunErrorFinalOutput;
 
+export function invalidateAcceptedResponseReplayEvidence(
+  state: RunState<any, any> | undefined,
+): void {
+  if (
+    state?._currentStep?.type === 'next_step_interruption' &&
+    state._currentStep.data?.responseAccepted === true
+  ) {
+    state._lastProcessedResponse = undefined;
+  }
+}
+
 export const resolveRunErrorHandler = async <
   TContext,
   TAgent extends Agent<any, any>,
@@ -191,6 +205,7 @@ export const resolveRunErrorHandler = async <
   errorHandlers,
   context,
   runData,
+  attemptedErrors,
 }: ResolveRunErrorHandlerArgs<TContext, TAgent>): Promise<
   RunErrorHandlerResult<TAgent> | undefined
 > => {
@@ -224,6 +239,12 @@ export const resolveRunErrorHandler = async <
     return undefined;
   }
 
+  if (attemptedErrors?.has(typedError)) {
+    return undefined;
+  }
+  attemptedErrors?.add(typedError);
+
+  invalidateAcceptedResponseReplayEvidence(runData.state);
   const handlerResult = await handler({
     error: typedError,
     context,
@@ -240,12 +261,15 @@ export const prepareRunErrorFinalOutput = async <
   state,
   errorHandlers,
   streamResult,
+  responseAccepted,
+  attemptedErrors,
 }: TryHandleRunErrorArgs<TContext, TAgent>): Promise<boolean> => {
   const handlerResult = await resolveRunErrorHandler({
     error,
     errorHandlers,
     context: state._context,
     runData: buildRunData(state),
+    attemptedErrors,
   });
   if (!handlerResult) {
     return false;
@@ -269,6 +293,7 @@ export const prepareRunErrorFinalOutput = async <
   state._currentStep = {
     type: 'next_step_final_output',
     output: outputText,
+    ...(responseAccepted ? { responseAccepted: true } : {}),
   };
   state._finalOutputSource = 'error_handler';
   return true;

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -14,7 +14,8 @@ import {
   OutputGuardrailMetadata,
 } from '../guardrail';
 import { RunState } from '../runState';
-import { getTurnInput } from './items';
+import type { AgentInputItem } from '../types';
+import { getRunOutput } from './items';
 import { withGuardrailSpan } from '../tracing';
 import type { GuardrailFunctionOutput } from '../guardrail';
 import { processFinalOutputWithRedaction } from '../utils/finalOutputError';
@@ -209,14 +210,17 @@ export async function runInputGuardrails<
 >(
   state: RunState<TContext, TAgent>,
   guardrails: InputGuardrailDefinition[],
-  options: { onErrorObserved?: (error: unknown) => void } = {},
+  options: {
+    onErrorObserved?: (error: unknown) => void;
+    input?: string | AgentInputItem[];
+  } = {},
 ): Promise<InputGuardrailResult[]> {
   if (guardrails.length === 0) {
     return [];
   }
   const guardrailArgs = {
     agent: state._currentAgent,
-    input: state._originalInput,
+    input: options.input ?? state._originalInput,
     context: state._context,
   };
   return await runGuardrailsWithTripwire({
@@ -274,8 +278,7 @@ export async function runOutputGuardrails<
       : processFinalOutputWithRedaction(() =>
           state._currentAgent.processFinalOutput(output),
         );
-  const runOutput = getTurnInput(
-    [],
+  const runOutput = getRunOutput(
     state._generatedItems,
     state._reasoningItemIdPolicy,
   );

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -1,7 +1,7 @@
 import { RunItem } from '../items';
 import { UserError } from '../errors';
 import { getToolSearchProviderCallId } from '../tooling';
-import { AgentInputItem } from '../types';
+import { AgentInputItem, AgentOutputItem } from '../types';
 import * as protocol from '../types/protocol';
 import { serializeBinary } from '../utils/binary';
 import {
@@ -567,6 +567,19 @@ function getContinuationOutputItems(
     extractOutputItemsFromRunItems(generatedItems, reasoningItemIdPolicy),
   );
   return dropOrphanToolCalls(generatedOutputItems);
+}
+
+/**
+ * Extracts generated output without including input admitted while resuming a run.
+ */
+export function getRunOutput(
+  generatedItems: RunItem[],
+  reasoningItemIdPolicy?: ReasoningItemIdPolicy,
+): AgentOutputItem[] {
+  return getContinuationOutputItems(
+    generatedItems.filter((item) => item.type !== 'input_item'),
+    reasoningItemIdPolicy,
+  );
 }
 
 /**

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -63,6 +63,10 @@ type EvaluateRetryParams = {
   providerAdvice?: ModelRetryAdvice;
 };
 
+type ModelRetryHandlers = {
+  onPossiblyAcceptedRequestFailure?: () => void;
+};
+
 function addFailedRetryAttemptsToUsage(
   usage: Usage,
   failedRetryAttempts: number,
@@ -371,6 +375,14 @@ function createProviderRetryAuthority(
         : 'unknown',
     responseStarted: providerAdvice?.responseStarted,
   });
+}
+
+function requestMayHaveBeenAccepted(
+  authority: ProviderRetryAuthority,
+): boolean {
+  return (
+    authority.replaySafety === 'unsafe' || authority.responseStarted === true
+  );
 }
 
 function withProviderRetryAuthority(
@@ -853,6 +865,7 @@ export const retryPolicies = {
 export async function getResponseWithRetry(
   model: Model,
   request: ModelRequest,
+  handlers: ModelRetryHandlers = {},
 ): Promise<ModelResponse> {
   const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
   const retryPolicy = request.modelSettings.retry?.policy;
@@ -882,25 +895,43 @@ export async function getResponseWithRetry(
         stream: false,
         attempt,
       });
-      const decision = await evaluateRetry({
-        error,
-        attempt,
-        maxRetries,
-        retryPolicy,
-        retryBackoff,
-        signal: request.signal,
-        stream: false,
-        request,
-        emittedVisibleEvent: false,
-        emittedRawModelEvent: false,
-        providerAdvice,
-      });
+      const authority = createProviderRetryAuthority(providerAdvice);
+      const markPossiblyAcceptedFailure = () => {
+        if (requestMayHaveBeenAccepted(authority)) {
+          handlers.onPossiblyAcceptedRequestFailure?.();
+        }
+      };
+      let decision: ResolvedRetryDecision;
+      try {
+        decision = await evaluateRetry({
+          error,
+          attempt,
+          maxRetries,
+          retryPolicy,
+          retryBackoff,
+          signal: request.signal,
+          stream: false,
+          request,
+          emittedVisibleEvent: false,
+          emittedRawModelEvent: false,
+          providerAdvice,
+        });
+      } catch (retryError) {
+        markPossiblyAcceptedFailure();
+        throw retryError;
+      }
 
       if (!decision.retry) {
+        markPossiblyAcceptedFailure();
         throw error;
       }
 
-      await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+      try {
+        await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+      } catch (retryDelayError) {
+        markPossiblyAcceptedFailure();
+        throw retryDelayError;
+      }
       attempt += 1;
     }
   }
@@ -909,6 +940,7 @@ export async function getResponseWithRetry(
 export async function* getStreamedResponseWithRetry(
   model: Model,
   request: ModelRequest,
+  handlers: ModelRetryHandlers = {},
 ): AsyncIterable<StreamEvent> {
   const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
   const retryPolicy = request.modelSettings.retry?.policy;
@@ -953,25 +985,43 @@ export async function* getStreamedResponseWithRetry(
         stream: true,
         attempt,
       });
-      const decision = await evaluateRetry({
-        error,
-        attempt,
-        maxRetries,
-        retryPolicy,
-        retryBackoff,
-        signal: request.signal,
-        stream: true,
-        request,
-        emittedVisibleEvent,
-        emittedRawModelEvent,
-        providerAdvice,
-      });
+      const authority = createProviderRetryAuthority(providerAdvice);
+      const markPossiblyAcceptedFailure = () => {
+        if (requestMayHaveBeenAccepted(authority)) {
+          handlers.onPossiblyAcceptedRequestFailure?.();
+        }
+      };
+      let decision: ResolvedRetryDecision;
+      try {
+        decision = await evaluateRetry({
+          error,
+          attempt,
+          maxRetries,
+          retryPolicy,
+          retryBackoff,
+          signal: request.signal,
+          stream: true,
+          request,
+          emittedVisibleEvent,
+          emittedRawModelEvent,
+          providerAdvice,
+        });
+      } catch (retryError) {
+        markPossiblyAcceptedFailure();
+        throw retryError;
+      }
 
       if (!decision.retry) {
+        markPossiblyAcceptedFailure();
         throw error;
       }
 
-      await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+      try {
+        await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+      } catch (retryDelayError) {
+        markPossiblyAcceptedFailure();
+        throw retryDelayError;
+      }
       attempt += 1;
     }
   }

--- a/packages/agents-core/src/runner/pendingInput.ts
+++ b/packages/agents-core/src/runner/pendingInput.ts
@@ -1,0 +1,162 @@
+import { UserError } from '../errors';
+import { RunInputItem } from '../items';
+import { RunState } from '../runState';
+import type { AgentInputItem } from '../types';
+import { getAgentInputItemKey } from './items';
+import { mapOwnedInputItemsAfterContextProcessing } from './sessionPersistence';
+
+type PendingInputPreparation = {
+  turnInput: AgentInputItem[];
+  sourceItems: (AgentInputItem | undefined)[];
+  persistedItems: AgentInputItem[];
+  sourceMatchKinds: Array<'identity' | 'content' | 'fallback' | 'injected'>;
+};
+
+/**
+ * Resolves which staged occurrences reached the model after filtering.
+ */
+export function selectPendingInputForAdmission(
+  pendingItems: RunInputItem[],
+  preparation: PendingInputPreparation,
+): RunInputItem[] {
+  if (pendingItems.length === 0) {
+    return [];
+  }
+
+  const pendingByRawItem = new Map<object, RunInputItem>();
+  for (const item of pendingItems) {
+    pendingByRawItem.set(item.rawItem, item);
+  }
+
+  for (const [index, sourceItem] of preparation.sourceItems.entries()) {
+    if (
+      sourceItem &&
+      pendingByRawItem.has(sourceItem) &&
+      preparation.sourceMatchKinds[index] === 'fallback'
+    ) {
+      throw new UserError(
+        'callModelInputFilter cannot safely associate a reconstructed item with pending RunState input. Preserve the input item object, return an unchanged copy, or omit the pending item.',
+      );
+    }
+  }
+
+  const pendingKeys = new Set(
+    pendingItems.map((item) => getAgentInputItemKey(item.rawItem)),
+  );
+  for (const key of pendingKeys) {
+    const candidates = preparation.turnInput.filter(
+      (item) => getAgentInputItemKey(item) === key,
+    );
+    const reconstructedMatches = preparation.sourceItems.flatMap(
+      (sourceItem, index) =>
+        sourceItem &&
+        getAgentInputItemKey(sourceItem) === key &&
+        preparation.sourceMatchKinds[index] === 'content'
+          ? [sourceItem]
+          : [],
+    );
+    const hasPendingCandidate = candidates.some((candidate) =>
+      pendingByRawItem.has(candidate),
+    );
+    const hasNonPendingCandidate = candidates.some(
+      (candidate) => !pendingByRawItem.has(candidate),
+    );
+    if (
+      reconstructedMatches.length > 0 &&
+      reconstructedMatches.length < candidates.length &&
+      hasPendingCandidate &&
+      hasNonPendingCandidate
+    ) {
+      throw new UserError(
+        'callModelInputFilter cannot safely associate a reconstructed item with pending RunState input. Preserve the input item object, return an unchanged copy, or omit the pending item.',
+      );
+    }
+  }
+
+  const admitted: RunInputItem[] = [];
+  const acceptedIds = new Set<string>();
+  for (const [index, sourceItem] of preparation.sourceItems.entries()) {
+    if (!sourceItem) {
+      continue;
+    }
+    const pendingItem = pendingByRawItem.get(sourceItem);
+    if (!pendingItem || acceptedIds.has(pendingItem.inputId)) {
+      continue;
+    }
+    const persistedItem = preparation.persistedItems[index];
+    if (!persistedItem) {
+      continue;
+    }
+    acceptedIds.add(pendingItem.inputId);
+    admitted.push(
+      new RunInputItem(
+        structuredClone(persistedItem),
+        pendingItem.agent,
+        pendingItem.inputId,
+      ),
+    );
+  }
+  return admitted;
+}
+
+/**
+ * Preserves staged occurrence identity through sandbox capability processing.
+ */
+export function mapPendingInputAfterContextProcessing(
+  pendingItems: RunInputItem[],
+  preparedItems: AgentInputItem[],
+  processedItems: AgentInputItem[],
+): RunInputItem[] {
+  if (pendingItems.length === 0 || preparedItems === processedItems) {
+    return pendingItems;
+  }
+  return mapOwnedInputItemsAfterContextProcessing(
+    preparedItems,
+    processedItems,
+    pendingItems.map((item) => item.rawItem),
+  ).map(({ item, ownerIndex }) => {
+    const pendingItem = pendingItems[ownerIndex]!;
+    return new RunInputItem(item, pendingItem.agent, pendingItem.inputId);
+  });
+}
+
+/**
+ * Commits accepted occurrences to RunState and leaves omitted occurrences pending.
+ */
+export function commitPendingInput(
+  state: RunState<any, any>,
+  preparedItems: RunInputItem[],
+  admittedItems: RunInputItem[],
+  sourceItems: AgentInputItem[],
+): void {
+  if (preparedItems.length === 0) {
+    return;
+  }
+  const admittedIds = new Set(admittedItems.map((item) => item.inputId));
+  const sourceItemSet = new Set(sourceItems);
+  const preparedQueueIsIntact = sourceItems.every(
+    (item, index) => state._pendingInput[index] === item,
+  );
+  const newlyStagedItems = preparedQueueIsIntact
+    ? state._pendingInput.slice(sourceItems.length)
+    : state._pendingInput.filter((item) => !sourceItemSet.has(item));
+  state._generatedItems.push(...admittedItems);
+  state._pendingInput = [
+    ...(preparedQueueIsIntact
+      ? preparedItems
+          .filter((item) => !admittedIds.has(item.inputId))
+          .map((item) => structuredClone(item.rawItem))
+      : []),
+    ...structuredClone(newlyStagedItems),
+  ];
+}
+
+/**
+ * Returns whether a committed input occurrence still belongs to the unpersisted
+ * suffix for the current local-session turn.
+ */
+export function hasUnpersistedRunInput(state: RunState<any, any>): boolean {
+  return state._generatedItems
+    .slice(state._currentTurnPersistedItemCount)
+    .some((item) => item instanceof RunInputItem);
+}

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -1,10 +1,182 @@
 import type { Agent, AgentOutputType } from '../agent';
+import { UserError } from '../errors';
 import type { RunState } from '../runState';
 import type { RunConfig, Runner, ToolErrorFormatter } from '../run';
 import { getFunctionToolStateKeyForCall } from '../toolIdentity';
 import type { SingleStepResult } from './steps';
 import type { ProcessedResponse } from './types';
-import { resolveInterruptedTurn } from './turnResolution';
+import { getServerConversationOwner } from './conversation';
+import {
+  preflightToolInvocations,
+  resolveInterruptedTurn,
+  resolveTurnAfterModelResponse,
+} from './turnResolution';
+
+export function isAcceptedResponseCheckpoint(
+  state: RunState<any, any>,
+): boolean {
+  const isCheckpoint =
+    state._currentStep?.type === 'next_step_interruption' &&
+    state._currentStep.data?.responseAccepted === true;
+  if (isCheckpoint) {
+    assertAcceptedResponseServerOwnership(state);
+  }
+  return isCheckpoint;
+}
+
+function assertAcceptedResponseServerOwnership(
+  state: RunState<any, any>,
+): void {
+  if (
+    getServerConversationOwner(state._conversationId, state._previousResponseId)
+  ) {
+    return;
+  }
+  throw new UserError(
+    'Accepted model response state requires exactly one server-managed conversation owner',
+    state,
+  );
+}
+
+export function assertAcceptedResponseContinuationAuthority(
+  state: RunState<any, any>,
+  requestedConversationId?: string,
+  requestedPreviousResponseId?: string,
+): void {
+  const currentStep = state._currentStep;
+  const responseAccepted =
+    (currentStep?.type === 'next_step_interruption' &&
+      currentStep.data?.responseAccepted === true) ||
+    (currentStep?.type === 'next_step_final_output' &&
+      currentStep.responseAccepted === true);
+  if (!responseAccepted) {
+    return;
+  }
+  assertAcceptedResponseServerOwnership(state);
+  if (
+    (requestedConversationId !== undefined &&
+      requestedConversationId !== state._conversationId) ||
+    (requestedPreviousResponseId !== undefined &&
+      requestedPreviousResponseId !== state._previousResponseId)
+  ) {
+    throw new UserError(
+      'Accepted model response state cannot change its server-managed conversation owner',
+      state,
+    );
+  }
+}
+
+export function markAcceptedResponseProcessingStarted(
+  state: RunState<any, any>,
+): void {
+  const currentStep = state._currentStep;
+  if (
+    currentStep?.type === 'next_step_interruption' &&
+    currentStep.data?.responseAccepted === true
+  ) {
+    assertAcceptedResponseServerOwnership(state);
+    currentStep.data.localProcessingStarted = true;
+  }
+}
+
+export function markAcceptedResponseFinalizationStarted(
+  state: RunState<any, any>,
+): void {
+  const currentStep = state._currentStep;
+  if (
+    currentStep?.type !== 'next_step_final_output' ||
+    currentStep.responseAccepted !== true
+  ) {
+    return;
+  }
+  assertAcceptedResponseServerOwnership(state);
+  if (currentStep.localFinalizationStarted === true) {
+    throw new UserError(
+      'An accepted model response has unfinished local finalization and cannot be resumed safely; start a new run instead',
+      state,
+    );
+  }
+  currentStep.localFinalizationStarted = true;
+}
+
+function hasUncommittedLocalEffects(
+  processedResponse: ProcessedResponse<any>,
+  suppressedToolCalls: ReadonlySet<unknown>,
+): boolean {
+  return [
+    ...processedResponse.functions.map((run) => run.toolCall),
+    ...processedResponse.computerActions.map((run) => run.toolCall),
+    ...processedResponse.shellActions.map((run) => run.toolCall),
+    ...processedResponse.applyPatchActions.map((run) => run.toolCall),
+    ...processedResponse.handoffs.map((run) => run.toolCall),
+  ].some((toolCall) => !suppressedToolCalls.has(toolCall));
+}
+
+/**
+ * Continues local processing for a response that was already accepted by the model provider.
+ */
+export async function resumeAcceptedModelResponse<
+  TContext,
+  TAgent extends Agent<TContext, AgentOutputType>,
+>(options: {
+  state: RunState<TContext, TAgent>;
+  runner: Runner;
+  toolErrorFormatter?: ToolErrorFormatter;
+  agentToolParentRunConfig?: Partial<RunConfig>;
+  signal?: AbortSignal;
+  onStepItems?: (turnResult: SingleStepResult) => void;
+}): Promise<SingleStepResult> {
+  const { state } = options;
+  if (!state._lastTurnResponse || !state._lastProcessedResponse) {
+    throw new UserError(
+      'An accepted model response could not be processed; start a new run instead of retrying it',
+      state,
+    );
+  }
+
+  const suppressedToolCalls = preflightToolInvocations(
+    state._currentAgent,
+    state,
+    state._lastProcessedResponse,
+  );
+  if (
+    state._currentStep?.type === 'next_step_interruption' &&
+    state._currentStep.data?.localProcessingStarted === true &&
+    hasUncommittedLocalEffects(
+      state._lastProcessedResponse,
+      suppressedToolCalls,
+    )
+  ) {
+    throw new UserError(
+      'An accepted model response has unfinished local tool work and cannot be resumed safely; start a new run instead',
+      state,
+    );
+  }
+  markAcceptedResponseProcessingStarted(state);
+  const turnResult = await resolveTurnAfterModelResponse(
+    state._currentAgent,
+    state._originalInput,
+    state._generatedItems,
+    state._lastTurnResponse,
+    state._lastProcessedResponse,
+    options.runner,
+    state,
+    options.toolErrorFormatter,
+    options.agentToolParentRunConfig,
+    undefined,
+    options.signal,
+    suppressedToolCalls,
+  );
+  applyTurnResult({
+    state,
+    turnResult,
+    agent: state._currentAgent,
+    toolsUsed: state._lastProcessedResponse.toolsUsed,
+    resetTurnPersistence: false,
+    onStepItems: options.onStepItems,
+  });
+  return turnResult;
+}
 
 export type InterruptedTurnOutcome = {
   nextStep: SingleStepResult['nextStep'];
@@ -41,6 +213,7 @@ export function applyTurnResult<
     resetTurnPersistence,
     onStepItems,
   } = options;
+  const responseAccepted = isAcceptedResponseCheckpoint(state);
   onStepItems?.(turnResult);
   state._commitToolInvocations(turnResult.toolInvocationCommitItems);
   state._toolUseTracker.addToolUse(agent, toolsUsed);
@@ -52,7 +225,10 @@ export function applyTurnResult<
   ) {
     state.resetTurnPersistence();
   }
-  state._currentStep = turnResult.nextStep;
+  state._currentStep =
+    responseAccepted && turnResult.nextStep.type === 'next_step_final_output'
+      ? { ...turnResult.nextStep, responseAccepted: true }
+      : turnResult.nextStep;
   state._finalOutputSource =
     turnResult.nextStep.type === 'next_step_final_output'
       ? (turnResult.finalOutputSource ?? 'turn_resolution')

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -927,6 +927,21 @@ function mapPreparedSourcesAfterContextProcessing(
   });
 }
 
+/**
+ * Maps selected input occurrences through sandbox capability context processing.
+ */
+export function mapOwnedInputItemsAfterContextProcessing(
+  preparedItems: AgentInputItem[],
+  processedItems: AgentInputItem[],
+  ownedItems: AgentInputItem[],
+): Array<{ item: AgentInputItem; ownerIndex: number }> {
+  return mapPreparedSourcesAfterContextProcessing(
+    preparedItems,
+    processedItems,
+    findOwnedItemIndexes(preparedItems, ownedItems),
+  );
+}
+
 function reconcilePersistableFilteredItems(options: {
   preparedSources: PreparedOwnedSource[];
   sourceItems: (AgentInputItem | undefined)[];

--- a/packages/agents-core/src/runner/steps.ts
+++ b/packages/agents-core/src/runner/steps.ts
@@ -12,6 +12,8 @@ export const nextStepSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('next_step_final_output'),
     output: z.string(),
+    responseAccepted: z.literal(true).optional(),
+    localFinalizationStarted: z.literal(true).optional(),
   }),
   z.object({
     type: z.literal('next_step_run_again'),

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -25,6 +25,7 @@ import {
   RunItem,
   RunMessageOutputItem,
   RunToolApprovalItem,
+  RunToolCallItem,
   RunToolCallOutputItem,
 } from '../items';
 import { assistant } from '../helpers/message';
@@ -1030,6 +1031,7 @@ async function runApprovedFunctionTool<TContext>(
     let toolStarted = false;
     let invocationPending = false;
     let cancellationFinalizationAttempted = false;
+    let committedOutputOnFailure = false;
     const buildSiblingCancellationResult = () => {
       if (toolStarted) {
         toolStarted = false;
@@ -1286,6 +1288,14 @@ async function runApprovedFunctionTool<TContext>(
         throw customDataError;
       }
 
+      const committedRunItem = new RunToolCallOutputItem(
+        rawItem,
+        agent,
+        toolOutput,
+        customData,
+        executionStatus,
+      );
+
       const redactedBeforeToolEnd = refreshRedaction();
       try {
         emitFunctionToolEnd(
@@ -1297,11 +1307,33 @@ async function runApprovedFunctionTool<TContext>(
           toolRun.toolCall,
           refreshRedaction,
         );
-      } catch (hookError) {
         throwIfRedactionPromoted(redactedBeforeToolEnd);
+      } catch (hookError) {
+        if (
+          state._currentStep?.type !== 'next_step_interruption' ||
+          state._currentStep.data?.responseAccepted !== true
+        ) {
+          throwIfRedactionPromoted(redactedBeforeToolEnd);
+          throw hookError;
+        }
+        const callRunItem = new RunToolCallItem(
+          toolRun.toolCall,
+          agent as Agent<any, any>,
+        );
+        const checkpointItems = state._generatedItems.some(
+          (item) =>
+            item instanceof RunToolCallItem &&
+            item.agent === agent &&
+            item.rawItem.type === 'function_call' &&
+            item.rawItem.callId === toolRun.toolCall.callId,
+        )
+          ? [committedRunItem]
+          : [callRunItem, committedRunItem];
+        state._generatedItems.push(...checkpointItems);
+        state._commitToolInvocations(checkpointItems);
+        committedOutputOnFailure = true;
         throw hookError;
       }
-      throwIfRedactionPromoted(redactedBeforeToolEnd);
 
       if (span && runner.config.traceIncludeSensitiveData) {
         span.spanData.output = stringResult;
@@ -1311,13 +1343,7 @@ async function runApprovedFunctionTool<TContext>(
         type: 'function_output' as const,
         tool: toolRun.tool,
         output: toolOutput,
-        runItem: new RunToolCallOutputItem(
-          rawItem,
-          agent,
-          toolOutput,
-          customData,
-          executionStatus,
-        ),
+        runItem: committedRunItem,
       };
 
       const nestedRunResult = consumeAgentToolRunResult(toolRun.toolCall) as
@@ -1345,6 +1371,9 @@ async function runApprovedFunctionTool<TContext>(
 
       return functionResult;
     } catch (error) {
+      if (committedOutputOnFailure) {
+        throw error;
+      }
       if (cancellationFinalizationAttempted) {
         throw error;
       }

--- a/packages/agents-core/src/runner/turnPreparation.ts
+++ b/packages/agents-core/src/runner/turnPreparation.ts
@@ -1,6 +1,6 @@
 import { Agent, AgentOutputType } from '../agent';
 import { MaxTurnsExceededError } from '../errors';
-import { RunHandoffOutputItem, RunItem } from '../items';
+import { RunHandoffOutputItem, RunInputItem, RunItem } from '../items';
 import logger from '../logger';
 import { RunState } from '../runState';
 import type { AgentInputItem } from '../types';
@@ -21,13 +21,14 @@ import { getToolCallOutputItem } from './toolExecution';
 import type { ProcessedResponse } from './types';
 
 type GuardrailHandlers = {
-  onParallelStart?: () => void;
+  onParallelPromise?: (promise: Promise<InputGuardrailResult[]>) => void;
   onParallelError?: (error: unknown) => void;
 };
 
 type PreparedTurn = {
   turnInput: AgentInputItem[];
-  parallelGuardrailPromise?: Promise<InputGuardrailResult[]>;
+  pendingInputItems: RunInputItem[];
+  pendingInputSourceItems: AgentInputItem[];
 };
 
 type PrepareTurnOptions<
@@ -103,22 +104,28 @@ export async function prepareTurn<
   );
   onAgentSpanReady?.(state._currentTurn, state._currentAgent.name);
 
-  const { parallelGuardrailPromise } = await runInputGuardrailsForTurn(
+  const pendingInputSourceItems = [...state._pendingInput];
+  await runInputGuardrailsForTurn(
     state,
     inputGuardrailDefs,
     isResumingFromInterruption,
     guardrailHandlers,
   );
 
+  const pendingInputItems = pendingInputSourceItems.map(
+    (item) => new RunInputItem(structuredClone(item), state._currentAgent),
+  );
+  const generatedItemsForTurn = generatedItems.concat(pendingInputItems);
+
   const turnInput = serverConversationTracker
     ? serverConversationTracker.prepareInput(
         input,
-        generatedItems,
+        generatedItemsForTurn,
         getManagedConversationSupplementalItems(state),
       )
     : prepareModelInputItems(
         input,
-        generatedItems,
+        generatedItemsForTurn,
         state._reasoningItemIdPolicy,
       );
 
@@ -134,7 +141,8 @@ export async function prepareTurn<
 
   return {
     turnInput,
-    parallelGuardrailPromise,
+    pendingInputItems,
+    pendingInputSourceItems,
   };
 }
 
@@ -194,27 +202,34 @@ async function runInputGuardrailsForTurn<
   runnerGuardrails: InputGuardrailDefinition[],
   isResumingFromInterruption: boolean,
   handlers: GuardrailHandlers = {},
-): Promise<{ parallelGuardrailPromise?: Promise<InputGuardrailResult[]> }> {
-  if (state._currentTurn !== 1 || isResumingFromInterruption) {
-    return {};
+): Promise<void> {
+  const guardrailInput =
+    state._pendingInput.length > 0 ? state.pendingInput : undefined;
+  if (
+    guardrailInput === undefined &&
+    (state._currentTurn !== 1 || isResumingFromInterruption)
+  ) {
+    return;
   }
 
   const guardrailDefs = buildInputGuardrailDefinitions(state, runnerGuardrails);
   const guardrails = splitInputGuardrails(guardrailDefs);
   if (guardrails.blocking.length > 0) {
-    await runInputGuardrails(state, guardrails.blocking);
+    await runInputGuardrails(state, guardrails.blocking, {
+      input: guardrailInput,
+    });
   }
   if (guardrails.parallel.length > 0) {
-    handlers.onParallelStart?.();
     const parallelGuardrailPromise = runInputGuardrails(
       state,
       guardrails.parallel,
-      { onErrorObserved: handlers.onParallelError },
+      {
+        input: guardrailInput,
+        onErrorObserved: handlers.onParallelError,
+      },
     ).catch(() => []);
-    return { parallelGuardrailPromise };
+    handlers.onParallelPromise?.(parallelGuardrailPromise);
   }
-
-  return {};
 }
 
 function beginTurn<TContext, TAgent extends Agent<TContext, AgentOutputType>>(

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -64,11 +64,12 @@ import type { RunErrorData, RunErrorHandlers } from './errorHandlers';
 import {
   createRunErrorFinalOutputItem,
   formatRunErrorFinalOutput,
+  invalidateAcceptedResponseReplayEvidence,
   preserveInvalidFinalOutputRedaction,
   resolveRunErrorHandler,
   validateRunErrorHandlerFinalOutput,
 } from './errorHandlers';
-import { getTurnInput } from './items';
+import { getRunOutput, getTurnInput } from './items';
 import {
   buildApplyPatchAbortResult,
   buildFunctionAbortResult,
@@ -899,7 +900,7 @@ function buildTurnRunErrorData<TContext, TAgent extends Agent<TContext, any>>(
       generatedItems,
       state._reasoningItemIdPolicy,
     ),
-    output: getTurnInput([], generatedItems, state._reasoningItemIdPolicy),
+    output: getRunOutput(generatedItems, state._reasoningItemIdPolicy),
     rawResponses: state._modelResponses,
     lastAgent: agent,
     state,
@@ -917,6 +918,7 @@ async function resolveInvalidFinalOutput<
   preStepItems: RunItem[];
   newItems: RunItem[];
   state: RunState<TContext, TAgent>;
+  attemptedErrors?: WeakSet<object>;
 }): Promise<string | undefined> {
   return preserveInvalidFinalOutputRedaction(async (redactFromStart) => {
     const handlerResult = await resolveRunErrorHandler({
@@ -931,8 +933,10 @@ async function resolveInvalidFinalOutput<
         args.preStepItems,
         args.newItems,
       ),
+      attemptedErrors: args.attemptedErrors,
     });
     if (!handlerResult) {
+      invalidateAcceptedResponseReplayEvidence(args.state);
       return undefined;
     }
 
@@ -1327,6 +1331,7 @@ export async function resolveTurnAfterModelResponse<
   errorHandlers?: RunErrorHandlers<TContext, TAgent>,
   signal?: AbortSignal,
   preflightedToolCalls?: ReadonlySet<ApprovalCapableToolCall>,
+  attemptedErrors?: WeakSet<object>,
 ): Promise<SingleStepResult> {
   const suppressedToolCalls =
     preflightedToolCalls ??
@@ -1569,6 +1574,7 @@ export async function resolveTurnAfterModelResponse<
           preStepItems,
           newItems,
         ),
+        attemptedErrors,
       });
       if (!handlerResult) {
         throw refusalError;
@@ -1613,6 +1619,7 @@ export async function resolveTurnAfterModelResponse<
         preStepItems,
         newItems,
         state,
+        attemptedErrors,
       });
       if (typeof handledOutput !== 'undefined') {
         return new SingleStepResult(
@@ -1679,6 +1686,7 @@ export async function resolveTurnAfterModelResponse<
           preStepItems,
           newItems,
           state,
+          attemptedErrors,
         });
         if (typeof handledOutput === 'undefined') {
           throw outputError;

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -122,6 +122,8 @@ export type PreparedModelCall<TContext = UnknownContext> =
     previousResponseId?: string;
     conversationId?: string;
     sourceItems: (AgentInputItem | undefined)[];
+    persistedItems: AgentInputItem[];
+    sourceMatchKinds: Array<'identity' | 'content' | 'fallback' | 'injected'>;
     filterApplied: boolean;
     turnInput: AgentInputItem[];
   };

--- a/packages/agents-core/test/index.test.ts
+++ b/packages/agents-core/test/index.test.ts
@@ -26,6 +26,7 @@ describe('index.ts', () => {
     expect(agent.name).toEqual('TestAgent');
     expect(typeof AgentsCore.setSensitiveDataLoggingEnabled).toBe('function');
     expect(typeof AgentsCore.RunCompactionItem).toBe('function');
+    expect(typeof AgentsCore.RunInputItem).toBe('function');
     expect(typeof AgentsCore.isSessionHistoryTransactionAwareSession).toBe(
       'function',
     );

--- a/packages/agents-core/test/runState.pendingInput.test.ts
+++ b/packages/agents-core/test/runState.pendingInput.test.ts
@@ -1,0 +1,2916 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  InputGuardrailTripwireTriggered,
+  ModelRefusalError,
+  RunInputItem,
+  RunState,
+  Runner,
+  UserError,
+  run,
+  tool,
+  type AgentInputItem,
+} from '../src';
+import type { Model, ModelRequest, ModelResponse } from '../src/model';
+import { RunContext } from '../src/runContext';
+import { RunToolApprovalItem } from '../src/items';
+import { MemorySession } from '../src/memory/memorySession';
+import type { Session } from '../src/memory/session';
+import type * as protocol from '../src/types/protocol';
+import { Usage } from '../src/usage';
+import { fakeModelMessage, fakeModelRefusal } from './stubs';
+
+class RecordingModel implements Model {
+  readonly requests: ModelRequest[] = [];
+
+  constructor(private readonly responses: ModelResponse[]) {}
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(structuredClone(request));
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error('No response found');
+    }
+    return response;
+  }
+
+  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
+    yield* [];
+    throw new Error('Not implemented');
+  }
+}
+
+class FailOnceModel implements Model {
+  readonly requests: ModelRequest[] = [];
+  private failed = false;
+
+  constructor(private readonly response: ModelResponse) {}
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(structuredClone(request));
+    if (!this.failed) {
+      this.failed = true;
+      throw new Error('model request failed');
+    }
+    return this.response;
+  }
+
+  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
+    yield* [];
+    throw new Error('Not implemented');
+  }
+}
+
+class FailingAcceptedStreamModel implements Model {
+  streamCalls = 0;
+
+  async getResponse(): Promise<ModelResponse> {
+    throw new Error('Not implemented');
+  }
+
+  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
+    this.streamCalls += 1;
+    yield {
+      type: 'output_text_delta',
+      delta: 'accepted',
+      providerData: {},
+    } as protocol.StreamEvent;
+    throw new Error('stream failed after acceptance');
+  }
+}
+
+class RecordingStreamModel implements Model {
+  readonly requests: ModelRequest[] = [];
+
+  constructor(private readonly responses: ModelResponse[]) {}
+
+  async getResponse(): Promise<ModelResponse> {
+    throw new Error('Not implemented');
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<protocol.StreamEvent> {
+    this.requests.push(structuredClone(request));
+    const response = this.responses.shift();
+    if (!response) {
+      throw new Error('No response found');
+    }
+    yield {
+      type: 'response_done',
+      response: {
+        id: response.responseId,
+        requestId: response.requestId,
+        usage: {
+          requests: response.usage.requests,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          totalTokens: response.usage.totalTokens,
+        },
+        output: response.output,
+      },
+    } as protocol.StreamEvent;
+  }
+}
+
+class AbortBeforeEventStreamModel implements Model {
+  streamCalls = 0;
+  started!: Promise<void>;
+  private markStarted!: () => void;
+
+  constructor() {
+    this.started = new Promise<void>((resolve) => {
+      this.markStarted = resolve;
+    });
+  }
+
+  async getResponse(): Promise<ModelResponse> {
+    throw new Error('Not implemented');
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<protocol.StreamEvent> {
+    this.streamCalls += 1;
+    this.markStarted();
+    await new Promise<void>((_resolve, reject) => {
+      const abort = () => {
+        const error = new Error('aborted before first event');
+        error.name = 'AbortError';
+        reject(error);
+      };
+      if (request.signal?.aborted) {
+        abort();
+        return;
+      }
+      request.signal?.addEventListener('abort', abort, { once: true });
+    });
+    yield* [];
+  }
+}
+
+class NeverCalledStreamModel implements Model {
+  streamCalls = 0;
+
+  async getResponse(): Promise<ModelResponse> {
+    throw new Error('Not implemented');
+  }
+
+  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
+    this.streamCalls += 1;
+    yield* [];
+    throw new Error('Model should not be called');
+  }
+}
+
+class FailOnceSession implements Session {
+  readonly inner = new MemorySession();
+  addAttempts = 0;
+
+  getSessionId(): Promise<string> {
+    return this.inner.getSessionId();
+  }
+
+  getItems(limit?: number): Promise<AgentInputItem[]> {
+    return this.inner.getItems(limit);
+  }
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.addAttempts += 1;
+    if (this.addAttempts === 1) {
+      throw new Error('session write failed');
+    }
+    await this.inner.addItems(items);
+  }
+
+  popItem(): Promise<AgentInputItem | undefined> {
+    return this.inner.popItem();
+  }
+
+  clearSession(): Promise<void> {
+    return this.inner.clearSession();
+  }
+}
+
+class BlockingSession implements Session {
+  readonly inner = new MemorySession();
+  readonly addStarted: Promise<void>;
+  private markAddStarted!: () => void;
+  private releaseAdd!: () => void;
+  private readonly addCanFinish: Promise<void>;
+
+  constructor() {
+    this.addStarted = new Promise<void>((resolve) => {
+      this.markAddStarted = resolve;
+    });
+    this.addCanFinish = new Promise<void>((resolve) => {
+      this.releaseAdd = resolve;
+    });
+  }
+
+  getSessionId(): Promise<string> {
+    return this.inner.getSessionId();
+  }
+
+  getItems(limit?: number): Promise<AgentInputItem[]> {
+    return this.inner.getItems(limit);
+  }
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.markAddStarted();
+    await this.addCanFinish;
+    await this.inner.addItems(items);
+  }
+
+  release(): void {
+    this.releaseAdd();
+  }
+
+  popItem(): Promise<AgentInputItem | undefined> {
+    return this.inner.popItem();
+  }
+
+  clearSession(): Promise<void> {
+    return this.inner.clearSession();
+  }
+}
+
+function message(text: string): AgentInputItem {
+  return { type: 'message', role: 'user', content: text };
+}
+
+function createResumableState<TAgent extends Agent<any, any>>(
+  agent: TAgent,
+  maxTurns = 3,
+) {
+  const state = new RunState(new RunContext(), 'initial', agent, maxTurns);
+  state._currentTurn = 1;
+  state._currentStep = { type: 'next_step_run_again' };
+  return state;
+}
+
+describe('RunState pending input', () => {
+  it('stages immutable input in order and round-trips it', async () => {
+    const agent = new Agent({ name: 'pending-input' });
+    const state = createResumableState(agent);
+
+    state.addInput('first');
+    state.addInput([message('second')]);
+    const observed = state.pendingInput;
+    observed.push(message('mutated copy'));
+    (observed[0] as { content: string }).content = 'changed copy';
+
+    expect(state.pendingInput).toEqual([message('first'), message('second')]);
+    const restored = await RunState.fromString(agent, state.toString());
+    expect(restored.pendingInput).toEqual([
+      message('first'),
+      message('second'),
+    ]);
+
+    restored.clearPendingInput();
+    expect(restored.pendingInput).toEqual([]);
+    expect(
+      (await RunState.fromString(agent, restored.toString())).pendingInput,
+    ).toEqual([]);
+  });
+
+  it('defaults older snapshots and rejects pending input under an older schema', async () => {
+    const agent = new Agent({ name: 'legacy-pending-input' });
+    const state = createResumableState(agent);
+    const legacy = state.toJSON() as Record<string, unknown>;
+    legacy.$schemaVersion = '1.17';
+    delete legacy.pendingInput;
+
+    const restored = await RunState.fromString(agent, JSON.stringify(legacy));
+    expect(restored.pendingInput).toEqual([]);
+
+    legacy.pendingInput = [];
+    await expect(
+      RunState.fromString(agent, JSON.stringify(legacy)),
+    ).rejects.toThrow(/does not support pending input/);
+
+    legacy.pendingInput = [message('unsupported')];
+    await expect(
+      RunState.fromString(agent, JSON.stringify(legacy)),
+    ).rejects.toThrow(/does not support pending input/);
+
+    const malformed = state.toJSON() as Record<string, unknown>;
+    malformed.pendingInput = ['not an input item'];
+    await expect(
+      RunState.fromString(agent, JSON.stringify(malformed)),
+    ).rejects.toThrow();
+
+    const itemState = createResumableState(agent);
+    itemState._generatedItems.push(
+      new RunInputItem(message('accepted'), agent, 'input-occurrence'),
+    );
+    const oldItemSnapshot = itemState.toJSON() as Record<string, unknown>;
+    oldItemSnapshot.$schemaVersion = '1.17';
+    await expect(
+      RunState.fromString(agent, JSON.stringify(oldItemSnapshot)),
+    ).rejects.toThrow(/does not support pending input/);
+
+    const acceptedState = createResumableState(agent);
+    acceptedState._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [], responseAccepted: true },
+    };
+    const oldAcceptedSnapshot = acceptedState.toJSON() as Record<
+      string,
+      unknown
+    >;
+    oldAcceptedSnapshot.$schemaVersion = '1.17';
+    await expect(
+      RunState.fromString(agent, JSON.stringify(oldAcceptedSnapshot)),
+    ).rejects.toThrow(/does not support pending input/);
+
+    for (const data of [
+      { responseAccepted: false },
+      { localProcessingStarted: false },
+      { localProcessingStarted: true },
+    ]) {
+      const oldCheckpointSnapshot = createResumableState(
+        agent,
+      ).toJSON() as Record<string, unknown>;
+      oldCheckpointSnapshot.$schemaVersion = '1.17';
+      oldCheckpointSnapshot.currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [], ...data },
+      };
+      await expect(
+        RunState.fromString(agent, JSON.stringify(oldCheckpointSnapshot)),
+      ).rejects.toThrow(/does not support pending input/);
+    }
+  });
+
+  it('rejects terminal and unsupported interrupted states before mutation', () => {
+    const approvalCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'approval_tool',
+      callId: 'approval-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const terminalAgent = new Agent({ name: 'terminal' });
+    const terminal = new RunState(
+      new RunContext(),
+      'initial',
+      terminalAgent,
+      3,
+    );
+    const terminalBefore = terminal.toString();
+    expect(() => terminal.addInput('later')).toThrow(UserError);
+    expect(terminal.toString()).toBe(terminalBefore);
+
+    const stoppingAgent = new Agent({
+      name: 'stopping',
+      toolUseBehavior: 'stop_on_first_tool',
+    });
+    const interrupted = createResumableState(stoppingAgent);
+    const approvalItem = new RunToolApprovalItem(approvalCall, stoppingAgent);
+    interrupted._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [approvalItem] },
+    };
+    const interruptedBefore = interrupted.toString();
+    expect(() => interrupted.addInput('later')).toThrow(
+      /tool result may end the run/,
+    );
+    expect(interrupted.toString()).toBe(interruptedBefore);
+
+    const accepted = createResumableState(terminalAgent);
+    accepted._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [], responseAccepted: true },
+    };
+    const acceptedBefore = accepted.toString();
+    expect(() => accepted.addInput('later')).toThrow(
+      /accepted model response is awaiting local processing/,
+    );
+    expect(accepted.toString()).toBe(acceptedBefore);
+
+    const exhausted = createResumableState(terminalAgent, 1);
+    const exhaustedBefore = exhausted.toString();
+    expect(() => exhausted.addInput('later')).toThrow(
+      /no remaining model turns/,
+    );
+    expect(exhausted.toString()).toBe(exhaustedBefore);
+
+    const namespacedAgent = new Agent({
+      name: 'namespaced-stopping',
+      toolUseBehavior: { stopAtToolNames: ['lookup_account'] },
+    });
+    const namespacedInterrupted = createResumableState(namespacedAgent);
+    const namespacedCall: protocol.FunctionCallItem = {
+      ...approvalCall,
+      name: 'lookup_account',
+      namespace: 'crm',
+    };
+    namespacedInterrupted._currentStep = {
+      type: 'next_step_interruption',
+      data: {
+        interruptions: [
+          new RunToolApprovalItem(namespacedCall, namespacedAgent),
+        ],
+      },
+    };
+    const namespacedBefore = namespacedInterrupted.toString();
+    expect(namespacedInterrupted.getInterruptions()[0]?.name).toBe(
+      'crm.lookup_account',
+    );
+    expect(() => namespacedInterrupted.addInput('later')).toThrow(
+      /tool result may end the run/,
+    );
+    expect(namespacedInterrupted.toString()).toBe(namespacedBefore);
+  });
+
+  it('admits staged input after an approved tool output', async () => {
+    const execute = vi.fn(async () => 'approved result');
+    const approvalTool = tool({
+      name: 'approval_tool',
+      description: 'Requires approval.',
+      parameters: z.object({}).strict(),
+      needsApproval: true,
+      execute,
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'approval_tool',
+      callId: 'approval-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const model = new RecordingModel([
+      { output: [functionCall], usage: new Usage() },
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agent = new Agent({
+      name: 'approval-pending-input',
+      model,
+      tools: [approvalTool],
+    });
+    const session = new MemorySession();
+
+    const first = await run(agent, 'initial', { session, maxTurns: 1 });
+    const approval = first.interruptions[0];
+    expect(approval).toBeDefined();
+    expect(first.state._currentTurn).toBe(1);
+    expect(first.state._currentTurnInProgress).toBe(true);
+    first.state.addInput('follow-up');
+    first.state.approve(approval!);
+
+    const completed = await new Runner().run(agent, first.state, { session });
+    const secondInput = model.requests[1]?.input as AgentInputItem[];
+    const resultIndex = secondInput.findIndex(
+      (item) => item.type === 'function_call_result',
+    );
+    const pendingIndex = secondInput.findIndex(
+      (item) =>
+        item.type === 'message' &&
+        item.role === 'user' &&
+        item.content === 'follow-up',
+    );
+
+    expect(resultIndex).toBeGreaterThanOrEqual(0);
+    expect(pendingIndex).toBeGreaterThan(resultIndex);
+    expect(completed.state.pendingInput).toEqual([]);
+    const admitted = completed.newItems.filter(
+      (item): item is RunInputItem => item instanceof RunInputItem,
+    );
+    expect(admitted).toHaveLength(1);
+    expect(admitted[0]?.rawItem).toEqual(message('follow-up'));
+    expect(admitted[0]?.inputId).toBeTruthy();
+    const restored = await RunState.fromString(
+      agent,
+      completed.state.toString(),
+    );
+    const restoredAdmission = restored._generatedItems.find(
+      (item): item is RunInputItem => item instanceof RunInputItem,
+    );
+    expect(restoredAdmission?.inputId).toBe(admitted[0]?.inputId);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(
+      (await session.getItems()).filter(
+        (item) => item.type === 'message' && item.content === 'follow-up',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('keeps admitted input out of output-only views', async () => {
+    const model = new RecordingModel([
+      { output: [fakeModelRefusal('refused')], usage: new Usage() },
+    ]);
+    const agent = new Agent({ name: 'pending-output-view', model });
+    const state = createResumableState(agent);
+    state.addInput('follow-up');
+    let errorHandlerOutput: AgentInputItem[] | undefined;
+    let guardrailOutput: AgentInputItem[] | undefined;
+    const runner = new Runner({
+      outputGuardrails: [
+        {
+          name: 'capture-output',
+          execute: async ({ details }) => {
+            guardrailOutput = details?.output;
+            return { tripwireTriggered: false, outputInfo: {} };
+          },
+        },
+      ],
+    });
+
+    const result = await runner.run(agent, state, {
+      errorHandlers: {
+        modelRefusal: ({ runData }) => {
+          errorHandlerOutput = runData.output;
+          return { finalOutput: 'handled refusal' };
+        },
+      },
+    });
+
+    expect(result.history).toContainEqual(message('follow-up'));
+    expect(
+      result.newItems.some(
+        (item) =>
+          item instanceof RunInputItem &&
+          item.rawItem.type === 'message' &&
+          item.rawItem.role === 'user' &&
+          item.rawItem.content === 'follow-up',
+      ),
+    ).toBe(true);
+    for (const output of [result.output, errorHandlerOutput, guardrailOutput]) {
+      expect(output).toBeDefined();
+      expect(output).not.toContainEqual(message('follow-up'));
+    }
+    expect(result.output).toContainEqual(fakeModelRefusal('refused'));
+  });
+
+  it('keeps staged input pending until an approval is resolved', async () => {
+    const execute = vi.fn(async () => 'approved result');
+    const approvalTool = tool({
+      name: 'approval_tool',
+      description: 'Requires approval.',
+      parameters: z.object({}).strict(),
+      needsApproval: true,
+      execute,
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'approval_tool',
+      callId: 'approval-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const model = new RecordingModel([
+      { output: [functionCall], usage: new Usage() },
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agent = new Agent({
+      name: 'unresolved-approval-pending-input',
+      model,
+      tools: [approvalTool],
+    });
+    const runner = new Runner();
+
+    const first = await runner.run(agent, 'initial');
+    first.state.addInput('wait for approval');
+    const stillInterrupted = await runner.run(agent, first.state);
+
+    expect(stillInterrupted.interruptions).toHaveLength(1);
+    expect(first.state.pendingInput).toEqual([message('wait for approval')]);
+    expect(model.requests).toHaveLength(1);
+    expect(execute).not.toHaveBeenCalled();
+
+    first.state.approve(first.state.getInterruptions()[0]!);
+    const completed = await runner.run(agent, first.state);
+    expect(completed.finalOutput).toBe('done');
+    expect(first.state.pendingInput).toEqual([]);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs guardrails before admission and retries staged input', async () => {
+    const model = new RecordingModel([
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agent = new Agent({ name: 'guarded-pending-input', model });
+    const state = createResumableState(agent);
+    state.addInput('guard me');
+    const guardrail = vi
+      .fn()
+      .mockResolvedValueOnce({
+        tripwireTriggered: true,
+        outputInfo: { reason: 'blocked' },
+      })
+      .mockResolvedValueOnce({ tripwireTriggered: false, outputInfo: {} });
+    const runner = new Runner({
+      inputGuardrails: [
+        {
+          name: 'pending-guardrail',
+          runInParallel: false,
+          execute: guardrail,
+        },
+      ],
+    });
+
+    await expect(runner.run(agent, state)).rejects.toBeInstanceOf(
+      InputGuardrailTripwireTriggered,
+    );
+    expect(model.requests).toHaveLength(0);
+    expect(state.pendingInput).toEqual([message('guard me')]);
+    expect(state._generatedItems).toHaveLength(0);
+    expect(state._currentTurn).toBe(1);
+
+    const completed = await runner.run(agent, state);
+    expect(completed.finalOutput).toBe('done');
+    expect(model.requests).toHaveLength(1);
+    expect(state.pendingInput).toEqual([]);
+    expect(guardrail).toHaveBeenCalledTimes(2);
+    expect(guardrail.mock.calls[0]?.[0].input).toEqual([message('guard me')]);
+  });
+
+  it('runs default staged-input guardrails in parallel with the model', async () => {
+    let releaseGuardrail!: () => void;
+    let markGuardrailStarted!: () => void;
+    let markModelStarted!: () => void;
+    const guardrailCanFinish = new Promise<void>((resolve) => {
+      releaseGuardrail = resolve;
+    });
+    const guardrailStarted = new Promise<void>((resolve) => {
+      markGuardrailStarted = resolve;
+    });
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    let guardrailCompleted = false;
+    const guardrail = vi.fn(async () => {
+      markGuardrailStarted();
+      await guardrailCanFinish;
+      guardrailCompleted = true;
+      return { tripwireTriggered: false, outputInfo: {} };
+    });
+
+    class ParallelGuardrailModel implements Model {
+      async getResponse(): Promise<ModelResponse> {
+        expect(guardrailCompleted).toBe(false);
+        markModelStarted();
+        return {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        };
+      }
+
+      async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
+        yield* [];
+        throw new Error('Not implemented');
+      }
+    }
+
+    const agent = new Agent({
+      name: 'parallel-pending-guardrail',
+      model: new ParallelGuardrailModel(),
+    });
+    const state = createResumableState(agent);
+    state.addInput('guard in parallel');
+    const runner = new Runner({
+      inputGuardrails: [{ name: 'pending-guardrail', execute: guardrail }],
+    });
+
+    const runPromise = runner.run(agent, state);
+    await guardrailStarted;
+    await modelStarted;
+    expect(guardrailCompleted).toBe(false);
+    expect(guardrail).toHaveBeenCalledWith(
+      expect.objectContaining({ input: [message('guard in parallel')] }),
+    );
+
+    releaseGuardrail();
+    const completed = await runPromise;
+    expect(completed.finalOutput).toBe('done');
+    expect(state.pendingInput).toEqual([]);
+  });
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'keeps local staged input pending after a late parallel guardrail failure in a $label run',
+    async ({ stream }) => {
+      let markFirstModelStarted!: () => void;
+      const firstModelStarted = new Promise<void>((resolve) => {
+        markFirstModelStarted = resolve;
+      });
+      let modelCalls = 0;
+      const nextResponse = (): ModelResponse => {
+        modelCalls += 1;
+        if (modelCalls === 1) {
+          markFirstModelStarted();
+        }
+        return {
+          output: [fakeModelMessage(modelCalls === 1 ? 'blocked' : 'done')],
+          usage: new Usage(),
+          responseId: `local-guardrail-${modelCalls}`,
+        };
+      };
+      const model: Model = {
+        async getResponse() {
+          return nextResponse();
+        },
+        async *getStreamedResponse() {
+          const response = nextResponse();
+          yield {
+            type: 'response_done',
+            response: {
+              id: response.responseId,
+              usage: {
+                requests: response.usage.requests,
+                inputTokens: response.usage.inputTokens,
+                outputTokens: response.usage.outputTokens,
+                totalTokens: response.usage.totalTokens,
+              },
+              output: response.output,
+            },
+          } as protocol.StreamEvent;
+        },
+      };
+      const guardrail = vi
+        .fn(async () => ({ tripwireTriggered: false, outputInfo: {} }))
+        .mockImplementationOnce(async () => {
+          await firstModelStarted;
+          return {
+            tripwireTriggered: true,
+            outputInfo: { reason: 'blocked after model start' },
+          };
+        });
+      const agent = new Agent({ name: 'local-late-guardrail', model });
+      const state = createResumableState(agent);
+      state.addInput('guard local staged input');
+      const session = new MemorySession();
+      const runner = new Runner({
+        inputGuardrails: [{ name: 'pending-guardrail', execute: guardrail }],
+      });
+
+      if (stream) {
+        const failed = await runner.run(agent, state, {
+          session,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toBeInstanceOf(
+          InputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(
+          runner.run(agent, state, { session }),
+        ).rejects.toBeInstanceOf(InputGuardrailTripwireTriggered);
+      }
+
+      expect(modelCalls).toBe(1);
+      expect(guardrail).toHaveBeenCalledTimes(1);
+      expect(state.pendingInput).toEqual([message('guard local staged input')]);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(0);
+      expect(await session.getItems()).toEqual([]);
+
+      if (stream) {
+        const completed = await runner.run(agent, state, {
+          session,
+          stream: true,
+        });
+        await completed.completed;
+      } else {
+        await runner.run(agent, state, { session });
+      }
+
+      expect(modelCalls).toBe(2);
+      expect(guardrail).toHaveBeenCalledTimes(2);
+      expect(state.pendingInput).toEqual([]);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(1);
+      expect(await session.getItems()).toEqual([
+        message('guard local staged input'),
+        fakeModelMessage('done'),
+      ]);
+    },
+  );
+
+  it('commits local staged input after a parallel guardrail succeeds following model failure', async () => {
+    let releaseGuardrail!: () => void;
+    let markModelFailed!: () => void;
+    const guardrailCanFinish = new Promise<void>((resolve) => {
+      releaseGuardrail = resolve;
+    });
+    const modelFailed = new Promise<void>((resolve) => {
+      markModelFailed = resolve;
+    });
+    let modelCalls = 0;
+    const model: Model = {
+      async getResponse() {
+        modelCalls += 1;
+        if (modelCalls === 1) {
+          markModelFailed();
+          throw new Error('model failed before guardrail completion');
+        }
+        return {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+        throw new Error('Not implemented');
+      },
+    };
+    const guardrail = vi.fn(async () => {
+      await guardrailCanFinish;
+      return { tripwireTriggered: false, outputInfo: {} };
+    });
+    const agent = new Agent({ name: 'guardrail-after-model-failure', model });
+    const state = createResumableState(agent);
+    state.addInput('persist after guardrail success');
+    const session = new MemorySession();
+    const runner = new Runner({
+      inputGuardrails: [{ name: 'pending-guardrail', execute: guardrail }],
+    });
+    let runSettled = false;
+
+    const running = runner.run(agent, state, { session }).finally(() => {
+      runSettled = true;
+    });
+    await modelFailed;
+    await Promise.resolve();
+
+    expect(runSettled).toBe(false);
+    expect(state.pendingInput).toEqual([
+      message('persist after guardrail success'),
+    ]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(0);
+    expect(await session.getItems()).toEqual([]);
+
+    releaseGuardrail();
+    await expect(running).rejects.toThrow(
+      'model failed before guardrail completion',
+    );
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(await session.getItems()).toEqual([
+      message('persist after guardrail success'),
+    ]);
+
+    const completed = await runner.run(agent, state, { session });
+    expect(completed.finalOutput).toBe('done');
+    expect(modelCalls).toBe(2);
+    expect(guardrail).toHaveBeenCalledTimes(1);
+    expect(await session.getItems()).toEqual([
+      message('persist after guardrail success'),
+      fakeModelMessage('done'),
+    ]);
+  });
+
+  it('prefers a parallel staged-input guardrail failure over a model refusal handler', async () => {
+    let releaseGuardrail!: () => void;
+    let markModelFailed!: () => void;
+    const guardrailCanFinish = new Promise<void>((resolve) => {
+      releaseGuardrail = resolve;
+    });
+    const modelFailed = new Promise<void>((resolve) => {
+      markModelFailed = resolve;
+    });
+    const guardrail = vi.fn(async () => {
+      await guardrailCanFinish;
+      return {
+        tripwireTriggered: true,
+        outputInfo: { reason: 'blocked after model failure' },
+      };
+    });
+    const model: Model = {
+      async getResponse() {
+        markModelFailed();
+        throw new ModelRefusalError('refused before guardrail completion');
+      },
+      async *getStreamedResponse() {
+        yield* [];
+        throw new Error('Not implemented');
+      },
+    };
+    const agent = new Agent({ name: 'guardrail-before-refusal', model });
+    const state = createResumableState(agent);
+    state.addInput('guard before fallback');
+    const refusalHandler = vi.fn(() => ({ finalOutput: 'fallback' }));
+    const runner = new Runner({
+      inputGuardrails: [{ name: 'pending-guardrail', execute: guardrail }],
+    });
+    let runSettled = false;
+
+    const running = runner
+      .run(agent, state, {
+        errorHandlers: { modelRefusal: refusalHandler },
+      })
+      .finally(() => {
+        runSettled = true;
+      });
+    await modelFailed;
+    await Promise.resolve();
+
+    expect(runSettled).toBe(false);
+    expect(refusalHandler).not.toHaveBeenCalled();
+
+    releaseGuardrail();
+    await expect(running).rejects.toBeInstanceOf(
+      InputGuardrailTripwireTriggered,
+    );
+    expect(refusalHandler).not.toHaveBeenCalled();
+    expect(state.pendingInput).toEqual([message('guard before fallback')]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(0);
+  });
+
+  it('fails closed after a late non-streaming staged-input guardrail failure', async () => {
+    let releaseGuardrail!: () => void;
+    const guardrailCanFinish = new Promise<void>((resolve) => {
+      releaseGuardrail = resolve;
+    });
+    const execute = vi.fn(async () => 'must not run');
+    const guardedTool = tool({
+      name: 'guarded_tool',
+      description: 'Must not run after a guardrail failure.',
+      parameters: z.object({}).strict(),
+      execute,
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'guarded_tool',
+      callId: 'guarded-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const model = new RecordingModel([
+      {
+        output: [functionCall],
+        usage: new Usage(),
+        responseId: 'guarded-accepted-response',
+      },
+    ]);
+    const agent = new Agent({
+      name: 'late-guardrail-accepted-response',
+      model,
+      tools: [guardedTool],
+    });
+    const state = createResumableState(agent);
+    state.setConversationContext('late-guardrail-conversation');
+    state.addInput('guard accepted response');
+    const runner = new Runner({
+      inputGuardrails: [
+        {
+          name: 'pending-guardrail',
+          execute: async () => {
+            await guardrailCanFinish;
+            return {
+              tripwireTriggered: true,
+              outputInfo: { reason: 'reject accepted response' },
+            };
+          },
+        },
+      ],
+    });
+
+    const running = runner.run(agent, state, {
+      conversationId: 'late-guardrail-conversation',
+    });
+    await vi.waitFor(() => {
+      expect(state._lastProcessedResponse).toBeDefined();
+    });
+    releaseGuardrail();
+
+    await expect(running).rejects.toBeInstanceOf(
+      InputGuardrailTripwireTriggered,
+    );
+    expect(state.pendingInput).toEqual([]);
+    expect(state._lastProcessedResponse).toBeUndefined();
+    expect(state._currentStep).toMatchObject({
+      type: 'next_step_interruption',
+      data: { responseAccepted: true },
+    });
+
+    const restored = await RunState.fromString(agent, state.toString());
+    await expect(
+      runner.run(agent, restored, {
+        conversationId: 'late-guardrail-conversation',
+      }),
+    ).rejects.toThrow(/accepted model response could not be processed/i);
+    expect(model.requests).toHaveLength(1);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('persists local admission once before a failed model request', async () => {
+    const model = new FailOnceModel({
+      output: [fakeModelMessage('done')],
+      usage: new Usage(),
+    });
+    const agent = new Agent({ name: 'local-failure', model });
+    const state = createResumableState(agent);
+    state.addInput('durable local input');
+    const session = new MemorySession();
+    const runner = new Runner();
+
+    await expect(runner.run(agent, state, { session })).rejects.toThrow(
+      'model request failed',
+    );
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(await session.getItems()).toEqual([message('durable local input')]);
+
+    const completed = await runner.run(agent, state, { session });
+    expect(completed.finalOutput).toBe('done');
+    expect(await session.getItems()).toEqual([
+      message('durable local input'),
+      fakeModelMessage('done'),
+    ]);
+    const retryInput = model.requests[1]?.input as AgentInputItem[];
+    expect(
+      retryInput.filter(
+        (item) =>
+          item.type === 'message' && item.content === 'durable local input',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'retries a failed local admission write before the $label model request',
+    async ({ stream }) => {
+      const session = new FailOnceSession();
+      let modelCalls = 0;
+      const response: ModelResponse = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model: Model = {
+        async getResponse() {
+          modelCalls += 1;
+          expect(session.addAttempts).toBe(2);
+          return response;
+        },
+        async *getStreamedResponse() {
+          modelCalls += 1;
+          expect(session.addAttempts).toBe(2);
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'response-local-session-retry',
+              usage: {
+                requests: response.usage.requests,
+                inputTokens: response.usage.inputTokens,
+                outputTokens: response.usage.outputTokens,
+                totalTokens: response.usage.totalTokens,
+              },
+              output: response.output,
+            },
+          } as protocol.StreamEvent;
+        },
+      };
+      const agent = new Agent({ name: 'local-session-retry', model });
+      const state = createResumableState(agent);
+      state.addInput('retry durable input');
+      const runner = new Runner();
+
+      if (stream) {
+        const failed = await runner.run(agent, state, {
+          session,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toThrow('session write failed');
+      } else {
+        await expect(runner.run(agent, state, { session })).rejects.toThrow(
+          'session write failed',
+        );
+      }
+
+      expect(modelCalls).toBe(0);
+      expect(session.addAttempts).toBe(1);
+      expect(state.pendingInput).toEqual([]);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(1);
+
+      if (stream) {
+        const completed = await runner.run(agent, state, {
+          session,
+          stream: true,
+        });
+        await completed.completed;
+        expect(completed.finalOutput).toBe('done');
+      } else {
+        const completed = await runner.run(agent, state, { session });
+        expect(completed.finalOutput).toBe('done');
+      }
+
+      expect(modelCalls).toBe(1);
+      expect(await session.getItems()).toEqual([
+        message('retry durable input'),
+        fakeModelMessage('done'),
+      ]);
+    },
+  );
+
+  it('keeps server-managed input pending until a response is accepted', async () => {
+    const model = new FailOnceModel({
+      output: [fakeModelMessage('done')],
+      usage: new Usage(),
+      responseId: 'response-1',
+    });
+    const agent = new Agent({ name: 'server-failure', model });
+    const state = createResumableState(agent);
+    state.setConversationContext('conversation-1');
+    state.addInput('durable server input');
+    const runner = new Runner();
+
+    await expect(
+      runner.run(agent, state, { conversationId: 'conversation-1' }),
+    ).rejects.toThrow('model request failed');
+    expect(state.pendingInput).toEqual([message('durable server input')]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(0);
+
+    const completed = await runner.run(agent, state, {
+      conversationId: 'conversation-1',
+    });
+    expect(completed.finalOutput).toBe('done');
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      label: 'unsafe replay',
+      advice: { replaySafety: 'unsafe' as const },
+      conversationId: 'unsafe-failure-conversation',
+      previousResponseId: undefined,
+    },
+    {
+      label: 'response-start evidence',
+      advice: { responseStarted: true },
+      conversationId: undefined,
+      previousResponseId: 'response-started-previous',
+    },
+  ])(
+    'fails closed after a server-managed request reports $label',
+    async ({ advice, conversationId, previousResponseId }) => {
+      let modelCalls = 0;
+      const model: Model = {
+        async getResponse() {
+          modelCalls += 1;
+          throw new Error('request may have been accepted');
+        },
+        getRetryAdvice() {
+          return { suggested: false, ...advice };
+        },
+        async *getStreamedResponse() {
+          yield* [];
+          throw new Error('Not implemented');
+        },
+      };
+      const agent = new Agent({ name: 'unsafe-server-failure', model });
+      const state = createResumableState(agent);
+      state.setConversationContext(conversationId, previousResponseId);
+      state.addInput('accepted without a response');
+      const options = { conversationId, previousResponseId };
+
+      await expect(run(agent, state, options)).rejects.toThrow(
+        'request may have been accepted',
+      );
+      expect(state.pendingInput).toEqual([]);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(1);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_interruption',
+        data: { responseAccepted: true },
+      });
+
+      const restored = await RunState.fromString(agent, state.toString());
+      await expect(run(agent, restored, options)).rejects.toThrow(
+        /accepted model response could not be processed/i,
+      );
+      expect(modelCalls).toBe(1);
+    },
+  );
+
+  it('keeps server-managed input replayable when the application approves an unsafe retry', async () => {
+    let modelCalls = 0;
+    const model: Model = {
+      async getResponse() {
+        modelCalls += 1;
+        if (modelCalls === 1) {
+          throw new Error('request may have been accepted');
+        }
+        return {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+          responseId: 'approved-retry-response',
+        };
+      },
+      getRetryAdvice() {
+        return {
+          suggested: false,
+          replaySafety: 'unsafe',
+          responseStarted: true,
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+        throw new Error('Not implemented');
+      },
+    };
+    const agent = new Agent({
+      name: 'approved-unsafe-server-retry',
+      model,
+      modelSettings: {
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy: () => ({ retry: true, approveUnsafeReplay: true }),
+        },
+      },
+    });
+    const state = createResumableState(agent);
+    state.setConversationContext('approved-retry-conversation');
+    state.addInput('approved replay occurrence');
+
+    const result = await run(agent, state, {
+      conversationId: 'approved-retry-conversation',
+    });
+
+    expect(result.finalOutput).toBe('done');
+    expect(modelCalls).toBe(2);
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+  });
+
+  it('fails closed when an approved unsafe retry is aborted before the next attempt', async () => {
+    const controller = new AbortController();
+    let modelCalls = 0;
+    const model: Model = {
+      async getResponse() {
+        modelCalls += 1;
+        throw new Error('request may have been accepted');
+      },
+      getRetryAdvice() {
+        return {
+          suggested: false,
+          replaySafety: 'unsafe',
+          responseStarted: true,
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+        throw new Error('Not implemented');
+      },
+    };
+    const agent = new Agent({
+      name: 'aborted-approved-unsafe-server-retry',
+      model,
+      modelSettings: {
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 100, jitter: false },
+          policy: () => {
+            queueMicrotask(() => controller.abort());
+            return { retry: true, approveUnsafeReplay: true };
+          },
+        },
+      },
+    });
+    const state = createResumableState(agent);
+    state.setConversationContext('aborted-approved-retry-conversation');
+    state.addInput('possibly accepted before abort');
+
+    await expect(
+      run(agent, state, {
+        conversationId: 'aborted-approved-retry-conversation',
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+    expect(modelCalls).toBe(1);
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(state._currentStep).toMatchObject({
+      type: 'next_step_interruption',
+      data: { responseAccepted: true },
+    });
+
+    const restored = await RunState.fromString(agent, state.toString());
+    await expect(
+      run(agent, restored, {
+        conversationId: 'aborted-approved-retry-conversation',
+      }),
+    ).rejects.toThrow(/accepted model response could not be processed/i);
+    expect(modelCalls).toBe(1);
+  });
+
+  it('preserves input appended while a server-managed request is in flight', async () => {
+    let markFirstRequestStarted!: () => void;
+    let releaseFirstRequest!: () => void;
+    const firstRequestStarted = new Promise<void>((resolve) => {
+      markFirstRequestStarted = resolve;
+    });
+    const firstRequestCanFinish = new Promise<void>((resolve) => {
+      releaseFirstRequest = resolve;
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'continue_turn',
+      callId: 'continue-turn-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const requests: ModelRequest[] = [];
+    const model: Model = {
+      async getResponse(request) {
+        requests.push(structuredClone(request));
+        if (requests.length === 1) {
+          markFirstRequestStarted();
+          await firstRequestCanFinish;
+          return {
+            output: [functionCall],
+            usage: new Usage(),
+            responseId: 'append-first-response',
+          };
+        }
+        return {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+          responseId: 'append-second-response',
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+        throw new Error('Not implemented');
+      },
+    };
+    const continueTurn = tool({
+      name: 'continue_turn',
+      description: 'Continues the current run.',
+      parameters: z.object({}).strict(),
+      execute: async () => 'continued',
+    });
+    const agent = new Agent({
+      name: 'append-during-admission',
+      model,
+      tools: [continueTurn],
+    });
+    const state = createResumableState(agent, 4);
+    state.setConversationContext('append-during-admission-conversation');
+    state.addInput('first occurrence');
+
+    const running = run(agent, state, {
+      conversationId: 'append-during-admission-conversation',
+    });
+    await firstRequestStarted;
+    state.addInput('second occurrence');
+    releaseFirstRequest();
+    const result = await running;
+
+    expect(result.finalOutput).toBe('done');
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.input).toContainEqual(message('first occurrence'));
+    expect(requests[0]?.input).not.toContainEqual(message('second occurrence'));
+    expect(requests[1]?.input).toContainEqual(message('second occurrence'));
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(2);
+  });
+
+  it('commits previous-response input only after successful acceptance', async () => {
+    const model = new RecordingModel([
+      {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+        responseId: 'response-next',
+      },
+    ]);
+    const agent = new Agent({ name: 'previous-response-input', model });
+    const state = createResumableState(agent);
+    state.setConversationContext(undefined, 'response-previous');
+    state.addInput('previous response delta');
+    const session = new MemorySession();
+
+    const completed = await run(agent, state, {
+      previousResponseId: 'response-previous',
+      session,
+    });
+
+    expect(completed.finalOutput).toBe('done');
+    expect(model.requests[0]?.previousResponseId).toBe('response-previous');
+    expect(state._previousResponseId).toBe('response-next');
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(await session.getItems()).toEqual([]);
+  });
+
+  it('admits staged input once on a streaming resume', async () => {
+    const model = new RecordingStreamModel([
+      {
+        output: [fakeModelMessage('streamed')],
+        usage: new Usage(),
+        responseId: 'stream-response',
+      },
+    ]);
+    const agent = new Agent({ name: 'streaming-pending-input', model });
+    const state = createResumableState(agent);
+    state.addInput('streamed input');
+
+    const completed = await run(agent, state, { stream: true });
+    await completed.completed;
+
+    expect(completed.finalOutput).toBe('streamed');
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      (model.requests[0]?.input as AgentInputItem[]).filter(
+        (item) => item.type === 'message' && item.content === 'streamed input',
+      ),
+    ).toHaveLength(1);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+  });
+
+  it('distinguishes an identical staged occurrence after state restoration', async () => {
+    const model = new RecordingModel([
+      {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+        responseId: 'response-next',
+      },
+    ]);
+    const agent = new Agent({ name: 'identical-occurrence', model });
+    const state = createResumableState(agent);
+    state._generatedItems.push(
+      new RunInputItem(message('Repeat'), agent, 'first-occurrence'),
+    );
+    state._modelResponses.push({
+      output: [],
+      usage: new Usage(),
+      responseId: 'response-previous',
+    });
+    state.setConversationContext(undefined, 'response-previous');
+    const restored = await RunState.fromString(agent, state.toString());
+    restored.addInput('Repeat');
+
+    const completed = await run(agent, restored, {
+      previousResponseId: 'response-previous',
+    });
+
+    expect(completed.finalOutput).toBe('done');
+    expect(
+      (model.requests[0]?.input as AgentInputItem[]).filter(
+        (item) => item.type === 'message' && item.content === 'Repeat',
+      ),
+    ).toHaveLength(1);
+    const admitted = restored._generatedItems.filter(
+      (item): item is RunInputItem => item instanceof RunInputItem,
+    );
+    expect(admitted).toHaveLength(2);
+    expect(new Set(admitted.map((item) => item.inputId)).size).toBe(2);
+  });
+
+  it.each([
+    { label: 'conversationId non-streaming', stream: false },
+    { label: 'previousResponseId streaming', stream: true },
+  ])(
+    'does not resend accepted input on an immediate $label continuation',
+    async ({ label, stream }) => {
+      const execute = vi.fn(async () => 'tool result');
+      const continuationTool = tool({
+        name: 'continuation_tool',
+        description: 'Continues to another model turn.',
+        parameters: z.object({}).strict(),
+        execute,
+      });
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'continuation_tool',
+        callId: `continuation-${label}`,
+        status: 'completed',
+        arguments: '{}',
+      };
+      const responses: ModelResponse[] = [
+        {
+          output: [functionCall],
+          usage: new Usage(),
+          responseId: `first-${label}`,
+        },
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+          responseId: `second-${label}`,
+        },
+      ];
+      const model = stream
+        ? new RecordingStreamModel(responses)
+        : new RecordingModel(responses);
+      const agent = new Agent({
+        name: `immediate-continuation-${label}`,
+        model,
+        tools: [continuationTool],
+      });
+      const state = createResumableState(agent, 4);
+      const serverOptions = stream
+        ? { previousResponseId: 'response-previous' }
+        : { conversationId: 'conversation-immediate' };
+      if (stream) {
+        state._modelResponses.push({
+          output: [],
+          usage: new Usage(),
+          responseId: 'response-previous',
+        });
+        state.setConversationContext(undefined, 'response-previous');
+      } else {
+        state.setConversationContext('conversation-immediate');
+      }
+      state.addInput('accepted once');
+
+      let finalOutput: string | undefined;
+      if (stream) {
+        const streamed = await run(agent, state, {
+          ...serverOptions,
+          stream: true,
+        });
+        await streamed.completed;
+        finalOutput = streamed.finalOutput;
+      } else {
+        finalOutput = (await run(agent, state, serverOptions)).finalOutput;
+      }
+
+      expect(finalOutput).toBe('done');
+      expect(model.requests).toHaveLength(2);
+      expect(
+        (model.requests[0]?.input as AgentInputItem[]).filter(
+          (item) => item.type === 'message' && item.content === 'accepted once',
+        ),
+      ).toHaveLength(1);
+      expect(
+        (model.requests[1]?.input as AgentInputItem[]).filter(
+          (item) => item.type === 'message' && item.content === 'accepted once',
+        ),
+      ).toHaveLength(0);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(1);
+      expect(execute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('keeps omitted input pending and commits an in-place rewrite', async () => {
+    const omittedModel = new RecordingModel([
+      { output: [fakeModelMessage('omitted')], usage: new Usage() },
+    ]);
+    const omittedAgent = new Agent({
+      name: 'omitted-input',
+      model: omittedModel,
+    });
+    const omittedState = createResumableState(omittedAgent);
+    omittedState.addInput('omit me');
+    await run(omittedAgent, omittedState, {
+      callModelInputFilter: ({ modelData }) => ({
+        ...modelData,
+        input: modelData.input.filter(
+          (item) => item.type !== 'message' || item.content !== 'omit me',
+        ),
+      }),
+    });
+    expect(omittedState.pendingInput).toEqual([message('omit me')]);
+    expect(
+      omittedState._generatedItems.filter(
+        (item) => item instanceof RunInputItem,
+      ),
+    ).toHaveLength(0);
+
+    const rewrittenModel = new RecordingModel([
+      { output: [fakeModelMessage('rewritten')], usage: new Usage() },
+    ]);
+    const rewrittenAgent = new Agent({
+      name: 'rewritten-input',
+      model: rewrittenModel,
+    });
+    const rewrittenState = createResumableState(rewrittenAgent);
+    rewrittenState.addInput('rewrite me');
+    await run(rewrittenAgent, rewrittenState, {
+      callModelInputFilter: ({ modelData }) => {
+        const pending = modelData.input.find(
+          (item) => item.type === 'message' && item.content === 'rewrite me',
+        );
+        if (pending?.type === 'message') {
+          pending.content = 'rewritten input';
+        }
+        return modelData;
+      },
+    });
+    const admitted = rewrittenState._generatedItems.find(
+      (item): item is RunInputItem => item instanceof RunInputItem,
+    );
+    expect(admitted?.rawItem).toEqual(message('rewritten input'));
+    expect(rewrittenState.pendingInput).toEqual([]);
+  });
+
+  it('rejects an ambiguous reconstructed filter item before model invocation', async () => {
+    const model = new RecordingModel([
+      { output: [fakeModelMessage('unused')], usage: new Usage() },
+    ]);
+    const agent = new Agent({ name: 'ambiguous-filter', model });
+    const state = createResumableState(agent);
+    state._originalInput = 'same';
+    state.addInput('same');
+    const beforeTurn = state._currentTurn;
+    const beforeStep = structuredClone(state._currentStep);
+
+    await expect(
+      run(agent, state, {
+        callModelInputFilter: ({ modelData }) => ({
+          ...modelData,
+          input: [message('same')],
+        }),
+      }),
+    ).rejects.toThrow(/cannot safely associate a reconstructed item/);
+    expect(model.requests).toHaveLength(0);
+    expect(state.pendingInput).toEqual([message('same')]);
+    expect(state._generatedItems).toHaveLength(0);
+    expect(state._currentTurn).toBe(beforeTurn);
+    expect(state._currentStep).toEqual(beforeStep);
+  });
+
+  it('fails closed after accepted response validation fails', async () => {
+    const execute = vi.fn(async () => 'should not run');
+    const strictTool = tool({
+      name: 'strict_tool',
+      description: 'Requires a string value.',
+      parameters: z.object({ value: z.string() }).strict(),
+      execute,
+      errorFunction: null,
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'strict_tool',
+      callId: 'strict-call',
+      status: 'completed',
+      arguments: '{"value":1}',
+    };
+    const model = new RecordingModel([
+      { output: [functionCall], usage: new Usage(), responseId: 'accepted-1' },
+    ]);
+    const agent = new Agent({
+      name: 'accepted-validation-failure',
+      model,
+      tools: [strictTool],
+    });
+    const state = createResumableState(agent);
+    state.setConversationContext('accepted-validation-conversation');
+    state.addInput('accepted once');
+    const runner = new Runner();
+
+    await expect(
+      runner.run(agent, state, {
+        conversationId: 'accepted-validation-conversation',
+      }),
+    ).rejects.toThrow();
+    expect(model.requests).toHaveLength(1);
+    expect(state._currentStep).toMatchObject({
+      type: 'next_step_interruption',
+      data: { responseAccepted: true, localProcessingStarted: true },
+    });
+
+    await expect(
+      runner.run(agent, state, {
+        conversationId: 'accepted-validation-conversation',
+      }),
+    ).rejects.toThrow(/unfinished local tool work/);
+    expect(model.requests).toHaveLength(1);
+    expect(execute).toHaveBeenCalledTimes(0);
+  });
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'checkpoints an accepted $label response when filtering omits pending input',
+    async ({ stream }) => {
+      const execute = vi.fn(async () => 'should not run');
+      const strictTool = tool({
+        name: 'strict_tool',
+        description: 'Requires a string value.',
+        parameters: z.object({ value: z.string() }).strict(),
+        execute,
+        errorFunction: null,
+      });
+      const functionCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'strict_tool',
+        callId: 'filtered-strict-call',
+        status: 'completed',
+        arguments: '{"value":1}',
+      };
+      const response = {
+        output: [functionCall],
+        usage: new Usage(),
+        responseId: 'filtered-accepted-response',
+      };
+      const model = stream
+        ? new RecordingStreamModel([response])
+        : new RecordingModel([response]);
+      const agent = new Agent({
+        name: 'filtered-accepted-validation-failure',
+        model,
+        tools: [strictTool],
+      });
+      const state = createResumableState(agent);
+      state.setConversationContext('filtered-accepted-conversation');
+      state.addInput('omit this occurrence');
+      const options = {
+        conversationId: 'filtered-accepted-conversation',
+        callModelInputFilter: ({
+          modelData,
+        }: {
+          modelData: { input: AgentInputItem[]; instructions?: string };
+        }) => ({
+          ...modelData,
+          input: modelData.input.filter(
+            (item: AgentInputItem) =>
+              !(
+                item.type === 'message' &&
+                item.role === 'user' &&
+                item.content === 'omit this occurrence'
+              ),
+          ),
+        }),
+      };
+
+      if (stream) {
+        const failed = await new Runner().run(agent, state, {
+          ...options,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toThrow();
+      } else {
+        await expect(new Runner().run(agent, state, options)).rejects.toThrow();
+      }
+
+      expect(model.requests).toHaveLength(1);
+      expect(state.pendingInput).toEqual([message('omit this occurrence')]);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_interruption',
+        data: { responseAccepted: true, localProcessingStarted: true },
+      });
+      const restored = await RunState.fromString(agent, state.toString());
+
+      if (stream) {
+        const retried = await new Runner().run(agent, restored, {
+          ...options,
+          stream: true,
+        });
+        await expect(retried.completed).rejects.toThrow(
+          /unfinished local tool work/,
+        );
+      } else {
+        await expect(
+          new Runner().run(agent, restored, options),
+        ).rejects.toThrow(/unfinished local tool work/);
+      }
+      expect(model.requests).toHaveLength(1);
+      expect(execute).toHaveBeenCalledTimes(0);
+    },
+  );
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'fails closed after accepted $label structured-output validation fails',
+    async ({ stream }) => {
+      let validationCalls = 0;
+      const outputType = z.object({
+        value: z.string().refine(() => {
+          validationCalls += 1;
+          return false;
+        }, 'validation failed after side effect'),
+      });
+      const response = {
+        output: [fakeModelMessage('{"value":"invalid"}')],
+        usage: new Usage(),
+        responseId: 'accepted-structured-response',
+      };
+      const model = stream
+        ? new RecordingStreamModel([response])
+        : new RecordingModel([response]);
+      const agent = new Agent({
+        name: 'accepted-structured-validation',
+        model,
+        outputType,
+      });
+      const state = createResumableState(agent);
+      state.setConversationContext('accepted-structured-conversation');
+      state.addInput('validate once');
+      const options = {
+        conversationId: 'accepted-structured-conversation',
+      };
+
+      if (stream) {
+        const failed = await new Runner().run(agent, state, {
+          ...options,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toThrow(/Invalid output type/);
+      } else {
+        await expect(new Runner().run(agent, state, options)).rejects.toThrow(
+          /Invalid output type/,
+        );
+      }
+
+      expect(validationCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+      expect(state._lastProcessedResponse).toBeUndefined();
+      const restored = await RunState.fromString(agent, state.toString());
+
+      if (stream) {
+        const retried = await new Runner().run(agent, restored, {
+          ...options,
+          stream: true,
+        });
+        await expect(retried.completed).rejects.toThrow(
+          /accepted model response could not be processed/,
+        );
+      } else {
+        await expect(
+          new Runner().run(agent, restored, options),
+        ).rejects.toThrow(/accepted model response could not be processed/);
+      }
+      expect(validationCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+    },
+  );
+
+  it('rejects accepted response authority without server ownership', async () => {
+    const model = new RecordingModel([
+      { output: [fakeModelMessage('must not run')], usage: new Usage() },
+    ]);
+    const agent = new Agent({ name: 'unowned-accepted-response', model });
+    const state = createResumableState(agent);
+    state._currentStep = {
+      type: 'next_step_interruption',
+      data: { interruptions: [], responseAccepted: true },
+    };
+    state._lastTurnResponse = {
+      output: [fakeModelMessage('stored')],
+      usage: new Usage(),
+    };
+    state._modelResponses.push(state._lastTurnResponse);
+    state._lastProcessedResponse = {
+      newItems: [],
+      handoffs: [],
+      functions: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: [],
+      hasToolsOrApprovalsToRun: () => false,
+    };
+
+    await expect(new Runner().run(agent, state)).rejects.toThrow(
+      /requires exactly one server-managed conversation owner/,
+    );
+    expect(model.requests).toHaveLength(0);
+    await expect(RunState.fromString(agent, state.toString())).rejects.toThrow(
+      /requires exactly one server-managed conversation owner/,
+    );
+
+    for (const ownership of [
+      { conversationId: 'conversation-owned' },
+      { previousResponseId: 'response-owned' },
+    ]) {
+      const ownedState = createResumableState(agent);
+      ownedState._currentStep = structuredClone(state._currentStep);
+      ownedState._lastTurnResponse = state._lastTurnResponse;
+      ownedState._modelResponses.push(state._lastTurnResponse);
+      ownedState._lastProcessedResponse = state._lastProcessedResponse;
+      ownedState.setConversationContext(
+        ownership.conversationId,
+        ownership.previousResponseId,
+      );
+      await expect(
+        RunState.fromString(agent, ownedState.toString()),
+      ).resolves.toBeInstanceOf(RunState);
+    }
+
+    const dualOwner = createResumableState(agent);
+    dualOwner._currentStep = structuredClone(state._currentStep);
+    dualOwner._lastTurnResponse = state._lastTurnResponse;
+    dualOwner._modelResponses.push(state._lastTurnResponse);
+    dualOwner._lastProcessedResponse = state._lastProcessedResponse;
+    dualOwner.setConversationContext('conversation-owned', 'response-owned');
+    await expect(
+      RunState.fromString(agent, dualOwner.toString()),
+    ).rejects.toThrow(/exactly one server-managed conversation owner/);
+
+    for (const ownership of [
+      { conversationId: '', previousResponseId: 'response-owned' },
+      { conversationId: 'conversation-owned', previousResponseId: '' },
+    ]) {
+      const emptySecondOwner = createResumableState(agent);
+      emptySecondOwner._currentStep = structuredClone(state._currentStep);
+      emptySecondOwner._lastTurnResponse = state._lastTurnResponse;
+      emptySecondOwner._modelResponses.push(state._lastTurnResponse);
+      emptySecondOwner._lastProcessedResponse = state._lastProcessedResponse;
+      emptySecondOwner.setConversationContext(
+        ownership.conversationId,
+        ownership.previousResponseId,
+      );
+      const before = emptySecondOwner.toString();
+
+      await expect(RunState.fromString(agent, before)).rejects.toThrow(
+        /exactly one server-managed conversation owner/,
+      );
+      await expect(new Runner().run(agent, emptySecondOwner)).rejects.toThrow(
+        /exactly one server-managed conversation owner/,
+      );
+      expect(model.requests).toHaveLength(0);
+      expect(emptySecondOwner.toString()).toBe(before);
+    }
+  });
+
+  it.each([
+    {
+      label: 'non-streaming conversation value',
+      stream: false,
+      stored: { conversationId: 'conversation-a' },
+      requested: { conversationId: 'conversation-b' },
+    },
+    {
+      label: 'streaming previous-response value',
+      stream: true,
+      stored: { previousResponseId: 'response-a' },
+      requested: { previousResponseId: 'response-b' },
+    },
+    {
+      label: 'non-streaming conversation mode',
+      stream: false,
+      stored: { conversationId: 'conversation-a' },
+      requested: { previousResponseId: 'response-b' },
+    },
+    {
+      label: 'streaming previous-response mode',
+      stream: true,
+      stored: { previousResponseId: 'response-a' },
+      requested: { conversationId: 'conversation-b' },
+    },
+  ])(
+    'rejects an accepted checkpoint with mismatched $label authority before mutation',
+    async ({ stream, stored, requested }) => {
+      const model = stream
+        ? new RecordingStreamModel([
+            { output: [fakeModelMessage('must not run')], usage: new Usage() },
+          ])
+        : new RecordingModel([
+            { output: [fakeModelMessage('must not run')], usage: new Usage() },
+          ]);
+      const agent = new Agent({ name: 'mismatched-accepted-owner', model });
+      const state = createResumableState(agent);
+      state._currentStep = {
+        type: 'next_step_interruption',
+        data: { interruptions: [], responseAccepted: true },
+      };
+      state.setConversationContext(
+        stored.conversationId,
+        stored.previousResponseId,
+      );
+      const before = state.toString();
+
+      if (stream) {
+        await expect(
+          new Runner().run(agent, state, { ...requested, stream: true }),
+        ).rejects.toThrow(
+          /cannot change its server-managed conversation owner/,
+        );
+      } else {
+        await expect(new Runner().run(agent, state, requested)).rejects.toThrow(
+          /cannot change its server-managed conversation owner/,
+        );
+      }
+      expect(model.requests).toHaveLength(0);
+      expect(state.toString()).toBe(before);
+    },
+  );
+
+  it.each([
+    {
+      label: 'non-streaming dual owner',
+      stream: false,
+      conversationId: 'conversation-a',
+      previousResponseId: 'response-a',
+    },
+    {
+      label: 'streaming dual owner',
+      stream: true,
+      conversationId: 'conversation-a',
+      previousResponseId: 'response-a',
+    },
+    {
+      label: 'non-streaming empty conversation owner',
+      stream: false,
+      conversationId: '',
+      previousResponseId: 'response-a',
+    },
+    {
+      label: 'streaming empty previous-response owner',
+      stream: true,
+      conversationId: 'conversation-a',
+      previousResponseId: '',
+    },
+  ])(
+    'rejects $label before pending-input request publication',
+    async ({ stream, conversationId, previousResponseId }) => {
+      const model = stream
+        ? new RecordingStreamModel([
+            { output: [fakeModelMessage('must not run')], usage: new Usage() },
+          ])
+        : new RecordingModel([
+            { output: [fakeModelMessage('must not run')], usage: new Usage() },
+          ]);
+      const agent = new Agent({ name: 'invalid-pending-owner', model });
+      const state = createResumableState(agent);
+      state.setConversationContext(conversationId, previousResponseId);
+      state.addInput('must remain pending');
+      const before = state.toString();
+      const options = { conversationId, previousResponseId };
+
+      if (stream) {
+        const failed = await new Runner().run(agent, state, {
+          ...options,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toThrow(
+          /requires exactly one server-managed conversation owner/,
+        );
+      } else {
+        await expect(new Runner().run(agent, state, options)).rejects.toThrow(
+          /requires exactly one server-managed conversation owner/,
+        );
+      }
+
+      expect(model.requests).toHaveLength(0);
+      expect(state.toString()).toBe(before);
+    },
+  );
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'does not replay accepted $label finalization after a callback failure',
+    async ({ stream }) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+        responseId: 'accepted-final-response',
+      };
+      const model = stream
+        ? new RecordingStreamModel([response])
+        : new RecordingModel([response]);
+      const agent = new Agent({ name: 'accepted-finalization', model });
+      const state = createResumableState(agent);
+      state.setConversationContext('accepted-final-conversation');
+      state.addInput('accepted final input');
+      const runner = new Runner();
+      let callbackCalls = 0;
+      runner.on('agent_end', () => {
+        callbackCalls += 1;
+        throw new Error('agent end failed');
+      });
+
+      if (stream) {
+        const failed = await runner.run(agent, state, {
+          conversationId: 'accepted-final-conversation',
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toThrow('agent end failed');
+      } else {
+        await expect(
+          runner.run(agent, state, {
+            conversationId: 'accepted-final-conversation',
+          }),
+        ).rejects.toThrow('agent end failed');
+      }
+
+      expect(callbackCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_final_output',
+        responseAccepted: true,
+        localFinalizationStarted: true,
+      });
+      const restored = await RunState.fromString(agent, state.toString());
+
+      if (stream) {
+        const retried = await runner.run(agent, restored, {
+          conversationId: 'accepted-final-conversation',
+          stream: true,
+        });
+        await expect(retried.completed).rejects.toThrow(
+          /unfinished local finalization/,
+        );
+      } else {
+        await expect(
+          runner.run(agent, restored, {
+            conversationId: 'accepted-final-conversation',
+          }),
+        ).rejects.toThrow(/unfinished local finalization/);
+      }
+      expect(callbackCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+    },
+  );
+
+  it('scopes error-handler attempt tracking to one run invocation', async () => {
+    const errorStateAgent = new Agent({ name: 'shared-error-state' });
+    const sharedError = new ModelRefusalError(
+      'shared refusal',
+      createResumableState(errorStateAgent),
+    );
+    const model: Model = {
+      async getResponse() {
+        throw sharedError;
+      },
+      async *getStreamedResponse() {
+        yield* [];
+        throw new Error('Not implemented');
+      },
+    };
+    const agent = new Agent({ name: 'shared-refusal-error', model });
+    let handlerCalls = 0;
+    const options = {
+      errorHandlers: {
+        modelRefusal: () => {
+          handlerCalls += 1;
+          return { finalOutput: 'handled' };
+        },
+      },
+    };
+
+    const first = await new Runner().run(
+      agent,
+      createResumableState(agent),
+      options,
+    );
+    const second = await new Runner().run(
+      agent,
+      createResumableState(agent),
+      options,
+    );
+
+    expect(first.finalOutput).toBe('handled');
+    expect(second.finalOutput).toBe('handled');
+    expect(handlerCalls).toBe(2);
+  });
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'does not replay accepted $label error-handler finalization after a callback failure',
+    async ({ stream }) => {
+      const response = {
+        output: [fakeModelRefusal('refused')],
+        usage: new Usage(),
+        responseId: 'accepted-refusal-response',
+      };
+      const model = stream
+        ? new RecordingStreamModel([response])
+        : new RecordingModel([response]);
+      const agent = new Agent({ name: 'accepted-error-handler', model });
+      const state = createResumableState(agent);
+      state.setConversationContext('accepted-error-handler-conversation');
+      state.addInput('accepted error-handler input');
+      const runner = new Runner();
+      let callbackCalls = 0;
+      runner.on('agent_end', () => {
+        callbackCalls += 1;
+        throw new Error('error-handler agent end failed');
+      });
+      const options = {
+        conversationId: 'accepted-error-handler-conversation',
+        errorHandlers: {
+          modelRefusal: () => ({ finalOutput: 'safe fallback' }),
+        },
+      };
+
+      if (stream) {
+        const failed = await runner.run(agent, state, {
+          ...options,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toThrow(
+          'error-handler agent end failed',
+        );
+      } else {
+        await expect(runner.run(agent, state, options)).rejects.toThrow(
+          'error-handler agent end failed',
+        );
+      }
+
+      expect(callbackCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_final_output',
+        responseAccepted: true,
+        localFinalizationStarted: true,
+      });
+      const restored = await RunState.fromString(agent, state.toString());
+
+      if (stream) {
+        const retried = await runner.run(agent, restored, {
+          ...options,
+          stream: true,
+        });
+        await expect(retried.completed).rejects.toThrow(
+          /unfinished local finalization/,
+        );
+      } else {
+        await expect(runner.run(agent, restored, options)).rejects.toThrow(
+          /unfinished local finalization/,
+        );
+      }
+      expect(callbackCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'invokes a declining accepted $label error handler only once',
+    async ({ stream }) => {
+      const response = {
+        output: [fakeModelRefusal('refused')],
+        usage: new Usage(),
+        responseId: 'accepted-declined-handler-response',
+      };
+      const model = stream
+        ? new RecordingStreamModel([response])
+        : new RecordingModel([response]);
+      const agent = new Agent({ name: 'accepted-declined-handler', model });
+      const state = createResumableState(agent);
+      state.setConversationContext('accepted-declined-handler-conversation');
+      state.addInput('accepted declined-handler input');
+      let handlerCalls = 0;
+      const options = {
+        conversationId: 'accepted-declined-handler-conversation',
+        errorHandlers: {
+          modelRefusal: () => {
+            handlerCalls += 1;
+          },
+        },
+      };
+
+      if (stream) {
+        const failed = await new Runner().run(agent, state, {
+          ...options,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toBeInstanceOf(
+          ModelRefusalError,
+        );
+      } else {
+        await expect(
+          new Runner().run(agent, state, options),
+        ).rejects.toBeInstanceOf(ModelRefusalError);
+      }
+
+      expect(handlerCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_interruption',
+        data: { responseAccepted: true, localProcessingStarted: true },
+      });
+      expect(state._lastProcessedResponse).toBeUndefined();
+      const restored = await RunState.fromString(agent, state.toString());
+
+      if (stream) {
+        const retried = await new Runner().run(agent, restored, {
+          ...options,
+          stream: true,
+        });
+        await expect(retried.completed).rejects.toThrow(
+          /accepted model response could not be processed/,
+        );
+      } else {
+        await expect(
+          new Runner().run(agent, restored, options),
+        ).rejects.toThrow(/accepted model response could not be processed/);
+      }
+      expect(handlerCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    { label: 'non-streaming', stream: false },
+    { label: 'streaming', stream: true },
+  ])(
+    'does not replay an accepted $label error handler that throws',
+    async ({ stream }) => {
+      const response = {
+        output: [fakeModelRefusal('refused')],
+        usage: new Usage(),
+        responseId: 'accepted-throwing-handler-response',
+      };
+      const model = stream
+        ? new RecordingStreamModel([response])
+        : new RecordingModel([response]);
+      const agent = new Agent({ name: 'accepted-throwing-handler', model });
+      const state = createResumableState(agent);
+      state.setConversationContext('accepted-throwing-handler-conversation');
+      state.addInput('accepted throwing-handler input');
+      let handlerCalls = 0;
+      const options = {
+        conversationId: 'accepted-throwing-handler-conversation',
+        errorHandlers: {
+          modelRefusal: async () => {
+            handlerCalls += 1;
+            throw new Error('error handler failed after side effect');
+          },
+        },
+      };
+
+      if (stream) {
+        const failed = await new Runner().run(agent, state, {
+          ...options,
+          stream: true,
+        });
+        await expect(failed.completed).rejects.toThrow(
+          'error handler failed after side effect',
+        );
+      } else {
+        await expect(new Runner().run(agent, state, options)).rejects.toThrow(
+          'error handler failed after side effect',
+        );
+      }
+
+      expect(handlerCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_interruption',
+        data: { responseAccepted: true, localProcessingStarted: true },
+      });
+      expect(state._lastProcessedResponse).toBeUndefined();
+      const restored = await RunState.fromString(agent, state.toString());
+
+      if (stream) {
+        const retried = await new Runner().run(agent, restored, {
+          ...options,
+          stream: true,
+        });
+        await expect(retried.completed).rejects.toThrow(
+          /accepted model response could not be processed/,
+        );
+      } else {
+        await expect(
+          new Runner().run(agent, restored, options),
+        ).rejects.toThrow(/accepted model response could not be processed/);
+      }
+      expect(handlerCalls).toBe(1);
+      expect(model.requests).toHaveLength(1);
+    },
+  );
+
+  it('does not start a non-streaming model request after cancellation during local persistence', async () => {
+    const model = new RecordingModel([
+      { output: [fakeModelMessage('must not run')], usage: new Usage() },
+    ]);
+    const agent = new Agent({ name: 'cancel-local-persistence', model });
+    const state = createResumableState(agent);
+    state.addInput('persist before cancellation');
+    const session = new BlockingSession();
+    const controller = new AbortController();
+
+    const running = new Runner().run(agent, state, {
+      session,
+      signal: controller.signal,
+    });
+    await session.addStarted;
+    controller.abort();
+    session.release();
+
+    await expect(running).rejects.toThrow();
+    expect(model.requests).toHaveLength(0);
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(
+      (await session.getItems()).filter(
+        (item) =>
+          item.type === 'message' &&
+          item.content === 'persist before cancellation',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('does not start a streaming model request after cancellation during local persistence', async () => {
+    const model = new NeverCalledStreamModel();
+    const agent = new Agent({ name: 'cancel-stream-persistence', model });
+    const state = createResumableState(agent);
+    state.addInput('persist before stream cancellation');
+    const session = new BlockingSession();
+
+    const streamed = await new Runner().run(agent, state, {
+      session,
+      stream: true,
+    });
+    const reader = (streamed.toStream() as any).getReader();
+    await session.addStarted;
+    const cancellation = reader.cancel('cancel during persistence');
+    session.release();
+    await cancellation;
+    await streamed.completed;
+
+    expect(model.streamCalls).toBe(0);
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(
+      (await session.getItems()).filter(
+        (item) =>
+          item.type === 'message' &&
+          item.content === 'persist before stream cancellation',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('commits tool output before a failing end hook and does not rerun it', async () => {
+    const execute = vi.fn(async () => 'side effect completed');
+    const sideEffectTool = tool({
+      name: 'side_effect_tool',
+      description: 'Runs once.',
+      parameters: z.object({}).strict(),
+      execute,
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'side_effect_tool',
+      callId: 'side-effect-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const model = new RecordingModel([
+      { output: [functionCall], usage: new Usage(), responseId: 'accepted-2' },
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agent = new Agent({
+      name: 'tool-end-failure',
+      model,
+      tools: [sideEffectTool],
+    });
+    const state = createResumableState(agent);
+    state.setConversationContext('tool-end-conversation');
+    state.addInput('accepted once');
+    const runner = new Runner();
+    let failEndHook = true;
+    runner.on('agent_tool_end', () => {
+      if (failEndHook) {
+        failEndHook = false;
+        throw new Error('tool end hook failed');
+      }
+    });
+
+    await expect(
+      runner.run(agent, state, {
+        conversationId: 'tool-end-conversation',
+      }),
+    ).rejects.toThrow('tool end hook failed');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(
+      state._generatedItems.filter(
+        (item) =>
+          item.type === 'tool_call_output_item' &&
+          item.rawItem.callId === 'side-effect-call',
+      ),
+    ).toHaveLength(1);
+
+    const restored = await RunState.fromString(agent, state.toString());
+    const completed = await runner.run(agent, restored, {
+      conversationId: 'tool-end-conversation',
+    });
+    expect(completed.finalOutput).toBe('done');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(model.requests).toHaveLength(2);
+  });
+
+  it('keeps one local occurrence across an explicitly approved unsafe replay', async () => {
+    let attempts = 0;
+    const requestInputs: AgentInputItem[][] = [];
+    const model: Model = {
+      async getResponse(request) {
+        attempts += 1;
+        requestInputs.push(structuredClone(request.input as AgentInputItem[]));
+        if (attempts === 1) {
+          throw new Error('request may have been accepted');
+        }
+        return {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        };
+      },
+      getRetryAdvice() {
+        return {
+          suggested: false,
+          replaySafety: 'unsafe',
+          responseStarted: true,
+        };
+      },
+      async *getStreamedResponse() {
+        yield* [];
+        throw new Error('Not implemented');
+      },
+    };
+    const agent = new Agent({
+      name: 'unsafe-replay-pending-input',
+      model,
+      modelSettings: {
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy: () => ({ retry: true, approveUnsafeReplay: true }),
+        },
+      },
+    });
+    const state = createResumableState(agent);
+    state.addInput('logical occurrence');
+    const session = new MemorySession();
+
+    const completed = await run(agent, state, { session });
+
+    expect(completed.finalOutput).toBe('done');
+    expect(attempts).toBe(2);
+    expect(requestInputs[0]).toEqual(requestInputs[1]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(
+      (await session.getItems()).filter(
+        (item) =>
+          item.type === 'message' && item.content === 'logical occurrence',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('fails closed when a server-managed stream was accepted without a final response', async () => {
+    const model = new FailingAcceptedStreamModel();
+    const agent = new Agent({ name: 'accepted-stream', model });
+    const state = createResumableState(agent);
+    state.setConversationContext('conversation-stream');
+    state._lastTurnResponse = {
+      output: [fakeModelMessage('prior response')],
+      usage: new Usage(),
+      responseId: 'prior-response',
+    };
+    state._modelResponses.push(state._lastTurnResponse);
+    state._lastProcessedResponse = {
+      newItems: [],
+      handoffs: [],
+      functions: [],
+      computerActions: [],
+      shellActions: [],
+      applyPatchActions: [],
+      mcpApprovalRequests: [],
+      toolsUsed: [],
+      hasToolsOrApprovalsToRun: () => false,
+    };
+    state.addInput('stream occurrence');
+
+    const streamed = await run(agent, state, {
+      stream: true,
+      conversationId: 'conversation-stream',
+    });
+    await expect(streamed.completed).rejects.toThrow(
+      'stream failed after acceptance',
+    );
+    expect(state.pendingInput).toEqual([]);
+    expect(state._currentStep).toMatchObject({
+      type: 'next_step_interruption',
+      data: { responseAccepted: true },
+    });
+    expect(state._lastTurnResponse).toBeUndefined();
+    expect(state._lastProcessedResponse).toBeUndefined();
+
+    const restored = await RunState.fromString(agent, state.toString());
+
+    await expect(
+      run(agent, restored, { conversationId: 'conversation-stream' }),
+    ).rejects.toThrow(/accepted model response could not be processed/i);
+    expect(model.streamCalls).toBe(1);
+  });
+
+  it.each([
+    {
+      label: 'unsafe replay',
+      advice: { replaySafety: 'unsafe' as const },
+      conversationId: 'unsafe-stream-conversation',
+      previousResponseId: undefined,
+    },
+    {
+      label: 'response-start evidence',
+      advice: { responseStarted: true },
+      conversationId: undefined,
+      previousResponseId: 'response-started-stream-previous',
+    },
+  ])(
+    'fails closed before the first server-managed stream event after $label',
+    async ({ advice, conversationId, previousResponseId }) => {
+      let streamCalls = 0;
+      const model: Model = {
+        async getResponse() {
+          throw new Error('Not implemented');
+        },
+        async *getStreamedResponse() {
+          streamCalls += 1;
+          yield* [];
+          throw new Error('stream request may have been accepted');
+        },
+        getRetryAdvice() {
+          return { suggested: false, ...advice };
+        },
+      };
+      const agent = new Agent({ name: 'unsafe-server-stream', model });
+      const state = createResumableState(agent);
+      state.setConversationContext(conversationId, previousResponseId);
+      state.addInput('accepted streamed occurrence');
+      const options = {
+        conversationId,
+        previousResponseId,
+      };
+
+      const streamed = await run(agent, state, { ...options, stream: true });
+      await expect(streamed.completed).rejects.toThrow(
+        'stream request may have been accepted',
+      );
+      expect(state.pendingInput).toEqual([]);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(1);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_interruption',
+        data: { responseAccepted: true },
+      });
+
+      const restored = await RunState.fromString(agent, state.toString());
+      await expect(run(agent, restored, options)).rejects.toThrow(
+        /accepted model response could not be processed/i,
+      );
+      expect(streamCalls).toBe(1);
+    },
+  );
+
+  it('keeps staged input replayable after a provider-safe pre-event stream failure', async () => {
+    let streamCalls = 0;
+    const model: Model = {
+      async getResponse() {
+        throw new Error('Not implemented');
+      },
+      async *getStreamedResponse() {
+        streamCalls += 1;
+        yield* [];
+        throw new Error('safe stream failure');
+      },
+      getRetryAdvice() {
+        return { suggested: false, replaySafety: 'safe' };
+      },
+    };
+    const agent = new Agent({ name: 'safe-server-stream', model });
+    const state = createResumableState(agent);
+    state.setConversationContext('safe-stream-conversation');
+    state.addInput('replayable streamed occurrence');
+
+    const streamed = await run(agent, state, {
+      conversationId: 'safe-stream-conversation',
+      stream: true,
+    });
+    await expect(streamed.completed).rejects.toThrow('safe stream failure');
+    expect(state.pendingInput).toEqual([
+      message('replayable streamed occurrence'),
+    ]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(0);
+    expect(streamCalls).toBe(1);
+  });
+
+  it('checkpoints server acceptance before surfacing a parallel staged-input guardrail failure', async () => {
+    let releaseFirstEvent!: () => void;
+    let markModelStarted!: () => void;
+    const firstEventCanArrive = new Promise<void>((resolve) => {
+      releaseFirstEvent = resolve;
+    });
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    let streamCalls = 0;
+    const model: Model = {
+      async getResponse() {
+        throw new Error('Not implemented');
+      },
+      async *getStreamedResponse() {
+        streamCalls += 1;
+        markModelStarted();
+        await firstEventCanArrive;
+        yield {
+          type: 'output_text_delta',
+          delta: 'accepted but guarded',
+          providerData: {},
+        } as protocol.StreamEvent;
+      },
+    };
+    const agent = new Agent({ name: 'accepted-guardrail-stream', model });
+    const state = createResumableState(agent);
+    state.setConversationContext('accepted-guardrail-conversation');
+    state.addInput('accepted guarded occurrence');
+    const guardrail = vi.fn(async () => {
+      await modelStarted;
+      return {
+        tripwireTriggered: true,
+        outputInfo: { reason: 'blocked after server acceptance' },
+      };
+    });
+    const runner = new Runner({
+      inputGuardrails: [{ name: 'pending-guardrail', execute: guardrail }],
+    });
+
+    const streamed = await runner.run(agent, state, {
+      stream: true,
+      conversationId: 'accepted-guardrail-conversation',
+    });
+    const consumed = (async () => {
+      const events: unknown[] = [];
+      let error: unknown;
+      try {
+        for await (const event of streamed) {
+          events.push(event);
+        }
+      } catch (caughtError) {
+        error = caughtError;
+      }
+      return { events, error };
+    })();
+
+    await vi.waitFor(() => {
+      expect(state._inputGuardrailResults).toHaveLength(1);
+    });
+    releaseFirstEvent();
+
+    await expect(streamed.completed).rejects.toBeInstanceOf(
+      InputGuardrailTripwireTriggered,
+    );
+    const streamOutcome = await consumed;
+    expect(streamOutcome.error).toBeInstanceOf(InputGuardrailTripwireTriggered);
+    expect(streamOutcome.events).toEqual([]);
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(1);
+    expect(state._currentStep).toMatchObject({
+      type: 'next_step_interruption',
+      data: { responseAccepted: true },
+    });
+
+    const restored = await RunState.fromString(agent, state.toString());
+    await expect(
+      runner.run(agent, restored, {
+        conversationId: 'accepted-guardrail-conversation',
+      }),
+    ).rejects.toThrow(/accepted model response could not be processed/i);
+    expect(streamCalls).toBe(1);
+  });
+
+  it('treats an explicit server-managed stream abort as an unsafe accepted request', async () => {
+    const model = new AbortBeforeEventStreamModel();
+    const agent = new Agent({ name: 'aborted-server-stream', model });
+    const state = createResumableState(agent);
+    state.setConversationContext('conversation-abort');
+    state.addInput('possibly accepted');
+
+    const streamed = await run(agent, state, {
+      stream: true,
+      conversationId: 'conversation-abort',
+    });
+    const reader = (streamed.toStream() as any).getReader();
+    await model.started;
+    await reader.cancel('stop');
+    await streamed.completed;
+
+    expect(state.pendingInput).toEqual([]);
+    expect(state._currentStep).toMatchObject({
+      type: 'next_step_interruption',
+      data: { responseAccepted: true },
+    });
+    await expect(
+      run(agent, state, { conversationId: 'conversation-abort' }),
+    ).rejects.toThrow(/accepted model response could not be processed/i);
+    expect(model.streamCalls).toBe(1);
+  });
+
+  it('leaves pending input untouched when cancellation follows approval tool work', async () => {
+    let markInstructionsStarted!: () => void;
+    let releaseInstructions!: () => void;
+    const instructionsStarted = new Promise<void>((resolve) => {
+      markInstructionsStarted = resolve;
+    });
+    const instructionsCanFinish = new Promise<void>((resolve) => {
+      releaseInstructions = resolve;
+    });
+    const execute = vi.fn(async () => 'approved output');
+    const approvalTool = tool({
+      name: 'approval_tool',
+      description: 'Requires approval.',
+      parameters: z.object({}).strict(),
+      needsApproval: true,
+      execute,
+    });
+    const functionCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'approval_tool',
+      callId: 'approval-call',
+      status: 'completed',
+      arguments: '{}',
+    };
+    const initialModel = new RecordingModel([
+      { output: [functionCall], usage: new Usage() },
+    ]);
+    let instructionCalls = 0;
+    const agent = new Agent({
+      name: 'cancel-after-approval-tool',
+      model: initialModel,
+      tools: [approvalTool],
+      instructions: async () => {
+        instructionCalls += 1;
+        if (instructionCalls > 1) {
+          markInstructionsStarted();
+          await instructionsCanFinish;
+        }
+        return 'ready';
+      },
+    });
+    const interrupted = await run(agent, 'initial');
+    const state = interrupted.state;
+    state.addInput('not admitted');
+    state.approve(state.getInterruptions()[0]!);
+    const model = new NeverCalledStreamModel();
+    agent.model = model;
+
+    const streamed = await run(agent, state, { stream: true });
+    const reader = (streamed.toStream() as any).getReader();
+    await instructionsStarted;
+    const cancellation = reader.cancel('stop before request');
+    releaseInstructions();
+    await cancellation;
+    await streamed.completed;
+
+    expect(streamed.cancelled).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(model.streamCalls).toBe(0);
+    expect(state.pendingInput).toEqual([message('not admitted')]);
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(0);
+    expect(state._currentTurn).toBe(1);
+
+    const finalModel = new RecordingModel([
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    agent.model = finalModel;
+    const completed = await run(agent, state);
+    expect(completed.finalOutput).toBe('done');
+    expect(
+      (finalModel.requests[0]?.input as AgentInputItem[]).filter(
+        (item) => item.type === 'message' && item.content === 'not admitted',
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -17,6 +17,7 @@ import { RunContext } from '../src/runContext';
 import {
   run,
   MemorySession,
+  RunInputItem,
   RunItemStreamEvent,
   RunState,
   Runner,
@@ -1060,6 +1061,65 @@ function fakeSandboxSessionStateEnvelope(
 }
 
 describe('sandbox runner integration', () => {
+  it.each([
+    { label: 'local non-streaming', stream: false, serverManaged: false },
+    { label: 'server-managed streaming', stream: true, serverManaged: true },
+  ])(
+    'preserves staged input through cloned sandbox context for $label',
+    async ({ stream, serverManaged }) => {
+      const response = {
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      };
+      const model = stream
+        ? new RecordingStreamingModel([response])
+        : new RecordingFakeModel([response]);
+      const agent = new SandboxAgent({
+        name: 'ClonedPendingInputAgent',
+        model,
+        capabilities: [new CloningContextCapability()],
+      });
+      const state = new RunState(new RunContext(), 'initial', agent, 3);
+      state._currentTurn = 1;
+      state._currentStep = { type: 'next_step_run_again' };
+      state.addInput('staged sandbox input');
+      const session = serverManaged ? undefined : new MemorySession();
+      const conversationId = serverManaged
+        ? 'sandbox-pending-conversation'
+        : undefined;
+      state.setConversationContext(conversationId);
+      const options = {
+        sandbox: { client: new FakeSandboxClient() },
+        ...(session ? { session } : {}),
+        ...(conversationId ? { conversationId } : {}),
+      };
+
+      if (stream) {
+        const result = await run(agent, state, { ...options, stream: true });
+        await result.completed;
+        expect(result.finalOutput).toBe('done');
+      } else {
+        const result = await run(agent, state, options);
+        expect(result.finalOutput).toBe('done');
+      }
+
+      expect(state.pendingInput).toEqual([]);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(1);
+      expect(
+        JSON.stringify(model.requests[0]?.input).match(/staged sandbox input/g),
+      ).toHaveLength(1);
+      if (session) {
+        expect(
+          JSON.stringify(await session.getItems()).match(
+            /staged sandbox input/g,
+          ),
+        ).toHaveLength(1);
+      }
+    },
+  );
+
   it.each([false, true])(
     'persists reordered equal-content session input when a sandbox capability clones context (stream=%s)',
     async (stream) => {

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -23,6 +23,7 @@ describe('Exports', () => {
     expect(agent.name).toBe('Test');
     expect(typeof Agents.setSensitiveDataLoggingEnabled).toBe('function');
     expect(typeof Agents.RunCompactionItem).toBe('function');
+    expect(typeof Agents.RunInputItem).toBe('function');
     expect(typeof Agents.isSessionHistoryTransactionAwareSession).toBe(
       'function',
     );


### PR DESCRIPTION
This pull request adds durable pending input to resumable `RunState` instances.

It exposes `addInput`, immutable `pendingInput` observation, and `clearPendingInput`, while preserving occurrence identity through serialization, approval resolution, guardrails, input filtering, local session persistence, and server-managed conversation continuation. It also checkpoints accepted responses and fails closed when safe local recovery cannot be proven, while retaining streaming and non-streaming parity and existing retry authority.

Documentation is intentionally deferred until the behavior is available in a published release.
