### PR TITLE
fix(extensions): redact Modal inline mount credential errors

### DIFF
--- a/.changeset/redact-modal-mount-credential-errors.md
+++ b/.changeset/redact-modal-mount-credential-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: redact Modal inline mount credential failures

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -1829,6 +1829,7 @@ async function modalCloudBucketMountSecret(
       'create cloud bucket secret',
       async () => await modal.secrets.fromObject(config.credentials ?? {}),
       { bucketName: config.bucketName },
+      { redactProviderError: true },
     ),
   };
 }

--- a/packages/agents-extensions/src/sandbox/shared/session.ts
+++ b/packages/agents-extensions/src/sandbox/shared/session.ts
@@ -79,10 +79,22 @@ export async function withProviderError<T>(
   operation: string,
   fn: () => Promise<T>,
   context: Record<string, unknown> = {},
+  options: { redactProviderError?: boolean } = {},
 ): Promise<T> {
   try {
     return await fn();
   } catch (error) {
+    if (options.redactProviderError) {
+      throw new SandboxProviderError(
+        `${providerName} failed to ${operation}.`,
+        {
+          provider,
+          operation,
+          ...context,
+          retryable: safelyReadProviderErrorRetryability(error),
+        },
+      );
+    }
     if (error instanceof UserError) {
       throw error;
     }
@@ -158,6 +170,14 @@ export function providerErrorDetails(error: unknown): Record<string, unknown> {
 
 export function providerErrorRetryability(error: unknown): boolean | null {
   return readProviderErrorRetryability(error, new Set<object>(), 0);
+}
+
+function safelyReadProviderErrorRetryability(error: unknown): boolean | null {
+  try {
+    return providerErrorRetryability(error);
+  } catch {
+    return null;
+  }
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -804,6 +804,72 @@ describe('ModalSandboxClient', () => {
     });
   });
 
+  test('redacts Modal inline cloud bucket credential failures', async () => {
+    const accessKeyId = 'MODAL_ACCESS_KEY_SENTINEL';
+    const secretAccessKey = 'MODAL_SECRET_KEY_SENTINEL';
+    const providerError = Object.assign(
+      new Error(`secret creation failed for ${accessKeyId}`),
+      {
+        statusCode: 503,
+        requestId: `req_${secretAccessKey}`,
+        response: {
+          status: 503,
+          data: {
+            error: {
+              message: secretAccessKey,
+            },
+          },
+        },
+        cause: new Error(secretAccessKey),
+      },
+    );
+    secretFromObjectMock.mockRejectedValueOnce(providerError);
+    const client = new ModalSandboxClient();
+
+    const caught = await client
+      .create(
+        new Manifest({
+          entries: {
+            data: {
+              type: 's3_mount',
+              bucket: 'logs',
+              accessKeyId,
+              secretAccessKey,
+              mountStrategy: new ModalCloudBucketMountStrategy(),
+            },
+          },
+        }),
+        {
+          appName: 'sandbox-tests',
+        },
+      )
+      .then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+    expect(caught).toBeInstanceOf(SandboxProviderError);
+    const exposedError = caught as SandboxProviderError;
+    expect(exposedError.message).toBe(
+      'ModalSandboxClient failed to create cloud bucket secret.',
+    );
+    expect(exposedError.details).toEqual({
+      provider: 'modal',
+      operation: 'create cloud bucket secret',
+      bucketName: 'logs',
+      retryable: true,
+    });
+    expect(secretFromObjectMock).toHaveBeenCalledWith({
+      AWS_ACCESS_KEY_ID: accessKeyId,
+      AWS_SECRET_ACCESS_KEY: secretAccessKey,
+    });
+    expect(String(caught)).not.toContain(accessKeyId);
+    expect(String(caught)).not.toContain(secretAccessKey);
+    expect(JSON.stringify(caught)).not.toContain(accessKeyId);
+    expect(JSON.stringify(caught)).not.toContain(secretAccessKey);
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
   test('supports image and sandbox selectors without snake_case aliases', async () => {
     const existingSandbox = {
       sandboxId: 'sbx_existing',


### PR DESCRIPTION
This pull request fixes a credential exposure risk when Modal rejects creation of an inline cloud bucket mount secret. The inline-credential path now returns a fresh `SandboxProviderError` containing only SDK-owned context and retryability, while named-secret resolution and other provider errors retain their existing diagnostics.

It adds adversarial coverage that places credential sentinels in provider error messages, request metadata, nested response data, and causes, then verifies that neither string nor JSON output exposes them.
