### PR TITLE
feat(realtime): support GA transcription options

### DIFF
--- a/.changeset/fresh-transcription-context.md
+++ b/.changeset/fresh-transcription-context.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+feat: support GA Realtime transcription options in session configuration

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -41,15 +41,11 @@ export type RealtimeAudioFormatDefinition =
  * @deprecated Use a {type: "audio/pcm"} format instead. String shorthands are deprecated.
  */
 export type RealtimeAudioFormatLegacy =
-  | 'pcm16'
-  | 'g711_ulaw'
-  | 'g711_alaw'
-  | (string & {});
+  'pcm16' | 'g711_ulaw' | 'g711_alaw' | (string & {});
 
 // User-facing union (legacy accepted, GA preferred)
 export type RealtimeAudioFormat =
-  | RealtimeAudioFormatLegacy
-  | RealtimeAudioFormatDefinition;
+  RealtimeAudioFormatLegacy | RealtimeAudioFormatDefinition;
 
 export type RealtimeTracingConfig =
   | {
@@ -64,10 +60,18 @@ export type RealtimeInputAudioNoiseReductionConfig = {
 };
 
 export type RealtimeInputAudioTranscriptionConfig = {
+  delay?: 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+  keywords?: string[];
   language?: string;
+  languages?: string[];
   model?:
+    | 'gpt-transcribe'
+    | 'gpt-live-transcribe'
     | 'gpt-4o-transcribe'
     | 'gpt-4o-mini-transcribe'
+    | 'gpt-4o-mini-transcribe-2025-12-15'
+    | 'gpt-4o-transcribe-diarize'
+    | 'gpt-realtime-whisper'
     | 'whisper-1'
     | (string & {});
   prompt?: string;
@@ -99,8 +103,7 @@ export type RealtimeTurnDetectionConfigCamelCase = {
 };
 
 export type RealtimeTurnDetectionConfig = (
-  | RealtimeTurnDetectionConfigAsIs
-  | RealtimeTurnDetectionConfigCamelCase
+  RealtimeTurnDetectionConfigAsIs | RealtimeTurnDetectionConfigCamelCase
 ) &
   Record<string, any>;
 
@@ -123,11 +126,7 @@ export type RealtimeAudioConfig = {
 };
 
 export type RealtimeReasoningEffort =
-  | 'minimal'
-  | 'low'
-  | 'medium'
-  | 'high'
-  | 'xhigh';
+  'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 
 export type RealtimeReasoningConfig = {
   effort?: RealtimeReasoningEffort;
@@ -179,8 +178,7 @@ export type RealtimeSessionConfigDeprecated = RealtimeSessionConfigCommon & {
 
 // Union of configs; users should not mix-and-match; runtime converter will normalize
 export type RealtimeSessionConfig =
-  | RealtimeSessionConfigDefinition
-  | RealtimeSessionConfigDeprecated;
+  RealtimeSessionConfigDefinition | RealtimeSessionConfigDeprecated;
 
 function isDefined(
   key:
@@ -332,8 +330,7 @@ export type HostedMCPToolDefinition = RealtimeHostedMCPSharedFields & {
 };
 
 export type RealtimeToolDefinition =
-  | FunctionToolDefinition
-  | HostedMCPToolDefinition;
+  FunctionToolDefinition | HostedMCPToolDefinition;
 
 // Describes a tool as returned by an MCP server (via mcp_list_tools).
 // Shape mirrors the realtime event payload (with room for extensions).

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -8,7 +8,7 @@ import {
   expectTypeOf,
 } from 'vitest';
 import type { MessageEvent as WebSocketMessageEvent } from 'ws';
-import type { RealtimeClientMessage } from '../src/clientMessages';
+import type { RealtimeClientMessage, RealtimeSessionConfig } from '../src';
 import {
   DEFAULT_OPENAI_REALTIME_SESSION_CONFIG,
   OpenAIRealtimeBase,
@@ -172,6 +172,46 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(config.model).toBe('gpt-realtime-2.1');
     expect(config.parallel_tool_calls).toBe(false);
     expect(config.reasoning).toEqual({ effort: 'low' });
+  });
+
+  it('forwards GA input audio transcription options', () => {
+    const base = new TestBase();
+    const contextualTranscriptionConfig = {
+      audio: {
+        input: {
+          transcription: {
+            model: 'gpt-transcribe',
+            keywords: ['LegalOn', 'TomoniAI'],
+            languages: ['ja', 'en'],
+            prompt: 'A Japanese conversation about LegalOn and TomoniAI.',
+          },
+        },
+      },
+    } satisfies Partial<RealtimeSessionConfig>;
+    const lowLatencyTranscriptionConfig = {
+      audio: {
+        input: {
+          transcription: {
+            model: 'gpt-live-transcribe',
+            delay: 'low',
+          },
+        },
+      },
+    } satisfies Partial<RealtimeSessionConfig>;
+
+    const contextualPayload = base.buildSessionPayload(
+      contextualTranscriptionConfig,
+    );
+    const lowLatencyPayload = base.buildSessionPayload(
+      lowLatencyTranscriptionConfig,
+    );
+
+    expect(contextualPayload.audio?.input?.transcription).toEqual(
+      contextualTranscriptionConfig.audio.input.transcription,
+    );
+    expect(lowLatencyPayload.audio?.input?.transcription).toEqual(
+      lowLatencyTranscriptionConfig.audio.input.transcription,
+    );
   });
 
   it('preserves explicit null audio input config values', () => {


### PR DESCRIPTION
This pull request adds typed support for GA Realtime input transcription configuration so applications can pass language and keyword context, latency preferences, and current transcription model names without falling back to `providerData`.

- Add `keywords`, `languages`, and `delay` while retaining singular `language` compatibility.
- Add current GA transcription model IDs without restricting forward-compatible strings.
- Verify that typed transcription configuration is preserved in generated session payloads.
