### PR TITLE
test: add historical RunState compatibility corpus

### DIFF
--- a/.changeset/quiet-runstate-history.md
+++ b/.changeset/quiet-runstate-history.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+test: add immutable historical RunState compatibility coverage

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -159,7 +159,7 @@ import {
  *   and accepted-response resume state.
  */
 export const CURRENT_SCHEMA_VERSION = '1.18' as const;
-const SUPPORTED_SCHEMA_VERSIONS = [
+export const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
   '1.2',

--- a/packages/agents-core/test/fixtures/run-state/README.md
+++ b/packages/agents-core/test/fixtures/run-state/README.md
@@ -1,0 +1,29 @@
+# Historical RunState compatibility corpus
+
+This directory is immutable compatibility evidence for released `RunState` writers. Ordinary tests only read these files. They never regenerate, normalize in place, or update snapshots.
+
+`sources.json` accounts for every schema accepted by the production reader:
+
+- `published_writer` means a released `@openai/agents-core` package actually emitted the schema and has checked-in writer output.
+- `published_reader_only` means a released reader accepted the schema, but no published writer emitted it. Such a schema has an explicit policy entry and no fabricated historical fixture.
+- `current_unreleased` means the schema exists on `main` but has not been published.
+
+Each historical fixture records its package version, release tag, full source commit, npm integrity, scenario, path, and SHA-256 in `sources.json`. The published package and npm integrity identify the primary writer artifact; the tag and commit are supplementary source provenance. Minimal fixtures prove the writer format for every published schema. Feature and resume fixtures are intentionally limited to durable boundaries that need more than an empty state to exercise compatibility.
+
+The released `1.17` sandbox format predates the mount-credential redaction boundary added by unreleased schema `1.18`, so this corpus intentionally does not fabricate a released credential-redaction fixture. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
+
+## Regeneration
+
+Regeneration is an explicit maintainer action and does not make OpenAI API calls. Remove any ambient API credential and generate candidates outside the checked-in corpus:
+
+```bash
+env -u OPENAI_API_KEY pnpm tsx packages/agents-core/test/fixtures/run-state/generate-corpus.mts --all
+```
+
+Review candidates and provenance before promotion. Promotion is the only mode allowed to replace checked-in files:
+
+```bash
+env -u OPENAI_API_KEY pnpm tsx packages/agents-core/test/fixtures/run-state/generate-corpus.mts --all --promote
+```
+
+The generator verifies the local tag commit and registry metadata, downloads the exact published npm tarball, independently verifies its bytes against the recorded SRI, and runs the artifact's shipped entrypoint. It uses the exact source commit's checked-in lockfile and pinned pnpm version only to provide deterministic historical dependencies. All candidates are generated successfully before promotion begins. Fixture changes are durable compatibility-contract changes and should receive the same scrutiny as reader changes.

--- a/packages/agents-core/test/fixtures/run-state/expected/v1.0-normalized-current.json
+++ b/packages/agents-core/test/fixtures/run-state/expected/v1.0-normalized-current.json
@@ -1,0 +1,40 @@
+{
+  "$schemaVersion": "1.18",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "approvalInvocations": [],
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "completedToolInvocations": [],
+  "completedToolInvocationEvidence": [],
+  "ambiguousToolInvocationCallIds": [],
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
+++ b/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
@@ -1,0 +1,675 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { format } from 'prettier';
+
+type FixtureRecord = {
+  scenario: string;
+  kind: 'minimal' | 'feature' | 'resume';
+  path: string;
+  sha256: string;
+};
+
+type WriterSchema = {
+  schemaVersion: string;
+  status: 'published_writer';
+  packageVersion: string;
+  tag: string;
+  commit: string;
+  npmIntegrity: string;
+  fixtures: FixtureRecord[];
+};
+
+type PolicySchema = {
+  schemaVersion: string;
+  status: 'published_reader_only' | 'current_unreleased';
+};
+
+type Manifest = {
+  formatVersion: number;
+  currentSchemaAtCreation: string;
+  schemas: Array<WriterSchema | PolicySchema>;
+  negativeFixtures?: Array<{
+    scenario: string;
+    path: string;
+    sha256: string;
+    expectedError: string;
+  }>;
+};
+
+const fixtureRoot = dirname(fileURLToPath(import.meta.url));
+const repositoryRoot = resolve(fixtureRoot, '../../../../..');
+const manifestPath = join(fixtureRoot, 'sources.json');
+const args = new Set(process.argv.slice(2));
+const promote = args.has('--promote');
+const all = args.has('--all');
+const schemaArgumentIndex = process.argv.indexOf('--schema');
+const requestedSchema =
+  schemaArgumentIndex >= 0 ? process.argv[schemaArgumentIndex + 1] : undefined;
+
+if (!all && !requestedSchema) {
+  throw new Error('Pass --all or --schema <version>.');
+}
+if (all && requestedSchema) {
+  throw new Error('Pass either --all or --schema <version>, not both.');
+}
+if (process.env.OPENAI_API_KEY) {
+  throw new Error(
+    'Refusing to generate fixtures while OPENAI_API_KEY is present. Remove it with env -u OPENAI_API_KEY.',
+  );
+}
+
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as Manifest;
+const selected = manifest.schemas.filter(
+  (entry): entry is WriterSchema =>
+    entry.status === 'published_writer' &&
+    (all || entry.schemaVersion === requestedSchema),
+);
+if (selected.length === 0) {
+  throw new Error(
+    `No published writer is recorded for schema ${requestedSchema}.`,
+  );
+}
+
+const candidateRoot = mkdtempSync(
+  join(tmpdir(), 'runstate-corpus-candidates-'),
+);
+const outputRoot = candidateRoot;
+
+for (const source of selected) {
+  const npmArtifact = verifySource(source);
+  const generated = await generateReleasedPayloads(source, npmArtifact);
+  const fixtureRecords: FixtureRecord[] = [];
+  for (const [scenario, payload] of Object.entries(generated)) {
+    if (
+      (payload as Record<string, unknown>).$schemaVersion !==
+      source.schemaVersion
+    ) {
+      throw new Error(
+        `${source.tag} emitted ${(payload as Record<string, unknown>).$schemaVersion} for ${scenario}, expected ${source.schemaVersion}.`,
+      );
+    }
+    const kind = fixtureKind(scenario);
+    const relativePath = `historical/v${source.schemaVersion}-${scenario}.json`;
+    const absolutePath = join(outputRoot, relativePath);
+    const bytes = await format(JSON.stringify(payload, null, 2), {
+      parser: 'json',
+    });
+    execFileSync('mkdir', ['-p', dirname(absolutePath)]);
+    writeFileSync(absolutePath, bytes);
+    fixtureRecords.push({
+      scenario,
+      kind,
+      path: relativePath,
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+    });
+  }
+  fixtureRecords.sort((left, right) => left.path.localeCompare(right.path));
+  source.fixtures = fixtureRecords;
+}
+
+if (all) {
+  manifest.negativeFixtures = generateNegativeFixtures(outputRoot);
+}
+
+if (promote) {
+  for (const source of selected) {
+    for (const fixture of source.fixtures) {
+      promoteFixture(fixture.path);
+    }
+  }
+  if (all) {
+    for (const fixture of manifest.negativeFixtures ?? []) {
+      promoteFixture(fixture.path);
+    }
+  }
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  rmSync(candidateRoot, { recursive: true, force: true });
+  console.log(
+    `Promoted ${selected.length} released writer source(s) into ${fixtureRoot}.`,
+  );
+} else {
+  writeFileSync(
+    join(candidateRoot, 'sources.json'),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  console.log(`Wrote candidates to ${candidateRoot}.`);
+  console.log(
+    'Review them, then rerun with --promote to replace checked-in fixtures.',
+  );
+}
+
+function verifySource(source: WriterSchema): { tarballUrl: string } {
+  const tagCommit = execFileSync('git', ['rev-list', '-n', '1', source.tag], {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+  }).trim();
+  if (tagCommit !== source.commit) {
+    throw new Error(
+      `${source.tag} resolves to ${tagCommit}, expected ${source.commit}.`,
+    );
+  }
+
+  const npmMetadata = JSON.parse(
+    execFileSync(
+      'npm',
+      [
+        'view',
+        `@openai/agents-core@${source.packageVersion}`,
+        'version',
+        'dist.integrity',
+        'dist.tarball',
+        '--json',
+      ],
+      { encoding: 'utf8', env: withoutOpenAIKey(process.env) },
+    ),
+  ) as {
+    version: string;
+    'dist.integrity': string;
+    'dist.tarball': string;
+  };
+  if (npmMetadata.version !== source.packageVersion) {
+    throw new Error(
+      `Registry returned version ${npmMetadata.version}, expected ${source.packageVersion}.`,
+    );
+  }
+  if (npmMetadata['dist.integrity'] !== source.npmIntegrity) {
+    throw new Error(
+      `Registry integrity changed for @openai/agents-core@${source.packageVersion}.`,
+    );
+  }
+  if (!npmMetadata['dist.tarball']) {
+    throw new Error(
+      `Registry returned no tarball for @openai/agents-core@${source.packageVersion}.`,
+    );
+  }
+  return { tarballUrl: npmMetadata['dist.tarball'] };
+}
+
+type PackageExportTarget =
+  | string
+  | {
+      import?: PackageExportTarget;
+      node?: PackageExportTarget;
+      default?: string;
+    };
+
+type PublishedPackageJson = {
+  version: string;
+  module?: string;
+  main?: string;
+  exports?: { '.'?: PackageExportTarget };
+};
+
+async function generateReleasedPayloads(
+  source: WriterSchema,
+  npmArtifact: { tarballUrl: string },
+): Promise<Record<string, Record<string, unknown>>> {
+  const sourceRoot = mkdtempSync(
+    join(tmpdir(), `runstate-${source.schemaVersion}-`),
+  );
+  try {
+    const archivePath = join(sourceRoot, 'source.tar');
+    execFileSync(
+      'git',
+      ['archive', '--format=tar', '--output', archivePath, source.commit],
+      { cwd: repositoryRoot, env: withoutOpenAIKey(process.env) },
+    );
+    execFileSync('tar', ['-xf', archivePath, '-C', sourceRoot]);
+    rmSync(archivePath);
+
+    const packageRoot = join(sourceRoot, 'packages', 'agents-core');
+    const sourcePackageJson = JSON.parse(
+      readFileSync(join(packageRoot, 'package.json'), 'utf8'),
+    ) as { version: string };
+    if (sourcePackageJson.version !== source.packageVersion) {
+      throw new Error(
+        `Tagged source package version ${sourcePackageJson.version}, expected ${source.packageVersion}.`,
+      );
+    }
+    const rootPackageJson = JSON.parse(
+      readFileSync(join(sourceRoot, 'package.json'), 'utf8'),
+    ) as { packageManager?: string };
+    if (!rootPackageJson.packageManager?.startsWith('pnpm@')) {
+      throw new Error(
+        `${source.tag} does not pin a pnpm packageManager version.`,
+      );
+    }
+    execFileSync(
+      'corepack',
+      ['pnpm', 'install', '--frozen-lockfile', '--ignore-scripts'],
+      {
+        cwd: sourceRoot,
+        stdio: 'inherit',
+        env: withoutOpenAIKey(process.env),
+      },
+    );
+
+    const artifactArchivePath = join(sourceRoot, 'published-package.tgz');
+    await downloadAndVerifyArtifact(
+      npmArtifact.tarballUrl,
+      source.npmIntegrity,
+      artifactArchivePath,
+    );
+    const artifactRoot = join(sourceRoot, 'published-package');
+    mkdirSync(artifactRoot);
+    execFileSync('tar', ['-xzf', artifactArchivePath, '-C', artifactRoot], {
+      cwd: sourceRoot,
+      env: withoutOpenAIKey(process.env),
+    });
+
+    const artifactPackageRoot = join(artifactRoot, 'package');
+    const artifactPackageJson = JSON.parse(
+      readFileSync(join(artifactPackageRoot, 'package.json'), 'utf8'),
+    ) as PublishedPackageJson;
+    if (artifactPackageJson.version !== source.packageVersion) {
+      throw new Error(
+        `Published package version ${artifactPackageJson.version}, expected ${source.packageVersion}.`,
+      );
+    }
+    const packageNodeModules = join(packageRoot, 'node_modules');
+    const rootNodeModules = join(sourceRoot, 'node_modules');
+    const historicalNodeModules = existsSync(packageNodeModules)
+      ? packageNodeModules
+      : rootNodeModules;
+    if (!existsSync(historicalNodeModules)) {
+      throw new Error(
+        `Historical dependencies were not installed for ${source.tag}.`,
+      );
+    }
+    symlinkSync(
+      historicalNodeModules,
+      join(artifactPackageRoot, 'node_modules'),
+      'dir',
+    );
+
+    const entry = resolvePublishedEntrypoint(artifactPackageJson);
+    if (!entry) {
+      throw new Error(
+        `Cannot resolve the published entrypoint for ${source.packageVersion}.`,
+      );
+    }
+    const workerOutput = execFileSync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        releasedWriterProgram(),
+        join(artifactPackageRoot, entry),
+        sourceRoot,
+        source.schemaVersion,
+      ],
+      {
+        encoding: 'utf8',
+        env: withoutOpenAIKey(process.env),
+        maxBuffer: 20 * 1024 * 1024,
+      },
+    );
+    return JSON.parse(workerOutput) as Record<string, Record<string, unknown>>;
+  } finally {
+    rmSync(sourceRoot, { recursive: true, force: true });
+  }
+}
+
+async function downloadAndVerifyArtifact(
+  tarballUrl: string,
+  expectedIntegrity: string,
+  destinationPath: string,
+): Promise<void> {
+  const response = await fetch(tarballUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${tarballUrl}: ${response.status} ${response.statusText}.`,
+    );
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const separator = expectedIntegrity.indexOf('-');
+  if (separator < 1) {
+    throw new Error(`Unsupported npm integrity value ${expectedIntegrity}.`);
+  }
+  const algorithm = expectedIntegrity.slice(0, separator);
+  const expectedDigest = expectedIntegrity.slice(separator + 1);
+  const actualDigest = createHash(algorithm).update(bytes).digest('base64');
+  if (actualDigest !== expectedDigest) {
+    throw new Error(
+      `Downloaded npm artifact integrity mismatch: expected ${expectedIntegrity}, got ${algorithm}-${actualDigest}.`,
+    );
+  }
+  writeFileSync(destinationPath, bytes);
+}
+
+function resolvePublishedEntrypoint(
+  packageJson: PublishedPackageJson,
+): string | undefined {
+  return (
+    resolveExportTarget(packageJson.exports?.['.']) ??
+    packageJson.module ??
+    packageJson.main
+  );
+}
+
+function resolveExportTarget(
+  target: PackageExportTarget | undefined,
+): string | undefined {
+  if (typeof target === 'string') {
+    return target;
+  }
+  if (!target) {
+    return undefined;
+  }
+  return (
+    resolveExportTarget(target.import) ??
+    resolveExportTarget(target.node) ??
+    target.default
+  );
+}
+
+function promoteFixture(relativePath: string): void {
+  const sourcePath = join(candidateRoot, relativePath);
+  const destinationPath = join(fixtureRoot, relativePath);
+  mkdirSync(dirname(destinationPath), { recursive: true });
+  copyFileSync(sourcePath, destinationPath);
+}
+
+function fixtureKind(scenario: string): FixtureRecord['kind'] {
+  if (scenario === 'minimal') {
+    return 'minimal';
+  }
+  if (scenario.includes('approval') || scenario.includes('side-effect')) {
+    return 'resume';
+  }
+  return 'feature';
+}
+
+function generateNegativeFixtures(outputRoot: string) {
+  const readHistorical = (schemaVersion: string) =>
+    JSON.parse(
+      readFileSync(
+        join(outputRoot, `historical/v${schemaVersion}-minimal.json`),
+        'utf8',
+      ),
+    ) as Record<string, unknown>;
+  const envelope = (version: number) => ({
+    version,
+    backendId: 'fixture-sandbox',
+    manifest: {},
+    workspaceReady: true,
+    providerState: {},
+  });
+  const sandbox = (version: number) => ({
+    backendId: 'fixture-sandbox',
+    currentAgentKey: 'HistoricalAgent',
+    currentAgentName: 'HistoricalAgent',
+    sessionState: envelope(version),
+    sessionsByAgent: {},
+  });
+
+  const missingSchema = readHistorical('1.0');
+  delete missingSchema.$schemaVersion;
+  const futureSchema = readHistorical('1.17');
+  futureSchema.$schemaVersion = '99.0';
+  const malformedSchema = readHistorical('1.17');
+  malformedSchema.$schemaVersion = 117;
+  const preToolSearch = readHistorical('1.7');
+  preToolSearch.generatedItems = [
+    {
+      type: 'tool_search_call_item',
+      rawItem: {
+        type: 'tool_search_call',
+        id: 'tool-search-negative',
+        status: 'completed',
+        arguments: { query: 'sentinel' },
+      },
+      agent: { name: 'HistoricalAgent' },
+    },
+  ];
+  const sandboxV2 = readHistorical('1.14');
+  sandboxV2.sandbox = sandbox(2);
+  const sandboxV3 = readHistorical('1.17');
+  sandboxV3.sandbox = sandbox(3);
+  const protoKey = readHistorical('1.0');
+  const protoContext = JSON.parse(
+    '{"__proto__":{"polluted":"sentinel-not-a-secret"}}',
+  ) as Record<string, unknown>;
+  (protoKey.context as { context: Record<string, unknown> }).context =
+    protoContext;
+
+  const fixtures = [
+    ['missing-schema', missingSchema, 'schema version'],
+    ['future-schema', futureSchema, 'schema version'],
+    ['malformed-schema', malformedSchema, 'schema version'],
+    [
+      'pre-1.8-tool-search',
+      preToolSearch,
+      'does not support tool_search items',
+    ],
+    [
+      'v1.14-sandbox-v2',
+      sandboxV2,
+      'does not support sandbox session state version 2',
+    ],
+    [
+      'v1.17-sandbox-v3',
+      sandboxV3,
+      'does not support sandbox session state version 3',
+    ],
+  ] as const;
+  const records = fixtures.map(([scenario, payload, expectedError]) => {
+    const path = `negative/${scenario}.json`;
+    const bytes = `${JSON.stringify(payload, null, 2)}\n`;
+    const absolutePath = join(outputRoot, path);
+    execFileSync('mkdir', ['-p', dirname(absolutePath)]);
+    writeFileSync(absolutePath, bytes);
+    return {
+      scenario,
+      path,
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+      expectedError,
+    };
+  });
+
+  const protoPath = 'negative/prototype-key.json';
+  const protoBytes = `${JSON.stringify(protoKey, null, 2)}\n`;
+  execFileSync('mkdir', ['-p', dirname(join(outputRoot, protoPath))]);
+  writeFileSync(join(outputRoot, protoPath), protoBytes);
+  records.push({
+    scenario: 'prototype-key',
+    path: protoPath,
+    sha256: createHash('sha256').update(protoBytes).digest('hex'),
+    expectedError: '',
+  });
+  return records;
+}
+
+function withoutOpenAIKey(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const sanitized = { ...env };
+  delete sanitized.OPENAI_API_KEY;
+  return sanitized;
+}
+
+function releasedWriterProgram(): string {
+  return String.raw`
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const [entryPath, installRoot, schemaVersion] = process.argv.slice(1);
+const sdk = await import(pathToFileURL(entryPath).href);
+const require = createRequire(installRoot + '/package.json');
+const { z } = require('zod');
+sdk.setDefaultModelProvider({
+  getModel() {
+    throw new Error('Historical fixture agents must provide an explicit fake model.');
+  },
+});
+if (typeof sdk.setTracingDisabled === 'function') {
+  sdk.setTracingDisabled(true);
+}
+
+class QueueModel {
+  constructor(outputs) {
+    this.outputs = [...outputs];
+  }
+  async getResponse() {
+    if (this.outputs.length === 0) {
+      throw new Error('No queued historical model output.');
+    }
+    return {
+      output: this.outputs.shift(),
+      usage: new sdk.Usage(),
+      responseId: 'fixture-response',
+    };
+  }
+  async *getStreamedResponse() {
+    throw new Error('Historical fixture generation does not stream.');
+  }
+}
+
+function functionCall(name, callId, args = '{}') {
+  return {
+    id: 'fc_' + callId,
+    type: 'function_call',
+    name,
+    callId,
+    status: 'completed',
+    arguments: args,
+    providerData: {},
+  };
+}
+
+const outputs = {};
+const minimalAgent = new sdk.Agent({ name: 'HistoricalAgent' });
+const minimalState = new sdk.RunState(
+  new sdk.RunContext({ fixture: 'minimal' }),
+  'hello',
+  minimalAgent,
+  3,
+);
+outputs.minimal = JSON.parse(minimalState.toString());
+
+if (schemaVersion === '1.1') {
+  const continuation = new sdk.RunState(
+    new sdk.RunContext({ fixture: 'continuation' }),
+    'continue',
+    minimalAgent,
+    4,
+  );
+  continuation._currentTurnInProgress = true;
+  continuation._conversationId = 'conversation-historical';
+  continuation._previousResponseId = 'response-historical';
+  outputs['server-continuation'] = JSON.parse(continuation.toString());
+}
+
+if (schemaVersion === '1.2') {
+  const approvalTool = sdk.tool({
+    name: 'secure_tool',
+    description: 'Requires approval.',
+    parameters: z.object({ text: z.string() }),
+    needsApproval: true,
+    execute: async ({ text }) => 'approved:' + text,
+  });
+  const nestedModel = new QueueModel([
+    [functionCall('secure_tool', 'nested-call', JSON.stringify({ text: 'sentinel' }))],
+  ]);
+  const nestedAgent = new sdk.Agent({
+    name: 'NestedAgent',
+    model: nestedModel,
+    tools: [approvalTool],
+    modelSettings: { toolChoice: 'required' },
+  });
+  const nestedTool = nestedAgent.asTool({
+    toolName: 'nested_tool',
+    toolDescription: 'Nested agent tool.',
+    runOptions: { context: { nested: true } },
+  });
+  const outerAgent = new sdk.Agent({
+    name: 'OuterAgent',
+    model: new QueueModel([
+      [functionCall('nested_tool', 'outer-call', JSON.stringify({ input: 'hello' }))],
+    ]),
+    tools: [nestedTool],
+    modelSettings: { toolChoice: 'required' },
+  });
+  const interrupted = await new sdk.Runner({
+    traceId: 'trace_11111111111111111111111111111111',
+    tracingDisabled: true,
+  }).run(outerAgent, 'start');
+  if (interrupted.interruptions.length !== 1) {
+    throw new Error('Historical nested approval scenario did not interrupt.');
+  }
+  interrupted.state._trace = null;
+  interrupted.state._currentAgentSpan = undefined;
+  for (const [key, serializedNestedState] of interrupted.state
+    ._pendingAgentToolRuns) {
+    const nestedState = await sdk.RunState.fromString(
+      nestedAgent,
+      serializedNestedState,
+    );
+    nestedState._trace = null;
+    nestedState._currentAgentSpan = undefined;
+    interrupted.state._pendingAgentToolRuns.set(key, nestedState.toString());
+  }
+  outputs['nested-approval'] = JSON.parse(interrupted.state.toString());
+}
+
+if (schemaVersion === '1.17') {
+  const sideEffectTool = sdk.tool({
+    name: 'side_effect_tool',
+    description: 'Runs once.',
+    parameters: z.object({}).strict(),
+    execute: async () => 'side effect completed',
+  });
+  const sideEffectAgent = new sdk.Agent({
+    name: 'SideEffectAgent',
+    model: new QueueModel([]),
+    tools: [sideEffectTool],
+  });
+  const sideEffectState = new sdk.RunState(
+    new sdk.RunContext({ fixture: 'side-effect' }),
+    'run once',
+    sideEffectAgent,
+    3,
+  );
+  const sideEffectCall = functionCall('side_effect_tool', 'side-effect-call');
+  const sideEffectResult = {
+    type: 'function_call_result',
+    name: 'side_effect_tool',
+    callId: 'side-effect-call',
+    status: 'completed',
+    output: 'side effect completed',
+  };
+  sideEffectState._currentTurn = 1;
+  sideEffectState._currentTurnInProgress = true;
+  sideEffectState._noActiveAgentRun = false;
+  sideEffectState._lastTurnResponse = {
+    output: [sideEffectCall],
+    usage: new sdk.Usage(),
+    responseId: 'side-effect-response',
+  };
+  sideEffectState._modelResponses = [sideEffectState._lastTurnResponse];
+  sideEffectState._generatedItems = [
+    new sdk.RunToolCallItem(sideEffectCall, sideEffectAgent),
+    new sdk.RunToolCallOutputItem(
+      sideEffectResult,
+      sideEffectAgent,
+      'side effect completed',
+    ),
+  ];
+  sideEffectState._currentStep = { type: 'next_step_run_again' };
+  outputs['side-effect-committed'] = JSON.parse(sideEffectState.toString());
+}
+
+process.stdout.write(JSON.stringify(outputs));
+`;
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.0-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.0-minimal.json
@@ -1,0 +1,28 @@
+{
+  "$schemaVersion": "1.0",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "generatedItems": [],
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.1-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.1-minimal.json
@@ -1,0 +1,34 @@
+{
+  "$schemaVersion": "1.1",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.1-server-continuation.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.1-server-continuation.json
@@ -1,0 +1,36 @@
+{
+  "$schemaVersion": "1.1",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "continue",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "continuation"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 4,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": true,
+  "generatedItems": [],
+  "currentTurnPersistedItemCount": 0,
+  "conversationId": "conversation-historical",
+  "previousResponseId": "response-historical",
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.10-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.10-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.10",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.11-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.11-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.11",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.12-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.12-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.12",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.13-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.13-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.13",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.14-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.14-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.14",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.15-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.15-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.15",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.17-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.17-minimal.json
@@ -1,0 +1,36 @@
+{
+  "$schemaVersion": "1.17",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.17-side-effect-committed.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.17-side-effect-committed.json
@@ -1,0 +1,114 @@
+{
+  "$schemaVersion": "1.17",
+  "currentTurn": 1,
+  "currentAgent": {
+    "name": "SideEffectAgent"
+  },
+  "originalInput": "run once",
+  "modelResponses": [
+    {
+      "usage": {
+        "requests": 0,
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "totalTokens": 0,
+        "inputTokensDetails": [],
+        "outputTokensDetails": []
+      },
+      "output": [
+        {
+          "providerData": {},
+          "id": "fc_side-effect-call",
+          "type": "function_call",
+          "callId": "side-effect-call",
+          "name": "side_effect_tool",
+          "status": "completed",
+          "arguments": "{}"
+        }
+      ],
+      "responseId": "side-effect-response"
+    }
+  ],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "side-effect"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": false,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": true,
+  "currentStep": {
+    "type": "next_step_run_again"
+  },
+  "lastModelResponse": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "output": [
+      {
+        "providerData": {},
+        "id": "fc_side-effect-call",
+        "type": "function_call",
+        "callId": "side-effect-call",
+        "name": "side_effect_tool",
+        "status": "completed",
+        "arguments": "{}"
+      }
+    ],
+    "responseId": "side-effect-response"
+  },
+  "generatedItems": [
+    {
+      "type": "tool_call_item",
+      "rawItem": {
+        "providerData": {},
+        "id": "fc_side-effect-call",
+        "type": "function_call",
+        "callId": "side-effect-call",
+        "name": "side_effect_tool",
+        "status": "completed",
+        "arguments": "{}"
+      },
+      "agent": {
+        "name": "SideEffectAgent"
+      }
+    },
+    {
+      "type": "tool_call_output_item",
+      "rawItem": {
+        "type": "function_call_result",
+        "name": "side_effect_tool",
+        "callId": "side-effect-call",
+        "status": "completed",
+        "output": "side effect completed"
+      },
+      "agent": {
+        "name": "SideEffectAgent"
+      },
+      "output": "side effect completed"
+    }
+  ],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.2-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.2-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.2",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.2-nested-approval.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.2-nested-approval.json
@@ -1,0 +1,178 @@
+{
+  "$schemaVersion": "1.2",
+  "currentTurn": 1,
+  "currentAgent": {
+    "name": "OuterAgent"
+  },
+  "originalInput": "start",
+  "modelResponses": [
+    {
+      "usage": {
+        "requests": 0,
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "totalTokens": 0,
+        "inputTokensDetails": [],
+        "outputTokensDetails": []
+      },
+      "output": [
+        {
+          "providerData": {},
+          "id": "fc_outer-call",
+          "type": "function_call",
+          "callId": "outer-call",
+          "name": "nested_tool",
+          "status": "completed",
+          "arguments": "{\"input\":\"hello\"}"
+        }
+      ],
+      "responseId": "fixture-response"
+    }
+  ],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {}
+  },
+  "toolUseTracker": {
+    "OuterAgent": ["nested_tool"]
+  },
+  "maxTurns": 10,
+  "noActiveAgentRun": false,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": true,
+  "currentStep": {
+    "type": "next_step_interruption",
+    "data": {
+      "interruptions": [
+        {
+          "type": "tool_approval_item",
+          "rawItem": {
+            "id": "fc_nested-call",
+            "type": "function_call",
+            "name": "secure_tool",
+            "callId": "nested-call",
+            "status": "completed",
+            "arguments": "{\"text\":\"sentinel\"}",
+            "providerData": {}
+          },
+          "agent": {
+            "name": "NestedAgent"
+          },
+          "toolName": "secure_tool"
+        }
+      ]
+    }
+  },
+  "lastModelResponse": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "output": [
+      {
+        "providerData": {},
+        "id": "fc_outer-call",
+        "type": "function_call",
+        "callId": "outer-call",
+        "name": "nested_tool",
+        "status": "completed",
+        "arguments": "{\"input\":\"hello\"}"
+      }
+    ],
+    "responseId": "fixture-response"
+  },
+  "generatedItems": [
+    {
+      "type": "tool_call_item",
+      "rawItem": {
+        "providerData": {},
+        "id": "fc_outer-call",
+        "type": "function_call",
+        "callId": "outer-call",
+        "name": "nested_tool",
+        "status": "completed",
+        "arguments": "{\"input\":\"hello\"}"
+      },
+      "agent": {
+        "name": "OuterAgent"
+      }
+    }
+  ],
+  "pendingAgentToolRuns": {
+    "nested_tool:outer-call": "{\"$schemaVersion\":\"1.2\",\"currentTurn\":1,\"currentAgent\":{\"name\":\"NestedAgent\"},\"originalInput\":\"hello\",\"modelResponses\":[{\"usage\":{\"requests\":0,\"inputTokens\":0,\"outputTokens\":0,\"totalTokens\":0,\"inputTokensDetails\":[],\"outputTokensDetails\":[]},\"output\":[{\"providerData\":{},\"id\":\"fc_nested-call\",\"type\":\"function_call\",\"callId\":\"nested-call\",\"name\":\"secure_tool\",\"status\":\"completed\",\"arguments\":\"{\\\"text\\\":\\\"sentinel\\\"}\"}],\"responseId\":\"fixture-response\"}],\"context\":{\"usage\":{\"requests\":0,\"inputTokens\":0,\"outputTokens\":0,\"totalTokens\":0,\"inputTokensDetails\":[],\"outputTokensDetails\":[]},\"approvals\":{},\"context\":{\"nested\":true}},\"toolUseTracker\":{\"NestedAgent\":[\"secure_tool\"]},\"maxTurns\":10,\"noActiveAgentRun\":false,\"inputGuardrailResults\":[],\"outputGuardrailResults\":[],\"toolInputGuardrailResults\":[],\"toolOutputGuardrailResults\":[],\"currentTurnInProgress\":true,\"currentStep\":{\"type\":\"next_step_interruption\",\"data\":{\"interruptions\":[{\"type\":\"tool_approval_item\",\"rawItem\":{\"id\":\"fc_nested-call\",\"type\":\"function_call\",\"name\":\"secure_tool\",\"callId\":\"nested-call\",\"status\":\"completed\",\"arguments\":\"{\\\"text\\\":\\\"sentinel\\\"}\",\"providerData\":{}},\"agent\":{\"name\":\"NestedAgent\"},\"toolName\":\"secure_tool\"}]}},\"lastModelResponse\":{\"usage\":{\"requests\":0,\"inputTokens\":0,\"outputTokens\":0,\"totalTokens\":0,\"inputTokensDetails\":[],\"outputTokensDetails\":[]},\"output\":[{\"providerData\":{},\"id\":\"fc_nested-call\",\"type\":\"function_call\",\"callId\":\"nested-call\",\"name\":\"secure_tool\",\"status\":\"completed\",\"arguments\":\"{\\\"text\\\":\\\"sentinel\\\"}\"}],\"responseId\":\"fixture-response\"},\"generatedItems\":[{\"type\":\"tool_call_item\",\"rawItem\":{\"providerData\":{},\"id\":\"fc_nested-call\",\"type\":\"function_call\",\"callId\":\"nested-call\",\"name\":\"secure_tool\",\"status\":\"completed\",\"arguments\":\"{\\\"text\\\":\\\"sentinel\\\"}\"},\"agent\":{\"name\":\"NestedAgent\"}},{\"type\":\"tool_approval_item\",\"rawItem\":{\"providerData\":{},\"id\":\"fc_nested-call\",\"type\":\"function_call\",\"callId\":\"nested-call\",\"name\":\"secure_tool\",\"status\":\"completed\",\"arguments\":\"{\\\"text\\\":\\\"sentinel\\\"}\"},\"agent\":{\"name\":\"NestedAgent\"},\"toolName\":\"secure_tool\"}],\"pendingAgentToolRuns\":{},\"lastProcessedResponse\":{\"newItems\":[{\"type\":\"tool_call_item\",\"rawItem\":{\"providerData\":{},\"id\":\"fc_nested-call\",\"type\":\"function_call\",\"callId\":\"nested-call\",\"name\":\"secure_tool\",\"status\":\"completed\",\"arguments\":\"{\\\"text\\\":\\\"sentinel\\\"}\"},\"agent\":{\"name\":\"NestedAgent\"}}],\"toolsUsed\":[\"secure_tool\"],\"handoffs\":[],\"functions\":[{\"toolCall\":{\"id\":\"fc_nested-call\",\"type\":\"function_call\",\"name\":\"secure_tool\",\"callId\":\"nested-call\",\"status\":\"completed\",\"arguments\":\"{\\\"text\\\":\\\"sentinel\\\"}\",\"providerData\":{}},\"tool\":{\"type\":\"function\",\"name\":\"secure_tool\",\"description\":\"Requires approval.\",\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"text\":{\"type\":\"string\"}},\"required\":[\"text\"],\"additionalProperties\":false},\"strict\":true,\"inputGuardrails\":[],\"outputGuardrails\":[]}}],\"computerActions\":[],\"shellActions\":[],\"applyPatchActions\":[],\"mcpApprovalRequests\":[]},\"currentTurnPersistedItemCount\":0,\"trace\":null}"
+  },
+  "lastProcessedResponse": {
+    "newItems": [
+      {
+        "type": "tool_call_item",
+        "rawItem": {
+          "providerData": {},
+          "id": "fc_outer-call",
+          "type": "function_call",
+          "callId": "outer-call",
+          "name": "nested_tool",
+          "status": "completed",
+          "arguments": "{\"input\":\"hello\"}"
+        },
+        "agent": {
+          "name": "OuterAgent"
+        }
+      }
+    ],
+    "toolsUsed": ["nested_tool"],
+    "handoffs": [],
+    "functions": [
+      {
+        "toolCall": {
+          "id": "fc_outer-call",
+          "type": "function_call",
+          "name": "nested_tool",
+          "callId": "outer-call",
+          "status": "completed",
+          "arguments": "{\"input\":\"hello\"}",
+          "providerData": {}
+        },
+        "tool": {
+          "type": "function",
+          "name": "nested_tool",
+          "description": "Nested agent tool.",
+          "parameters": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+              "input": {
+                "type": "string"
+              }
+            },
+            "required": ["input"],
+            "additionalProperties": false
+          },
+          "strict": true,
+          "inputGuardrails": [],
+          "outputGuardrails": []
+        }
+      }
+    ],
+    "computerActions": [],
+    "shellActions": [],
+    "applyPatchActions": [],
+    "mcpApprovalRequests": []
+  },
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.4-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.4-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.4",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.5-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.5-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.5",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.6-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.6-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.6",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.7-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.7-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.7",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.8-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.8-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.8",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.9-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.9-minimal.json
@@ -1,0 +1,35 @@
+{
+  "$schemaVersion": "1.9",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/negative/future-schema.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/future-schema.json
@@ -1,0 +1,36 @@
+{
+  "$schemaVersion": "99.0",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/negative/malformed-schema.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/malformed-schema.json
@@ -1,0 +1,36 @@
+{
+  "$schemaVersion": 117,
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/negative/missing-schema.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/missing-schema.json
@@ -1,0 +1,27 @@
+{
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "generatedItems": [],
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/negative/pre-1.8-tool-search.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/pre-1.8-tool-search.json
@@ -1,0 +1,50 @@
+{
+  "$schemaVersion": "1.7",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [
+    {
+      "type": "tool_search_call_item",
+      "rawItem": {
+        "type": "tool_search_call",
+        "id": "tool-search-negative",
+        "status": "completed",
+        "arguments": {
+          "query": "sentinel"
+        }
+      },
+      "agent": {
+        "name": "HistoricalAgent"
+      }
+    }
+  ],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/negative/prototype-key.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/prototype-key.json
@@ -1,0 +1,30 @@
+{
+  "$schemaVersion": "1.0",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0
+    },
+    "approvals": {},
+    "context": {
+      "__proto__": {
+        "polluted": "sentinel-not-a-secret"
+      }
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "generatedItems": [],
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/negative/v1.14-sandbox-v2.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/v1.14-sandbox-v2.json
@@ -1,0 +1,48 @@
+{
+  "$schemaVersion": "1.14",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null,
+  "sandbox": {
+    "backendId": "fixture-sandbox",
+    "currentAgentKey": "HistoricalAgent",
+    "currentAgentName": "HistoricalAgent",
+    "sessionState": {
+      "version": 2,
+      "backendId": "fixture-sandbox",
+      "manifest": {},
+      "workspaceReady": true,
+      "providerState": {}
+    },
+    "sessionsByAgent": {}
+  }
+}

--- a/packages/agents-core/test/fixtures/run-state/negative/v1.17-sandbox-v3.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/v1.17-sandbox-v3.json
@@ -1,0 +1,49 @@
+{
+  "$schemaVersion": "1.17",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "trace": null,
+  "sandbox": {
+    "backendId": "fixture-sandbox",
+    "currentAgentKey": "HistoricalAgent",
+    "currentAgentName": "HistoricalAgent",
+    "sessionState": {
+      "version": 3,
+      "backendId": "fixture-sandbox",
+      "manifest": {},
+      "workspaceReady": true,
+      "providerState": {}
+    },
+    "sessionsByAgent": {}
+  }
+}

--- a/packages/agents-core/test/fixtures/run-state/sources.json
+++ b/packages/agents-core/test/fixtures/run-state/sources.json
@@ -1,0 +1,353 @@
+{
+  "formatVersion": 1,
+  "currentSchemaAtCreation": "1.18",
+  "schemas": [
+    {
+      "schemaVersion": "1.0",
+      "status": "published_writer",
+      "packageVersion": "0.0.3",
+      "tag": "v0.0.3",
+      "commit": "be52a88cece8d8ea062b17441d94a6e93b690b83",
+      "npmIntegrity": "sha512-sgJkum0BiNUjXvTu1yFrzQ5jp2+R4C2JzDvoOg3pvOMxMDMxf3gu83mYmDC1YB/275JT1tHu9krtWdp0+1ANZA==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.0-minimal.json",
+          "sha256": "19efcb016d1e6ed31d2fde2379b9960f8eed814e293f3eb8c37800793262b159"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.1",
+      "status": "published_writer",
+      "packageVersion": "0.3.8",
+      "tag": "v0.3.8",
+      "commit": "6041edc4cddb29e0ec168a658cadf410c4380ebf",
+      "npmIntegrity": "sha512-TGvbVNHqiskLB+h4fBI9k7lERDxtUtKQYVzoX9eZGEDDPxPl6UcHkGjerXknDLtkodZlWG7cTOFQcx1cz5jbNQ==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.1-minimal.json",
+          "sha256": "01a1b35006f3e7fca3b44586652acf848f5e8f45f0d7e10ff2f24ccca3c59a4c"
+        },
+        {
+          "scenario": "server-continuation",
+          "kind": "feature",
+          "path": "historical/v1.1-server-continuation.json",
+          "sha256": "9fa2dad5f1245eccc890d56de4c786d72f07cd8f798800b7cab04cfec9cb9980"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.2",
+      "status": "published_writer",
+      "packageVersion": "0.4.4",
+      "tag": "v0.4.4",
+      "commit": "871d933e004d39fd8553d085afe8115035f1b79e",
+      "npmIntegrity": "sha512-M3WqK4meb/FdHwS0xNJ4JU+WA8j8fX1n/0z42gtg3zOHF7Bayq10xtCHXMQWOTcmNQNlJyl3OgXRhZJVJZlJog==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.2-minimal.json",
+          "sha256": "c7279b0d0fcb6b67f5c459807a712d78c4664ecdb00bc526f657137e7ff4682c"
+        },
+        {
+          "scenario": "nested-approval",
+          "kind": "resume",
+          "path": "historical/v1.2-nested-approval.json",
+          "sha256": "8364cae7dee515fe5ca8da870b5e52e138e85de9adf085af3bceead8acde5f4c"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.3",
+      "status": "published_reader_only",
+      "firstReaderPackageVersion": "0.4.5",
+      "tag": "v0.4.5",
+      "commit": "eae0df646bc6f52b39d2be50222d0277860e3b23",
+      "reason": "No published package emitted schema 1.3; v0.4.5 emitted schema 1.4."
+    },
+    {
+      "schemaVersion": "1.4",
+      "status": "published_writer",
+      "packageVersion": "0.4.5",
+      "tag": "v0.4.5",
+      "commit": "eae0df646bc6f52b39d2be50222d0277860e3b23",
+      "npmIntegrity": "sha512-/eaXhWykCvlq9IPDfpeMREj9QK7uyOzMbg/4rWXdQF7wwCRQqRhhK8sQy6mbXZowAivurjtb0hdQDHMhbRYnBA==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.4-minimal.json",
+          "sha256": "ea1b7097f5ebf39eeeb6ad6d2c2c665daee51f3b7bd6d388bac62b4d9a2d535a"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.5",
+      "status": "published_writer",
+      "packageVersion": "0.4.13",
+      "tag": "v0.4.13",
+      "commit": "2de7fbf54ee718d0030312a4d0035b914f279bf0",
+      "npmIntegrity": "sha512-/tHxtkbI9btI3Rdvpct4YbCt+LrvLI1dgwtL/JpleKW6JgracsStYnKdhnNE1rtQEtZVAJWbCWRtORfvnJl9cA==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.5-minimal.json",
+          "sha256": "a4c9b39bad63e77fdf4acaa6977bcd9b8ab6aca674cbce5a9294ce629bc0107f"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.6",
+      "status": "published_writer",
+      "packageVersion": "0.5.2",
+      "tag": "v0.5.2",
+      "commit": "322d2a815b7f96393f97bcd0103754b754766f6c",
+      "npmIntegrity": "sha512-9B6Ndo8/jyD32ZRfFc9j7JGdGRyh89gSMV281LHewoJ8Py4zopQBjiYDn3kBmREvHoO/kaPXgf8yHPtwT3OoDw==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.6-minimal.json",
+          "sha256": "f6524e4cdcc15513c370365d992595c20f117e5b7c818c8c55890ac5273bb881"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.7",
+      "status": "published_writer",
+      "packageVersion": "0.5.4",
+      "tag": "v0.5.4",
+      "commit": "50e8db0cbdb82ede419b2ca0b7ea9f4d15316573",
+      "npmIntegrity": "sha512-qAT9zGIIM7GT5/WGkLpp8Fuar7NL5qu30b5+o2jP3mE6aMfx9OZjdj0za/iYLeV5kzQ5pOcbvRXenfzHrhvd/A==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.7-minimal.json",
+          "sha256": "a52123b50ce48f2adaf2a46a400862172ffe46db8f4ca3284d17347b4efe3c4d"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.8",
+      "status": "published_writer",
+      "packageVersion": "0.6.0",
+      "tag": "v0.6.0",
+      "commit": "ec90b9014840bfc33596e2f025a02d61152c1855",
+      "npmIntegrity": "sha512-uR2isgbukRL7AX1OMYo81o0P3A7cDmJVca8He3H2jRan4m2StHVZ7rslD1m4gcl2EfRXCFVXkmuOyTvcWjdaIA==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.8-minimal.json",
+          "sha256": "ab82a6920ce440ce8b536380f7dc2c10e1358af4fa9579c38228c794c8e1243b"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.9",
+      "status": "published_writer",
+      "packageVersion": "0.9.0",
+      "tag": "v0.9.0",
+      "commit": "84ba9f1b530b87c3425d881d31e0d0a7982b9e7b",
+      "npmIntegrity": "sha512-t4XMlDqK7YxrroV57+lGEEiQ7GM4tnrDzJNIuetU6SZqXAUJD365nqm1W/ejnpUyxXpsr7rxA2BmPscT8Qa4mw==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.9-minimal.json",
+          "sha256": "8cf77fe31cb42da4feffb7006e003b69323cf021f62c3dbd9f3678028aaa28c9"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.10",
+      "status": "published_writer",
+      "packageVersion": "0.9.1",
+      "tag": "v0.9.1",
+      "commit": "cc8f41374db99ea609c5ab0f6a19e3e030fc646f",
+      "npmIntegrity": "sha512-WSH7S46qopzNCGfHrJxeDVeZCKU0pK9gqhVevRfHdlrcWUcjm7Sj58SiTdGi3v/v1sw2xKDzVN08C4K8qxjNoQ==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.10-minimal.json",
+          "sha256": "2fe8dbcb0cd416ae6c8e7130b9f60fff5a4dfe813b00e2a3e9db58acdb7bf23a"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.11",
+      "status": "published_writer",
+      "packageVersion": "0.10.0",
+      "tag": "v0.10.0",
+      "commit": "df71db2509517582ec9ea0bf4e3e8aeb8524a7ea",
+      "npmIntegrity": "sha512-qtsv9dtLQe/hoUzT19RfnnM6JW9kcF5zLMtU26FNV4C4981F/5n6m9TQCQWKAs6Rb/Aex/lHyqK1cB1XFLvLIg==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.11-minimal.json",
+          "sha256": "56b87d2ef78b3ab60bdc1b3b6c98f37b1754a1728e30fb370c487672e0da5db1"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.12",
+      "status": "published_writer",
+      "packageVersion": "0.11.5",
+      "tag": "v0.11.5",
+      "commit": "42b2276df2121c3f358c63447c470448998feac5",
+      "npmIntegrity": "sha512-djqc3VUMw6wZlGOHa/+1jqIcEJnzI6PBNKPuf6tXO1MoE+o4NuTYgMpZ+pDUDvV6cor8+dEdmF5bsuqhb2dOMw==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.12-minimal.json",
+          "sha256": "eeec97983bb68a2740eb9eabb1b08bbb5a059496237a9feb5d080177b447f340"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.13",
+      "status": "published_writer",
+      "packageVersion": "0.11.8",
+      "tag": "v0.11.8",
+      "commit": "7e73145758cf1314ffa4a3804527574c509cc44c",
+      "npmIntegrity": "sha512-TrE34RXXPoWYv2PjXf5hq3Eq+uvRJMNiY+Q5WBgEPjAg60yt2hya8cS2I8qkO6i25MjNJl37a25X0vL/gs5Wdg==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.13-minimal.json",
+          "sha256": "6321f44bd3b2951abd3370530138689dfb546b6ca2ac9366ee53c1aa2916882c"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.14",
+      "status": "published_writer",
+      "packageVersion": "0.14.0",
+      "tag": "v0.14.0",
+      "commit": "5f54ddc1e1389a6e419c93056b2d46aaae998da4",
+      "npmIntegrity": "sha512-jnxFllprHk6OI0l5vKssIrPYerng+DR3tM4HLT5/ze7c6juotf8T/dmhOhsqcqT5fE0B74j9CsiFZ4AGXEn7SA==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.14-minimal.json",
+          "sha256": "e86e3ebb5e239254080dfb45d0ce015909967046011be375a9249bafb706f558"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.15",
+      "status": "published_writer",
+      "packageVersion": "0.14.2",
+      "tag": "v0.14.2",
+      "commit": "4d806abaacfbd0434cfa1454b2284ad4b2fdfcc9",
+      "npmIntegrity": "sha512-THeFCwm45ajgh62PigjQMpc+DyABGdtF/x8iHRcevpGnkFW1zCckQrlFPO7Hpn+fOHiJZueS7KPgBM30grMYqA==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.15-minimal.json",
+          "sha256": "4c1863618034ec3d917dda7c2f566040b5878f0d7823e29d0f2a7719b820e89c"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.16",
+      "status": "published_reader_only",
+      "firstReaderPackageVersion": "0.14.3",
+      "tag": "v0.14.3",
+      "commit": "94a3edc3e5318fdbc4ceb045df4dad934ca4ab2b",
+      "reason": "No published package emitted schema 1.16; v0.14.3 emitted schema 1.17."
+    },
+    {
+      "schemaVersion": "1.17",
+      "status": "published_writer",
+      "packageVersion": "0.14.3",
+      "tag": "v0.14.3",
+      "commit": "94a3edc3e5318fdbc4ceb045df4dad934ca4ab2b",
+      "npmIntegrity": "sha512-5tJnFL4Ei34GtArVatM9TUtILDYUXJ2/H0+9jIU8B7y5eINjrQtajmeaudFHmxA4/t7blRgG1SuKQfoA0FPy7A==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.17-minimal.json",
+          "sha256": "a5e0ed7c1a65deecfc771e6fa9ea3c60de38c976773531b442b4c2ecf8cd5d28"
+        },
+        {
+          "scenario": "side-effect-committed",
+          "kind": "resume",
+          "path": "historical/v1.17-side-effect-committed.json",
+          "sha256": "8cc382d6532b4421f564488b03dfaedf65f3a3960b5ebc084aa2a4475611ca93"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.18",
+      "status": "current_unreleased",
+      "commit": "49fe593b603410e713f67cf853a578e61d480b48",
+      "reason": "Supported on main but not emitted by the latest released package v0.14.3."
+    }
+  ],
+  "expectedNormalizedFixtures": [
+    {
+      "sourceSchemaVersion": "1.0",
+      "path": "expected/v1.0-normalized-current.json",
+      "sha256": "114f59b4c2a6a52fa1597a61c9cbfed52f003e8d57e7c55dfa5a31586416515f"
+    }
+  ],
+  "negativeFixtures": [
+    {
+      "scenario": "missing-schema",
+      "path": "negative/missing-schema.json",
+      "sha256": "e04b9a21f11a373d753edbba13974eeb352e2028bae21c9070ec1d05f5d0315d",
+      "expectedError": "schema version"
+    },
+    {
+      "scenario": "future-schema",
+      "path": "negative/future-schema.json",
+      "sha256": "e7c10a0950ab76e2cefcab9377e27c1dd6c679df654d494af4642bb96b6ba9de",
+      "expectedError": "schema version"
+    },
+    {
+      "scenario": "malformed-schema",
+      "path": "negative/malformed-schema.json",
+      "sha256": "55bf752f9aeb49a288019e7b3d8b24cd304d3a56261e0bc22dbb2f677f9dff4c",
+      "expectedError": "schema version"
+    },
+    {
+      "scenario": "pre-1.8-tool-search",
+      "path": "negative/pre-1.8-tool-search.json",
+      "sha256": "371b05068f2961cba458761caceebcf5f4de7ccb7c36ad45a11ea99fd4478606",
+      "expectedError": "does not support tool_search items"
+    },
+    {
+      "scenario": "v1.14-sandbox-v2",
+      "path": "negative/v1.14-sandbox-v2.json",
+      "sha256": "00df8d036ae318f6dde2c3c98d94edc16ee95e4e92fecb1ebbff86f8d4c842a4",
+      "expectedError": "does not support sandbox session state version 2"
+    },
+    {
+      "scenario": "v1.17-sandbox-v3",
+      "path": "negative/v1.17-sandbox-v3.json",
+      "sha256": "686c6b8e7deafce9afcb306acbeebef180e74fa9921e9cebcac74186981dce0c",
+      "expectedError": "does not support sandbox session state version 3"
+    },
+    {
+      "scenario": "prototype-key",
+      "path": "negative/prototype-key.json",
+      "sha256": "ff0860ddeaa6ffd8e590fcf2e6b3fb17c58c3986bfd57862b5199ee93159e347",
+      "expectedError": ""
+    }
+  ]
+}

--- a/packages/agents-core/test/runState.compatibility.test.ts
+++ b/packages/agents-core/test/runState.compatibility.test.ts
@@ -1,0 +1,436 @@
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { Agent } from '../src/agent';
+import type { Model, ModelRequest, ModelResponse } from '../src/model';
+import { Runner } from '../src/run';
+import {
+  CURRENT_SCHEMA_VERSION,
+  RunState,
+  SUPPORTED_SCHEMA_VERSIONS,
+} from '../src/runState';
+import { setDefaultModelProvider } from '../src/providers';
+import { tool } from '../src/tool';
+import { Usage } from '../src/usage';
+
+type FixtureRecord = {
+  scenario: string;
+  kind: 'minimal' | 'feature' | 'resume';
+  path: string;
+  sha256: string;
+};
+
+type WriterSchema = {
+  schemaVersion: string;
+  status: 'published_writer';
+  packageVersion: string;
+  tag: string;
+  commit: string;
+  npmIntegrity: string;
+  fixtures: FixtureRecord[];
+};
+
+type PolicySchema = {
+  schemaVersion: string;
+  status: 'published_reader_only' | 'current_unreleased';
+  reason: string;
+};
+
+type NegativeFixture = {
+  scenario: string;
+  path: string;
+  sha256: string;
+  expectedError: string;
+};
+
+type CorpusManifest = {
+  formatVersion: number;
+  currentSchemaAtCreation: string;
+  schemas: Array<WriterSchema | PolicySchema>;
+  expectedNormalizedFixtures: Array<{
+    sourceSchemaVersion: string;
+    path: string;
+    sha256: string;
+  }>;
+  negativeFixtures: NegativeFixture[];
+};
+
+const fixtureRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'run-state',
+);
+const manifest = readJson<CorpusManifest>('sources.json');
+
+class QueueModel implements Model {
+  readonly requests: ModelRequest[] = [];
+
+  constructor(private readonly outputs: ModelResponse['output'][]) {}
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.requests.push(request);
+    const output = this.outputs.shift();
+    if (!output) {
+      throw new Error('No queued compatibility-test model output.');
+    }
+    return { output, usage: new Usage() };
+  }
+
+  async *getStreamedResponse(): AsyncIterable<never> {
+    yield* [];
+    throw new Error('Compatibility tests do not stream.');
+  }
+}
+
+beforeAll(() => {
+  setDefaultModelProvider({
+    getModel() {
+      throw new Error(
+        'Compatibility-test agents require an explicit fake model.',
+      );
+    },
+  });
+});
+
+describe('historical RunState compatibility corpus', () => {
+  it('accounts for every supported schema with explicit release policy', () => {
+    expect(manifest.currentSchemaAtCreation).toBe(CURRENT_SCHEMA_VERSION);
+    expect(manifest.schemas.map((entry) => entry.schemaVersion)).toEqual([
+      ...SUPPORTED_SCHEMA_VERSIONS,
+    ]);
+
+    const writerVersions = manifest.schemas
+      .filter(
+        (entry): entry is WriterSchema => entry.status === 'published_writer',
+      )
+      .map((entry) => entry.schemaVersion);
+    expect(writerVersions).toEqual([
+      '1.0',
+      '1.1',
+      '1.2',
+      '1.4',
+      '1.5',
+      '1.6',
+      '1.7',
+      '1.8',
+      '1.9',
+      '1.10',
+      '1.11',
+      '1.12',
+      '1.13',
+      '1.14',
+      '1.15',
+      '1.17',
+    ]);
+    expect(
+      manifest.schemas
+        .filter((entry) => entry.status === 'published_reader_only')
+        .map((entry) => entry.schemaVersion),
+    ).toEqual(['1.3', '1.16']);
+    expect(
+      manifest.schemas
+        .filter((entry) => entry.status === 'current_unreleased')
+        .map((entry) => entry.schemaVersion),
+    ).toEqual(['1.18']);
+  });
+
+  it('pins every fixture to immutable bytes and complete writer provenance', () => {
+    for (const source of writerSources()) {
+      expect(source.commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(source.tag).toBe(`v${source.packageVersion}`);
+      expect(source.npmIntegrity).toMatch(/^sha512-/);
+      expect(
+        source.fixtures.filter((fixture) => fixture.kind === 'minimal'),
+      ).toHaveLength(1);
+      for (const fixture of source.fixtures) {
+        expect(hashFixture(fixture.path)).toBe(fixture.sha256);
+        expect(
+          readJson<Record<string, unknown>>(fixture.path).$schemaVersion,
+        ).toBe(source.schemaVersion);
+      }
+    }
+    for (const fixture of manifest.negativeFixtures) {
+      expect(hashFixture(fixture.path)).toBe(fixture.sha256);
+    }
+    for (const fixture of manifest.expectedNormalizedFixtures) {
+      expect(hashFixture(fixture.path)).toBe(fixture.sha256);
+    }
+  });
+
+  it.each(
+    writerSources().map((source) => [source.schemaVersion, source] as const),
+  )(
+    'reads, normalizes, and idempotently rewrites released minimal schema %s',
+    async (_schemaVersion, source) => {
+      const fixture = source.fixtures.find(
+        (candidate) => candidate.kind === 'minimal',
+      );
+      expect(fixture).toBeDefined();
+      const bytes = readFixture(fixture!.path);
+      const historical = JSON.parse(bytes) as Record<string, unknown>;
+      const agent = new Agent({ name: 'HistoricalAgent' });
+
+      const restored = await RunState.fromString(agent, bytes);
+      expect(restored._currentTurn).toBe(historical.currentTurn);
+      expect(restored._originalInput).toEqual(historical.originalInput);
+      expect(restored._maxTurns).toBe(historical.maxTurns);
+      expect(restored._context.context).toEqual({ fixture: 'minimal' });
+
+      const firstRewrite = JSON.parse(restored.toString()) as Record<
+        string,
+        unknown
+      >;
+      if (source.schemaVersion === '1.0') {
+        expect(firstRewrite).toEqual(
+          readJson('expected/v1.0-normalized-current.json'),
+        );
+      }
+      expect(firstRewrite.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
+      expectJsonScalars(firstRewrite);
+
+      const rewritten = await RunState.fromString(
+        agent,
+        JSON.stringify(firstRewrite),
+      );
+      expect(JSON.parse(rewritten.toString())).toEqual(firstRewrite);
+    },
+  );
+
+  it('preserves released mid-turn server continuation identifiers', async () => {
+    const restored = await RunState.fromString(
+      new Agent({ name: 'HistoricalAgent' }),
+      readFixture('historical/v1.1-server-continuation.json'),
+    );
+
+    expect(restored._currentTurnInProgress).toBe(true);
+    expect(restored._conversationId).toBe('conversation-historical');
+    expect(restored._previousResponseId).toBe('response-historical');
+  });
+
+  it('approves and resumes a released nested-agent interruption', async () => {
+    let executions = 0;
+    const { outerAgent, outerModel } = createNestedApprovalAgents(() => {
+      executions += 1;
+    });
+    const restored = await RunState.fromString(
+      outerAgent,
+      readFixture('historical/v1.2-nested-approval.json'),
+    );
+    const approval = restored.getInterruptions()[0];
+    expect(approval?.agent.name).toBe('NestedAgent');
+
+    restored.approve(approval!);
+    const result = await new Runner().run(outerAgent, restored);
+
+    expect(result.finalOutput).toBe('Outer done');
+    expect(result.interruptions).toEqual([]);
+    expect(executions).toBe(1);
+    expect(outerModel.requests).toHaveLength(1);
+  });
+
+  it('rejects and resumes a released nested-agent interruption', async () => {
+    let executions = 0;
+    const { outerAgent } = createNestedApprovalAgents(() => {
+      executions += 1;
+    });
+    const restored = await RunState.fromString(
+      outerAgent,
+      readFixture('historical/v1.2-nested-approval.json'),
+    );
+    const approval = restored.getInterruptions()[0];
+
+    restored.reject(approval!);
+    const result = await new Runner().run(outerAgent, restored);
+
+    expect(result.finalOutput).toBe('Outer done');
+    expect(result.interruptions).toEqual([]);
+    expect(executions).toBe(0);
+  });
+
+  it('resumes after a released committed side effect without executing it again', async () => {
+    let executions = 0;
+    const finalModel = new QueueModel([[message('done')]]);
+    const sideEffectTool = tool({
+      name: 'side_effect_tool',
+      description: 'Runs once.',
+      parameters: z.object({}).strict(),
+      execute: async () => {
+        executions += 1;
+        return 'unexpected duplicate';
+      },
+    });
+    const agent = new Agent({
+      name: 'SideEffectAgent',
+      model: finalModel,
+      tools: [sideEffectTool],
+    });
+    const restored = await RunState.fromString(
+      agent,
+      readFixture('historical/v1.17-side-effect-committed.json'),
+    );
+
+    const result = await new Runner().run(agent, restored);
+
+    expect(result.finalOutput).toBe('done');
+    expect(executions).toBe(0);
+    expect(finalModel.requests).toHaveLength(1);
+    const resumedInput = finalModel.requests[0]!.input;
+    expect(Array.isArray(resumedInput)).toBe(true);
+    if (!Array.isArray(resumedInput)) {
+      throw new Error('Expected resumed model input to be an item array.');
+    }
+    expect(
+      resumedInput.filter(
+        (item) =>
+          item.type === 'function_call' && item.callId === 'side-effect-call',
+      ),
+    ).toHaveLength(1);
+    expect(
+      resumedInput.filter(
+        (item) =>
+          item.type === 'function_call_result' &&
+          item.callId === 'side-effect-call' &&
+          item.output === 'side effect completed',
+      ),
+    ).toHaveLength(1);
+  });
+
+  it.each(manifest.negativeFixtures.filter((fixture) => fixture.expectedError))(
+    'rejects negative fixture $scenario before side effects',
+    async (fixture) => {
+      let modelCalls = 0;
+      let toolCalls = 0;
+      const model: Model = {
+        async getResponse() {
+          modelCalls += 1;
+          return { output: [message('unexpected')], usage: new Usage() };
+        },
+        async *getStreamedResponse() {
+          yield* [];
+          throw new Error('Compatibility tests do not stream.');
+        },
+      };
+      const agent = new Agent({
+        name: 'HistoricalAgent',
+        model,
+        tools: [
+          tool({
+            name: 'side_effect_tool',
+            description: 'Must not run.',
+            parameters: z.object({}).strict(),
+            execute: async () => {
+              toolCalls += 1;
+              return 'unexpected';
+            },
+          }),
+        ],
+      });
+
+      await expect(
+        RunState.fromString(agent, readFixture(fixture.path)),
+      ).rejects.toThrow(fixture.expectedError);
+      expect(modelCalls).toBe(0);
+      expect(toolCalls).toBe(0);
+    },
+  );
+
+  it('parses an own __proto__ key without polluting object prototypes', async () => {
+    expect(
+      (Object.prototype as { polluted?: unknown }).polluted,
+    ).toBeUndefined();
+    const restored = await RunState.fromString(
+      new Agent({ name: 'HistoricalAgent' }),
+      readFixture('negative/prototype-key.json'),
+    );
+    const context = restored._context.context as Record<string, unknown>;
+    expect(context.polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(context)).toBe(Object.prototype);
+    expect(
+      (Object.prototype as { polluted?: unknown }).polluted,
+    ).toBeUndefined();
+  });
+});
+
+function writerSources(): WriterSchema[] {
+  return manifest.schemas.filter(
+    (entry): entry is WriterSchema => entry.status === 'published_writer',
+  );
+}
+
+function readFixture(relativePath: string): string {
+  return readFileSync(join(fixtureRoot, relativePath), 'utf8');
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readFixture(relativePath)) as T;
+}
+
+function hashFixture(relativePath: string): string {
+  return createHash('sha256').update(readFixture(relativePath)).digest('hex');
+}
+
+function expectJsonScalars(value: unknown): void {
+  if (value === null) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      expectJsonScalars(item);
+    }
+    return;
+  }
+  if (typeof value === 'object') {
+    for (const item of Object.values(value as Record<string, unknown>)) {
+      expectJsonScalars(item);
+    }
+    return;
+  }
+  expect(['string', 'number', 'boolean']).toContain(typeof value);
+  if (typeof value === 'number') {
+    expect(Number.isFinite(value)).toBe(true);
+  }
+}
+
+function createNestedApprovalAgents(onExecute: () => void) {
+  const approvalTool = tool({
+    name: 'secure_tool',
+    description: 'Requires approval.',
+    parameters: z.object({ text: z.string() }),
+    needsApproval: true,
+    execute: async ({ text }) => {
+      onExecute();
+      return `approved:${text}`;
+    },
+  });
+  const nestedAgent = new Agent({
+    name: 'NestedAgent',
+    model: new QueueModel([[message('Nested done')]]),
+    tools: [approvalTool],
+    modelSettings: { toolChoice: 'required' },
+  });
+  const nestedTool = nestedAgent.asTool({
+    toolName: 'nested_tool',
+    toolDescription: 'Nested agent tool.',
+    runOptions: { context: { nested: true } },
+  });
+  const outerModel = new QueueModel([[message('Outer done')]]);
+  const outerAgent = new Agent({
+    name: 'OuterAgent',
+    model: outerModel,
+    tools: [nestedTool],
+    modelSettings: { toolChoice: 'required' },
+  });
+  return { outerAgent, outerModel };
+}
+
+function message(text: string): ModelResponse['output'][number] {
+  return {
+    type: 'message',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ type: 'output_text', text }],
+  };
+}


### PR DESCRIPTION
This pull request adds an immutable compatibility corpus for released RunState writers so current reader changes are checked against real historical payloads instead of fixtures derived from current serializers.

It:

- records release, package, tag, commit, integrity, and hash provenance for every published writer schema while explicitly accounting for reader-only and unreleased schemas;
- verifies normalization, idempotent current-schema rewrites, scalar stability, representative approval resume, and prevention of duplicate committed tool effects;
- keeps regeneration as an explicit, credential-free maintainer action using each historical commit's frozen dependency graph.
