### PR TITLE
fix: preserve structured tool outputs in RunState

### DIFF
--- a/.changeset/structured-runstate-outputs.md
+++ b/.changeset/structured-runstate-outputs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve structured tool outputs in RunState

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -150,7 +150,8 @@ import {
  * - 1.18: Adds sandbox session-state envelope version 3 so credential-redacted
  *   mount authority cannot be consumed by older SDKs, and binds per-call approvals
  *   and committed local tool results to canonical invocation fingerprints. It also
- *   scopes persistent hosted MCP approvals by server label and tool name.
+ *   scopes persistent hosted MCP approvals by server label and tool name, and preserves
+ *   JSON-compatible tool outputs as structured data.
  */
 export const CURRENT_SCHEMA_VERSION = '1.18' as const;
 const SUPPORTED_SCHEMA_VERSIONS = [
@@ -1103,6 +1104,131 @@ const modelResponseSchema = z.object({
   providerData: z.record(z.string(), z.any()).optional(),
 });
 
+type JsonCompatibleValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonCompatibleValue[]
+  | { [key: string]: JsonCompatibleValue };
+
+const INVALID_JSON_COMPATIBLE_VALUE = Symbol('invalidJsonCompatibleValue');
+
+function normalizeJsonCompatibleValue(
+  value: unknown,
+): JsonCompatibleValue | typeof INVALID_JSON_COMPATIBLE_VALUE {
+  try {
+    return normalizeJsonCompatibleValueInternal(value, new Set<object>());
+  } catch {
+    return INVALID_JSON_COMPATIBLE_VALUE;
+  }
+}
+
+function normalizeJsonCompatibleValueInternal(
+  value: unknown,
+  ancestors: Set<object>,
+): JsonCompatibleValue | typeof INVALID_JSON_COMPATIBLE_VALUE {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return INVALID_JSON_COMPATIBLE_VALUE;
+    }
+    return Object.is(value, -0) ? 0 : value;
+  }
+  if (typeof value !== 'object' || ancestors.has(value)) {
+    return INVALID_JSON_COMPATIBLE_VALUE;
+  }
+  if (hasUnsupportedToJsonProtocol(value)) {
+    return INVALID_JSON_COMPATIBLE_VALUE;
+  }
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      if (Object.getOwnPropertySymbols(value).length > 0) {
+        return INVALID_JSON_COMPATIBLE_VALUE;
+      }
+      const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+      if (!lengthDescriptor || !('value' in lengthDescriptor)) {
+        return INVALID_JSON_COMPATIBLE_VALUE;
+      }
+      const normalized: JsonCompatibleValue[] = [];
+      for (let index = 0; index < lengthDescriptor.value; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, index);
+        if (!descriptor || !('value' in descriptor)) {
+          return INVALID_JSON_COMPATIBLE_VALUE;
+        }
+        const entry = normalizeJsonCompatibleValueInternal(
+          descriptor.value,
+          ancestors,
+        );
+        if (entry === INVALID_JSON_COMPATIBLE_VALUE) {
+          return INVALID_JSON_COMPATIBLE_VALUE;
+        }
+        normalized.push(entry);
+      }
+      return normalized;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      return INVALID_JSON_COMPATIBLE_VALUE;
+    }
+    const entries: Array<[string, JsonCompatibleValue]> = [];
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== 'string') {
+        return INVALID_JSON_COMPATIBLE_VALUE;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (!descriptor) {
+        return INVALID_JSON_COMPATIBLE_VALUE;
+      }
+      if (!descriptor.enumerable) {
+        continue;
+      }
+      if (!('value' in descriptor)) {
+        return INVALID_JSON_COMPATIBLE_VALUE;
+      }
+      const entry = normalizeJsonCompatibleValueInternal(
+        descriptor.value,
+        ancestors,
+      );
+      if (entry === INVALID_JSON_COMPATIBLE_VALUE) {
+        return INVALID_JSON_COMPATIBLE_VALUE;
+      }
+      entries.push([key, entry]);
+    }
+    return Object.fromEntries(entries);
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function hasUnsupportedToJsonProtocol(value: object): boolean {
+  let current: object | null = value;
+  while (current !== null) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, 'toJSON');
+    if (descriptor) {
+      return !('value' in descriptor) || typeof descriptor.value === 'function';
+    }
+    current = Object.getPrototypeOf(current);
+  }
+  return false;
+}
+
+const jsonCompatibleValueSchema = z.preprocess(
+  normalizeJsonCompatibleValue,
+  z.custom<JsonCompatibleValue>(
+    (value) => value !== INVALID_JSON_COMPATIBLE_VALUE,
+    { message: 'Expected JSON-compatible data.' },
+  ),
+);
+
 const itemSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('message_output_item'),
