### PR TITLE
fix(mcp): serialize manager lifecycle operations

### DIFF
--- a/.changeset/quiet-lifecycles-wait.md
+++ b/.changeset/quiet-lifecycles-wait.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: serialize MCP manager lifecycle operations

--- a/packages/agents-core/src/mcpServers.ts
+++ b/packages/agents-core/src/mcpServers.ts
@@ -23,17 +23,23 @@ type ServerCommand = {
   reject: (error: Error) => void;
 };
 
+type TrackedCloseTask = {
+  task: Promise<void>;
+  settled: boolean;
+};
+
 class ServerWorker {
   private queue: ServerCommand[] = [];
   private draining = false;
   private done = false;
-  private closing: Promise<void> | null = null;
+  private closing: TrackedCloseTask | null = null;
   private closeResult: Promise<void> | null = null;
 
   constructor(
     private readonly server: MCPServer,
     private readonly connectTimeoutMs: number | null,
     private readonly closeTimeoutMs: number | null,
+    private readonly onCloseSettled: (error: Error | null) => void,
   ) {}
 
   get isDone(): boolean {
@@ -44,7 +50,31 @@ class ServerWorker {
     return this.submit('connect', this.connectTimeoutMs);
   }
 
-  close(): Promise<void> {
+  async close(): Promise<void> {
+    if (this.done) {
+      return;
+    }
+    if (this.closeResult) {
+      return this.closeResult;
+    }
+    if (this.closing) {
+      const existingClose = this.closing;
+      try {
+        await runWithTimeoutTask(
+          existingClose.task,
+          this.closeTimeoutMs,
+          createTimeoutError('close', this.server, this.closeTimeoutMs),
+        );
+        return;
+      } catch (error) {
+        if (!existingClose.settled) {
+          throw error;
+        }
+        if (this.closing === existingClose) {
+          this.closing = null;
+        }
+      }
+    }
     return this.submit('close', this.closeTimeoutMs);
   }
 
@@ -102,14 +132,16 @@ class ServerWorker {
           );
         } else {
           const closeTask = this.server.close();
-          this.closing = closeTask
-            .then(
-              () => undefined,
-              () => undefined,
-            )
-            .finally(() => {
-              this.closing = null;
-            });
+          const trackedClose = trackCloseTask(closeTask, (error) => {
+            if (this.closing !== trackedClose) {
+              return;
+            }
+            if (!error) {
+              this.done = true;
+            }
+            this.onCloseSettled(error);
+          });
+          this.closing = trackedClose;
           await runWithTimeoutTask(
             closeTask,
             command.timeoutMs,
@@ -167,7 +199,8 @@ export class MCPServers {
   private errorsByServer = new Map<MCPServer, Error>();
   private suppressedAbortFailures = new Set<MCPServer>();
   private workers = new Map<MCPServer, ServerWorker>();
-  private serialCloseTasks = new Map<MCPServer, Promise<void>>();
+  private serialCloseTasks = new Map<MCPServer, TrackedCloseTask>();
+  private lifecycleTail: Promise<void> = Promise.resolve();
 
   private readonly connectTimeoutMs: number | null;
   private readonly closeTimeoutMs: number | null;
@@ -239,6 +272,12 @@ export class MCPServers {
   async reconnect(
     options: MCPServersReconnectOptions = {},
   ): Promise<MCPServer[]> {
+    return this.enqueueLifecycle(() => this.reconnectNow(options));
+  }
+
+  private async reconnectNow(
+    options: MCPServersReconnectOptions,
+  ): Promise<MCPServer[]> {
     const failedOnly = options.failedOnly ?? true;
     const serversToCleanup = failedOnly
       ? uniqueServers(this.failedServers)
@@ -295,7 +334,16 @@ export class MCPServers {
   }
 
   async close(): Promise<void> {
-    await this.closeAll();
+    await this.enqueueLifecycle(() => this.closeAll());
+  }
+
+  private enqueueLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.lifecycleTail.then(operation, operation);
+    this.lifecycleTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   private async connectAll(): Promise<MCPServer[]> {
@@ -410,6 +458,7 @@ export class MCPServers {
       await worker.connect();
       return;
     }
+    this.serialCloseTasks.delete(server);
     await runWithTimeout(
       () => server.connect(),
       this.connectTimeoutMs,
@@ -452,27 +501,34 @@ export class MCPServers {
       const worker = this.workers.get(server);
       if (worker) {
         await worker.close();
-        if (worker.isDone) {
-          this.workers.delete(server);
-        }
         return;
       }
     }
-    if (this.serialCloseTasks.has(server)) {
-      throw createClosingError(server);
+    const existingClose = this.serialCloseTasks.get(server);
+    if (existingClose) {
+      try {
+        await runWithTimeoutTask(
+          existingClose.task,
+          this.closeTimeoutMs,
+          createTimeoutError('close', server, this.closeTimeoutMs),
+        );
+        return;
+      } catch (error) {
+        if (!existingClose.settled) {
+          throw error;
+        }
+        if (this.serialCloseTasks.get(server) === existingClose) {
+          this.serialCloseTasks.delete(server);
+        }
+      }
     }
 
     const closeTask = server.close();
-    const trackedCloseTask = closeTask
-      .then(
-        () => undefined,
-        () => undefined,
-      )
-      .finally(() => {
-        if (this.serialCloseTasks.get(server) === trackedCloseTask) {
-          this.serialCloseTasks.delete(server);
-        }
-      });
+    const trackedCloseTask = trackCloseTask(closeTask, (error) => {
+      if (error && this.serialCloseTasks.get(server) === trackedCloseTask) {
+        this.errorsByServer.set(server, error);
+      }
+    });
     this.serialCloseTasks.set(server, trackedCloseTask);
     await runWithTimeoutTask(
       closeTask,
@@ -531,6 +587,11 @@ export class MCPServers {
         server,
         this.connectTimeoutMs,
         this.closeTimeoutMs,
+        (error) => {
+          if (error && this.workers.get(server) === next) {
+            this.errorsByServer.set(server, error);
+          }
+        },
       );
       this.workers.set(server, next);
       return next;
@@ -547,6 +608,27 @@ export class MCPServers {
       (failedServer) => failedServer !== server,
     );
   }
+}
+
+function trackCloseTask(
+  task: Promise<void>,
+  onSettled: (error: Error | null) => void,
+): TrackedCloseTask {
+  const tracked: TrackedCloseTask = {
+    task,
+    settled: false,
+  };
+  void task.then(
+    () => {
+      tracked.settled = true;
+      onSettled(null);
+    },
+    (error) => {
+      tracked.settled = true;
+      onSettled(toError(error));
+    },
+  );
+  return tracked;
 }
 
 /**

--- a/packages/agents-core/test/mcpServers.test.ts
+++ b/packages/agents-core/test/mcpServers.test.ts
@@ -163,6 +163,24 @@ class SlowCloseServer extends BaseTestServer {
   }
 }
 
+class SequencedCloseServer extends BaseTestServer {
+  constructor(
+    name: string,
+    private readonly closeGates: Deferred<void>[],
+  ) {
+    super(name);
+  }
+
+  async close(): Promise<void> {
+    const closeGate = this.closeGates[this.closeCalls];
+    this.closeCalls += 1;
+    if (closeGate) {
+      await closeGate.promise;
+    }
+    this.cleaned = true;
+  }
+}
+
 class FlakyCloseServer extends BaseTestServer {
   constructor(
     name: string,
@@ -411,6 +429,209 @@ describe('MCPServers', () => {
     expect(error?.message).not.toContain('password_marker');
     await session.close();
   });
+
+  it.each([false, true])(
+    'serializes overlapping close calls (parallel=%s)',
+    async (connectInParallel) => {
+      const closeGate = createDeferred<void>();
+      const server = new SlowCloseServer('slow', closeGate);
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+        closeTimeoutMs: null,
+      });
+
+      const firstClose = session.close();
+      const secondClose = session.close();
+      await Promise.resolve();
+
+      expect(server.closeCalls).toBe(1);
+
+      closeGate.resolve();
+      await Promise.all([firstClose, secondClose]);
+
+      expect(server.closeCalls).toBe(1);
+      expect(session.errors.size).toBe(0);
+    },
+  );
+
+  it.each([false, true])(
+    'waits for an overlapping close before reconnecting all servers (parallel=%s)',
+    async (connectInParallel) => {
+      const closeGate = createDeferred<void>();
+      const server = new SlowCloseServer('slow', closeGate);
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+        closeTimeoutMs: null,
+      });
+
+      const closePromise = session.close();
+      const reconnectPromise = session.reconnect({ failedOnly: false });
+      await Promise.resolve();
+
+      expect(server.closeCalls).toBe(1);
+      expect(server.connectCalls).toBe(1);
+
+      closeGate.resolve();
+      await closePromise;
+      await expect(reconnectPromise).resolves.toEqual([server]);
+
+      expect(server.closeCalls).toBe(1);
+      expect(server.connectCalls).toBe(2);
+      expect(session.active).toEqual([server]);
+      expect(session.failed).toEqual([]);
+      expect(session.errors.size).toBe(0);
+
+      await session.close();
+    },
+  );
+
+  it.each([false, true])(
+    'serializes overlapping full reconnects across multiple servers (parallel=%s)',
+    async (connectInParallel) => {
+      const lifecycleEvents: string[] = [];
+      const first = new ResourceTrackingServer('first', lifecycleEvents);
+      const second = new ResourceTrackingServer('second', lifecycleEvents);
+      const session = await connectMcpServers([first, second], {
+        connectInParallel,
+        connectTimeoutMs: null,
+        closeTimeoutMs: null,
+      });
+      lifecycleEvents.length = 0;
+
+      const firstReconnect = session.reconnect({ failedOnly: false });
+      const secondReconnect = session.reconnect({ failedOnly: false });
+      await Promise.all([firstReconnect, secondReconnect]);
+
+      expect(lifecycleEvents).toEqual([
+        'second:close',
+        'first:close',
+        'first:connect',
+        'second:connect',
+        'second:close',
+        'first:close',
+        'first:connect',
+        'second:connect',
+      ]);
+      expect(first.connectCalls).toBe(3);
+      expect(second.connectCalls).toBe(3);
+      expect(first.closeCalls).toBe(2);
+      expect(second.closeCalls).toBe(2);
+      expect(session.active).toEqual([first, second]);
+      expect(session.failed).toEqual([]);
+      expect(session.errors.size).toBe(0);
+
+      await session.close();
+    },
+  );
+
+  it.each([false, true])(
+    'bounds later waiters and reconnects after a timed-out close succeeds (parallel=%s)',
+    async (connectInParallel) => {
+      const closeGate = createDeferred<void>();
+      const server = new SlowCloseServer('slow', closeGate);
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+        closeTimeoutMs: 10,
+      });
+
+      await withTimeout(session.close(), 500);
+      expect(session.errors.get(server)?.name).toBe('TimeoutError');
+
+      await expect(
+        withTimeout(session.reconnect({ failedOnly: false }), 500),
+      ).resolves.toEqual([]);
+      expect(server.closeCalls).toBe(1);
+      expect(server.connectCalls).toBe(1);
+      expect(session.active).toEqual([]);
+      expect(session.failed).toEqual([server]);
+      expect(session.errors.get(server)?.name).toBe('TimeoutError');
+
+      closeGate.resolve();
+      await closeGate.promise;
+      await Promise.resolve();
+
+      await expect(session.reconnect({ failedOnly: false })).resolves.toEqual([
+        server,
+      ]);
+      expect(server.closeCalls).toBe(1);
+      expect(server.connectCalls).toBe(2);
+      expect(session.active).toEqual([server]);
+      expect(session.failed).toEqual([]);
+      expect(session.errors.size).toBe(0);
+
+      await session.close();
+    },
+  );
+
+  it.each([false, true])(
+    'preserves a late close failure and permits a later retry (parallel=%s)',
+    async (connectInParallel) => {
+      const firstCloseGate = createDeferred<void>();
+      const secondCloseGate = createDeferred<void>();
+      secondCloseGate.resolve();
+      const server = new SequencedCloseServer('sequenced', [
+        firstCloseGate,
+        secondCloseGate,
+      ]);
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+        closeTimeoutMs: 10,
+      });
+      const lateError = new Error('late close failed');
+
+      await withTimeout(session.close(), 500);
+      expect(session.errors.get(server)?.name).toBe('TimeoutError');
+
+      firstCloseGate.reject(lateError);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(session.errors.get(server)).toBe(lateError);
+
+      await expect(session.reconnect({ failedOnly: false })).resolves.toEqual([
+        server,
+      ]);
+      expect(server.closeCalls).toBe(2);
+      expect(server.connectCalls).toBe(2);
+      expect(session.active).toEqual([server]);
+      expect(session.failed).toEqual([]);
+      expect(session.errors.size).toBe(0);
+
+      await session.close();
+    },
+  );
+
+  it.each([false, true])(
+    'continues queued lifecycle work after a strict reconnect failure (parallel=%s)',
+    async (connectInParallel) => {
+      const lifecycleEvents: string[] = [];
+      const server = new ResourceTrackingServer('strict', lifecycleEvents, {
+        failConnectCall: 2,
+      });
+      const session = await connectMcpServers([server], {
+        connectInParallel,
+        connectTimeoutMs: null,
+        closeTimeoutMs: null,
+        strict: true,
+      });
+
+      const reconnectPromise = session.reconnect({ failedOnly: false });
+      const closePromise = session.close();
+
+      await expect(reconnectPromise).rejects.toThrow(
+        'connect failed after opening resource',
+      );
+      await expect(closePromise).resolves.toBeUndefined();
+
+      expect(server.resourceOpen).toBe(false);
+      expect(server.connectCalls).toBe(2);
+      expect(server.closeCalls).toBe(2);
+      expect(session.failed).toEqual([server]);
+      expect(session.errors.get(server)?.message).toBe(
+        'connect failed after opening resource',
+      );
+    },
+  );
 
   it('reconnects failed servers only by default', async () => {
     const server = new FlakyServer('flaky', 1);
@@ -714,7 +935,7 @@ describe('MCPServers', () => {
   );
 
   it.each([false, true])(
-    'rejects commands while a timed-out close is still in flight (parallel=%s)',
+    'bounds commands while a timed-out close is still in flight (parallel=%s)',
     async (connectInParallel) => {
       const closeGate = createDeferred<void>();
       const server = new SlowCloseServer('slow', closeGate);
@@ -727,7 +948,7 @@ describe('MCPServers', () => {
       const reconnectPromise = session.reconnect({ failedOnly: false });
       await expect(withTimeout(reconnectPromise, 500)).resolves.toEqual([]);
       expect(session.failed).toEqual([server]);
-      expect(session.errors.get(server)?.name).toBe('ClosingError');
+      expect(session.errors.get(server)?.name).toBe('TimeoutError');
       closeGate.resolve();
     },
   );


### PR DESCRIPTION
This pull request fixes overlapping `MCPServers.close()` and `MCPServers.reconnect()` operations by serializing public manager lifecycle calls.

It retains each underlying close task across timeout boundaries, bounds later waiters, preserves late close failures, and permits cleanup retry only after the original outcome is known. The change preserves existing public APIs, timeout defaults, failure handling, reverse close ordering, and serial and parallel connection behavior.

It also adds deterministic regression coverage for overlapping lifecycle calls, multiple servers, timeout followed by late success or failure, strict cleanup, queue recovery, and public state snapshots.
