### PR TITLE
ci: bound workflow job runtimes

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -11,6 +11,7 @@ jobs:
     # Use pull_request_target so labels can be updated.
     # Always checkout base and fetch head to avoid executing forked code and reduce skipped checks.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -44,6 +45,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       run_ci: ${{ steps.filter.outputs.run_ci }}
     steps:
@@ -89,6 +90,7 @@ jobs:
   test:
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       NODE_OPTIONS: "--max_old_space_size=6144"
     strategy:
@@ -141,6 +143,7 @@ jobs:
   windows-sandbox-paths:
     needs: changes
     runs-on: windows-latest
+    timeout-minutes: 15
     env:
       CI: "1"
       NODE_ENV: test
@@ -182,6 +185,7 @@ jobs:
   coverage:
     needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       NODE_OPTIONS: "--max_old_space_size=6144"
     steps:


### PR DESCRIPTION
This pull request adds finite job-level timeouts to the pull request CI, docs, and changeset validation workflows so stalled setup, build, test, coverage, Windows, or deployment work cannot consume the platform's full default timeout.

It uses 5 minutes for path filtering, 10 minutes for changeset validation and Pages deployment, and 15 minutes for the test matrix, Windows path tests, coverage, and docs build. Triggers, dependencies, conditions, matrices, permissions, steps, and action pins remain unchanged.
