### PR TITLE
fix(core): reject overly deep strict JSON schemas

### DIFF
--- a/.changeset/safe-strict-schema-depth.md
+++ b/.changeset/safe-strict-schema-depth.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reject overly deep strict JSON schemas safely

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -47,7 +47,10 @@ import {
   cachedMcpTools as _cachedTools,
 } from './mcpToolCache';
 import { getToolCallParentSpanFromDetails } from './agentToolRunConfig';
-import { assertOpenAIStrictToolSchemaPreservesOpenObjects } from './utils/strictToolSchema';
+import {
+  assertOpenAIStrictToolSchemaPreservesOpenObjects,
+  isJsonSchemaDepthError,
+} from './utils/strictToolSchema';
 
 export {
   BaseMCPServerSSE,
@@ -1269,6 +1272,9 @@ export function mcpToFunctionTool(
         },
       });
     } catch (e) {
+      if (convertSchemasToStrict && isJsonSchemaDepthError(e)) {
+        throw e;
+      }
       preserveSchemaOnFallback = true;
       logToolActionWarning(
         globalLogger,

--- a/packages/agents-core/src/utils/strictToolSchema.ts
+++ b/packages/agents-core/src/utils/strictToolSchema.ts
@@ -8,6 +8,17 @@ type SyntheticNullableSchema = {
 
 type JsonSchemaNullability = 'allows' | 'disallows' | 'unknown';
 
+const MAX_JSON_SCHEMA_DEPTH = 100;
+const JSON_SCHEMA_DEPTH_ERROR =
+  'JSON schema is too deeply nested to process safely. Simplify or flatten the schema, or disable strict mode.';
+
+class JsonSchemaDepthError extends UserError {}
+
+type JsonSchemaTraversalState = {
+  activeSchemas: WeakSet<object>;
+  visitedDepths: WeakMap<object, number>;
+};
+
 type StrictSchemaPreparationContext = {
   originalRoot: unknown;
   preparedRoot: unknown;
@@ -24,6 +35,80 @@ type PreparedOpenAIStrictToolSchema<T> = {
   normalizeInput: (value: unknown) => unknown;
 };
 
+function assertSafeJsonSchemaDepth(depth: number): void {
+  if (depth > MAX_JSON_SCHEMA_DEPTH) {
+    throw new JsonSchemaDepthError(JSON_SCHEMA_DEPTH_ERROR);
+  }
+}
+
+function createJsonSchemaTraversalState(): JsonSchemaTraversalState {
+  return {
+    activeSchemas: new WeakSet(),
+    visitedDepths: new WeakMap(),
+  };
+}
+
+function enterJsonSchemaTraversal(
+  schema: object,
+  state: JsonSchemaTraversalState,
+  depth: number,
+): boolean {
+  if (state.activeSchemas.has(schema)) {
+    return false;
+  }
+
+  const visitedDepth = state.visitedDepths.get(schema);
+  if (typeof visitedDepth === 'number' && visitedDepth >= depth) {
+    return false;
+  }
+
+  assertSafeJsonSchemaDepth(depth);
+  state.visitedDepths.set(schema, depth);
+  state.activeSchemas.add(schema);
+  return true;
+}
+
+function leaveJsonSchemaTraversal(
+  schema: object,
+  state: JsonSchemaTraversalState,
+): void {
+  state.activeSchemas.delete(schema);
+}
+
+function assertJsonSchemaDepth(schema: unknown): void {
+  assertJsonSchemaPhysicalDepth(schema);
+}
+
+function assertJsonSchemaPhysicalDepth(schema: unknown): void {
+  const pending: Array<{ value: object; depth: number }> = [];
+  const visitedDepths = new WeakMap<object, number>();
+
+  if (typeof schema === 'object' && schema !== null) {
+    pending.push({ value: schema, depth: 1 });
+  }
+
+  while (pending.length > 0) {
+    const { value, depth } = pending.pop()!;
+    assertSafeJsonSchemaDepth(depth);
+
+    const visitedDepth = visitedDepths.get(value);
+    if (typeof visitedDepth === 'number' && visitedDepth >= depth) {
+      continue;
+    }
+    visitedDepths.set(value, depth);
+
+    for (const child of Object.values(value)) {
+      if (typeof child === 'object' && child !== null) {
+        pending.push({ value: child, depth: depth + 1 });
+      }
+    }
+  }
+}
+
+export function isJsonSchemaDepthError(error: unknown): error is UserError {
+  return error instanceof JsonSchemaDepthError;
+}
+
 export function toOpenAIStrictToolSchema<T extends JsonObjectSchema<any>>(
   schema: T,
 ): T {
@@ -39,18 +124,26 @@ export function prepareOpenAIStrictToolSchema<T extends JsonObjectSchema<any>>(
 export function assertOpenAIStrictToolSchemaPreservesOpenObjects(
   schema: JsonObjectSchema<any>,
 ): void {
-  validateOpenAIStrictJsonSchema(schema, schema, new WeakSet(), true, true);
+  assertJsonSchemaDepth(schema);
+  validateOpenAIStrictJsonSchema(
+    schema,
+    schema,
+    createJsonSchemaTraversalState(),
+    true,
+    true,
+  );
 }
 
 function prepareOpenAIStrictToolSchemaInternal<T extends JsonObjectSchema<any>>(
   schema: T,
   requireUnambiguousNormalization: boolean,
 ): PreparedOpenAIStrictToolSchema<T> {
+  assertJsonSchemaDepth(schema);
   validateOpenAIStrictProviderSchema(schema, schema);
   validateOpenAIStrictJsonSchema(
     schema,
     schema,
-    new WeakSet(),
+    createJsonSchemaTraversalState(),
     requireUnambiguousNormalization,
   );
   const preparedSchemas = new WeakMap<object, object>();
@@ -482,9 +575,11 @@ const anyOfMetadataKeywords = new Set([...referenceMetadataKeywords, 'anyOf']);
 function validateOpenAIStrictProviderSchema(
   schema: unknown,
   rootSchema: unknown,
-  visitedSchemas: WeakSet<object> = new WeakSet(),
+  state: JsonSchemaTraversalState = createJsonSchemaTraversalState(),
+  depth = 1,
 ): void {
   if (typeof schema === 'boolean') {
+    assertSafeJsonSchemaDepth(depth);
     return;
   }
   if (!isRecord(schema)) {
@@ -492,10 +587,9 @@ function validateOpenAIStrictProviderSchema(
       'Cannot convert a JSON schema containing a non-boolean, non-object schema node to strict mode. Replace the invalid node with a JSON schema object or boolean, or disable strict mode.',
     );
   }
-  if (visitedSchemas.has(schema)) {
+  if (!enterJsonSchemaTraversal(schema, state, depth)) {
     return;
   }
-  visitedSchemas.add(schema);
 
   if (schema !== rootSchema && '$id' in schema) {
     throw new UserError(
@@ -523,7 +617,7 @@ function validateOpenAIStrictProviderSchema(
         `Cannot convert unresolved or external JSON schema reference \`${schema.$ref}\` to strict mode. Use a local reference or disable strict mode.`,
       );
     }
-    validateOpenAIStrictProviderSchema(resolved, rootSchema, visitedSchemas);
+    validateOpenAIStrictProviderSchema(resolved, rootSchema, state, depth + 1);
   }
 
   if ('anyOf' in schema) {
@@ -533,7 +627,7 @@ function validateOpenAIStrictProviderSchema(
       );
     }
     for (const branch of schema.anyOf) {
-      validateOpenAIStrictProviderSchema(branch, rootSchema, visitedSchemas);
+      validateOpenAIStrictProviderSchema(branch, rootSchema, state, depth + 1);
     }
   }
 
@@ -545,7 +639,8 @@ function validateOpenAIStrictProviderSchema(
       validateOpenAIStrictProviderSchema(
         propertySchema,
         rootSchema,
-        visitedSchemas,
+        state,
+        depth + 1,
       );
     }
   }
@@ -553,17 +648,18 @@ function validateOpenAIStrictProviderSchema(
   const items = schema.items;
   if (Array.isArray(items)) {
     for (const item of items) {
-      validateOpenAIStrictProviderSchema(item, rootSchema, visitedSchemas);
+      validateOpenAIStrictProviderSchema(item, rootSchema, state, depth + 1);
     }
   } else if (typeof items !== 'undefined') {
-    validateOpenAIStrictProviderSchema(items, rootSchema, visitedSchemas);
+    validateOpenAIStrictProviderSchema(items, rootSchema, state, depth + 1);
   }
 
   if ('additionalProperties' in schema) {
     validateOpenAIStrictProviderSchema(
       schema.additionalProperties,
       rootSchema,
-      visitedSchemas,
+      state,
+      depth + 1,
     );
   }
 
@@ -576,26 +672,30 @@ function validateOpenAIStrictProviderSchema(
       validateOpenAIStrictProviderSchema(
         definition,
         rootSchema,
-        visitedSchemas,
+        state,
+        depth + 1,
       );
     }
   }
+
+  leaveJsonSchemaTraversal(schema, state);
 }
 
 function validateOpenAIStrictJsonSchema(
   schema: unknown,
   rootSchema: unknown,
-  visitedSchemas: WeakSet<object> = new WeakSet(),
+  state: JsonSchemaTraversalState = createJsonSchemaTraversalState(),
   requireUnambiguousNormalization = true,
   rejectOpenObjects = false,
+  depth = 1,
 ): void {
   if (typeof schema === 'boolean') {
+    assertSafeJsonSchemaDepth(depth);
     return;
   }
-  if (!isRecord(schema) || visitedSchemas.has(schema)) {
+  if (!isRecord(schema) || !enterJsonSchemaTraversal(schema, state, depth)) {
     return;
   }
-  visitedSchemas.add(schema);
 
   if ('$ref' in schema) {
     if (typeof schema.$ref !== 'string') {
@@ -620,9 +720,10 @@ function validateOpenAIStrictJsonSchema(
     validateOpenAIStrictJsonSchema(
       resolved,
       rootSchema,
-      visitedSchemas,
+      state,
       requireUnambiguousNormalization,
       rejectOpenObjects,
+      depth + 1,
     );
   }
 
@@ -644,9 +745,10 @@ function validateOpenAIStrictJsonSchema(
       validateOpenAIStrictJsonSchema(
         branch,
         rootSchema,
-        visitedSchemas,
+        state,
         requireUnambiguousNormalization,
         rejectOpenObjects,
+        depth + 1,
       );
     }
     // Plain JSON Schema tools do not have a runtime validator that selects the
@@ -655,7 +757,12 @@ function validateOpenAIStrictJsonSchema(
     if (
       requireUnambiguousNormalization &&
       schema.anyOf.some((branch) =>
-        jsonSchemaRequiresSyntheticNullStripping(branch, rootSchema),
+        jsonSchemaRequiresSyntheticNullStripping(
+          branch,
+          rootSchema,
+          createJsonSchemaTraversalState(),
+          depth + 1,
+        ),
       )
     ) {
       throw new UserError(
@@ -690,12 +797,13 @@ function validateOpenAIStrictJsonSchema(
       validateOpenAIStrictJsonSchema(
         propertySchema,
         rootSchema,
-        visitedSchemas,
+        state,
         requireUnambiguousNormalization,
         rejectOpenObjects,
+        depth + 1,
       );
       if (!required.has(key)) {
-        getKnownJsonSchemaNullability(propertySchema, rootSchema);
+        getKnownJsonSchemaNullability(propertySchema, rootSchema, depth + 1);
       }
     }
   }
@@ -706,18 +814,20 @@ function validateOpenAIStrictJsonSchema(
       validateOpenAIStrictJsonSchema(
         item,
         rootSchema,
-        visitedSchemas,
+        state,
         requireUnambiguousNormalization,
         rejectOpenObjects,
+        depth + 1,
       );
     }
   } else if (typeof items !== 'undefined') {
     validateOpenAIStrictJsonSchema(
       items,
       rootSchema,
-      visitedSchemas,
+      state,
       requireUnambiguousNormalization,
       rejectOpenObjects,
+      depth + 1,
     );
   }
 
@@ -730,19 +840,28 @@ function validateOpenAIStrictJsonSchema(
       validateOpenAIStrictJsonSchema(
         definition,
         rootSchema,
-        visitedSchemas,
+        state,
         requireUnambiguousNormalization,
         rejectOpenObjects,
+        depth + 1,
       );
     }
   }
+
+  leaveJsonSchemaTraversal(schema, state);
 }
 
 function getKnownJsonSchemaNullability(
   schema: unknown,
   rootSchema: unknown,
+  depth = 1,
 ): Exclude<JsonSchemaNullability, 'unknown'> {
-  const nullability = getJsonSchemaNullability(schema, rootSchema);
+  const nullability = getJsonSchemaNullability(
+    schema,
+    rootSchema,
+    new Set(),
+    depth,
+  );
   if (nullability === 'unknown') {
     throw new UserError(
       'Cannot determine whether an optional JSON schema property accepts `null`. Make its nullability explicit with a supported schema form, make the property required, or disable strict mode.',
@@ -755,7 +874,9 @@ function getJsonSchemaNullability(
   schema: unknown,
   rootSchema: unknown,
   visitedReferences: ReadonlySet<string> = new Set(),
+  depth = 1,
 ): JsonSchemaNullability {
+  assertSafeJsonSchemaDepth(depth);
   if (schema === true) {
     return 'allows';
   }
@@ -794,6 +915,7 @@ function getJsonSchemaNullability(
       schema.$ref,
       rootSchema,
       visitedReferences,
+      depth + 1,
     );
     if (referencedNullability !== 'allows') {
       return referencedNullability;
@@ -805,7 +927,7 @@ function getJsonSchemaNullability(
       return 'unknown';
     }
     const entries = schema.anyOf.map((entry) =>
-      getJsonSchemaNullability(entry, rootSchema, visitedReferences),
+      getJsonSchemaNullability(entry, rootSchema, visitedReferences, depth + 1),
     );
     if (entries.includes('allows')) {
       return 'allows';
@@ -828,74 +950,87 @@ function getJsonSchemaNullability(
 function jsonSchemaRequiresSyntheticNullStripping(
   schema: unknown,
   rootSchema: unknown,
-  visitedSchemas: WeakSet<object> = new WeakSet(),
+  state: JsonSchemaTraversalState = createJsonSchemaTraversalState(),
+  depth = 1,
 ): boolean {
-  if (!isRecord(schema) || visitedSchemas.has(schema)) {
+  if (!isRecord(schema) || !enterJsonSchemaTraversal(schema, state, depth)) {
     return false;
   }
-  visitedSchemas.add(schema);
 
-  if (typeof schema.$ref === 'string') {
-    const resolved = resolveLocalJsonSchemaReference(schema.$ref, rootSchema);
-    return jsonSchemaRequiresSyntheticNullStripping(
-      resolved,
-      rootSchema,
-      visitedSchemas,
-    );
-  }
-
-  if (Array.isArray(schema.anyOf)) {
-    return schema.anyOf.some((branch) =>
-      jsonSchemaRequiresSyntheticNullStripping(
-        branch,
+  try {
+    if (typeof schema.$ref === 'string') {
+      const resolved = resolveLocalJsonSchemaReference(schema.$ref, rootSchema);
+      return jsonSchemaRequiresSyntheticNullStripping(
+        resolved,
         rootSchema,
-        visitedSchemas,
-      ),
-    );
-  }
-
-  const properties =
-    schemaConvertsObjectProperties(schema) && isRecord(schema.properties)
-      ? schema.properties
-      : {};
-  const required = new Set(
-    Array.isArray(schema.required) ? schema.required.map(String) : [],
-  );
-  for (const [key, propertySchema] of Object.entries(properties)) {
-    if (
-      (!required.has(key) &&
-        getKnownJsonSchemaNullability(propertySchema, rootSchema) ===
-          'disallows') ||
-      jsonSchemaRequiresSyntheticNullStripping(
-        propertySchema,
-        rootSchema,
-        visitedSchemas,
-      )
-    ) {
-      return true;
-    }
-  }
-
-  const items = schema.items;
-  return Array.isArray(items)
-    ? items.some((item) =>
-        jsonSchemaRequiresSyntheticNullStripping(
-          item,
-          rootSchema,
-          visitedSchemas,
-        ),
-      )
-    : jsonSchemaRequiresSyntheticNullStripping(
-        items,
-        rootSchema,
-        visitedSchemas,
+        state,
+        depth + 1,
       );
+    }
+
+    if (Array.isArray(schema.anyOf)) {
+      return schema.anyOf.some((branch) =>
+        jsonSchemaRequiresSyntheticNullStripping(
+          branch,
+          rootSchema,
+          state,
+          depth + 1,
+        ),
+      );
+    }
+
+    const properties =
+      schemaConvertsObjectProperties(schema) && isRecord(schema.properties)
+        ? schema.properties
+        : {};
+    const required = new Set(
+      Array.isArray(schema.required) ? schema.required.map(String) : [],
+    );
+    for (const [key, propertySchema] of Object.entries(properties)) {
+      if (
+        (!required.has(key) &&
+          getKnownJsonSchemaNullability(
+            propertySchema,
+            rootSchema,
+            depth + 1,
+          ) === 'disallows') ||
+        jsonSchemaRequiresSyntheticNullStripping(
+          propertySchema,
+          rootSchema,
+          state,
+          depth + 1,
+        )
+      ) {
+        return true;
+      }
+    }
+
+    const items = schema.items;
+    return Array.isArray(items)
+      ? items.some((item) =>
+          jsonSchemaRequiresSyntheticNullStripping(
+            item,
+            rootSchema,
+            state,
+            depth + 1,
+          ),
+        )
+      : jsonSchemaRequiresSyntheticNullStripping(
+          items,
+          rootSchema,
+          state,
+          depth + 1,
+        );
+  } finally {
+    leaveJsonSchemaTraversal(schema, state);
+  }
 }
 
 function getReferencedJsonSchemaNullability(
   reference: unknown,
   rootSchema: unknown,
   visitedReferences: ReadonlySet<string>,
+  depth: number,
 ): JsonSchemaNullability {
   if (typeof reference !== 'string' || visitedReferences.has(reference)) {
     return 'unknown';
@@ -909,6 +1044,7 @@ function getReferencedJsonSchemaNullability(
     resolved,
     rootSchema,
     new Set([...visitedReferences, reference]),
+    depth,
   );
 }
 

--- a/packages/agents-core/test/handoff.test.ts
+++ b/packages/agents-core/test/handoff.test.ts
@@ -6,6 +6,35 @@ import { z } from 'zod';
 import logger from '../src/logger';
 import { RunContext } from '../src/runContext';
 
+function createSegmentedReferenceSchema(): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {
+    terminal: { type: 'string' },
+  };
+  const properties: Record<string, Record<string, unknown>> = {};
+  const required: string[] = [];
+  let previousReference = '#/$defs/terminal';
+
+  for (let segment = 0; segment < 2; segment += 1) {
+    for (let index = 59; index >= 0; index -= 1) {
+      const name = `segment${segment}_${index}`;
+      definitions[name] = { $ref: previousReference };
+      previousReference = `#/$defs/${name}`;
+    }
+
+    const checkpoint = `checkpoint${segment}`;
+    properties[checkpoint] = { $ref: previousReference };
+    required.push(checkpoint);
+  }
+
+  return {
+    type: 'object',
+    properties,
+    required,
+    additionalProperties: false,
+    $defs: definitions,
+  };
+}
+
 const agent = new Agent({ name: 'A' });
 
 describe('handoff()', () => {
@@ -13,6 +42,27 @@ describe('handoff()', () => {
     expect(() => handoff(agent, { inputType: z.object({}) })).toThrow(
       UserError,
     );
+  });
+
+  it('rejects required-only over-depth schemas before constructing a handoff', () => {
+    const inputType = createSegmentedReferenceSchema();
+    const original = structuredClone(inputType);
+    const onHandoff = vi.fn();
+    let thrown: unknown;
+
+    try {
+      handoff(agent, { inputType: inputType as any, onHandoff });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect(thrown).not.toBeInstanceOf(RangeError);
+    expect((thrown as Error).message).toContain(
+      'JSON schema is too deeply nested to process safely.',
+    );
+    expect(inputType).toEqual(original);
+    expect(onHandoff).not.toHaveBeenCalled();
   });
 
   it('allows onHandoff without inputType', async () => {

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -7,6 +7,107 @@ import { sanitizeMcpTransportError } from '../src/mcpLogging';
 import { withTrace } from '../src/tracing';
 import { withCustomSpan } from '../src/tracing/createSpans';
 import { getCurrentSpan } from '../src/tracing';
+import { UserError } from '../src/errors';
+
+const SCHEMA_DEPTH_ERROR =
+  'JSON schema is too deeply nested to process safely. Simplify or flatten the schema, or disable strict mode.';
+
+function createNestedObjectSchema(depth: number): Record<string, any> {
+  const root = {
+    type: 'object',
+    properties: {},
+    required: [],
+  } as Record<string, any>;
+  let current = root;
+
+  for (let index = 0; index < depth; index += 1) {
+    const child = {
+      type: 'object',
+      properties: {},
+      required: [],
+    };
+    current.properties.child = child;
+    current = child;
+  }
+
+  return root;
+}
+
+function createSegmentedReferenceSchema(): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {
+    terminal: { type: 'string' },
+  };
+  const properties: Record<string, Record<string, unknown>> = {};
+  const required: string[] = [];
+  let previousReference = '#/$defs/terminal';
+
+  for (let segment = 0; segment < 2; segment += 1) {
+    for (let index = 0; index < 60; index += 1) {
+      const name = `segment${segment}_${index}`;
+      definitions[name] = {
+        $ref:
+          index < 59
+            ? `#/$defs/segment${segment}_${index + 1}`
+            : previousReference,
+      };
+    }
+    previousReference = `#/$defs/segment${segment}_0`;
+    const checkpoint = `checkpoint${segment}`;
+    properties[checkpoint] = { $ref: previousReference };
+    required.push(checkpoint);
+  }
+
+  return { type: 'object', properties, required, $defs: definitions };
+}
+
+function createRecursiveDefinitionSchema(): Record<string, any> {
+  return {
+    type: 'object',
+    properties: {
+      root: { $ref: '#/$defs/node' },
+    },
+    required: ['root'],
+    additionalProperties: false,
+    $defs: {
+      node: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+          children: {
+            type: 'array',
+            items: { $ref: '#/$defs/node' },
+          },
+        },
+        required: ['value', 'children'],
+        additionalProperties: false,
+      },
+    },
+  };
+}
+
+function createWideRecursiveDefinitionSchema(): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {};
+  for (let index = 0; index < 100; index += 1) {
+    definitions[`node${index}`] = { $ref: '#' };
+  }
+
+  return {
+    type: 'object',
+    properties: {},
+    required: [],
+    additionalProperties: false,
+    $defs: definitions,
+  };
+}
+
+function captureMcpConversionError(callback: () => unknown): unknown {
+  try {
+    callback();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
 
 function convertExpectingStrictFallback(
   convert: () => ReturnType<typeof mcpToFunctionTool>,
@@ -781,6 +882,123 @@ describe('mcpToFunctionTool', () => {
     expect(strictTool.parameters.additionalProperties).toBe(false);
     expect(strictTool.parameters.required).toEqual(['foo']);
   });
+
+  it('preserves recursive local definitions during explicit strict conversion', () => {
+    const callTool = vi.fn(async () => []);
+    const server: MCPServer = {
+      name: 'recursive-schema-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool,
+      invalidateToolsCache: async () => {},
+    };
+    const inputSchema = createRecursiveDefinitionSchema();
+    const original = structuredClone(inputSchema);
+
+    const strictTool = mcpToFunctionTool(
+      {
+        name: 'recursive_schema',
+        description: '',
+        inputSchema,
+      } as any,
+      server,
+      true,
+    );
+
+    expect(strictTool.strict).toBe(true);
+    expect(strictTool.parameters.properties.root).toEqual({
+      $ref: '#/$defs/node',
+    });
+    expect(
+      (strictTool.parameters as any).$defs.node.properties.children.items,
+    ).toEqual({ $ref: '#/$defs/node' });
+    expect(inputSchema).toEqual(original);
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it('preserves wide shallow recursive definitions during explicit strict conversion', () => {
+    const callTool = vi.fn(async () => []);
+    const server: MCPServer = {
+      name: 'wide-recursive-schema-server',
+      cacheToolsList: false,
+      connect: async () => {},
+      close: async () => {},
+      listTools: async () => [],
+      callTool,
+      invalidateToolsCache: async () => {},
+    };
+    const inputSchema = createWideRecursiveDefinitionSchema();
+    const original = structuredClone(inputSchema);
+
+    const strictTool = mcpToFunctionTool(
+      {
+        name: 'wide_recursive_schema',
+        description: '',
+        inputSchema,
+      } as any,
+      server,
+      true,
+    );
+
+    expect(strictTool.strict).toBe(true);
+    expect((strictTool.parameters as any).$defs.node0).toEqual({ $ref: '#' });
+    expect((strictTool.parameters as any).$defs.node99).toEqual({ $ref: '#' });
+    expect(inputSchema).toEqual(original);
+    expect(callTool).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['physical nesting', () => createNestedObjectSchema(1_000), true],
+    [
+      'required-only shared reference suffixes',
+      createSegmentedReferenceSchema,
+      false,
+    ],
+  ])(
+    'rejects overly deep explicit strict conversion from %s and preserves non-strict conversion',
+    (_name, createSchema, additionalProperties) => {
+      const callTool = vi.fn(async () => []);
+      const server: MCPServer = {
+        name: 'deep-schema-server',
+        cacheToolsList: false,
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool,
+        invalidateToolsCache: async () => {},
+      };
+      const inputSchema = createSchema();
+      inputSchema.additionalProperties = additionalProperties;
+      const mcpTool = {
+        name: 'deep_schema',
+        description: '',
+        inputSchema,
+      } as any;
+
+      const error = captureMcpConversionError(() =>
+        mcpToFunctionTool(mcpTool, server, true),
+      );
+
+      expect(error).toBeInstanceOf(UserError);
+      expect(error).not.toBeInstanceOf(RangeError);
+      expect((error as Error).message).toBe(SCHEMA_DEPTH_ERROR);
+      expect(callTool).not.toHaveBeenCalled();
+      expect(inputSchema.additionalProperties).toBe(additionalProperties);
+
+      const convertNonStrict = () => mcpToFunctionTool(mcpTool, server, false);
+      const nonStrictTool = additionalProperties
+        ? convertExpectingStrictFallback(convertNonStrict)
+        : convertNonStrict();
+
+      expect(nonStrictTool.strict).toBe(false);
+      expect(nonStrictTool.parameters.properties).toBe(inputSchema.properties);
+      expect(nonStrictTool.parameters.additionalProperties).toBe(true);
+      expect(inputSchema.additionalProperties).toBe(additionalProperties);
+      expect(callTool).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     ['properties omitted', { type: 'object' }],

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -31,6 +31,106 @@ interface Bar {
   bar: string;
 }
 
+const SCHEMA_DEPTH_ERROR =
+  'JSON schema is too deeply nested to process safely. Simplify or flatten the schema, or disable strict mode.';
+
+function createNestedObjectSchema(depth: number): Record<string, any> {
+  const root = {
+    type: 'object',
+    properties: {},
+    required: [],
+  } as Record<string, any>;
+  let current = root;
+
+  for (let index = 0; index < depth; index += 1) {
+    const child = {
+      type: 'object',
+      properties: {},
+      required: [],
+    };
+    current.properties.child = child;
+    current = child;
+  }
+
+  return root;
+}
+
+function createSegmentedReferenceSchema(): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {
+    terminal: { type: 'string' },
+  };
+  const properties: Record<string, Record<string, unknown>> = {};
+  const required: string[] = [];
+  let previousReference = '#/$defs/terminal';
+
+  for (let segment = 0; segment < 2; segment += 1) {
+    for (let index = 0; index < 60; index += 1) {
+      const name = `segment${segment}_${index}`;
+      definitions[name] = {
+        $ref:
+          index < 59
+            ? `#/$defs/segment${segment}_${index + 1}`
+            : previousReference,
+      };
+    }
+    previousReference = `#/$defs/segment${segment}_0`;
+    const checkpoint = `checkpoint${segment}`;
+    properties[checkpoint] = { $ref: previousReference };
+    required.push(checkpoint);
+  }
+
+  return { type: 'object', properties, required, $defs: definitions };
+}
+
+function createRecursiveDefinitionSchema(): Record<string, any> {
+  return {
+    type: 'object',
+    properties: {
+      root: { $ref: '#/$defs/node' },
+    },
+    required: ['root'],
+    additionalProperties: false,
+    $defs: {
+      node: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+          children: {
+            type: 'array',
+            items: { $ref: '#/$defs/node' },
+          },
+        },
+        required: ['value', 'children'],
+        additionalProperties: false,
+      },
+    },
+  };
+}
+
+function createWideRecursiveDefinitionSchema(): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {};
+  for (let index = 0; index < 100; index += 1) {
+    definitions[`node${index}`] = { $ref: '#' };
+  }
+
+  return {
+    type: 'object',
+    properties: {},
+    required: [],
+    additionalProperties: false,
+    $defs: definitions,
+  };
+}
+
+function captureToolConstructionError(callback: () => unknown): unknown {
+  try {
+    callback();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
 describe('Tool', () => {
   it('create a tool with zod definition', () => {
     const t = tool({
@@ -755,6 +855,90 @@ describe('Tool', () => {
     });
     expect(parameters.properties.nested).not.toHaveProperty('type');
   });
+
+  it('preserves recursive local definitions in strict tools', () => {
+    const parameters = createRecursiveDefinitionSchema();
+    const original = structuredClone(parameters);
+    const execute = vi.fn(async () => 'ok');
+
+    const recursiveTool = tool({
+      name: 'recursive_schema',
+      description: 'Accept a recursive strict schema.',
+      parameters: parameters as any,
+      execute,
+    });
+
+    expect(recursiveTool.strict).toBe(true);
+    expect(recursiveTool.parameters.properties.root).toEqual({
+      $ref: '#/$defs/node',
+    });
+    expect(
+      (recursiveTool.parameters as any).$defs.node.properties.children.items,
+    ).toEqual({ $ref: '#/$defs/node' });
+    expect(parameters).toEqual(original);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('preserves wide shallow recursive definitions in strict tools', () => {
+    const parameters = createWideRecursiveDefinitionSchema();
+    const original = structuredClone(parameters);
+    const execute = vi.fn(async () => 'ok');
+
+    const recursiveTool = tool({
+      name: 'wide_recursive_schema',
+      description: 'Accept a wide recursive strict schema.',
+      parameters: parameters as any,
+      execute,
+    });
+
+    expect(recursiveTool.strict).toBe(true);
+    expect((recursiveTool.parameters as any).$defs.node0).toEqual({
+      $ref: '#',
+    });
+    expect((recursiveTool.parameters as any).$defs.node99).toEqual({
+      $ref: '#',
+    });
+    expect(parameters).toEqual(original);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['physical nesting', () => createNestedObjectSchema(1_000)],
+    ['required-only shared reference suffixes', createSegmentedReferenceSchema],
+  ])(
+    'rejects overly deep strict schemas from %s and preserves non-strict schemas',
+    (_name, createSchema) => {
+      const parameters = createSchema();
+      const execute = vi.fn(async () => 'ok');
+
+      const error = captureToolConstructionError(() =>
+        tool({
+          name: 'overly_deep_strict_schema',
+          description: 'Reject an overly deep strict schema.',
+          parameters: parameters as any,
+          execute,
+        }),
+      );
+
+      expect(error).toBeInstanceOf(UserError);
+      expect(error).not.toBeInstanceOf(RangeError);
+      expect((error as Error).message).toBe(SCHEMA_DEPTH_ERROR);
+      expect(execute).not.toHaveBeenCalled();
+      expect(parameters).not.toHaveProperty('additionalProperties');
+
+      const nonStrictTool = tool({
+        name: 'overly_deep_non_strict_schema',
+        description: 'Preserve an overly deep non-strict schema.',
+        parameters: parameters as any,
+        strict: false,
+        execute,
+      });
+
+      expect(nonStrictTool.strict).toBe(false);
+      expect(nonStrictTool.parameters).toBe(parameters);
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
 
   it('rejects typeless open objects when constructing strict tools', () => {
     const parameters: JsonObjectSchema<any> = {

--- a/packages/agents-core/test/utils/strictToolSchema.test.ts
+++ b/packages/agents-core/test/utils/strictToolSchema.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 
+import { UserError } from '../../src/errors';
 import {
   prepareOpenAIStrictToolSchema,
   stripStrictNullsForJsonSchema,
@@ -8,7 +9,316 @@ import {
   toOpenAIStrictToolSchema,
 } from '../../src/utils/strictToolSchema';
 
+const SCHEMA_DEPTH_ERROR =
+  'JSON schema is too deeply nested to process safely. Simplify or flatten the schema, or disable strict mode.';
+
+function createNestedObjectSchema(depth: number): Record<string, any> {
+  const root = {
+    type: 'object',
+    properties: {},
+    required: [],
+  } as Record<string, any>;
+  let current = root;
+
+  for (let index = 0; index < depth; index += 1) {
+    const child = {
+      type: 'object',
+      properties: {},
+      required: [],
+    };
+    current.properties.child = child;
+    current = child;
+  }
+
+  return root;
+}
+
+function createChainedReferenceSchema(depth: number): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {};
+  for (let index = 0; index < depth; index += 1) {
+    definitions[`level${index}`] = {
+      $ref: `#/$defs/level${index + 1}`,
+    };
+  }
+  definitions[`level${depth}`] = { type: 'string' };
+
+  return {
+    type: 'object',
+    properties: {
+      value: { $ref: '#/$defs/level0' },
+    },
+    required: ['value'],
+    $defs: definitions,
+  };
+}
+
+function createSegmentedReferenceSchema(
+  segmentCount: number,
+  segmentLength: number,
+  includeOptionalProperty = true,
+): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {
+    terminal: { type: 'string' },
+  };
+  const properties: Record<string, Record<string, unknown>> = {};
+  const required: string[] = [];
+  let previousReference = '#/$defs/terminal';
+
+  for (let segment = 0; segment < segmentCount; segment += 1) {
+    for (let index = 0; index < segmentLength; index += 1) {
+      const name = `segment${segment}_${index}`;
+      const nextReference =
+        index + 1 < segmentLength
+          ? `#/$defs/segment${segment}_${index + 1}`
+          : previousReference;
+      definitions[name] = { $ref: nextReference };
+    }
+
+    previousReference = `#/$defs/segment${segment}_0`;
+    const checkpoint = `checkpoint${segment}`;
+    properties[checkpoint] = { $ref: previousReference };
+    required.push(checkpoint);
+  }
+
+  if (includeOptionalProperty) {
+    properties.optional = { $ref: previousReference };
+  }
+  return {
+    type: 'object',
+    properties,
+    required,
+    $defs: definitions,
+  };
+}
+
+function createRecursiveDefinitionSchema(): Record<string, any> {
+  return {
+    type: 'object',
+    properties: {
+      root: { $ref: '#/$defs/node' },
+    },
+    required: ['root'],
+    additionalProperties: false,
+    $defs: {
+      node: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+          children: {
+            type: 'array',
+            items: { $ref: '#/$defs/node' },
+          },
+        },
+        required: ['value', 'children'],
+        additionalProperties: false,
+      },
+    },
+  };
+}
+
+function createWideRecursiveDefinitionSchema(
+  definitionCount: number,
+): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {};
+  for (let index = 0; index < definitionCount; index += 1) {
+    definitions[`node${index}`] = { $ref: '#' };
+  }
+
+  return {
+    type: 'object',
+    properties: {},
+    required: [],
+    additionalProperties: false,
+    $defs: definitions,
+  };
+}
+
+function createCyclicReferenceSchema(length: number): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {};
+  for (let index = 0; index < length; index += 1) {
+    definitions[`node${index}`] = {
+      $ref: `#/$defs/node${(index + 1) % length}`,
+    };
+  }
+
+  return {
+    type: 'object',
+    properties: {
+      value: { $ref: '#/$defs/node0' },
+    },
+    required: ['value'],
+    $defs: definitions,
+  };
+}
+
+function createHybridRecursiveReferenceSchema(): Record<string, any> {
+  const definitions: Record<string, Record<string, unknown>> = {
+    terminal: { type: 'string' },
+  };
+
+  for (let index = 0; index < 20; index += 1) {
+    definitions[`tail${index}`] = {
+      $ref: index < 19 ? `#/$defs/tail${index + 1}` : '#/$defs/terminal',
+    };
+  }
+
+  for (const prefix of ['a', 'b']) {
+    for (let index = 0; index < 80; index += 1) {
+      definitions[`${prefix}${index}`] = {
+        $ref: index < 79 ? `#/$defs/${prefix}${index + 1}` : '#/$defs/shared',
+      };
+    }
+  }
+
+  definitions.shared = { $ref: '#/$defs/recursive' };
+  definitions.recursive = {
+    anyOf: [{ $ref: '#/$defs/a0' }, { $ref: '#/$defs/tail0' }],
+  };
+
+  return {
+    type: 'object',
+    properties: {
+      alternate: { $ref: '#/$defs/b0' },
+      checkpoint: { $ref: '#/$defs/recursive' },
+    },
+    required: ['checkpoint', 'alternate'],
+    additionalProperties: false,
+    $defs: definitions,
+  };
+}
+
+function captureError(callback: () => unknown): unknown {
+  try {
+    callback();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+function expectSchemaDepthError(error: unknown): void {
+  expect(error).toBeInstanceOf(UserError);
+  expect(error).not.toBeInstanceOf(RangeError);
+  expect((error as Error).message).toBe(SCHEMA_DEPTH_ERROR);
+}
+
 describe('utils/strictToolSchema', () => {
+  it('rejects schemas that exceed the safe container depth', () => {
+    const input = createNestedObjectSchema(1_000);
+
+    const error = captureError(() => toOpenAIStrictToolSchema(input as any));
+
+    expectSchemaDepthError(error);
+    expect(input).not.toHaveProperty('additionalProperties');
+    expect(input.properties.child).not.toHaveProperty('additionalProperties');
+  });
+
+  it('rejects schemas that exceed the safe local reference depth', () => {
+    const input = createChainedReferenceSchema(1_000);
+
+    const error = captureError(() => toOpenAIStrictToolSchema(input as any));
+
+    expectSchemaDepthError(error);
+    expect(input.properties.value).toEqual({ $ref: '#/$defs/level0' });
+  });
+
+  it('rejects shared reference suffixes reached beyond the safe depth', () => {
+    const input = createSegmentedReferenceSchema(100, 60);
+
+    const error = captureError(() => toOpenAIStrictToolSchema(input as any));
+
+    expectSchemaDepthError(error);
+    expect(input.properties.optional).toEqual({
+      $ref: '#/$defs/segment99_0',
+    });
+  });
+
+  it('rejects required-only shared reference suffixes reached beyond the safe depth', () => {
+    const input = createSegmentedReferenceSchema(2, 60, false);
+    const original = structuredClone(input);
+
+    const error = captureError(() => toOpenAIStrictToolSchema(input as any));
+
+    expectSchemaDepthError(error);
+    expect(input).toEqual(original);
+  });
+
+  it('enforces the safe local reference depth boundary', () => {
+    expect(() =>
+      toOpenAIStrictToolSchema(createChainedReferenceSchema(97) as any),
+    ).not.toThrow();
+
+    const error = captureError(() =>
+      toOpenAIStrictToolSchema(createChainedReferenceSchema(98) as any),
+    );
+    expectSchemaDepthError(error);
+  });
+
+  it('preserves direct root recursion at the safe depth boundary', () => {
+    const accepted = createChainedReferenceSchema(97);
+    accepted.$defs.level97 = { $ref: '#' };
+    expect(() => toOpenAIStrictToolSchema(accepted as any)).not.toThrow();
+
+    const rejected = createChainedReferenceSchema(98);
+    rejected.$defs.level98 = { $ref: '#' };
+    const error = captureError(() => toOpenAIStrictToolSchema(rejected as any));
+
+    expectSchemaDepthError(error);
+  });
+
+  it('preserves recursive local definitions without mutating the input', () => {
+    const input = createRecursiveDefinitionSchema();
+    const original = structuredClone(input);
+
+    const result = toOpenAIStrictToolSchema(input as any);
+
+    expect(result.properties.root).toEqual({ $ref: '#/$defs/node' });
+    expect(result.$defs.node.properties.children.items).toEqual({
+      $ref: '#/$defs/node',
+    });
+    expect(input).toEqual(original);
+  });
+
+  it('preserves wide shallow recursive definitions without mutating the input', () => {
+    const input = createWideRecursiveDefinitionSchema(100);
+    const original = structuredClone(input);
+
+    const result = toOpenAIStrictToolSchema(input as any);
+
+    expect(result.$defs.node0).toEqual({ $ref: '#' });
+    expect(result.$defs.node99).toEqual({ $ref: '#' });
+    expect(input).toEqual(original);
+  });
+
+  it('enforces the safe depth boundary for recursive components', () => {
+    expect(() =>
+      toOpenAIStrictToolSchema(createCyclicReferenceSchema(98) as any),
+    ).not.toThrow();
+
+    const error = captureError(() =>
+      toOpenAIStrictToolSchema(createCyclicReferenceSchema(99) as any),
+    );
+    expectSchemaDepthError(error);
+  });
+
+  it('rejects over-depth paths leaving recursive components', () => {
+    const input = createHybridRecursiveReferenceSchema();
+
+    const error = captureError(() => toOpenAIStrictToolSchema(input as any));
+
+    expectSchemaDepthError(error);
+  });
+
+  it('continues to convert reasonably nested schemas without mutation', () => {
+    const input = createNestedObjectSchema(10);
+
+    const result = toOpenAIStrictToolSchema(input as any);
+
+    expect(result.additionalProperties).toBe(false);
+    expect(input).not.toHaveProperty('additionalProperties');
+    expect(input.properties.child).not.toHaveProperty('additionalProperties');
+  });
+
   it('converts nested JSON schemas into OpenAI strict-compatible schemas', () => {
     const input = {
       type: 'object',
@@ -944,14 +1254,6 @@ describe('utils/strictToolSchema', () => {
   });
 
   it.each([
-    [
-      'cyclic',
-      '#/$defs/first',
-      {
-        first: { $ref: '#/$defs/second' },
-        second: { $ref: '#/$defs/first' },
-      },
-    ],
     ['unresolved', '#/$defs/missing', {}],
     ['external', 'https://example.com/schema.json#/$defs/payload', {}],
   ])('rejects indeterminate %s references', (_name, $ref, $defs) => {


### PR DESCRIPTION
This pull request fixes strict JSON Schema conversion so pathologically deep schemas fail with an actionable SDK-owned `UserError` instead of overflowing the JavaScript call stack.

It applies a shared 100-level safety budget before recursive validation and cloning, preserves supported reasonable-depth and direct-root-reference behavior, and ensures explicit MCP strict conversion surfaces the same error before fallback. Callers can flatten or simplify oversized schemas, or disable strict mode where supported.