@@ -1131,7 +1257,7 @@ const itemSchema = z.discriminatedUnion('type', [
       .or(protocol.ApplyPatchCallResultItem)
       .or(protocol.ProgramCallResultItem),
     agent: serializedAgentSchema,
-    output: z.string(),
+    output: jsonCompatibleValueSchema,
     customData: z.record(z.string(), z.any()).optional(),
     executionStatus: z.literal('executed').optional(),
   }),
@@ -2656,6 +2782,10 @@ async function buildRunStateFromString<
     jsonResult,
   );
   const stateJson = SerializedRunState.parse(jsonResult);
+  assertSchemaVersionSupportsStructuredToolOutputs(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
   assertSchemaVersionSupportsToolSearch(
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
@@ -2787,6 +2917,22 @@ function assertSchemaVersionSupportsCustomData(
 
   throw new UserError(
     `Run state schema version ${schemaVersion} does not support tool output customData. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+  );
+}
+
+function assertSchemaVersionSupportsStructuredToolOutputs(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  if (
+    schemaVersionSupportsV118State(schemaVersion) ||
+    !containsStructuredToolOutputState(stateJson)
+  ) {
+    return;
+  }
+
+  throw new UserError(
+    `Run state schema version ${schemaVersion} does not support structured tool output values. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
   );
 }
 
@@ -3891,6 +4037,44 @@ function containsSerializedToolOutputCustomData(
     containsToolOutputCustomDataRunItems(
       stateJson.lastProcessedResponse?.newItems,
     )
+  );
+}
+
+function containsStructuredToolOutputState(
+  stateJson: z.infer<typeof SerializedRunState>,
+): boolean {
+  if (
+    containsStructuredToolOutputRunItems(stateJson.generatedItems) ||
+    containsStructuredToolOutputRunItems(
+      stateJson.lastProcessedResponse?.newItems,
+    )
+  ) {
+    return true;
+  }
+
+  return Boolean(
+    stateJson.completedToolInvocationEvidence?.some(({ invocations }) =>
+      Object.values(invocations).some(({ items }) =>
+        items.some(
+          (reference) =>
+            'item' in reference &&
+            reference.item.type === 'tool_call_output_item' &&
+            typeof reference.item.output !== 'string',
+        ),
+      ),
+    ),
+  );
+}
+
+function containsStructuredToolOutputRunItems(
+  items: z.infer<typeof itemSchema>[] | undefined,
+): boolean {
+  return Boolean(
+    items?.some(
+      (item) =>
+        item.type === 'tool_call_output_item' &&
+        typeof item.output !== 'string',
+    ),
   );
 }
 
@@ -5426,6 +5610,12 @@ function serializeRunItem(
   agentIdentityKeys: ReadonlyMap<Agent<any, any>, string>,
 ): z.infer<typeof itemSchema> {
   const serialized = item.toJSON() as any;
+  if (item instanceof RunToolCallOutputItem) {
+    const normalizedOutput = jsonCompatibleValueSchema.safeParse(item.output);
+    if (normalizedOutput.success) {
+      serialized.output = normalizedOutput.data;
+    }
+  }
   switch (item.type) {
     case 'handoff_output_item':
       serialized.sourceAgent = serializeAgentReference(

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -1195,6 +1195,304 @@ export function registerRunStateCoreTests(): void {
       expect(JSON.parse(str)).toEqual(json);
     });
 
+    it.each([
+      { name: 'null', output: null },
+      { name: 'boolean', output: true },
+      { name: 'number', output: 42 },
+      {
+        name: 'nested object',
+        output: {
+          city: 'sf',
+          readings: [{ temperature: 18 }, null, true],
+        },
+      },
+      {
+        name: 'nested array',
+        output: [{ city: 'sf' }, [18, 19], null],
+      },
+    ])(
+      'round-trips a JSON-compatible $name tool output as structured data',
+      async ({ output }) => {
+        const agent = new Agent({ name: 'StructuredOutputAgent' });
+        const rawItem: protocol.FunctionCallResultItem = {
+          type: 'function_call_result',
+          name: 'weather',
+          callId: 'structured-output',
+          status: 'completed',
+          output: 'model-visible output',
+        };
+        const state = new RunState(new RunContext(), 'input', agent, 1);
+        state._generatedItems.push(
+          new RunToolCallOutputItem(rawItem, agent, output),
+        );
+
+        const serialized = state.toJSON();
+        expect((serialized.generatedItems[0] as any).output).toEqual(output);
+
+        const restoredFromJson = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+        const restoredFromString = await RunState.fromString(
+          agent,
+          state.toString(),
+        );
+
+        for (const restored of [restoredFromJson, restoredFromString]) {
+          expect(
+            (restored._generatedItems[0] as RunToolCallOutputItem).output,
+          ).toEqual(output);
+          const repeated = await RunState.fromString(
+            agent,
+            restored.toString(),
+          );
+          expect(
+            (repeated._generatedItems[0] as RunToolCallOutputItem).output,
+          ).toEqual(output);
+        }
+      },
+    );
+
+    it('preserves structured output across item carriers without leaking wrapper data', async () => {
+      const agent = new Agent({ name: 'StructuredCarrierAgent' });
+      const rawItem: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: 'lookup',
+        callId: 'structured-carrier',
+        status: 'completed',
+        output: 'provider-visible output',
+      };
+      const output = {
+        sdkOnlyMarker: 'wrapper-output-only',
+        nested: [{ value: 1 }],
+      };
+      const customData = { uiMarker: 'custom-data-only' };
+      const outputItem = new RunToolCallOutputItem(
+        rawItem,
+        agent,
+        output,
+        customData,
+      );
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(outputItem);
+      state._lastProcessedResponse = {
+        newItems: [outputItem],
+        toolsUsed: [],
+        handoffs: [],
+        functions: [],
+        computerActions: [],
+        shellActions: [],
+        applyPatchActions: [],
+        mcpApprovalRequests: [],
+        hasToolsOrApprovalsToRun: () => false,
+      };
+
+      const serialized = state.toJSON() as any;
+      expect(serialized.generatedItems[0].output).toEqual(output);
+      expect(serialized.lastProcessedResponse.newItems[0].output).toEqual(
+        output,
+      );
+
+      const restored = await RunState.fromString(agent, state.toString());
+      expect(
+        (restored._generatedItems[0] as RunToolCallOutputItem).output,
+      ).toEqual(output);
+      expect(
+        (restored._lastProcessedResponse?.newItems[0] as RunToolCallOutputItem)
+          .output,
+      ).toEqual(output);
+      expect(restored._generatedItems[0].rawItem).toEqual(rawItem);
+      expect(
+        (restored._generatedItems[0] as RunToolCallOutputItem).customData,
+      ).toEqual(customData);
+      expect(JSON.stringify(restored.history)).not.toContain(
+        'wrapper-output-only',
+      );
+      expect(JSON.stringify(restored.history)).not.toContain(
+        'custom-data-only',
+      );
+      expect(restored.history).toContainEqual(rawItem);
+    });
+
+    it('reads schema 1.17 string outputs and reserves structured outputs for 1.18', async () => {
+      const agent = new Agent({ name: 'StructuredOutputVersionAgent' });
+      const rawItem: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: 'lookup',
+        callId: 'structured-output-version',
+        status: 'completed',
+        output: 'provider-visible output',
+      };
+      const legacyState = new RunState(new RunContext(), 'input', agent, 1);
+      legacyState._generatedItems.push(
+        new RunToolCallOutputItem(rawItem, agent, 'legacy output'),
+      );
+      const legacySerialized = legacyState.toJSON() as any;
+      legacySerialized.$schemaVersion = '1.17';
+      delete legacySerialized.completedToolInvocations;
+      delete legacySerialized.completedToolInvocationEvidence;
+      delete legacySerialized.ambiguousToolInvocationCallIds;
+
+      const restoredLegacy = await RunState.fromString(
+        agent,
+        JSON.stringify(legacySerialized),
+      );
+      expect(
+        (restoredLegacy._generatedItems[0] as RunToolCallOutputItem).output,
+      ).toBe('legacy output');
+
+      const structuredState = new RunState(new RunContext(), 'input', agent, 1);
+      structuredState._generatedItems.push(
+        new RunToolCallOutputItem(rawItem, agent, { value: 1 }),
+      );
+      const structuredSerialized = structuredState.toJSON() as any;
+      structuredSerialized.$schemaVersion = '1.17';
+      delete structuredSerialized.completedToolInvocations;
+      delete structuredSerialized.completedToolInvocationEvidence;
+      delete structuredSerialized.ambiguousToolInvocationCallIds;
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(structuredSerialized)),
+      ).rejects.toThrow(
+        'Run state schema version 1.17 does not support structured tool output values.',
+      );
+    });
+
+    it('rejects a serialized tool output item with missing output data', async () => {
+      const agent = new Agent({ name: 'MissingOutputAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._generatedItems.push(
+        new RunToolCallOutputItem(
+          {
+            type: 'function_call_result',
+            name: 'lookup',
+            callId: 'missing-output',
+            status: 'completed',
+            output: 'provider-visible output',
+          },
+          agent,
+          'wrapper output',
+        ),
+      );
+      const serialized = state.toJSON() as any;
+      delete serialized.generatedItems[0].output;
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toBeInstanceOf(ZodError);
+    });
+
+    it('keeps unsupported live tool outputs on the released string fallback', async () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      const throwingGetter = Object.defineProperty({}, 'value', {
+        enumerable: true,
+        get() {
+          throw new Error('getter failed');
+        },
+      });
+      class SerializableResult {
+        toJSON() {
+          return { value: 1 };
+        }
+      }
+      const nonEnumerableToJson = Object.defineProperty(
+        { value: 1 },
+        'toJSON',
+        {
+          enumerable: false,
+          value() {
+            return { legacy: true };
+          },
+        },
+      );
+      let arrayToJsonCalls = 0;
+      const arrayWithToJson = Object.defineProperty([1, 2], 'toJSON', {
+        enumerable: false,
+        value() {
+          arrayToJsonCalls += 1;
+          return { call: arrayToJsonCalls };
+        },
+      });
+      let objectGetterReads = 0;
+      const objectWithGetter = Object.defineProperty({}, 'value', {
+        enumerable: true,
+        get() {
+          objectGetterReads += 1;
+          return objectGetterReads;
+        },
+      });
+      let arrayGetterReads = 0;
+      const arrayWithGetter = Object.defineProperty([0], 0, {
+        enumerable: true,
+        get() {
+          arrayGetterReads += 1;
+          return arrayGetterReads;
+        },
+      });
+      const unsupportedOutputs: unknown[] = [
+        circular,
+        BigInt(1),
+        undefined,
+        () => 'value',
+        Symbol('value'),
+        Number.POSITIVE_INFINITY,
+        new Uint8Array([1, 2]),
+        new Map([['value', 1]]),
+        new Set([1]),
+        new Date('2026-08-10T00:00:00.000Z'),
+        new SerializableResult(),
+        nonEnumerableToJson,
+        arrayWithToJson,
+        objectWithGetter,
+        arrayWithGetter,
+        throwingGetter,
+      ];
+
+      for (const [index, output] of unsupportedOutputs.entries()) {
+        const agent = new Agent({ name: `UnsupportedOutputAgent${index}` });
+        const state = new RunState(new RunContext(), 'input', agent, 1);
+        state._generatedItems.push(
+          new RunToolCallOutputItem(
+            {
+              type: 'function_call_result',
+              name: 'lookup',
+              callId: `unsupported-output-${index}`,
+              status: 'completed',
+              output: 'provider-visible output',
+            },
+            agent,
+            output,
+          ),
+        );
+
+        const serialized = state.toJSON() as any;
+        expect(typeof serialized.generatedItems[0].output).toBe('string');
+        if (output === nonEnumerableToJson) {
+          expect(serialized.generatedItems[0].output).toBe('{"legacy":true}');
+        }
+        if (output === arrayWithToJson) {
+          expect(arrayToJsonCalls).toBe(1);
+          expect(serialized.generatedItems[0].output).toBe('{"call":1}');
+        }
+        if (output === objectWithGetter) {
+          expect(objectGetterReads).toBe(1);
+          expect(serialized.generatedItems[0].output).toBe('{"value":1}');
+        }
+        if (output === arrayWithGetter) {
+          expect(arrayGetterReads).toBe(1);
+          expect(serialized.generatedItems[0].output).toBe('[1]');
+        }
+        const restored = await RunState.fromString(
+          agent,
+          JSON.stringify(serialized),
+        );
+        expect(
+          (restored._generatedItems[0] as RunToolCallOutputItem).output,
+        ).toBe(serialized.generatedItems[0].output);
+      }
+    });
+
     it('serializes null maxTurns', async () => {
       const context = new RunContext();
       const agent = new Agent({ name: 'NoMaxTurns' });
@@ -3115,6 +3413,12 @@ export function registerRunStateCompactionTests(): void {
           };
           const serialized = state.toJSON() as any;
           serialized.$schemaVersion = '1.15';
+          const serializedLocalResult = serialized.generatedItems.at(-1);
+          if (typeof serializedLocalResult.output !== 'string') {
+            serializedLocalResult.output = JSON.stringify(
+              serializedLocalResult.output,
+            );
+          }
 
           const restored = await RunState.fromString(
             agent,

--- a/packages/agents-core/test/toolInvocationReplay.test.ts
+++ b/packages/agents-core/test/toolInvocationReplay.test.ts
@@ -1322,6 +1322,11 @@ describe('tool invocation replay binding', () => {
     expect(shell.calls).toEqual([{ commands: ['echo once'] }]);
     const serialized = interrupted.state.toJSON() as any;
     serialized.$schemaVersion = '1.17';
+    for (const item of serialized.generatedItems) {
+      if (item.type === 'tool_call_output_item') {
+        item.output = JSON.stringify(item.output);
+      }
+    }
     delete serialized.context.approvalInvocations;
     delete serialized.completedToolInvocations;
 
@@ -1369,6 +1374,11 @@ describe('tool invocation replay binding', () => {
     );
     const serialized = state.toJSON() as any;
     serialized.$schemaVersion = '1.17';
+    for (const item of serialized.generatedItems) {
+      if (item.type === 'tool_call_output_item') {
+        item.output = JSON.stringify(item.output);
+      }
+    }
     delete serialized.context.approvalInvocations;
     delete serialized.completedToolInvocations;
 


### PR DESCRIPTION
This pull request fixes RunState serialization so JSON-compatible tool outputs, including nested objects and arrays, remain structured after serialization and resume.

The new representation is folded into unreleased schema 1.18. Released schema 1.17 string outputs remain readable, unsupported JavaScript values retain the existing smart-string fallback, and provider-facing `rawItem` and history behavior remain unchanged.
