### PR TITLE
feat: add scripted testing utilities

### DIFF
--- a/.changeset/scripted-testing-utilities.md
+++ b/.changeset/scripted-testing-utilities.md
@@ -1,0 +1,9 @@
+---
+'@openai/agents': minor
+'@openai/agents-core': minor
+'@openai/agents-extensions': minor
+'@openai/agents-openai': minor
+'@openai/agents-realtime': minor
+---
+
+feat: add scripted model, sandbox session, and Realtime testing utilities

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,7 @@ Before submitting changes, ensure all checks pass and augment tests when you tou
 When `$code-change-verification` applies (see Mandatory Skill Usage), invoke it to run the required verification stack from the repository root. Rerun the full stack after fixes.
 
 - Add or update unit tests for any code change unless it is truly infeasible; if something prevents adding tests, explain why in the PR.
+- For provider-neutral agent workflow tests, prefer `ScriptedModel` over adding a new mock or fake `Model`. Prefer `ScriptedRealtimeTransport` for Realtime session tests and `scriptedSandboxSession()` for deterministic Sandbox session calls. Keep a specialized double only for a boundary the scripted utilities cannot preserve, such as provider-wire conversion, malformed streams, controlled suspension or concurrency, or exact abort or lifecycle delivery, and document that reason in the test.
 
 #### Build and Type Checking
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,8 @@ CI=1 pnpm test
 
 Tests use Vitest and are located alongside source files in each package under `packages/*/test`.
 
+For provider-neutral agent workflow tests, prefer `ScriptedModel` from the Core testing utilities instead of adding a new mock or fake `Model`. Use `ScriptedRealtimeTransport` for Realtime session tests and `scriptedSandboxSession()` for deterministic Sandbox session calls. Keep a specialized test double only when the test specifically requires provider-wire conversion, malformed streams, controlled suspension or concurrency, or an exact abort or lifecycle boundary that the scripted utilities cannot preserve; document that boundary in the test.
+
 During an iterative review, `pnpm test:review` skips the slow subsystem-specific tests listed in `helpers/vitest/reviewTestProfile.ts`. Choose review coverage by impact:
 
 - For changes unrelated to every review-optional owner, run `pnpm test:review`.

--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -24,6 +24,11 @@
       "require": "./dist/model.js",
       "import": "./dist/model.mjs"
     },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "require": "./dist/testing/index.js",
+      "import": "./dist/testing/index.mjs"
+    },
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "require": "./dist/utils/index.js",
@@ -141,6 +146,9 @@
     "*": {
       "model": [
         "dist/model.d.ts"
+      ],
+      "testing": [
+        "dist/testing/index.d.ts"
       ],
       "utils": [
         "dist/utils/index.d.ts"

--- a/packages/agents-core/src/testing/index.ts
+++ b/packages/agents-core/src/testing/index.ts
@@ -1,0 +1,42 @@
+export {
+  ScriptedModel,
+  UnexpectedModelCallError,
+  UnconsumedModelStepsError,
+  InvalidScriptedModelStepError,
+  ScriptedModelRequestAbortedError,
+  assistantMessage,
+  functionCall,
+  modelError,
+  modelResponder,
+  modelResponse,
+  modelStream,
+  modelStreamResponder,
+} from './scriptedModel';
+
+export type {
+  AssistantMessageOptions,
+  FunctionCallOptions,
+  InvalidScriptedModelStepReason,
+  RecordedModelCall,
+  ScriptedModelInput,
+  ScriptedModelResponse,
+  ScriptedModelRetryAdvice,
+  ScriptedModelStream,
+} from './scriptedModel';
+
+export {
+  InvalidScriptedSandboxStepError,
+  SandboxCallMatcherError,
+  UnexpectedSandboxCallError,
+  UnconsumedSandboxStepsError,
+  scriptedSandboxSession,
+} from './scriptedSandboxSession';
+
+export type {
+  InvalidScriptedSandboxStepReason,
+  RecordedSandboxCall,
+  ScriptedSandboxCallFor,
+  ScriptedSandboxInput,
+  ScriptedSandboxMethod,
+  ScriptedSandboxSession,
+} from './scriptedSandboxSession';

--- a/packages/agents-core/src/testing/scriptedModel.ts
+++ b/packages/agents-core/src/testing/scriptedModel.ts
@@ -1,0 +1,790 @@
+import {
+  Model,
+  ModelRequest,
+  ModelResponse,
+  ModelRetryAdvice,
+  ModelRetryAdviceRequest,
+} from '../model';
+import type {
+  AssistantMessageItem,
+  FunctionCallItem,
+  StreamEvent,
+} from '../types/protocol';
+import { Usage } from '../usage';
+import { snapshotRawUsage } from '../utils/rawUsage';
+import { snapshotTestingValue } from '../utils/testingSnapshot';
+
+/**
+ * A complete normalized response or an output-only shorthand.
+ *
+ * Output-only responses count as one model request and receive a deterministic
+ * response ID. Automatic streaming also assigns a deterministic response ID
+ * when a complete response omits one because the normalized terminal stream
+ * event requires an ID.
+ */
+export type ScriptedModelResponse = ModelResponse | ModelResponse['output'];
+
+export type RecordedModelCall = Readonly<{
+  /** The zero-based position of this model call in `calls`. */
+  index: number;
+
+  /** Whether the runner requested a streamed response. */
+  streamed: boolean;
+
+  /**
+   * A frozen request snapshot with detached mutable input collections and
+   * model settings. Runtime object identities such as the abort signal remain
+   * unchanged.
+   */
+  request: Readonly<ModelRequest>;
+}>;
+
+export type ScriptedModelRetryAdvice =
+  | ModelRetryAdvice
+  | ((
+      request: ModelRetryAdviceRequest,
+    ) => ModelRetryAdvice | undefined | Promise<ModelRetryAdvice | undefined>);
+
+type ScriptedModelResponseStep = {
+  type: 'response';
+  response: ScriptedModelResponse;
+};
+
+type ScriptedModelErrorStep = {
+  type: 'error';
+  error: unknown;
+  retryAdvice?: ScriptedModelRetryAdvice;
+};
+
+type ScriptedModelResponderStep = {
+  type: 'responder';
+  respond: (
+    call: RecordedModelCall,
+  ) => ScriptedModelResponse | Promise<ScriptedModelResponse>;
+};
+
+export type ScriptedModelStream =
+  Iterable<StreamEvent> | AsyncIterable<StreamEvent>;
+
+type ScriptedModelStreamStep = {
+  type: 'stream';
+  events: ScriptedModelStream;
+};
+
+type ScriptedModelStreamResponderStep = {
+  type: 'stream_responder';
+  respond: (
+    call: RecordedModelCall,
+  ) => ScriptedModelStream | Promise<ScriptedModelStream>;
+};
+
+type ScriptedModelStep =
+  | ScriptedModelResponseStep
+  | ScriptedModelErrorStep
+  | ScriptedModelResponderStep
+  | ScriptedModelStreamStep
+  | ScriptedModelStreamResponderStep;
+
+export type ScriptedModelInput = ScriptedModelStep | ScriptedModelResponse;
+
+export type AssistantMessageOptions = {
+  id?: string;
+  phase?: AssistantMessageItem['phase'];
+  providerData?: Record<string, unknown>;
+};
+
+export type FunctionCallOptions = {
+  callId: string;
+  id?: string;
+  namespace?: string;
+  providerData?: Record<string, unknown>;
+};
+
+export type InvalidScriptedModelStepReason =
+  | 'invalid_input'
+  | 'unknown_step_type'
+  | 'missing_response'
+  | 'invalid_response'
+  | 'missing_error'
+  | 'missing_responder'
+  | 'invalid_stream'
+  | 'incompatible_call';
+
+export class UnexpectedModelCallError extends Error {
+  /** The zero-based position of the call in `ScriptedModel.calls`. */
+  readonly callIndex: number;
+  readonly streamed: boolean;
+
+  constructor(call: RecordedModelCall) {
+    super(
+      `ScriptedModel received unexpected ${call.streamed ? 'streaming' : 'non-streaming'} call #${displayIndex(call.index)}; no scripted steps remain.`,
+    );
+    this.name = 'UnexpectedModelCallError';
+    this.callIndex = call.index;
+    this.streamed = call.streamed;
+  }
+}
+
+export class UnconsumedModelStepsError extends Error {
+  readonly remainingSteps: number;
+
+  constructor(remainingSteps: number) {
+    super(
+      `ScriptedModel has ${remainingSteps} unconsumed scripted step${remainingSteps === 1 ? '' : 's'}.`,
+    );
+    this.name = 'UnconsumedModelStepsError';
+    this.remainingSteps = remainingSteps;
+  }
+}
+
+export class InvalidScriptedModelStepError extends Error {
+  readonly reason: InvalidScriptedModelStepReason;
+  /** The zero-based position of an invalid constructor or `enqueue()` input. */
+  readonly inputIndex?: number;
+  /** The zero-based position of a call in `ScriptedModel.calls`. */
+  readonly callIndex?: number;
+  readonly stepType?: string;
+
+  constructor(options: {
+    reason: InvalidScriptedModelStepReason;
+    message: string;
+    inputIndex?: number;
+    callIndex?: number;
+    stepType?: string;
+  }) {
+    super(options.message);
+    this.name = 'InvalidScriptedModelStepError';
+    this.reason = options.reason;
+    this.inputIndex = options.inputIndex;
+    this.callIndex = options.callIndex;
+    this.stepType = options.stepType;
+  }
+}
+
+export class ScriptedModelRequestAbortedError extends Error {
+  /** The zero-based position of a call in `ScriptedModel.calls`. */
+  readonly callIndex?: number;
+
+  constructor(callIndex?: number) {
+    super('Scripted model request was aborted.');
+    this.name = 'AbortError';
+    this.callIndex = callIndex;
+  }
+}
+
+/** Creates a scripted normalized model response step. */
+export function modelResponse(
+  response: ScriptedModelResponse,
+): ScriptedModelResponseStep {
+  return { type: 'response', response };
+}
+
+/** Creates a scripted model failure step. */
+export function modelError(
+  error: unknown,
+  retryAdvice?: ScriptedModelRetryAdvice,
+): ScriptedModelErrorStep {
+  return { type: 'error', error, retryAdvice };
+}
+
+/** Creates a response step that derives its output from the recorded call. */
+export function modelResponder(
+  respond: ScriptedModelResponderStep['respond'],
+): ScriptedModelResponderStep {
+  return { type: 'responder', respond };
+}
+
+/** Creates a raw normalized stream step. */
+export function modelStream(
+  events: ScriptedModelStreamStep['events'],
+): ScriptedModelStreamStep {
+  return { type: 'stream', events };
+}
+
+/** Creates a raw normalized stream derived from the recorded call. */
+export function modelStreamResponder(
+  respond: ScriptedModelStreamResponderStep['respond'],
+): ScriptedModelStreamResponderStep {
+  return { type: 'stream_responder', respond };
+}
+
+/** Creates a normalized assistant text message. */
+export function assistantMessage(
+  text: string,
+  options: AssistantMessageOptions = {},
+): AssistantMessageItem {
+  return {
+    type: 'message',
+    role: 'assistant',
+    status: 'completed',
+    ...(typeof options.id === 'undefined' ? {} : { id: options.id }),
+    ...(typeof options.phase === 'undefined' ? {} : { phase: options.phase }),
+    content: [
+      {
+        type: 'output_text',
+        text,
+      },
+    ],
+    ...(typeof options.providerData === 'undefined'
+      ? {}
+      : { providerData: options.providerData }),
+  };
+}
+
+/** Creates a normalized function call item. */
+export function functionCall(
+  name: string,
+  args: string | Record<string, unknown>,
+  options: FunctionCallOptions,
+): FunctionCallItem {
+  return {
+    type: 'function_call',
+    name,
+    callId: options.callId,
+    id: options.id ?? options.callId,
+    namespace: options.namespace,
+    status: 'completed',
+    arguments: typeof args === 'string' ? args : JSON.stringify(args),
+    providerData: options.providerData,
+  };
+}
+
+/**
+ * A deterministic model test double that consumes one scripted step per call.
+ */
+export class ScriptedModel implements Model {
+  readonly #steps: ScriptedModelStep[];
+  readonly #calls: RecordedModelCall[] = [];
+  readonly #retryAdvice = new Map<
+    unknown,
+    Array<{
+      request: ModelRequest;
+      streamed: boolean;
+      advice: ScriptedModelRetryAdvice | undefined;
+    }>
+  >();
+
+  constructor(inputs: Iterable<ScriptedModelInput> = []) {
+    this.#steps = Array.from(inputs, (input, index) =>
+      normalizeInput(input, index),
+    );
+  }
+
+  /** All calls recorded by this model in invocation order. */
+  get calls(): readonly RecordedModelCall[] {
+    return Object.freeze(this.#calls.map(snapshotRecordedModelCall));
+  }
+
+  /** The first recorded call, if one has occurred. */
+  get firstCall(): RecordedModelCall | undefined {
+    const call = this.#calls[0];
+    return call ? snapshotRecordedModelCall(call) : undefined;
+  }
+
+  /** The most recent recorded call, if one has occurred. */
+  get lastCall(): RecordedModelCall | undefined {
+    const call = this.#calls.at(-1);
+    return call ? snapshotRecordedModelCall(call) : undefined;
+  }
+
+  /** The number of scripted steps that have not been consumed. */
+  get remainingSteps(): number {
+    return this.#steps.length;
+  }
+
+  /** Adds steps to the end of the script. */
+  enqueue(...inputs: ScriptedModelInput[]): void {
+    const steps = inputs.map((input, index) => normalizeInput(input, index));
+    this.#steps.push(...steps);
+  }
+
+  /** Throws when the script still contains unconsumed steps. */
+  assertComplete(): void {
+    if (this.#steps.length > 0) {
+      throw new UnconsumedModelStepsError(this.#steps.length);
+    }
+  }
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    throwIfAborted(request.signal);
+    const { call, step } = this.#recordAndTakeStep(request, false);
+
+    if (step.type === 'stream' || step.type === 'stream_responder') {
+      throw new InvalidScriptedModelStepError({
+        reason: 'incompatible_call',
+        callIndex: call.index,
+        stepType: step.type,
+        message: `ScriptedModel cannot use raw stream step for non-streaming call #${displayIndex(call.index)}.`,
+      });
+    }
+
+    if (step.type === 'error') {
+      this.#rememberRetryAdvice(step, request, false);
+      throw step.error;
+    }
+
+    const response =
+      step.type === 'responder' ? await step.respond(call) : step.response;
+    throwIfAborted(request.signal, call.index);
+    return normalizeResponseForCall(response, call, false);
+  }
+
+  getStreamedResponse(request: ModelRequest): AsyncIterable<StreamEvent> {
+    throwIfAborted(request.signal);
+    const { call, step } = this.#recordAndTakeStep(request, true);
+
+    return this.#processStreamedStep(request, call, step);
+  }
+
+  async *#processStreamedStep(
+    request: ModelRequest,
+    call: RecordedModelCall,
+    step: ScriptedModelStep,
+  ): AsyncIterable<StreamEvent> {
+    throwIfAborted(request.signal, call.index);
+    if (step.type === 'error') {
+      this.#rememberRetryAdvice(step, request, true);
+      throw step.error;
+    }
+
+    if (step.type === 'stream' || step.type === 'stream_responder') {
+      const events =
+        step.type === 'stream' ? step.events : await step.respond(call);
+      throwIfAborted(request.signal, call.index);
+      if (step.type === 'stream_responder' && !isIterable(events)) {
+        throw new InvalidScriptedModelStepError({
+          reason: 'invalid_stream',
+          callIndex: call.index,
+          stepType: step.type,
+          message: `ScriptedModel stream responder returned an invalid stream for call #${displayIndex(call.index)}.`,
+        });
+      }
+      for await (const event of events) {
+        throwIfAborted(request.signal, call.index);
+        yield event;
+      }
+      throwIfAborted(request.signal, call.index);
+      return;
+    }
+
+    const scriptedResponse =
+      step.type === 'responder' ? await step.respond(call) : step.response;
+    throwIfAborted(request.signal, call.index);
+    const response = normalizeResponseForCall(scriptedResponse, call, true);
+    yield* streamResponse(response, request.signal, call.index);
+  }
+
+  async getRetryAdvice(
+    request: ModelRetryAdviceRequest,
+  ): Promise<ModelRetryAdvice | undefined> {
+    const records = this.#retryAdvice.get(request.error);
+    if (!records) {
+      return undefined;
+    }
+
+    let recordIndex = records.findIndex(
+      (record) =>
+        record.streamed === request.stream &&
+        record.request === request.request,
+    );
+    if (recordIndex === -1) {
+      recordIndex = records.findIndex(
+        (record) =>
+          record.streamed === request.stream &&
+          requestsShareCallInputs(record.request, request.request),
+      );
+    }
+    if (recordIndex === -1) {
+      recordIndex = records.findIndex(
+        (record) => record.streamed === request.stream,
+      );
+    }
+    if (recordIndex === -1) {
+      return undefined;
+    }
+
+    const [record] = records.splice(recordIndex, 1);
+    if (records.length === 0) {
+      this.#retryAdvice.delete(request.error);
+    }
+    const advice = record?.advice;
+    if (typeof advice === 'function') {
+      return await advice(request);
+    }
+    return advice;
+  }
+
+  #recordAndTakeStep(
+    request: ModelRequest,
+    streamed: boolean,
+  ): { call: RecordedModelCall; step: ScriptedModelStep } {
+    const recordedCall: RecordedModelCall = Object.freeze({
+      index: this.#calls.length,
+      streamed,
+      request: snapshotRequest(request),
+    });
+    this.#calls.push(recordedCall);
+
+    const step = this.#steps.shift();
+    if (!step) {
+      throw new UnexpectedModelCallError(recordedCall);
+    }
+    return { call: snapshotRecordedModelCall(recordedCall), step };
+  }
+
+  #rememberRetryAdvice(
+    step: ScriptedModelErrorStep,
+    request: ModelRequest,
+    streamed: boolean,
+  ): void {
+    const records = this.#retryAdvice.get(step.error) ?? [];
+    records.push({ request, streamed, advice: step.retryAdvice });
+    this.#retryAdvice.set(step.error, records);
+  }
+}
+
+function snapshotRequest(request: ModelRequest): Readonly<ModelRequest> {
+  return Object.freeze(snapshotTestingValue(request));
+}
+
+function snapshotRecordedModelCall(call: RecordedModelCall): RecordedModelCall {
+  return Object.freeze({
+    index: call.index,
+    streamed: call.streamed,
+    request: snapshotRequest(call.request),
+  });
+}
+
+function normalizeInput(
+  input: ScriptedModelInput,
+  inputIndex?: number,
+): ScriptedModelStep {
+  if (Array.isArray(input)) {
+    return { type: 'response', response: snapshotScriptedResponse(input) };
+  }
+  if (typeof input !== 'object' || input === null) {
+    throw invalidStep('invalid_input', inputIndex);
+  }
+
+  if ('type' in input) {
+    const stepType = typeof input.type === 'string' ? input.type : undefined;
+    switch (input.type) {
+      case 'response':
+        if (!('response' in input)) {
+          throw invalidStep('missing_response', inputIndex, stepType);
+        }
+        validateResponse(input.response, inputIndex);
+        return {
+          type: 'response',
+          response: snapshotScriptedResponse(input.response),
+        };
+      case 'error':
+        if (!('error' in input)) {
+          throw invalidStep('missing_error', inputIndex, stepType);
+        }
+        return {
+          type: 'error',
+          error: input.error,
+          retryAdvice:
+            typeof input.retryAdvice === 'function'
+              ? input.retryAdvice
+              : snapshotTestingValue(input.retryAdvice),
+        };
+      case 'responder':
+        if (typeof input.respond !== 'function') {
+          throw invalidStep('missing_responder', inputIndex, stepType);
+        }
+        return { type: 'responder', respond: input.respond };
+      case 'stream_responder':
+        if (typeof input.respond !== 'function') {
+          throw invalidStep('missing_responder', inputIndex, stepType);
+        }
+        return { type: 'stream_responder', respond: input.respond };
+      case 'stream':
+        if (!isIterable(input.events)) {
+          throw invalidStep('invalid_stream', inputIndex, stepType);
+        }
+        return {
+          type: 'stream',
+          events: snapshotScriptedStream(input.events),
+        };
+      default:
+        throw invalidStep('unknown_step_type', inputIndex, stepType);
+    }
+  }
+
+  if ('output' in input || 'usage' in input) {
+    validateResponse(input, inputIndex);
+    return { type: 'response', response: snapshotScriptedResponse(input) };
+  }
+  throw invalidStep('invalid_input', inputIndex);
+}
+
+function validateResponse(
+  response: unknown,
+  inputIndex?: number,
+  callIndex?: number,
+): asserts response is ScriptedModelResponse {
+  if (Array.isArray(response)) {
+    return;
+  }
+  if (
+    typeof response !== 'object' ||
+    response === null ||
+    !Array.isArray((response as Partial<ModelResponse>).output) ||
+    !((response as Partial<ModelResponse>).usage instanceof Usage)
+  ) {
+    throw new InvalidScriptedModelStepError({
+      reason: 'invalid_response',
+      inputIndex,
+      callIndex,
+      message:
+        typeof callIndex === 'number'
+          ? `ScriptedModel responder returned an invalid response for call #${displayIndex(callIndex)}.`
+          : `ScriptedModel input #${displayIndex(inputIndex ?? 0)} has an invalid response envelope.`,
+    });
+  }
+}
+
+function invalidStep(
+  reason: InvalidScriptedModelStepReason,
+  inputIndex?: number,
+  stepType?: string,
+): InvalidScriptedModelStepError {
+  const position = inputIndex ?? 0;
+  const detail =
+    reason === 'unknown_step_type' && stepType
+      ? ` has unknown type "${stepType}"`
+      : ` is invalid (${reason.replace(/_/g, ' ')})`;
+  return new InvalidScriptedModelStepError({
+    reason,
+    inputIndex: position,
+    stepType,
+    message: `ScriptedModel input #${displayIndex(position)}${detail}.`,
+  });
+}
+
+function snapshotScriptedResponse(
+  response: ScriptedModelResponse,
+): ScriptedModelResponse {
+  if (Array.isArray(response)) {
+    return snapshotTestingValue(response);
+  }
+
+  const snapshot: ModelResponse = {
+    output: snapshotTestingValue(response.output),
+    usage: snapshotUsage(response.usage),
+    ...(typeof response.responseId === 'undefined'
+      ? {}
+      : { responseId: response.responseId }),
+    ...(typeof response.requestId === 'undefined'
+      ? {}
+      : { requestId: response.requestId }),
+    ...(typeof response.providerData === 'undefined'
+      ? {}
+      : { providerData: snapshotTestingValue(response.providerData) }),
+  };
+  const rawUsageDescriptor = Object.getOwnPropertyDescriptor(
+    response,
+    'rawUsage',
+  );
+  if (rawUsageDescriptor) {
+    Object.defineProperty(snapshot, 'rawUsage', {
+      ...rawUsageDescriptor,
+      ...(Object.prototype.hasOwnProperty.call(rawUsageDescriptor, 'value')
+        ? { value: snapshotTestingValue(rawUsageDescriptor.value) }
+        : {}),
+    });
+  }
+  return snapshot;
+}
+
+function snapshotUsage(usage: Usage): Usage {
+  return new Usage({
+    requests: usage.requests,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+    inputTokensDetails: snapshotTestingValue(usage.inputTokensDetails),
+    outputTokensDetails: snapshotTestingValue(usage.outputTokensDetails),
+    requestUsageEntries: usage.requestUsageEntries?.map((entry) => ({
+      inputTokens: entry.inputTokens,
+      outputTokens: entry.outputTokens,
+      totalTokens: entry.totalTokens,
+      inputTokensDetails: snapshotTestingValue(entry.inputTokensDetails),
+      outputTokensDetails: snapshotTestingValue(entry.outputTokensDetails),
+      endpoint: entry.endpoint,
+    })),
+  });
+}
+
+function snapshotScriptedStream(
+  events: ScriptedModelStream,
+): ScriptedModelStream {
+  return Array.isArray(events) ? snapshotTestingValue(events) : events;
+}
+
+function displayIndex(index: number): number {
+  return index + 1;
+}
+
+function isIterable(value: unknown): value is ScriptedModelStream {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<
+    Iterable<StreamEvent> & AsyncIterable<StreamEvent>
+  >;
+  return (
+    typeof candidate[Symbol.iterator] === 'function' ||
+    typeof candidate[Symbol.asyncIterator] === 'function'
+  );
+}
+
+function requestsShareCallInputs(
+  recorded: ModelRequest,
+  advised: ModelRequest,
+): boolean {
+  return (
+    recorded.input === advised.input &&
+    recorded.modelSettings === advised.modelSettings &&
+    recorded.tools === advised.tools &&
+    recorded.handoffs === advised.handoffs
+  );
+}
+
+function normalizeResponse(
+  response: ScriptedModelResponse,
+  request: ModelRequest,
+  callIndex: number,
+  requireResponseId: boolean,
+): ModelResponse {
+  validateResponse(response, undefined, callIndex);
+  if (Array.isArray(response)) {
+    return {
+      output: response,
+      usage: new Usage({ requests: 1 }),
+      responseId: `scripted-response-${displayIndex(callIndex)}`,
+    };
+  }
+
+  let rawUsage: Record<string, unknown> | undefined;
+  const preserveRawUsage = request.modelSettings.preserveRawUsage === true;
+  if (preserveRawUsage) {
+    try {
+      rawUsage = snapshotRawUsage(response.rawUsage);
+    } catch {
+      rawUsage = undefined;
+    }
+  }
+  const responseId =
+    requireResponseId && typeof response.responseId === 'undefined'
+      ? `scripted-response-${displayIndex(callIndex)}`
+      : response.responseId;
+  const hasRawUsage = 'rawUsage' in response;
+  if (responseId === response.responseId && !hasRawUsage) {
+    return response;
+  }
+
+  const responseWithoutRawUsage = {} as Omit<ModelResponse, 'rawUsage'>;
+  for (const key of Object.keys(response) as Array<keyof ModelResponse>) {
+    if (key !== 'rawUsage') {
+      Object.assign(responseWithoutRawUsage, { [key]: response[key] });
+    }
+  }
+  return {
+    ...responseWithoutRawUsage,
+    ...(typeof responseId === 'undefined' ? {} : { responseId }),
+    ...(typeof rawUsage === 'undefined' ? {} : { rawUsage }),
+  };
+}
+
+function normalizeResponseForCall(
+  response: ScriptedModelResponse,
+  call: RecordedModelCall,
+  requireResponseId: boolean,
+): ModelResponse {
+  const normalized = normalizeResponse(
+    response,
+    call.request,
+    call.index,
+    requireResponseId,
+  );
+  throwIfAborted(call.request.signal, call.index);
+  return normalized;
+}
+
+async function* streamResponse(
+  response: ModelResponse,
+  signal?: AbortSignal,
+  callIndex?: number,
+): AsyncIterable<StreamEvent> {
+  throwIfAborted(signal, callIndex);
+  yield { type: 'response_started' };
+
+  for (const item of response.output) {
+    if (
+      item.type !== 'message' ||
+      item.role !== 'assistant' ||
+      !Array.isArray(item.content)
+    ) {
+      continue;
+    }
+    for (const part of item.content) {
+      if (part.type === 'output_text') {
+        throwIfAborted(signal, callIndex);
+        yield {
+          type: 'output_text_delta',
+          itemId: item.id,
+          delta: part.text,
+          ...(typeof part.providerData === 'undefined'
+            ? {}
+            : { providerData: part.providerData }),
+        };
+      }
+    }
+  }
+
+  throwIfAborted(signal, callIndex);
+  yield {
+    type: 'response_done',
+    response: {
+      id: response.responseId!,
+      requestId: response.requestId,
+      usage: {
+        requests: response.usage.requests,
+        inputTokens: response.usage.inputTokens,
+        outputTokens: response.usage.outputTokens,
+        totalTokens: response.usage.totalTokens,
+        inputTokensDetails:
+          response.usage.inputTokensDetails.length > 0
+            ? response.usage.inputTokensDetails
+            : undefined,
+        outputTokensDetails:
+          response.usage.outputTokensDetails.length > 0
+            ? response.usage.outputTokensDetails
+            : undefined,
+        requestUsageEntries: response.usage.requestUsageEntries?.map(
+          (entry) => ({
+            inputTokens: entry.inputTokens,
+            outputTokens: entry.outputTokens,
+            totalTokens: entry.totalTokens,
+            inputTokensDetails: entry.inputTokensDetails,
+            outputTokensDetails: entry.outputTokensDetails,
+            endpoint: entry.endpoint,
+          }),
+        ),
+      },
+      rawUsage: response.rawUsage,
+      providerData: response.providerData,
+      output: response.output,
+    },
+  } as StreamEvent;
+}
+
+function throwIfAborted(signal?: AbortSignal, callIndex?: number): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw new ScriptedModelRequestAbortedError(callIndex);
+}

--- a/packages/agents-core/src/testing/scriptedSandboxSession.ts
+++ b/packages/agents-core/src/testing/scriptedSandboxSession.ts
@@ -1,0 +1,428 @@
+import { Manifest } from '../sandbox/manifest';
+import type { SandboxSession, SandboxSessionState } from '../sandbox/session';
+import { snapshotTestingValue } from '../utils/testingSnapshot';
+
+type AnyFunction = (...args: any[]) => any;
+
+export type ScriptedSandboxMethod = {
+  [TKey in keyof SandboxSession]-?: NonNullable<
+    SandboxSession[TKey]
+  > extends AnyFunction
+    ? TKey
+    : never;
+}[keyof SandboxSession];
+
+type SandboxMethodFunction<TMethod extends ScriptedSandboxMethod> = Extract<
+  NonNullable<SandboxSession[TMethod]>,
+  AnyFunction
+>;
+
+type SandboxMethodArgs<TMethod extends ScriptedSandboxMethod> = Parameters<
+  SandboxMethodFunction<TMethod>
+>;
+
+type SandboxMethodResult<TMethod extends ScriptedSandboxMethod> = Awaited<
+  ReturnType<SandboxMethodFunction<TMethod>>
+>;
+
+type ScriptedSandboxResponderResult<TMethod extends ScriptedSandboxMethod> =
+  ReturnType<SandboxMethodFunction<TMethod>> extends PromiseLike<unknown>
+    ? SandboxMethodResult<TMethod> | PromiseLike<SandboxMethodResult<TMethod>>
+    : ReturnType<SandboxMethodFunction<TMethod>>;
+
+export type RecordedSandboxCall = Readonly<{
+  /** The zero-based position of this call in `calls`. */
+  index: number;
+  /** The invoked method. New SDK versions may add method names. */
+  method: string;
+  /** Detached invocation-time arguments in parameter order. */
+  args: readonly unknown[];
+}>;
+
+export type ScriptedSandboxCallFor<TMethod extends ScriptedSandboxMethod> =
+  Readonly<{
+    index: number;
+    method: TMethod;
+    args: Readonly<SandboxMethodArgs<TMethod>>;
+  }>;
+
+type ScriptedSandboxMatcher<TMethod extends ScriptedSandboxMethod> = (
+  ...args: SandboxMethodArgs<TMethod>
+) => boolean | void;
+
+type ScriptedSandboxResponder<TMethod extends ScriptedSandboxMethod> = (
+  call: ScriptedSandboxCallFor<TMethod>,
+) => ScriptedSandboxResponderResult<TMethod>;
+
+type ScriptedSandboxStepBase<TMethod extends ScriptedSandboxMethod> = {
+  method: TMethod;
+  match?: ScriptedSandboxMatcher<TMethod>;
+};
+
+type ScriptedSandboxResultStep<TMethod extends ScriptedSandboxMethod> =
+  ScriptedSandboxStepBase<TMethod> & {
+    result: SandboxMethodResult<TMethod>;
+    respond?: never;
+    error?: never;
+  };
+
+type ScriptedSandboxResponderStep<TMethod extends ScriptedSandboxMethod> =
+  ScriptedSandboxStepBase<TMethod> & {
+    respond: ScriptedSandboxResponder<TMethod>;
+    result?: never;
+    error?: never;
+  };
+
+type ScriptedSandboxErrorStep<TMethod extends ScriptedSandboxMethod> =
+  ScriptedSandboxStepBase<TMethod> & {
+    error: unknown;
+    result?: never;
+    respond?: never;
+  };
+
+type ScriptedSandboxStep<TMethod extends ScriptedSandboxMethod> =
+  | ScriptedSandboxResultStep<TMethod>
+  | ScriptedSandboxResponderStep<TMethod>
+  | ScriptedSandboxErrorStep<TMethod>;
+
+export type ScriptedSandboxInput<
+  TMethod extends ScriptedSandboxMethod = ScriptedSandboxMethod,
+> = {
+  [TCurrentMethod in TMethod]: ScriptedSandboxStep<TCurrentMethod>;
+}[TMethod];
+
+export type ScriptedSandboxSession<
+  TMethod extends ScriptedSandboxMethod = never,
+> = SandboxSession &
+  Required<Pick<SandboxSession, TMethod>> & {
+    /** All calls recorded by this session in invocation order. */
+    readonly calls: readonly RecordedSandboxCall[];
+    /** The number of scripted steps that have not been consumed. */
+    readonly remainingSteps: number;
+    /** Throws when the script still contains unconsumed steps. */
+    assertComplete(): void;
+  };
+
+export type InvalidScriptedSandboxStepReason =
+  'invalid_input' | 'unknown_method' | 'invalid_matcher' | 'invalid_outcome';
+
+export class InvalidScriptedSandboxStepError extends Error {
+  readonly reason: InvalidScriptedSandboxStepReason;
+  /** The zero-based position of the invalid factory input. */
+  readonly inputIndex: number;
+  readonly method?: string;
+
+  constructor(options: {
+    reason: InvalidScriptedSandboxStepReason;
+    inputIndex: number;
+    message: string;
+    method?: string;
+  }) {
+    super(options.message);
+    this.name = 'InvalidScriptedSandboxStepError';
+    this.reason = options.reason;
+    this.inputIndex = options.inputIndex;
+    this.method = options.method;
+  }
+}
+
+export class UnexpectedSandboxCallError extends Error {
+  /** The zero-based position of the call in `calls`. */
+  readonly callIndex: number;
+  readonly actualMethod: string;
+  readonly expectedMethod?: string;
+  readonly remainingSteps: number;
+
+  constructor(options: {
+    callIndex: number;
+    actualMethod: string;
+    expectedMethod?: string;
+    remainingSteps: number;
+  }) {
+    const expectation = options.expectedMethod
+      ? `; expected ${options.expectedMethod}`
+      : '; no scripted steps remain';
+    super(
+      `Scripted sandbox session received unexpected ${options.actualMethod} call #${displayIndex(options.callIndex)}${expectation}.`,
+    );
+    this.name = 'UnexpectedSandboxCallError';
+    this.callIndex = options.callIndex;
+    this.actualMethod = options.actualMethod;
+    this.expectedMethod = options.expectedMethod;
+    this.remainingSteps = options.remainingSteps;
+  }
+}
+
+export class SandboxCallMatcherError extends Error {
+  /** The zero-based position of the call in `calls`. */
+  readonly callIndex: number;
+  readonly method: string;
+
+  constructor(call: RecordedSandboxCall) {
+    super(
+      `Scripted sandbox session matcher rejected ${call.method} call #${displayIndex(call.index)}.`,
+    );
+    this.name = 'SandboxCallMatcherError';
+    this.callIndex = call.index;
+    this.method = call.method;
+  }
+}
+
+export class UnconsumedSandboxStepsError extends Error {
+  readonly remainingSteps: number;
+  readonly pendingMethods: readonly string[];
+
+  constructor(pendingMethods: readonly string[]) {
+    super(
+      `Scripted sandbox session has ${pendingMethods.length} unconsumed step${pendingMethods.length === 1 ? '' : 's'}: ${pendingMethods.join(', ')}.`,
+    );
+    this.name = 'UnconsumedSandboxStepsError';
+    this.remainingSteps = pendingMethods.length;
+    this.pendingMethods = Object.freeze([...pendingMethods]);
+  }
+}
+
+type NormalizedScriptedSandboxStep = {
+  method: ScriptedSandboxMethod;
+  match?: (...args: any[]) => boolean | void;
+} & (
+  | { type: 'result'; result: unknown }
+  | { type: 'responder'; respond: (call: RecordedSandboxCall) => unknown }
+  | { type: 'error'; error: unknown }
+);
+
+type InternalRecordedSandboxCall = Readonly<{
+  index: number;
+  method: ScriptedSandboxMethod;
+  args: readonly unknown[];
+}>;
+
+const sandboxMethodModes = {
+  start: 'async',
+  running: 'async',
+  registerPreStopHook: 'sync',
+  runPreStopHooks: 'async',
+  preStop: 'async',
+  stop: 'async',
+  shutdown: 'async',
+  delete: 'async',
+  createEditor: 'sync',
+  exec: 'async',
+  execCommand: 'async',
+  writeStdin: 'async',
+  viewImage: 'async',
+  readFile: 'async',
+  listDir: 'async',
+  pathExists: 'async',
+  materializeEntry: 'async',
+  applyManifest: 'async',
+  persistWorkspace: 'async',
+  hydrateWorkspace: 'async',
+  setArchiveLimits: 'sync',
+  resolveExposedPort: 'async',
+  supportsPty: 'sync',
+  close: 'async',
+} as const satisfies Record<ScriptedSandboxMethod, 'async' | 'sync'>;
+
+/**
+ * Creates a deterministic sandbox session with only the scripted optional
+ * methods installed on the returned object.
+ */
+export function scriptedSandboxSession<
+  const TInputs extends readonly ScriptedSandboxInput[],
+>(inputs: TInputs): ScriptedSandboxSession<TInputs[number]['method']>;
+export function scriptedSandboxSession<TMethod extends ScriptedSandboxMethod>(
+  inputs: Iterable<ScriptedSandboxInput<TMethod>>,
+): ScriptedSandboxSession<TMethod>;
+export function scriptedSandboxSession(): ScriptedSandboxSession<never>;
+export function scriptedSandboxSession(
+  inputs: Iterable<ScriptedSandboxInput> = [],
+): ScriptedSandboxSession<ScriptedSandboxMethod> {
+  const steps = Array.from(inputs, (input, index) =>
+    normalizeInput(input, index),
+  );
+  const calls: InternalRecordedSandboxCall[] = [];
+  const configuredMethods = new Set(steps.map((step) => step.method));
+  const state: SandboxSessionState = { manifest: new Manifest() };
+  const session = { state } as SandboxSession &
+    Partial<Record<ScriptedSandboxMethod, AnyFunction>> & {
+      calls: readonly RecordedSandboxCall[];
+      remainingSteps: number;
+      assertComplete(): void;
+    };
+
+  const invoke = (method: ScriptedSandboxMethod, args: unknown[]): unknown => {
+    const call: InternalRecordedSandboxCall = Object.freeze({
+      index: calls.length,
+      method,
+      args: Object.freeze(snapshotTestingValue(args)),
+    });
+    calls.push(call);
+
+    const step = steps.shift();
+    if (!step || step.method !== method) {
+      throw new UnexpectedSandboxCallError({
+        callIndex: call.index,
+        actualMethod: method,
+        expectedMethod: step?.method,
+        remainingSteps: steps.length,
+      });
+    }
+
+    if (step.match) {
+      const matchArgs = snapshotTestingValue(call.args) as unknown[];
+      if (step.match(...matchArgs) === false) {
+        throw new SandboxCallMatcherError(call);
+      }
+    }
+
+    if (step.type === 'error') {
+      throw step.error;
+    }
+    if (step.type === 'responder') {
+      return step.respond(snapshotRecordedCall(call));
+    }
+    return step.result;
+  };
+
+  for (const method of configuredMethods) {
+    const scriptedMethod = (...args: unknown[]) => {
+      if (sandboxMethodModes[method] === 'sync') {
+        return invoke(method, args);
+      }
+      try {
+        return Promise.resolve(invoke(method, args));
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    };
+    Object.defineProperty(session, method, {
+      configurable: false,
+      enumerable: true,
+      value: scriptedMethod,
+      writable: true,
+    });
+  }
+
+  Object.defineProperties(session, {
+    calls: {
+      configurable: false,
+      enumerable: true,
+      get: () => Object.freeze(calls.map(snapshotRecordedCall)),
+    },
+    remainingSteps: {
+      configurable: false,
+      enumerable: true,
+      get: () => steps.length,
+    },
+    assertComplete: {
+      configurable: false,
+      enumerable: true,
+      value: () => {
+        if (steps.length > 0) {
+          throw new UnconsumedSandboxStepsError(
+            steps.map((step) => step.method),
+          );
+        }
+      },
+      writable: false,
+    },
+  });
+
+  return session as ScriptedSandboxSession<ScriptedSandboxMethod>;
+}
+
+function normalizeInput(
+  input: unknown,
+  inputIndex: number,
+): NormalizedScriptedSandboxStep {
+  if (!isRecord(input)) {
+    throw new InvalidScriptedSandboxStepError({
+      reason: 'invalid_input',
+      inputIndex,
+      message: `Scripted sandbox step #${displayIndex(inputIndex)} must be an object.`,
+    });
+  }
+
+  const method = input.method;
+  if (
+    typeof method !== 'string' ||
+    !Object.prototype.hasOwnProperty.call(sandboxMethodModes, method)
+  ) {
+    throw new InvalidScriptedSandboxStepError({
+      reason: 'unknown_method',
+      inputIndex,
+      method: typeof method === 'string' ? method : undefined,
+      message: `Scripted sandbox step #${displayIndex(inputIndex)} has an unknown method.`,
+    });
+  }
+
+  if (typeof input.match !== 'undefined' && typeof input.match !== 'function') {
+    throw new InvalidScriptedSandboxStepError({
+      reason: 'invalid_matcher',
+      inputIndex,
+      method,
+      message: `Scripted sandbox step #${displayIndex(inputIndex)} for ${method} must use a function matcher.`,
+    });
+  }
+
+  const hasResult = Object.prototype.hasOwnProperty.call(input, 'result');
+  const hasResponder = Object.prototype.hasOwnProperty.call(input, 'respond');
+  const hasError = Object.prototype.hasOwnProperty.call(input, 'error');
+  if (Number(hasResult) + Number(hasResponder) + Number(hasError) !== 1) {
+    throw new InvalidScriptedSandboxStepError({
+      reason: 'invalid_outcome',
+      inputIndex,
+      method,
+      message: `Scripted sandbox step #${displayIndex(inputIndex)} for ${method} must define exactly one of result, respond, or error.`,
+    });
+  }
+
+  const base = {
+    method: method as ScriptedSandboxMethod,
+    ...(typeof input.match === 'function'
+      ? { match: input.match as (...args: any[]) => boolean | void }
+      : {}),
+  };
+  if (hasResponder) {
+    if (typeof input.respond !== 'function') {
+      throw new InvalidScriptedSandboxStepError({
+        reason: 'invalid_outcome',
+        inputIndex,
+        method,
+        message: `Scripted sandbox step #${displayIndex(inputIndex)} for ${method} must use a function responder.`,
+      });
+    }
+    return {
+      ...base,
+      type: 'responder',
+      respond: input.respond as (call: RecordedSandboxCall) => unknown,
+    };
+  }
+  if (hasError) {
+    return { ...base, type: 'error', error: input.error };
+  }
+  return {
+    ...base,
+    type: 'result',
+    result: snapshotTestingValue(input.result),
+  };
+}
+
+function displayIndex(index: number): number {
+  return index + 1;
+}
+
+function snapshotRecordedCall(
+  call: InternalRecordedSandboxCall,
+): RecordedSandboxCall {
+  return Object.freeze({
+    index: call.index,
+    method: call.method,
+    args: Object.freeze(snapshotTestingValue(call.args)),
+  });
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -6,6 +6,7 @@ export {
 } from '../runner/items';
 export { normalizeToolAllowedCallers } from './toolCallers';
 export { snapshotRawUsage } from './rawUsage';
+export { snapshotTestingValue } from './testingSnapshot';
 export {
   hasDynamicFunctionToolApprovalPolicy,
   hasInspectableFunctionToolArguments,

--- a/packages/agents-core/src/utils/testingSnapshot.ts
+++ b/packages/agents-core/src/utils/testingSnapshot.ts
@@ -1,0 +1,103 @@
+const objectConstructorSource = Function.prototype.toString.call(Object);
+
+function isPlainObject(value: object): boolean {
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype === null) {
+    return true;
+  }
+
+  const constructor = Object.prototype.hasOwnProperty.call(
+    prototype,
+    'constructor',
+  )
+    ? (prototype as { constructor?: unknown }).constructor
+    : undefined;
+  return (
+    typeof constructor === 'function' &&
+    Function.prototype.toString.call(constructor) === objectConstructorSource
+  );
+}
+
+function isCloneableBuffer(value: object): value is ArrayBuffer {
+  const tag = Object.prototype.toString.call(value);
+  return tag === '[object ArrayBuffer]' || tag === '[object SharedArrayBuffer]';
+}
+
+/**
+ * Copies mutable data containers used by public testing call records while
+ * preserving runtime identities such as signals, callbacks, and class
+ * instances. Cycles and shared references are preserved within the snapshot.
+ *
+ */
+export function snapshotTestingValue<T>(
+  value: T,
+  seen: WeakMap<object, unknown> = new WeakMap(),
+): T {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const existing = seen.get(value);
+  if (typeof existing !== 'undefined') {
+    return existing as T;
+  }
+
+  if (isCloneableBuffer(value)) {
+    const snapshot = value.slice(0);
+    seen.set(value, snapshot);
+    return snapshot as T;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    const buffer = snapshotTestingValue(value.buffer, seen);
+    let snapshot: ArrayBufferView;
+    if (Object.prototype.toString.call(value) === '[object DataView]') {
+      snapshot = new DataView(buffer, value.byteOffset, value.byteLength);
+    } else {
+      const TypedArray = value.constructor as new (
+        buffer: ArrayBufferLike,
+        byteOffset: number,
+        length: number,
+      ) => ArrayBufferView;
+      const length = (value as unknown as { length: number }).length;
+      snapshot = new TypedArray(buffer, value.byteOffset, length);
+    }
+    seen.set(value, snapshot);
+    return snapshot as T;
+  }
+
+  if (Array.isArray(value)) {
+    const snapshot: unknown[] = [];
+    seen.set(value, snapshot);
+    for (const entry of value) {
+      snapshot.push(snapshotTestingValue(entry, seen));
+    }
+    return snapshot as T;
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const snapshot = Object.create(Object.getPrototypeOf(value)) as Record<
+    PropertyKey,
+    unknown
+  >;
+  seen.set(value, snapshot);
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor?.enumerable) {
+      continue;
+    }
+    Object.defineProperty(snapshot, key, {
+      configurable: true,
+      enumerable: true,
+      value: snapshotTestingValue(
+        (value as Record<PropertyKey, unknown>)[key],
+        seen,
+      ),
+      writable: true,
+    });
+  }
+  return snapshot as T;
+}

--- a/packages/agents-core/test/agent.test.ts
+++ b/packages/agents-core/test/agent.test.ts
@@ -7,14 +7,14 @@ import { z } from 'zod';
 import { JsonSchemaDefinition, setDefaultModelProvider } from '../src';
 import type { AgentInputItem } from '../src/types';
 import {
-  FakeModel,
-  FakeModelProvider,
+  ScriptedModelProvider,
   TEST_MODEL_RESPONSE_BASIC,
   TEST_MODEL_RESPONSE_WITH_FUNCTION,
 } from './stubs';
 import { Runner, RunConfig } from '../src/run';
 import { RunState } from '../src/runState';
 import logger from '../src/logger';
+import { ScriptedModel, modelResponse } from '../src/testing';
 
 describe('Agent', () => {
   afterEach(() => {
@@ -696,7 +696,7 @@ describe('Agent', () => {
     expect(result1).toBe(
       'An error occurred while running the tool. Please try again. Error: InvalidToolInputError: Invalid JSON input for tool',
     );
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
     const result2 = await tool.invoke(
       {} as any,
       JSON.stringify({ input: 'hey how are you?' }),
@@ -1065,7 +1065,7 @@ describe('Agent', () => {
       toolDescription: 'You act as a tool.',
       customOutputExtractor: () => 'ok',
     });
-    const inheritedProvider = new FakeModelProvider();
+    const inheritedProvider = new ScriptedModelProvider();
     const parentInputGuardrail = {
       name: 'parent-input',
       execute: vi.fn().mockResolvedValue({
@@ -1127,7 +1127,7 @@ describe('Agent', () => {
       customOutputExtractor: () => 'ok',
     });
     const parentRunner = new Runner({
-      modelProvider: new FakeModelProvider(),
+      modelProvider: new ScriptedModelProvider(),
       modelSettings: {
         temperature: 0.2,
         toolChoice: 'required',
@@ -1164,7 +1164,7 @@ describe('Agent', () => {
     const runSpy = vi
       .spyOn(Runner.prototype, 'run')
       .mockResolvedValue({ rawResponses: [] } as any);
-    const childProvider = new FakeModelProvider();
+    const childProvider = new ScriptedModelProvider();
     const tool = agent.asTool({
       toolDescription: 'You act as a tool.',
       customOutputExtractor: () => 'ok',
@@ -1172,7 +1172,7 @@ describe('Agent', () => {
         modelProvider: childProvider,
       },
     });
-    const parentProvider = new FakeModelProvider();
+    const parentProvider = new ScriptedModelProvider();
     const parentRunner = new Runner({
       modelProvider: parentProvider,
       model: 'parent-model',
@@ -1212,7 +1212,7 @@ describe('Agent', () => {
       },
     });
     const parentRunner = new Runner({
-      modelProvider: new FakeModelProvider(),
+      modelProvider: new ScriptedModelProvider(),
       modelSettings: {
         reasoning: { effort: 'medium' },
         providerData: { tenant: 'acme' },
@@ -1254,7 +1254,7 @@ describe('Agent', () => {
       },
     });
     const parentRunner = new Runner({
-      modelProvider: new FakeModelProvider(),
+      modelProvider: new ScriptedModelProvider(),
       modelSettings: {
         reasoning: { effort: 'medium', summary: 'auto' },
         text: { verbosity: 'medium' },
@@ -1298,7 +1298,7 @@ describe('Agent', () => {
       },
     });
     const parentRunner = new Runner({
-      modelProvider: new FakeModelProvider(),
+      modelProvider: new ScriptedModelProvider(),
       modelSettings: {
         providerData: {
           extra_query: { tenant: 'acme' },
@@ -1349,7 +1349,7 @@ describe('Agent', () => {
       },
     });
     const parentRunner = new Runner({
-      modelProvider: new FakeModelProvider(),
+      modelProvider: new ScriptedModelProvider(),
       modelSettings: {
         providerData: {
           extra_headers: { 'X-Parent': '1', 'X-Shared': 'parent' },
@@ -1408,7 +1408,7 @@ describe('Agent', () => {
       },
     });
     const parentRunner = new Runner({
-      modelProvider: new FakeModelProvider(),
+      modelProvider: new ScriptedModelProvider(),
       modelSettings: {
         providerData: {
           extraQuery: { parentTenant: 'acme' },
@@ -1772,7 +1772,7 @@ describe('Agent', () => {
     const agent = new Agent({
       name: 'MaxTurnsTool',
       instructions: 'Short runs.',
-      model: new FakeModel([TEST_MODEL_RESPONSE_BASIC]),
+      model: new ScriptedModel([modelResponse(TEST_MODEL_RESPONSE_BASIC)]),
     });
     const tool = agent.asTool({
       toolDescription: 'desc',
@@ -1802,9 +1802,9 @@ describe('Agent', () => {
     const agent = new Agent({
       name: 'MaxTurnsToolAfterResponse',
       instructions: 'Short runs.',
-      model: new FakeModel([
-        TEST_MODEL_RESPONSE_WITH_FUNCTION,
-        TEST_MODEL_RESPONSE_BASIC,
+      model: new ScriptedModel([
+        modelResponse(TEST_MODEL_RESPONSE_WITH_FUNCTION),
+        modelResponse(TEST_MODEL_RESPONSE_BASIC),
       ]),
       tools: [testTool],
       toolUseBehavior: 'run_llm_again',
@@ -1850,7 +1850,7 @@ describe('Agent', () => {
   });
 
   it('returns the full concatenated assistant text from nested agent tools', async () => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
     const agent = new Agent({
       name: 'Segmented Streamer',
       instructions: 'Return segmented output.',
@@ -1886,7 +1886,7 @@ describe('Agent', () => {
   });
 
   it('returns the full concatenated structured output text from nested agent tools', async () => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
     const agent = new Agent({
       name: 'Structured Streamer',
       instructions: 'Return segmented structured output.',

--- a/packages/agents-core/test/agentScenarios.test.ts
+++ b/packages/agents-core/test/agentScenarios.test.ts
@@ -46,176 +46,43 @@ import { user } from '../src/helpers/message';
 import * as protocol from '../src/types/protocol';
 import logger from '../src/logger';
 import { getFunctionToolStateKey } from '../src/toolIdentity';
+import {
+  ScriptedModel,
+  modelError,
+  type ScriptedModelInput,
+} from '../src/testing';
 
 /**
- * Fake model for scenario-style tests. It queues per-turn outputs (or errors),
- * records the request args, and can emit streaming events including text deltas
- * and a final response_done event.
+ * Compatibility wrapper for the scenario tests' existing queue helpers.
  */
-class RecordingModel implements Model {
-  #turnOutputs: Array<ModelResponse | ModelResponse['output'] | Error> = [];
-  #hardcodedUsage: Usage | undefined;
-  public lastTurnArgs: Partial<ModelRequest> | undefined;
-  public firstTurnArgs: Partial<ModelRequest> | undefined;
-  public calls: Partial<ModelRequest>[] = [];
-  #responseCounter = 0;
-
+class RecordingModel extends ScriptedModel {
   constructor(initial?: ModelResponse | ModelResponse['output'] | Error) {
-    if (initial) {
-      this.#turnOutputs.push(initial);
-    }
+    super(typeof initial === 'undefined' ? [] : [toScriptedInput(initial)]);
   }
 
-  setHardcodedUsage(usage: Usage) {
-    this.#hardcodedUsage = usage;
+  get lastTurnArgs(): Readonly<ModelRequest> | undefined {
+    return this.lastCall?.request;
+  }
+
+  get firstTurnArgs(): Readonly<ModelRequest> | undefined {
+    return this.firstCall?.request;
   }
 
   setNextOutput(output: ModelResponse | ModelResponse['output'] | Error) {
-    this.#turnOutputs.push(output);
+    this.enqueue(toScriptedInput(output));
   }
 
   addMultipleTurnOutputs(
     outputs: Array<ModelResponse | ModelResponse['output'] | Error>,
   ) {
-    this.#turnOutputs.push(...outputs);
-  }
-
-  #getNextOutput(): ModelResponse | ModelResponse['output'] | Error {
-    if (this.#turnOutputs.length === 0) {
-      throw new Error('No queued output');
-    }
-    return this.#turnOutputs.shift() as
-      ModelResponse | ModelResponse['output'] | Error;
-  }
-
-  #recordArgs(request: ModelRequest) {
-    const recordedArgs: Partial<ModelRequest> = {
-      systemInstructions: request.systemInstructions,
-      input: request.input,
-      modelSettings: request.modelSettings,
-      tools: request.tools,
-      outputType: request.outputType,
-      handoffs: request.handoffs,
-      previousResponseId: request.previousResponseId,
-      conversationId: request.conversationId,
-      prompt: request.prompt,
-      overridePromptModel: request.overridePromptModel,
-    };
-    this.lastTurnArgs = recordedArgs;
-    this.calls.push(recordedArgs);
-    if (!this.firstTurnArgs) {
-      this.firstTurnArgs = this.lastTurnArgs;
-    }
-  }
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.#recordArgs(request);
-    const output = this.#getNextOutput();
-    if (output instanceof Error) {
-      throw output;
-    }
-    const { normalizedOutput, usage, responseId } = normalizeTurnOutput(
-      output,
-      this.#hardcodedUsage,
-    );
-    const finalResponseId = responseId ?? `resp-${++this.#responseCounter}`;
-    if (responseId) {
-      this.#responseCounter += 1;
-    }
-    return { output: normalizedOutput, usage, responseId: finalResponseId };
-  }
-
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<protocol.StreamEvent> {
-    this.#recordArgs(request);
-    const output = this.#getNextOutput();
-    if (output instanceof Error) {
-      throw output;
-    }
-    const { normalizedOutput, usage, responseId } = normalizeTurnOutput(
-      output,
-      this.#hardcodedUsage,
-    );
-    const finalResponseId =
-      responseId ?? `resp-stream-${++this.#responseCounter}`;
-    if (responseId) {
-      this.#responseCounter += 1;
-    }
-
-    const signal = request.signal;
-
-    const throwIfAborted = () => {
-      if (signal?.aborted) {
-        const err = new Error('Aborted');
-        err.name = 'AbortError';
-        throw err;
-      }
-    };
-
-    throwIfAborted();
-
-    yield* streamFromOutput(normalizedOutput, throwIfAborted);
-
-    throwIfAborted();
-
-    yield {
-      type: 'response_done',
-      response: {
-        id: finalResponseId,
-        usage: {
-          requests: usage.requests,
-          inputTokens: usage.inputTokens,
-          outputTokens: usage.outputTokens,
-          totalTokens: usage.totalTokens,
-          inputTokensDetails: usage.inputTokensDetails,
-          outputTokensDetails: usage.outputTokensDetails,
-        },
-        output: normalizedOutput,
-      },
-    } as protocol.StreamEvent;
+    this.enqueue(...outputs.map(toScriptedInput));
   }
 }
 
-function normalizeTurnOutput(
-  turn: ModelResponse | ModelResponse['output'],
-  hardcodedUsage: Usage | undefined,
-): {
-  normalizedOutput: ModelResponse['output'];
-  usage: Usage;
-  responseId?: string;
-} {
-  const responseLike = turn as Partial<ModelResponse>;
-  const normalizedOutput = (responseLike.output ??
-    turn) as ModelResponse['output'];
-  const usage =
-    hardcodedUsage !== undefined
-      ? new Usage(hardcodedUsage)
-      : responseLike.usage
-        ? new Usage(responseLike.usage)
-        : new Usage();
-  return { normalizedOutput, usage, responseId: responseLike.responseId };
-}
-
-async function* streamFromOutput(
-  output: ModelResponse['output'],
-  throwIfAborted: () => void,
-): AsyncIterable<protocol.StreamEvent> {
-  for (const item of output) {
-    throwIfAborted();
-    if (item.type !== 'message') {
-      continue;
-    }
-    const content = Array.isArray(item.content) ? item.content : [];
-    for (const part of content) {
-      if (part.type === 'output_text') {
-        yield {
-          type: 'output_text_delta',
-          delta: part.text,
-        } as protocol.StreamEvent;
-      }
-    }
-  }
+function toScriptedInput(
+  output: ModelResponse | ModelResponse['output'] | Error,
+): ScriptedModelInput {
+  return output instanceof Error ? modelError(output) : output;
 }
 
 /**
@@ -1374,7 +1241,7 @@ describe('Agent scenarios (examples and docs patterns)', () => {
     const second = await run(agent, 'Follow up', { session });
     expect(second.finalOutput).toBe('Second reply');
 
-    const secondInput = model.calls[1]?.input;
+    const secondInput = model.calls[1]?.request.input;
     expect(Array.isArray(secondInput)).toBe(true);
     if (Array.isArray(secondInput)) {
       const assistantMessages = secondInput.filter(
@@ -1433,15 +1300,15 @@ describe('Agent scenarios (examples and docs patterns)', () => {
       previousResponseId: 'seed-resp',
     });
     expect(first.finalOutput).toBe('First turn');
-    expect(model.calls[0]?.previousResponseId).toBe('seed-resp');
+    expect(model.calls[0]?.request.previousResponseId).toBe('seed-resp');
 
     const followUp = await run(agent, 'Follow up', {
       previousResponseId: first.rawResponses[0]?.responseId,
     });
     expect(followUp.finalOutput).toBe('Second turn');
-    expect(model.calls[1]?.previousResponseId).toBe('resp-100');
+    expect(model.calls[1]?.request.previousResponseId).toBe('resp-100');
 
-    const secondInput = model.calls[1]?.input;
+    const secondInput = model.calls[1]?.request.input;
     expect(Array.isArray(secondInput)).toBe(true);
     if (Array.isArray(secondInput)) {
       expect(secondInput.length).toBe(1);
@@ -1578,7 +1445,7 @@ describe('Agent scenarios (examples and docs patterns)', () => {
     expect(translationModel.calls.length).toBe(3);
     expect(
       translationModel.calls.every(
-        (call) => extractUserText(call.input) === 'Hello',
+        (call) => extractUserText(call.request.input) === 'Hello',
       ),
     ).toBe(true);
     expect(pickerResult.finalOutput).toBe('Pick: Dos');
@@ -2275,7 +2142,7 @@ describe('Agent scenarios (examples and docs patterns)', () => {
     expect(executed).toHaveLength(1);
     expect(executed[0].commands).toEqual(['echo hi']);
 
-    const secondInput = model.calls[1]?.input;
+    const secondInput = model.calls[1]?.request.input;
     expect(Array.isArray(secondInput)).toBe(true);
     if (Array.isArray(secondInput)) {
       const shellOutputs = secondInput.filter(
@@ -2327,7 +2194,7 @@ describe('Agent scenarios (examples and docs patterns)', () => {
     expect(result.finalOutput).toBe('patched');
     expect(operations).toHaveLength(1);
 
-    const secondInput = model.calls[1]?.input;
+    const secondInput = model.calls[1]?.request.input;
     expect(Array.isArray(secondInput)).toBe(true);
     if (Array.isArray(secondInput)) {
       const patchOutputs = secondInput.filter(

--- a/packages/agents-core/test/finalOutputRedaction.test.ts
+++ b/packages/agents-core/test/finalOutputRedaction.test.ts
@@ -10,7 +10,6 @@ import {
   setTracingDisabled,
   type AgentInputItem,
   type Model,
-  type ModelRequest,
   type ModelResponse,
   type ReasoningItem,
   type Session,
@@ -24,11 +23,11 @@ import { runOutputGuardrails } from '../src/runner/guardrails';
 import { RunState } from '../src/runState';
 import { Usage } from '../src/usage';
 import {
-  FakeModel,
-  FakeModelProvider,
+  ScriptedModelProvider,
   fakeModelMessage,
   fakeModelRefusal,
 } from './stubs';
+import { ScriptedModel, modelResponse, modelStream } from '../src/testing';
 
 const MODEL_OUTPUT_SECRET = 'SECRET_STRUCTURED_FINAL_OUTPUT_4207';
 const MISSING_OUTPUT_SECRET = 'SECRET_MISSING_STRUCTURED_OUTPUT_4208';
@@ -68,24 +67,20 @@ function responseWithMissingOutput(): ModelResponse {
   };
 }
 
-class StreamingModel implements Model {
-  constructor(private readonly response: ModelResponse) {}
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    throw new Error('Use getStreamedResponse for this model.');
-  }
-
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    yield {
-      type: 'response_done',
-      response: {
-        id: 'redacted-final-output-response',
-        output: this.response.output,
-        usage: this.response.usage,
-      },
-    } as StreamEvent;
+class StreamingModel extends ScriptedModel {
+  constructor(response: ModelResponse) {
+    super([
+      modelStream([
+        {
+          type: 'response_done',
+          response: {
+            id: 'redacted-final-output-response',
+            output: response.output,
+            usage: response.usage,
+          },
+        } as StreamEvent,
+      ]),
+    ]);
   }
 }
 
@@ -141,7 +136,9 @@ function createRejectingSession(secret: string): Session {
 async function captureRunError(stream: boolean): Promise<unknown> {
   const response = responseWithInvalidOutput();
   const agent = createAgent(
-    stream ? new StreamingModel(response) : new FakeModel([response]),
+    stream
+      ? new StreamingModel(response)
+      : new ScriptedModel([modelResponse(response)]),
   );
 
   try {
@@ -168,7 +165,9 @@ async function captureOverriddenParserRunError(
   };
   const agent = overrideFinalOutputParser(
     createAgent(
-      stream ? new StreamingModel(response) : new FakeModel([response]),
+      stream
+        ? new StreamingModel(response)
+        : new ScriptedModel([modelResponse(response)]),
     ),
   );
 
@@ -194,7 +193,7 @@ async function captureOverriddenParserRunErrorWithAgent(
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 afterEach(() => {
@@ -255,7 +254,7 @@ describe('structured final-output redaction', () => {
         outputType: z.object({ summary: z.string() }),
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       const errorHandlers =
         kind === 'max-turn'
@@ -364,7 +363,7 @@ describe('structured final-output redaction', () => {
       };
       const agent = new Agent({
         name: `${kind} text override agent`,
-        model: new FakeModel([response]),
+        model: new ScriptedModel([modelResponse(response)]),
       }) as Agent<unknown, any>;
       agent.processFinalOutput = (): never => {
         throw new Error(TEXT_OVERRIDE_SECRET);
@@ -433,7 +432,9 @@ describe('structured final-output redaction', () => {
       );
       const response = responseWithInvalidOutput();
       const agent = createAgent(
-        stream ? new StreamingModel(response) : new FakeModel([response]),
+        stream
+          ? new StreamingModel(response)
+          : new ScriptedModel([modelResponse(response)]),
       );
       agent.processFinalOutput = (): never => {
         throw hostileError;
@@ -479,7 +480,7 @@ describe('structured final-output redaction', () => {
         () => dontLogModelData,
       );
       const response = responseWithInvalidOutput();
-      const agent = createAgent(new FakeModel([response]));
+      const agent = createAgent(new ScriptedModel([modelResponse(response)]));
 
       let error: unknown;
       try {
@@ -515,7 +516,9 @@ describe('structured final-output redaction', () => {
         usage: new Usage(),
       };
       const agent = createAgent(
-        stream ? new StreamingModel(response) : new FakeModel([response]),
+        stream
+          ? new StreamingModel(response)
+          : new ScriptedModel([modelResponse(response)]),
       );
       let parserCalls = 0;
       agent.processFinalOutput = (output: string) => {
@@ -630,7 +633,9 @@ describe('structured final-output redaction', () => {
         usage: new Usage(),
       };
       const agent = createAgent(
-        stream ? new StreamingModel(response) : new FakeModel([response]),
+        stream
+          ? new StreamingModel(response)
+          : new ScriptedModel([modelResponse(response)]),
       );
       agent.processFinalOutput = (output: string): never => {
         dontLogModelData = false;
@@ -663,7 +668,9 @@ describe('structured final-output redaction', () => {
         usage: new Usage(),
       };
       const agent = createAgent(
-        stream ? new StreamingModel(response) : new FakeModel([response]),
+        stream
+          ? new StreamingModel(response)
+          : new ScriptedModel([modelResponse(response)]),
       );
       agent.processFinalOutput = (output: string): never => {
         dontLogModelData = false;
@@ -758,7 +765,7 @@ describe('structured final-output redaction', () => {
     vi.spyOn(logger, 'dontLogModelData', 'get').mockReturnValue(true);
     const retainedErrors: ModelBehaviorError[] = [];
     const response = responseWithInvalidOutput();
-    const agent = createAgent(new FakeModel([response]));
+    const agent = createAgent(new ScriptedModel([modelResponse(response)]));
 
     const result = await new Runner().run(agent, 'go', {
       errorHandlers: {
@@ -787,7 +794,7 @@ describe('structured final-output redaction', () => {
         dontLogModelData,
       );
       const response = responseWithInvalidOutput();
-      const agent = createAgent(new FakeModel([response]));
+      const agent = createAgent(new ScriptedModel([modelResponse(response)]));
 
       let error: unknown;
       try {
@@ -828,7 +835,9 @@ describe('structured final-output redaction', () => {
       const debugSpy = vi.spyOn(logger, 'debug').mockImplementation(() => {});
       const response = responseWithMissingOutput();
       const agent = createAgent(
-        stream ? new StreamingModel(response) : new FakeModel([response]),
+        stream
+          ? new StreamingModel(response)
+          : new ScriptedModel([modelResponse(response)]),
       );
 
       let error: unknown;

--- a/packages/agents-core/test/handoffs.test.ts
+++ b/packages/agents-core/test/handoffs.test.ts
@@ -6,14 +6,14 @@ import {
   setTracingDisabled,
 } from '../src/index';
 import { z } from 'zod';
-import { FakeModelProvider } from './stubs';
+import { ScriptedModelProvider } from './stubs';
 import { getTransferMessage, handoff } from '../src/handoff';
 import { RunContext } from '../src/runContext';
 
 describe('Agent + handoffs', () => {
   beforeAll(() => {
     setTracingDisabled(true);
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
 
   it('should resolve its valid finalOuptut type', async () => {
@@ -43,7 +43,7 @@ describe('Agent + handoffs', () => {
       }),
       handoffs: [agentC],
     });
-    // Note that FakeModel requires "text" output type
+    // The default scripted model returns text output.
     const agentE = Agent.create({
       name: 'Agent E',
       handoffs: [agentD],

--- a/packages/agents-core/test/hitlMemorySessionScenario.test.ts
+++ b/packages/agents-core/test/hitlMemorySessionScenario.test.ts
@@ -5,17 +5,15 @@ import {
   Agent,
   type AgentInputItem,
   MemorySession,
-  type Model,
   type ModelRequest,
-  type ModelResponse,
-  type ResponseStreamEvent,
   Usage,
   protocol,
   run,
   setDefaultModelProvider,
   tool,
 } from '../src';
-import { FakeModelProvider } from './stubs';
+import { ScriptedModelProvider } from './stubs';
+import { ScriptedModel, modelResponder } from '../src/testing';
 
 const TOOL_ECHO = 'approved_echo';
 const TOOL_NOTE = 'approved_note';
@@ -60,50 +58,43 @@ type ScenarioStep = {
   expectedOutput: string;
 };
 
-class ScenarioModel implements Model {
-  #counter = 0;
+function createScenarioModel(): ScriptedModel {
+  return new ScriptedModel(
+    USER_MESSAGES.map(() =>
+      modelResponder((call) => {
+        const request = call.request;
+        const toolName =
+          typeof request.modelSettings.toolChoice === 'string'
+            ? request.modelSettings.toolChoice
+            : TOOL_ECHO;
+        const callId = `call_${call.index}`;
+        const query = extractUserMessage(request.input);
+        const toolCall: protocol.FunctionCallItem = {
+          id: `fc_${callId}`,
+          type: 'function_call',
+          name: toolName,
+          callId,
+          status: 'completed',
+          arguments: JSON.stringify({ query }),
+          providerData: {},
+        };
 
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    const toolName =
-      typeof request.modelSettings.toolChoice === 'string'
-        ? request.modelSettings.toolChoice
-        : TOOL_ECHO;
-    const callId = `call_${(this.#counter += 1)}`;
-    const query = extractUserMessage(request.input);
-    const toolCall: protocol.FunctionCallItem = {
-      id: `fc_${callId}`,
-      type: 'function_call',
-      name: toolName,
-      callId,
-      status: 'completed',
-      arguments: JSON.stringify({ query }),
-      providerData: {},
-    };
-
-    return {
-      usage: new Usage(),
-      output: [toolCall],
-    };
-  }
-
-  // eslint-disable-next-line require-yield -- this scenario does not stream.
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<ResponseStreamEvent> {
-    throw new Error('Streaming is not supported in this scenario.');
-  }
+        return { usage: new Usage(), output: [toolCall] };
+      }),
+    ),
+  );
 }
 
 describe('MemorySession HITL scenario', () => {
   beforeAll(() => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
 
   it('persists approvals, rehydration, and rejections across tools', async () => {
     executeCounts.clear();
     const session = new MemorySession();
     const sessionId = await session.getSessionId();
-    const model = new ScenarioModel();
+    const model = createScenarioModel();
 
     const steps: ScenarioStep[] = [
       {
@@ -155,7 +146,7 @@ describe('MemorySession HITL scenario', () => {
 
 async function runScenarioStep(
   session: MemorySession,
-  model: ScenarioModel,
+  model: ScriptedModel,
   step: ScenarioStep,
 ): Promise<{
   approvalItem: protocol.FunctionCallItem;

--- a/packages/agents-core/test/mcpToolFilter.integration.test.ts
+++ b/packages/agents-core/test/mcpToolFilter.integration.test.ts
@@ -3,11 +3,12 @@ import { Agent, run, setDefaultModelProvider } from '../src';
 import { mcpToFunctionTool } from '../src/mcp';
 import { NodeMCPServerStdio } from '../src/shims/mcp-server/node';
 import { createMCPToolStaticFilter } from '../src/mcpUtil';
-import { FakeModel, FakeModelProvider } from './stubs';
+import { ScriptedModelProvider } from './stubs';
 import { Usage } from '../src/usage';
 import type { ModelResponse } from '../src';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { ScriptedModel, modelResponse } from '../src/testing';
 
 class StubFilesystemServer extends NodeMCPServerStdio {
   private dir: string;
@@ -86,7 +87,7 @@ class StubFilesystemServer extends NodeMCPServerStdio {
 
 describe('MCP tool filter integration', () => {
   beforeAll(() => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
   const samplesDir = path.join(__dirname, '../../../examples/mcp/sample_files');
   const filter = createMCPToolStaticFilter({
@@ -115,7 +116,7 @@ describe('MCP tool filter integration', () => {
     const agent = new Agent({
       name: 'Lister',
       toolUseBehavior: 'stop_on_first_tool',
-      model: new FakeModel(modelResponses),
+      model: new ScriptedModel(Array.from(modelResponses, modelResponse)),
       tools,
     });
     const result = await run(agent, 'List files');
@@ -142,7 +143,7 @@ describe('MCP tool filter integration', () => {
     const agent = new Agent({
       name: 'Writer',
       toolUseBehavior: 'stop_on_first_tool',
-      model: new FakeModel(modelResponses),
+      model: new ScriptedModel(Array.from(modelResponses, modelResponse)),
       tools,
     });
     const result = await run(agent, 'write');

--- a/packages/agents-core/test/reactNativeShims.test.ts
+++ b/packages/agents-core/test/reactNativeShims.test.ts
@@ -30,6 +30,15 @@ describe('React Native shims', () => {
     expect(realtimePackage.exports['./_shims'].import).toBe(
       './dist/shims/shims.mjs',
     );
+    expect(corePackage.exports['./testing'].import).toBe(
+      './dist/testing/index.mjs',
+    );
+    expect(realtimePackage.exports['./testing']['react-native'].import).toBe(
+      './dist/testing/index.mjs',
+    );
+    expect(realtimePackage.exports['./testing'].import).toBe(
+      './dist/testing/index.mjs',
+    );
   });
 
   it('emits events without DOM event globals', () => {

--- a/packages/agents-core/test/retryPolicy.test.ts
+++ b/packages/agents-core/test/retryPolicy.test.ts
@@ -17,7 +17,15 @@ import type {
 } from '../src/model';
 import type { StreamEvent } from '../src/types/protocol';
 import { RequestUsage, Usage } from '../src/usage';
-import { fakeModelMessage, FakeModelProvider } from './stubs';
+import {
+  ScriptedModel,
+  modelError,
+  modelResponder,
+  modelResponse,
+  modelStream,
+  modelStreamResponder,
+} from '../src/testing';
+import { fakeModelMessage, ScriptedModelProvider } from './stubs';
 
 function createDoneEvent(text: string): StreamEvent {
   return {
@@ -30,32 +38,28 @@ function createDoneEvent(text: string): StreamEvent {
   };
 }
 
+function errorWith<T extends Record<string, unknown>>(
+  message: string,
+  properties: T,
+): Error & T {
+  return Object.assign(new Error(message), properties);
+}
+
+function textResponse(text: string, usage = new Usage({ requests: 1 })) {
+  return modelResponse({ usage, output: [fakeModelMessage(text)] });
+}
+
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 describe('retry policies', () => {
   it('retries non-streaming requests only when the user policy opts in', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          const error = new Error('Rate limited');
-          (error as Error & { statusCode?: number }).statusCode = 429;
-          throw error;
-        }
-
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Recovered')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('Rate limited', { statusCode: 429 })),
+      textResponse('Recovered'),
+    ]);
 
     const agent = new Agent({
       name: 'RetryingAgent',
@@ -75,34 +79,26 @@ describe('retry policies', () => {
     const result = await run(agent, 'hello');
 
     expect(result.finalOutput).toBe('Recovered');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
     expect(result.state.usage.requests).toBe(2);
     expect(result.rawResponses[0]?.usage.requests).toBe(2);
   });
 
   it('preserves provider-managed retries on the first runner attempt and disables them on replay', async () => {
     const seenRunnerManagedRetry: Array<boolean | undefined> = [];
-    let attempts = 0;
-
-    const model: Model = {
-      async getResponse(request: ModelRequest) {
-        attempts += 1;
-        seenRunnerManagedRetry.push(request._internal?.runnerManagedRetry);
-        if (attempts === 1) {
-          const error = new Error('Rate limited');
-          (error as Error & { statusCode?: number }).statusCode = 429;
-          throw error;
-        }
-
+    const model = new ScriptedModel([
+      modelResponder((call) => {
+        seenRunnerManagedRetry.push(call.request._internal?.runnerManagedRetry);
+        throw errorWith('Rate limited', { statusCode: 429 });
+      }),
+      modelResponder((call) => {
+        seenRunnerManagedRetry.push(call.request._internal?.runnerManagedRetry);
         return {
           usage: new Usage({ requests: 1 }),
           output: [fakeModelMessage('Recovered')],
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+      }),
+    ]);
 
     const agent = new Agent({
       name: 'ProviderRetryOwnershipAgent',
@@ -125,18 +121,15 @@ describe('retry policies', () => {
   it('preserves provider-managed retries on the first stateful attempt', async () => {
     const seenRunnerManagedRetry: Array<boolean | undefined> = [];
 
-    const model: Model = {
-      async getResponse(request: ModelRequest) {
-        seenRunnerManagedRetry.push(request._internal?.runnerManagedRetry);
+    const model = new ScriptedModel([
+      modelResponder((call) => {
+        seenRunnerManagedRetry.push(call.request._internal?.runnerManagedRetry);
         return {
           usage: new Usage({ requests: 1 }),
           output: [fakeModelMessage('ok')],
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+      }),
+    ]);
 
     const result = await run(
       new Agent({
@@ -161,18 +154,9 @@ describe('retry policies', () => {
   });
 
   it('does not retry without a retry policy even when maxRetries is configured', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        const error = new Error('Rate limited');
-        (error as Error & { statusCode?: number }).statusCode = 429;
-        throw error;
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('Rate limited', { statusCode: 429 })),
+    ]);
 
     const agent = new Agent({
       name: 'NoPolicyAgent',
@@ -185,23 +169,20 @@ describe('retry policies', () => {
     });
 
     await expect(run(agent, 'hello')).rejects.toThrow('Rate limited');
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('preserves provider-managed retry metadata on the first attempt when maxRetries is set without a policy', async () => {
     const seenRequests: ModelRequest[] = [];
-    const model: Model = {
-      async getResponse(request) {
-        seenRequests.push(request);
+    const model = new ScriptedModel([
+      modelResponder((call) => {
+        seenRequests.push(call.request as ModelRequest);
         return {
           usage: new Usage({ requests: 1 }),
           output: [fakeModelMessage('ok')],
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+      }),
+    ]);
 
     const result = await run(
       new Agent({
@@ -223,18 +204,15 @@ describe('retry policies', () => {
 
   it('preserves provider-managed retry metadata on the first attempt when maxRetries is zero', async () => {
     const seenRequests: ModelRequest[] = [];
-    const model: Model = {
-      async getResponse(request) {
-        seenRequests.push(request);
+    const model = new ScriptedModel([
+      modelResponder((call) => {
+        seenRequests.push(call.request as ModelRequest);
         return {
           usage: new Usage({ requests: 1 }),
           output: [fakeModelMessage('ok')],
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+      }),
+    ]);
 
     const result = await run(
       new Agent({
@@ -256,38 +234,26 @@ describe('retry policies', () => {
   });
 
   it('preserves per-request usage entries when a retried request succeeds', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          const error = new Error('Rate limited');
-          (error as Error & { statusCode?: number }).statusCode = 429;
-          throw error;
-        }
-
-        return {
-          usage: new Usage({
-            requests: 1,
-            inputTokens: 11,
-            outputTokens: 7,
-            totalTokens: 18,
-            requestUsageEntries: [
-              new RequestUsage({
-                inputTokens: 11,
-                outputTokens: 7,
-                totalTokens: 18,
-                endpoint: 'responses.create',
-              }),
-            ],
-          }),
-          output: [fakeModelMessage('Recovered with usage entries')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('Rate limited', { statusCode: 429 })),
+      modelResponse({
+        usage: new Usage({
+          requests: 1,
+          inputTokens: 11,
+          outputTokens: 7,
+          totalTokens: 18,
+          requestUsageEntries: [
+            new RequestUsage({
+              inputTokens: 11,
+              outputTokens: 7,
+              totalTokens: 18,
+              endpoint: 'responses.create',
+            }),
+          ],
+        }),
+        output: [fakeModelMessage('Recovered with usage entries')],
+      }),
+    ]);
 
     const result = await run(
       new Agent({
@@ -304,7 +270,7 @@ describe('retry policies', () => {
       'hello',
     );
 
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
     expect(result.state.usage.requests).toBe(2);
     expect(result.state.usage.requestUsageEntries).toEqual([
       {
@@ -345,22 +311,10 @@ describe('retry policies', () => {
   });
 
   it('honors explicit retry decisions that set delayMs', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          throw new Error('Retry me');
-        }
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Recovered with explicit delay')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('Retry me')),
+      textResponse('Recovered with explicit delay'),
+    ]);
     const policy = vi.fn().mockResolvedValue({ retry: true, delayMs: 0 });
 
     const agent = new Agent({
@@ -377,24 +331,17 @@ describe('retry policies', () => {
     const result = await run(agent, 'hello');
 
     expect(result.finalOutput).toBe('Recovered with explicit delay');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
     expect(policy).toHaveBeenCalledTimes(1);
   });
 
   it('retries until maxRetries is exhausted, then throws the last error', async () => {
-    let attempts = 0;
     const policy = vi.fn().mockReturnValue(true);
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        const error = new Error(`failure ${attempts}`);
-        (error as Error & { statusCode?: number }).statusCode = 503;
-        throw error;
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('failure 1', { statusCode: 503 })),
+      modelError(errorWith('failure 2', { statusCode: 503 })),
+      modelError(errorWith('failure 3', { statusCode: 503 })),
+    ]);
 
     const agent = new Agent({
       name: 'ExhaustedRetriesAgent',
@@ -409,32 +356,21 @@ describe('retry policies', () => {
     });
 
     await expect(run(agent, 'hello')).rejects.toThrow('failure 3');
-    expect(attempts).toBe(3);
+    expect(model.calls).toHaveLength(3);
     expect(policy).toHaveBeenCalledTimes(2);
   });
 
   it('passes incrementing attempt numbers to the retry policy', async () => {
-    let attempts = 0;
     const seenAttempts: number[] = [];
     const policy = vi.fn().mockImplementation(({ attempt }) => {
       seenAttempts.push(attempt);
       return true;
     });
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts < 3) {
-          throw new Error(`retry ${attempts}`);
-        }
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Recovered on third attempt')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('retry 1')),
+      modelError(new Error('retry 2')),
+      textResponse('Recovered on third attempt'),
+    ]);
 
     const agent = new Agent({
       name: 'AttemptTrackingAgent',
@@ -451,40 +387,22 @@ describe('retry policies', () => {
     const result = await run(agent, 'hello');
 
     expect(result.finalOutput).toBe('Recovered on third attempt');
-    expect(attempts).toBe(3);
+    expect(model.calls).toHaveLength(3);
     expect(seenAttempts).toEqual([1, 2]);
   });
 
   it('prefers retry-after delays over backoff when a policy opts in without delayMs', async () => {
     vi.useFakeTimers();
-    let attempts = 0;
-
     try {
-      const model: Model = {
-        async getResponse() {
-          attempts += 1;
-          if (attempts === 1) {
-            const error = new Error('Rate limited');
-            (
-              error as Error & {
-                statusCode?: number;
-                responseHeaders?: Headers;
-              }
-            ).statusCode = 429;
-            (error as Error & { responseHeaders?: Headers }).responseHeaders =
-              new Headers([['retry-after-ms', '0']]);
-            throw error;
-          }
-
-          return {
-            usage: new Usage({ requests: 1 }),
-            output: [fakeModelMessage('Recovered after retry-after')],
-          };
-        },
-        async *getStreamedResponse() {
-          yield* [];
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(
+          errorWith('Rate limited', {
+            statusCode: 429,
+            responseHeaders: new Headers([['retry-after-ms', '0']]),
+          }),
+        ),
+        textResponse('Recovered after retry-after'),
+      ]);
 
       const agent = new Agent({
         name: 'RetryAfterPreferredAgent',
@@ -503,7 +421,7 @@ describe('retry policies', () => {
       const result = await resultPromise;
 
       expect(result.finalOutput).toBe('Recovered after retry-after');
-      expect(attempts).toBe(2);
+      expect(model.calls).toHaveLength(2);
     } finally {
       vi.useRealTimers();
     }
@@ -511,34 +429,16 @@ describe('retry policies', () => {
 
   it('honors retry-after-ms zero without falling back to backoff delays', async () => {
     vi.useFakeTimers();
-    let attempts = 0;
-
     try {
-      const model: Model = {
-        async getResponse() {
-          attempts += 1;
-          if (attempts === 1) {
-            const error = new Error('retry immediately');
-            (
-              error as Error & {
-                statusCode?: number;
-                responseHeaders?: Headers;
-              }
-            ).statusCode = 429;
-            (error as Error & { responseHeaders?: Headers }).responseHeaders =
-              new Headers([['retry-after-ms', '0']]);
-            throw error;
-          }
-
-          return {
-            usage: new Usage({ requests: 1 }),
-            output: [fakeModelMessage('Recovered immediately')],
-          };
-        },
-        async *getStreamedResponse() {
-          yield* [];
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(
+          errorWith('retry immediately', {
+            statusCode: 429,
+            responseHeaders: new Headers([['retry-after-ms', '0']]),
+          }),
+        ),
+        textResponse('Recovered immediately'),
+      ]);
 
       const resultPromise = run(
         new Agent({
@@ -557,7 +457,7 @@ describe('retry policies', () => {
 
       await vi.advanceTimersByTimeAsync(0);
 
-      expect(attempts).toBe(2);
+      expect(model.calls).toHaveLength(2);
       await expect(resultPromise).resolves.toMatchObject({
         finalOutput: 'Recovered immediately',
       });
@@ -568,26 +468,12 @@ describe('retry policies', () => {
 
   it('uses exponential backoff delays when no explicit delay or retry-after is provided', async () => {
     vi.useFakeTimers();
-    let attempts = 0;
-
     try {
-      const model: Model = {
-        async getResponse() {
-          attempts += 1;
-          if (attempts < 3) {
-            const error = new Error(`temporary failure ${attempts}`);
-            (error as Error & { statusCode?: number }).statusCode = 503;
-            throw error;
-          }
-          return {
-            usage: new Usage({ requests: 1 }),
-            output: [fakeModelMessage('Recovered after backoff')],
-          };
-        },
-        async *getStreamedResponse() {
-          yield* [];
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(errorWith('temporary failure 1', { statusCode: 503 })),
+        modelError(errorWith('temporary failure 2', { statusCode: 503 })),
+        textResponse('Recovered after backoff'),
+      ]);
 
       const resultPromise = run(
         new Agent({
@@ -610,18 +496,18 @@ describe('retry policies', () => {
       );
 
       await vi.advanceTimersByTimeAsync(99);
-      expect(attempts).toBe(1);
+      expect(model.calls).toHaveLength(1);
 
       await vi.advanceTimersByTimeAsync(1);
-      expect(attempts).toBe(2);
+      expect(model.calls).toHaveLength(2);
 
       await vi.advanceTimersByTimeAsync(149);
-      expect(attempts).toBe(2);
+      expect(model.calls).toHaveLength(2);
 
       await vi.advanceTimersByTimeAsync(1);
       const result = await resultPromise;
 
-      expect(attempts).toBe(3);
+      expect(model.calls).toHaveLength(3);
       expect(result.finalOutput).toBe('Recovered after backoff');
     } finally {
       vi.useRealTimers();
@@ -629,25 +515,14 @@ describe('retry policies', () => {
   });
 
   it('retries from retry-after seconds headers exposed as plain objects', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          throw Object.assign(new Error('retry after seconds header'), {
-            responseHeaders: { 'retry-after': '0' },
-          });
-        }
-
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Recovered from seconds header')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(
+        errorWith('retry after seconds header', {
+          responseHeaders: { 'retry-after': '0' },
+        }),
+      ),
+      textResponse('Recovered from seconds header'),
+    ]);
 
     const agent = new Agent({
       name: 'RetryAfterSecondsAgent',
@@ -663,28 +538,16 @@ describe('retry policies', () => {
     const result = await run(agent, 'hello');
 
     expect(result.finalOutput).toBe('Recovered from seconds header');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
   });
 
   it('preserves provider vetoes when providerSuggested() is composed with any()', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        const error = new Error('Provider said no');
-        (error as Error & { statusCode?: number }).statusCode = 429;
-        throw error;
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          reason: 'provider veto',
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('Provider said no', { statusCode: 429 }), {
+        suggested: false,
+        reason: 'provider veto',
+      }),
+    ]);
 
     const agent = new Agent({
       name: 'ProviderVetoAgent',
@@ -702,7 +565,7 @@ describe('retry policies', () => {
     });
 
     await expect(run(agent, 'hello')).rejects.toThrow('Provider said no');
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('preserves provider vetoes in any() even when an earlier policy opts in', async () => {
@@ -795,33 +658,15 @@ describe('retry policies', () => {
 
   it('retries when providerSuggested() opts in with a delay hint', async () => {
     vi.useFakeTimers();
-    let attempts = 0;
-
     try {
-      const model: Model = {
-        async getResponse() {
-          attempts += 1;
-          if (attempts === 1) {
-            const error = new Error('Provider suggested retry');
-            (error as Error & { statusCode?: number }).statusCode = 429;
-            throw error;
-          }
-          return {
-            usage: new Usage({ requests: 1 }),
-            output: [fakeModelMessage('Recovered from provider advice')],
-          };
-        },
-        getRetryAdvice() {
-          return {
-            suggested: true,
-            retryAfterMs: 50,
-            reason: 'provider requested retry',
-          };
-        },
-        async *getStreamedResponse() {
-          yield* [];
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(errorWith('Provider suggested retry', { statusCode: 429 }), {
+          suggested: true,
+          retryAfterMs: 50,
+          reason: 'provider requested retry',
+        }),
+        textResponse('Recovered from provider advice'),
+      ]);
 
       const resultPromise = run(
         new Agent({
@@ -838,12 +683,12 @@ describe('retry policies', () => {
       );
 
       await vi.advanceTimersByTimeAsync(49);
-      expect(attempts).toBe(1);
+      expect(model.calls).toHaveLength(1);
 
       await vi.advanceTimersByTimeAsync(1);
       const result = await resultPromise;
 
-      expect(attempts).toBe(2);
+      expect(model.calls).toHaveLength(2);
       expect(result.finalOutput).toBe('Recovered from provider advice');
     } finally {
       vi.useRealTimers();
@@ -905,20 +750,13 @@ describe('retry policies', () => {
 
   it('stops retrying when the signal aborts during retry delay', async () => {
     vi.useFakeTimers();
-    let attempts = 0;
     const controller = new AbortController();
     const policy = vi.fn().mockResolvedValue({ retry: true, delayMs: 100 });
 
     try {
-      const model: Model = {
-        async getResponse() {
-          attempts += 1;
-          throw new Error('retry me until aborted');
-        },
-        async *getStreamedResponse() {
-          yield* [];
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(new Error('retry me until aborted')),
+      ]);
 
       const resultPromise = new Runner().run(
         new Agent({
@@ -941,7 +779,7 @@ describe('retry policies', () => {
       await expect(resultPromise).rejects.toMatchObject({
         name: 'AbortError',
       });
-      expect(attempts).toBe(1);
+      expect(model.calls).toHaveLength(1);
       expect(policy).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
@@ -949,27 +787,10 @@ describe('retry policies', () => {
   });
 
   it('treats websocket transport error codes as network errors', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          const error = new Error('socket not open');
-          (error as Error & { code?: string }).code = 'socket_not_open';
-          throw error;
-        }
-
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [
-            fakeModelMessage('Recovered from websocket transport error'),
-          ],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('socket not open', { code: 'socket_not_open' })),
+      textResponse('Recovered from websocket transport error'),
+    ]);
 
     const agent = new Agent({
       name: 'WebSocketTransportRetryAgent',
@@ -986,27 +807,17 @@ describe('retry policies', () => {
     const result = await run(agent, 'hello');
 
     expect(result.finalOutput).toBe('Recovered from websocket transport error');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
   });
 
   it('retries streaming requests when the stream fails before any visible event', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        throw new Error('not used');
-      },
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        attempts += 1;
-        if (attempts === 1) {
-          const error = new Error('temporary stream failure');
-          (error as Error & { statusCode?: number }).statusCode = 503;
-          throw error;
-        }
-
-        yield { type: 'response_started' };
-        yield createDoneEvent('Stream recovered');
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('temporary stream failure', { statusCode: 503 })),
+      modelStream([
+        { type: 'response_started' },
+        createDoneEvent('Stream recovered'),
+      ]),
+    ]);
 
     const agent = new Agent({
       name: 'StreamingRetryAgent',
@@ -1026,31 +837,24 @@ describe('retry policies', () => {
     }
 
     expect(result.finalOutput).toBe('Stream recovered');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
     expect(result.state.usage.requests).toBe(2);
     expect(result.rawResponses[0]?.usage.requests).toBe(2);
   });
 
   it('does not retry streaming requests after raw model events are emitted', async () => {
-    let attempts = 0;
     const seenEvents: RunStreamEvent[] = [];
-    const model: Model = {
-      async getResponse() {
-        throw new Error('not used');
-      },
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        attempts += 1;
-        if (attempts === 1) {
+    const model = new ScriptedModel([
+      modelStreamResponder(() =>
+        (async function* () {
           yield {
             type: 'model',
             event: { type: 'provider.debug', detail: 'pre-output' } as any,
           };
-          const error = new Error('temporary stream failure');
-          (error as Error & { statusCode?: number }).statusCode = 503;
-          throw error;
-        }
-      },
-    };
+          throw errorWith('temporary stream failure', { statusCode: 503 });
+        })(),
+      ),
+    ]);
 
     const agent = new Agent({
       name: 'StreamingRetryAfterModelEventAgent',
@@ -1072,7 +876,7 @@ describe('retry policies', () => {
     };
 
     await expect(consume()).rejects.toThrow('temporary stream failure');
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
     expect(seenEvents).toHaveLength(1);
     expect(seenEvents[0]).toMatchObject({
       type: 'raw_model_stream_event',
@@ -1084,19 +888,14 @@ describe('retry policies', () => {
   });
 
   it('does not retry streaming requests after a visible event was emitted', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        throw new Error('not used');
-      },
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        attempts += 1;
-        yield { type: 'response_started' };
-        const error = new Error('stream broke after start');
-        (error as Error & { statusCode?: number }).statusCode = 503;
-        throw error;
-      },
-    };
+    const model = new ScriptedModel([
+      modelStreamResponder(() =>
+        (async function* () {
+          yield { type: 'response_started' } satisfies StreamEvent;
+          throw errorWith('stream broke after start', { statusCode: 503 });
+        })(),
+      ),
+    ]);
 
     const agent = new Agent({
       name: 'VisibleEventAgent',
@@ -1118,27 +917,22 @@ describe('retry policies', () => {
     };
 
     await expect(consume()).rejects.toThrow('stream broke after start');
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('does not retry streaming requests after a text delta was emitted', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        throw new Error('not used');
-      },
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        attempts += 1;
-        yield { type: 'response_started' };
-        yield {
-          type: 'output_text_delta',
-          delta: 'hel',
-        };
-        const error = new Error('stream broke after delta');
-        (error as Error & { statusCode?: number }).statusCode = 503;
-        throw error;
-      },
-    };
+    const model = new ScriptedModel([
+      modelStreamResponder(() =>
+        (async function* () {
+          yield { type: 'response_started' } satisfies StreamEvent;
+          yield {
+            type: 'output_text_delta',
+            delta: 'hel',
+          } satisfies StreamEvent;
+          throw errorWith('stream broke after delta', { statusCode: 503 });
+        })(),
+      ),
+    ]);
 
     const result = await run(
       new Agent({
@@ -1163,29 +957,20 @@ describe('retry policies', () => {
     };
 
     await expect(consume()).rejects.toThrow('stream broke after delta');
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('does not retry non-streaming requests when provider advice marks replay as unsafe', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        const error = new Error('request may have been accepted');
-        (error as Error & { statusCode?: number }).statusCode = 503;
-        throw error;
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
+    const model = new ScriptedModel([
+      modelError(
+        errorWith('request may have been accepted', { statusCode: 503 }),
+        {
           suggested: false,
           replaySafety: 'unsafe',
           reason: 'request may have been accepted',
-        };
-      },
-    };
+        },
+      ),
+    ]);
 
     const agent = new Agent({
       name: 'UnsafeReplayAgent',
@@ -1202,39 +987,24 @@ describe('retry policies', () => {
     await expect(run(agent, 'hello')).rejects.toThrow(
       'request may have been accepted',
     );
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('retries a non-streaming unsafe replay only with explicit application approval', async () => {
-    let attempts = 0;
     const seenContexts: Array<{
       replaySafety?: string;
       responseStarted?: boolean;
       statefulRequest?: boolean;
     }> = [];
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          throw new Error('request may have been accepted');
-        }
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Explicitly approved replay')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          replaySafety: 'unsafe',
-          responseStarted: true,
-          reason: 'request may have been accepted',
-        };
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('request may have been accepted'), {
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+        reason: 'request may have been accepted',
+      }),
+      textResponse('Explicitly approved replay'),
+    ]);
 
     const result = await run(
       new Agent({
@@ -1259,7 +1029,7 @@ describe('retry policies', () => {
     );
 
     expect(result.finalOutput).toBe('Explicitly approved replay');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
     expect(seenContexts).toHaveLength(1);
     expect(seenContexts[0]).toMatchObject({
       replaySafety: 'unsafe',
@@ -1269,7 +1039,6 @@ describe('retry policies', () => {
   });
 
   it('does not treat missing response-start evidence as explicit false', async () => {
-    let attempts = 0;
     const policy = vi.fn((context: RetryPolicyContext) => {
       expect(context.responseStarted).toBeUndefined();
       return {
@@ -1277,22 +1046,13 @@ describe('retry policies', () => {
         approveUnsafeReplay: context.responseStarted === false,
       };
     });
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        throw new Error('request may have been accepted');
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          replaySafety: 'unsafe',
-          reason: 'response-start state is unknown',
-        };
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('request may have been accepted'), {
+        suggested: false,
+        replaySafety: 'unsafe',
+        reason: 'response-start state is unknown',
+      }),
+    ]);
 
     await expect(
       run(
@@ -1311,7 +1071,7 @@ describe('retry policies', () => {
       ),
     ).rejects.toThrow('request may have been accepted');
 
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
     expect(policy).toHaveBeenCalledTimes(1);
   });
 
@@ -1320,7 +1080,6 @@ describe('retry policies', () => {
       previousResponseId?: string;
       conversationId?: string;
     }) => {
-      let attempts = 0;
       const seenContexts: Array<{
         previousResponseId?: string;
         conversationId?: string;
@@ -1328,28 +1087,14 @@ describe('retry policies', () => {
         responseStarted?: boolean;
         statefulRequest?: boolean;
       }> = [];
-      const model: Model = {
-        async getResponse() {
-          attempts += 1;
-          if (attempts === 1) {
-            throw new Error('stateful request may have been accepted');
-          }
-          return {
-            usage: new Usage({ requests: 1 }),
-            output: [fakeModelMessage('Recovered stateful request')],
-          };
-        },
-        async *getStreamedResponse() {
-          yield* [];
-        },
-        getRetryAdvice() {
-          return {
-            suggested: false,
-            replaySafety: 'unsafe',
-            reason: 'stateful request may have been accepted',
-          };
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(new Error('stateful request may have been accepted'), {
+          suggested: false,
+          replaySafety: 'unsafe',
+          reason: 'stateful request may have been accepted',
+        }),
+        textResponse('Recovered stateful request'),
+      ]);
 
       const result = await run(
         new Agent({
@@ -1370,7 +1115,11 @@ describe('retry policies', () => {
         options,
       );
 
-      return { attempts, finalOutput: result.finalOutput, seenContexts };
+      return {
+        attempts: model.calls.length,
+        finalOutput: result.finalOutput,
+        seenContexts,
+      };
     };
 
     const previousResponse = await exercise({
@@ -1405,7 +1154,6 @@ describe('retry policies', () => {
   });
 
   it('does not apply unsafe replay approval to stateful requests with unknown safety', async () => {
-    let attempts = 0;
     const policy = vi.fn((context) => {
       expect(context).toMatchObject({
         previousResponseId: 'resp_unknown',
@@ -1415,15 +1163,9 @@ describe('retry policies', () => {
       });
       return { retry: true, approveUnsafeReplay: true };
     });
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        throw new Error('unknown stateful failure');
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('unknown stateful failure')),
+    ]);
 
     await expect(
       run(
@@ -1443,33 +1185,18 @@ describe('retry policies', () => {
       ),
     ).rejects.toThrow('unknown stateful failure');
 
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
     expect(policy).toHaveBeenCalledTimes(1);
   });
 
   it('accepts captured provider-safe evidence for a custom stateful policy', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          throw new Error('safe stateful failure');
-        }
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Provider-safe replay')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
-          suggested: true,
-          replaySafety: 'safe',
-        };
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('safe stateful failure'), {
+        suggested: true,
+        replaySafety: 'safe',
+      }),
+      textResponse('Provider-safe replay'),
+    ]);
 
     const result = await run(
       new Agent({
@@ -1488,34 +1215,21 @@ describe('retry policies', () => {
     );
 
     expect(result.finalOutput).toBe('Provider-safe replay');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
   });
 
   it('does not let unsafe replay approval override provider-unsafe streaming failures', async () => {
-    let attempts = 0;
     const policy = vi.fn(() => ({
       retry: true,
       approveUnsafeReplay: true,
     }));
-    const model: Model = {
-      async getResponse() {
-        throw new Error('not used');
-      },
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        attempts += 1;
-        if (attempts > 0) {
-          throw new Error('unsafe streamed failure');
-        }
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          replaySafety: 'unsafe',
-          reason: 'unsafe streamed failure',
-        };
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('unsafe streamed failure'), {
+        suggested: false,
+        replaySafety: 'unsafe',
+        reason: 'unsafe streamed failure',
+      }),
+    ]);
 
     const result = await run(
       new Agent({
@@ -1539,34 +1253,24 @@ describe('retry policies', () => {
     };
 
     await expect(consume()).rejects.toThrow('unsafe streamed failure');
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
     expect(policy).not.toHaveBeenCalled();
   });
 
   it('does not let provider normalization clear raw abort evidence', async () => {
-    let attempts = 0;
     const policy = vi.fn(() => ({
       retry: true,
       approveUnsafeReplay: true,
     }));
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        const error = new Error('cancelled');
-        error.name = 'AbortError';
-        throw error;
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          replaySafety: 'unsafe',
-          normalized: { isAbort: false },
-        };
-      },
-    };
+    const abortError = new Error('cancelled');
+    abortError.name = 'AbortError';
+    const model = new ScriptedModel([
+      modelError(abortError, {
+        suggested: false,
+        replaySafety: 'unsafe',
+        normalized: { isAbort: false },
+      }),
+    ]);
 
     await expect(
       run(
@@ -1585,7 +1289,7 @@ describe('retry policies', () => {
       ),
     ).rejects.toThrow('cancelled');
 
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
     expect(policy).not.toHaveBeenCalled();
   });
 
@@ -1691,34 +1395,17 @@ describe('retry policies', () => {
   });
 
   it('retries stateful follow-up requests when providerSuggested() approves replay', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          const error = new Error('connection closed before opening');
-          (error as Error & { statusCode?: number }).statusCode = 503;
-          throw error;
-        }
-
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [
-            fakeModelMessage('Recovered after provider-approved replay'),
-          ],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
+    const model = new ScriptedModel([
+      modelError(
+        errorWith('connection closed before opening', { statusCode: 503 }),
+        {
           suggested: true,
           replaySafety: 'safe',
           reason: 'request never left the client',
-        };
-      },
-    };
+        },
+      ),
+      textResponse('Recovered after provider-approved replay'),
+    ]);
 
     const agent = new Agent({
       name: 'ProviderApprovedStatefulRetryAgent',
@@ -1740,36 +1427,21 @@ describe('retry policies', () => {
     });
 
     expect(result.finalOutput).toBe('Recovered after provider-approved replay');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
   });
 
   it('retries stateful follow-up requests when all() includes providerSuggested()', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          const error = new Error('connection closed before opening');
-          (error as Error & { statusCode?: number }).statusCode = 429;
-          throw error;
-        }
-
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Recovered after all() replay approval')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
+    const model = new ScriptedModel([
+      modelError(
+        errorWith('connection closed before opening', { statusCode: 429 }),
+        {
           suggested: true,
           replaySafety: 'safe',
           reason: 'request never left the client',
-        };
-      },
-    };
+        },
+      ),
+      textResponse('Recovered after all() replay approval'),
+    ]);
 
     const agent = new Agent({
       name: 'ProviderApprovedStatefulAllRetryAgent',
@@ -1791,28 +1463,16 @@ describe('retry policies', () => {
     });
 
     expect(result.finalOutput).toBe('Recovered after all() replay approval');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
   });
 
   it('does not retry stateful follow-up requests from non-provider policies alone', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        const error = new Error('temporary stateful failure');
-        (error as Error & { statusCode?: number }).statusCode = 503;
-        throw error;
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-      getRetryAdvice() {
-        return {
-          suggested: true,
-          reason: 'provider would allow retry',
-        };
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(errorWith('temporary stateful failure', { statusCode: 503 }), {
+        suggested: true,
+        reason: 'provider would allow retry',
+      }),
+    ]);
 
     const agent = new Agent({
       name: 'StatefulNonProviderPolicyAgent',
@@ -1831,7 +1491,7 @@ describe('retry policies', () => {
         previousResponseId: 'resp-no-provider-policy',
       }),
     ).rejects.toThrow('temporary stateful failure');
-    expect(attempts).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('deep merges inherited agent tool retry settings', () => {
@@ -1910,18 +1570,15 @@ describe('retry policies', () => {
     let capturedRetrySettings:
       ModelRequest['modelSettings']['retry'] | undefined;
 
-    const model: Model = {
-      async getResponse(request: ModelRequest) {
-        capturedRetrySettings = request.modelSettings.retry;
+    const model = new ScriptedModel([
+      modelResponder((call) => {
+        capturedRetrySettings = call.request.modelSettings.retry;
         return {
           usage: new Usage({ requests: 1 }),
           output: [fakeModelMessage('Merged retry settings')],
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+      }),
+    ]);
 
     const runner = new Runner({
       modelSettings: {
@@ -1965,18 +1622,15 @@ describe('retry policies', () => {
     let capturedRetrySettings:
       ModelRequest['modelSettings']['retry'] | undefined;
 
-    const model: Model = {
-      async getResponse(request: ModelRequest) {
-        capturedRetrySettings = request.modelSettings.retry;
+    const model = new ScriptedModel([
+      modelResponder((call) => {
+        capturedRetrySettings = call.request.modelSettings.retry;
         return {
           usage: new Usage({ requests: 1 }),
           output: [fakeModelMessage('Merged retry settings')],
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+      }),
+    ]);
 
     const runner = new Runner({
       modelSettings: {
@@ -2015,25 +1669,14 @@ describe('retry policies', () => {
   });
 
   it('retries when responseHeaders is a Headers instance', async () => {
-    let attempts = 0;
-    const model: Model = {
-      async getResponse() {
-        attempts += 1;
-        if (attempts === 1) {
-          throw Object.assign(new Error('retry after header'), {
-            responseHeaders: new Headers([['retry-after-ms', '0']]),
-          });
-        }
-
-        return {
-          usage: new Usage({ requests: 1 }),
-          output: [fakeModelMessage('Recovered from headers')],
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(
+        Object.assign(new Error('retry after header'), {
+          responseHeaders: new Headers([['retry-after-ms', '0']]),
+        }),
+      ),
+      textResponse('Recovered from headers'),
+    ]);
 
     const agent = new Agent({
       name: 'RetryAfterHeadersAgent',
@@ -2049,6 +1692,6 @@ describe('retry policies', () => {
     const result = await run(agent, 'hello');
 
     expect(result.finalOutput).toBe('Recovered from headers');
-    expect(attempts).toBe(2);
+    expect(model.calls).toHaveLength(2);
   });
 });

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -18,7 +18,6 @@ import {
   defineToolInputGuardrail,
   type AgentInputItem,
   type CallModelInputFilterArgs,
-  type Model,
   type ModelRequest,
   type ModelResponse,
   type OpenAIResponsesCompactionArgs,
@@ -30,6 +29,11 @@ import {
 import * as protocol from '../src/types/protocol';
 import { fakeModelMessage } from './stubs';
 import logger from '../src/logger';
+import {
+  ScriptedModel,
+  modelResponder,
+  modelStreamResponder,
+} from '../src/testing';
 
 type RunMode = 'non_streamed' | 'streamed';
 
@@ -86,32 +90,21 @@ class FailingCheckpointCompactionSession extends CompactionTrackingSession {
   }
 }
 
-class ApprovalSessionModel implements Model {
-  readonly requests: ModelRequest[] = [];
-
-  constructor(private readonly responses: ModelResponse[]) {}
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(request);
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response found.');
-    }
-    return response;
+class ApprovalSessionModel extends ScriptedModel {
+  constructor(responses: ModelResponse[]) {
+    super(
+      responses.map((response) =>
+        modelResponder((call) =>
+          call.streamed
+            ? { ...response, responseId: 'stream-response' }
+            : response,
+        ),
+      ),
+    );
   }
 
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const response = await this.getResponse(request);
-    yield {
-      type: 'response_done',
-      response: {
-        id: response.responseId ?? 'stream-response',
-        output: response.output,
-        usage: response.usage,
-      },
-    } as StreamEvent;
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
@@ -200,23 +193,22 @@ describe('committed tool output guardrail session persistence', () => {
     const modelCanFinish = new Promise<void>((resolve) => {
       releaseModel = resolve;
     });
-    const model: Model = {
-      async getResponse(): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming request.');
-      },
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        markModelStarted();
-        await modelCanFinish;
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'bound-stream-response',
-            output: [fakeModelMessage('done')],
-            usage: new Usage(),
-          },
-        } as StreamEvent;
-      },
-    };
+    const model = new ScriptedModel([
+      modelStreamResponder(() =>
+        (async function* () {
+          markModelStarted();
+          await modelCanFinish;
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'bound-stream-response',
+              output: [fakeModelMessage('done')],
+              usage: new Usage(),
+            },
+          } as StreamEvent;
+        })(),
+      ),
+    ]);
     const agent = new Agent({ name: 'Bound streaming state agent', model });
     const session = new DeferredSessionIdSession({
       sessionId: 'bound-stream-session',

--- a/packages/agents-core/test/run.sessionRunContext.test.ts
+++ b/packages/agents-core/test/run.sessionRunContext.test.ts
@@ -8,14 +8,10 @@ import {
   setTracingDisabled,
   tool,
   type AgentInputItem,
-  type Model,
-  type ModelRequest,
-  type ModelResponse,
   type OpenAIResponsesCompactionArgs,
   type RunContextAwareSession,
   type Session,
   type SessionHistoryTransactionArgs,
-  type StreamEvent,
 } from '../src';
 import {
   RunCompactionItem as CompactionItem,
@@ -29,6 +25,7 @@ import { RunState } from '../src/runState';
 import type * as protocol from '../src/types/protocol';
 import { fakeModelMessage } from './stubs';
 import { Usage } from '../src/usage';
+import { ScriptedModel, modelResponse } from '../src/testing';
 
 type TenantContext = {
   tenantId: string;
@@ -39,65 +36,39 @@ type SessionCall = {
   runContext: RunContext<TenantContext> | undefined;
 };
 
-class FinalResponseModel implements Model {
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    return {
-      output: [fakeModelMessage('done')],
-      usage: new Usage(),
-    };
-  }
-
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    yield {
-      type: 'response_done',
-      response: {
-        id: 'response-id',
+class FinalResponseModel extends ScriptedModel {
+  constructor() {
+    super([
+      modelResponse({
         output: [fakeModelMessage('done')],
-        usage: {
-          requests: 1,
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        },
-      },
-    } as StreamEvent;
+        usage: new Usage(),
+        responseId: 'response-id',
+      }),
+    ]);
   }
 }
 
-class ApprovalModel implements Model {
-  private readonly responses: ModelResponse[] = [
-    {
-      output: [
-        {
-          type: 'function_call',
-          id: 'approval-item',
-          callId: 'approval-call',
-          name: 'context_tool',
-          status: 'completed',
-          arguments: '{}',
-        },
-      ],
-      usage: new Usage(),
-    },
-    {
-      output: [fakeModelMessage('done')],
-      usage: new Usage(),
-    },
-  ];
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response found.');
-    }
-    return response;
-  }
-
-  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-    yield* [];
-    throw new Error('Unexpected streaming request.');
+class ApprovalModel extends ScriptedModel {
+  constructor() {
+    super([
+      modelResponse({
+        output: [
+          {
+            type: 'function_call',
+            id: 'approval-item',
+            callId: 'approval-call',
+            name: 'context_tool',
+            status: 'completed',
+            arguments: '{}',
+          },
+        ],
+        usage: new Usage(),
+      }),
+      modelResponse({
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      }),
+    ]);
   }
 }
 

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -17,7 +17,6 @@ import {
   RunMessageOutputItem,
   StreamedRunResult,
   handoff,
-  Model,
   ModelRequest,
   ModelResponse,
   StreamEvent,
@@ -34,8 +33,7 @@ import {
   shellTool,
 } from '../src';
 import {
-  FakeModel,
-  FakeModelProvider,
+  ScriptedModelProvider,
   TEST_MODEL_FUNCTION_CALL,
   fakeModelMessage,
   fakeModelRefusal,
@@ -48,6 +46,14 @@ import logger from '../src/logger';
 import { getEventListeners } from 'node:events';
 import { InvalidToolInputError, ToolCallError } from '../src/errors';
 import { getToolInvocationFingerprint } from '../src/toolInvocation';
+import {
+  ScriptedModel,
+  modelError,
+  modelResponse,
+  modelStream,
+  modelStreamResponder,
+  type ScriptedModelInput,
+} from '../src/testing';
 
 function getFirstTextContent(item: AgentInputItem): string | undefined {
   if (item.type !== 'message') {
@@ -67,160 +73,188 @@ function getRequestInputItems(request: ModelRequest): AgentInputItem[] {
   return Array.isArray(request.input) ? request.input : [];
 }
 
-class CountingFunctionToolStreamModel implements Model {
-  callCount = 0;
+function abortingHangingStream(): ScriptedModelInput {
+  return modelStreamResponder((call) =>
+    (async function* () {
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      const signal = call.request.signal;
+      await new Promise((_resolve, reject) => {
+        if (signal?.aborted) {
+          reject(abortError);
+          return;
+        }
+        const onAbort = () => {
+          signal?.removeEventListener('abort', onAbort);
+          reject(abortError);
+        };
+        signal?.addEventListener('abort', onAbort, { once: true });
+      });
+      yield* [] as StreamEvent[];
+    })(),
+  );
+}
 
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    throw new Error('Unexpected non-streaming model request');
-  }
-
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const output =
-      this.callCount++ === 0
-        ? [{ ...TEST_MODEL_FUNCTION_CALL }]
-        : [fakeModelMessage('done')];
-    yield {
+function terminalModelStream(
+  response: ModelResponse,
+  responseId: string,
+): ScriptedModelInput {
+  return modelStream([
+    {
       type: 'response_done',
       response: {
-        id: `resp-${this.callCount}`,
+        id: responseId,
         usage: {
-          requests: 1,
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
+          requests: response.usage.requests,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          totalTokens: response.usage.totalTokens,
         },
-        output,
+        output: response.output,
       },
-    } as StreamEvent;
+    } as StreamEvent,
+  ]);
+}
+
+function parsedTerminalModelStream(
+  response: ModelResponse,
+  responseId: string,
+): ScriptedModelInput {
+  return terminalModelStream(
+    {
+      ...response,
+      output: response.output.map((item) =>
+        protocol.OutputModelItem.parse(item),
+      ),
+    },
+    responseId,
+  );
+}
+
+class CountingFunctionToolStreamModel extends ScriptedModel {
+  constructor() {
+    super([
+      terminalModelStream(
+        {
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        },
+        'resp-1',
+      ),
+      terminalModelStream(
+        {
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        },
+        'resp-2',
+      ),
+    ]);
+  }
+
+  get callCount(): number {
+    return this.calls.length;
   }
 }
 
-class AbortAfterStreamedFunctionCallModel implements Model {
-  public requests: ModelRequest[] = [];
-
-  constructor(private readonly responseId: string) {}
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(request);
-    return {
+class AbortAfterStreamedFunctionCallModel extends ScriptedModel {
+  constructor(
+    responseId: string,
+    reconciliationStep: ScriptedModelInput = modelResponse({
       output: [fakeModelMessage('reconciled')],
       usage: new Usage(),
       responseId: 'resp-reconciled',
-    };
+    }),
+  ) {
+    super([
+      modelStreamResponder(() =>
+        (async function* () {
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.created',
+              response: { id: responseId },
+            },
+          } as StreamEvent;
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.output_item.done',
+              item: {
+                type: 'function_call',
+                id: 'fc_abort',
+                call_id: 'call_abort',
+                name: 'slow_tool',
+                arguments: '{}',
+                status: 'completed',
+              },
+            },
+          } as StreamEvent;
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          throw error;
+        })(),
+      ),
+      reconciliationStep,
+    ]);
   }
 
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    this.requests.push(request);
-    yield {
-      type: 'model',
-      event: {
-        type: 'response.created',
-        response: {
-          id: this.responseId,
-        },
-      },
-    };
-    yield {
-      type: 'model',
-      event: {
-        type: 'response.output_item.done',
-        item: {
-          type: 'function_call',
-          id: 'fc_abort',
-          call_id: 'call_abort',
-          name: 'slow_tool',
-          arguments: '{}',
-          status: 'completed',
-        },
-      },
-    };
-    const error = new Error('aborted');
-    error.name = 'AbortError';
-    throw error;
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
 class FailingAbortReconciliationModel extends AbortAfterStreamedFunctionCallModel {
-  constructor(
-    responseId: string,
-    private readonly reconciliationError: unknown,
-  ) {
-    super(responseId);
-  }
-
-  override async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(request);
-    throw this.reconciliationError;
+  constructor(responseId: string, reconciliationError: unknown) {
+    super(responseId, modelError(reconciliationError));
   }
 }
 
-class AbortAfterStreamedProgramModel implements Model {
-  public requests: ModelRequest[] = [];
-
-  constructor(private readonly responseId: string) {}
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(request);
-    return {
-      output: [fakeModelMessage('reconciled')],
-      usage: new Usage(),
-      responseId: 'resp-reconciled',
-    };
+class AbortAfterStreamedProgramModel extends ScriptedModel {
+  constructor(responseId: string) {
+    super([
+      modelStreamResponder(() =>
+        (async function* () {
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.created',
+              response: { id: responseId },
+            },
+          } as StreamEvent;
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.output_item.done',
+              item: {
+                type: 'program',
+                id: 'prog_abort',
+                call_id: 'call_prog_abort',
+                code: 'text("done");',
+                fingerprint: 'fingerprint:abort',
+              },
+            },
+          } as StreamEvent;
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          throw error;
+        })(),
+      ),
+      modelResponse({
+        output: [fakeModelMessage('reconciled')],
+        usage: new Usage(),
+        responseId: 'resp-reconciled',
+      }),
+    ]);
   }
 
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    this.requests.push(request);
-    yield {
-      type: 'model',
-      event: {
-        type: 'response.created',
-        response: {
-          id: this.responseId,
-        },
-      },
-    };
-    yield {
-      type: 'model',
-      event: {
-        type: 'response.output_item.done',
-        item: {
-          type: 'program',
-          id: 'prog_abort',
-          call_id: 'call_prog_abort',
-          code: 'text("done");',
-          fingerprint: 'fingerprint:abort',
-        },
-      },
-    };
-    const error = new Error('aborted');
-    error.name = 'AbortError';
-    throw error;
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
-class AbortAfterStreamedProgramToolCallsModel implements Model {
-  public requests: ModelRequest[] = [];
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(request);
-    return {
-      output: [fakeModelMessage('reconciled')],
-      usage: new Usage(),
-      responseId: 'resp-reconciled',
-    };
-  }
-
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    this.requests.push(request);
-    for (const item of [
+class AbortAfterStreamedProgramToolCallsModel extends ScriptedModel {
+  constructor() {
+    const items = [
       {
         type: 'program',
         id: 'prog_abort',
@@ -244,18 +278,31 @@ class AbortAfterStreamedProgramToolCallsModel implements Model {
         operation: { type: 'delete_file', path: 'temporary.txt' },
         caller: { type: 'program', caller_id: 'call_prog_abort' },
       },
-    ]) {
-      yield {
-        type: 'model',
-        event: {
-          type: 'response.output_item.done',
-          item,
-        },
-      };
-    }
-    const error = new Error('aborted');
-    error.name = 'AbortError';
-    throw error;
+    ];
+    super([
+      modelStreamResponder(() =>
+        (async function* () {
+          for (const item of items) {
+            yield {
+              type: 'model',
+              event: { type: 'response.output_item.done', item },
+            } as StreamEvent;
+          }
+          const error = new Error('aborted');
+          error.name = 'AbortError';
+          throw error;
+        })(),
+      ),
+      modelResponse({
+        output: [fakeModelMessage('reconciled')],
+        usage: new Usage(),
+        responseId: 'resp-reconciled',
+      }),
+    ]);
+  }
+
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
@@ -280,34 +327,6 @@ describe('Runner.run (streaming)', () => {
       { output: [approvalCall], usage: new Usage() },
       { output: [fakeModelMessage('done')], usage: new Usage() },
     ];
-    class HostedReplayStreamingModel implements Model {
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming model request');
-      }
-
-      async *getStreamedResponse(
-        _request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = responses.shift();
-        if (!response) {
-          throw new Error('No response found');
-        }
-        yield {
-          type: 'response_done',
-          response: {
-            id: `streamed-replay-${responses.length}`,
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as StreamEvent;
-      }
-    }
-
     const mcpTool = hostedMcpTool({
       serverLabel: 'streamed-replay-server',
       serverUrl: 'https://example.com',
@@ -315,7 +334,14 @@ describe('Runner.run (streaming)', () => {
     });
     const agent = new Agent({
       name: 'StreamedHostedReplayAgent',
-      model: new HostedReplayStreamingModel(),
+      model: new ScriptedModel(
+        responses.map((response, index) =>
+          terminalModelStream(
+            response,
+            `streamed-replay-${responses.length - index - 1}`,
+          ),
+        ),
+      ),
       tools: [mcpTool],
     });
     const state = new RunState(new RunContext(), 'start', agent, 3);
@@ -350,7 +376,7 @@ describe('Runner.run (streaming)', () => {
 
   beforeAll(() => {
     setTracingDisabled(true);
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
 
   afterEach(() => {
@@ -358,7 +384,7 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('does not emit unhandled rejection when stream loop fails', async () => {
-    const agent = new Agent({ name: 'StreamFail', model: new FakeModel() });
+    const agent = new Agent({ name: 'StreamFail', model: new ScriptedModel() });
 
     const rejections: unknown[] = [];
     const handler = (err: unknown) => {
@@ -378,12 +404,17 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('exposes model error to the consumer', async () => {
-    const agent = new Agent({ name: 'StreamError', model: new FakeModel() });
+    const agent = new Agent({
+      name: 'StreamError',
+      model: new ScriptedModel([
+        modelError(new Error('Scripted stream failure')),
+      ]),
+    });
 
     const result = await run(agent, 'hi', { stream: true });
-    await expect(result.completed).rejects.toThrow('Not implemented');
+    await expect(result.completed).rejects.toThrow('Scripted stream failure');
 
-    expect((result.error as Error).message).toBe('Not implemented');
+    expect((result.error as Error).message).toBe('Scripted stream failure');
   });
 
   it('emits a high-level run item event for streamed compaction', async () => {
@@ -393,17 +424,13 @@ describe('Runner.run (streaming)', () => {
       encrypted_content: 'ciphertext',
     };
 
-    class CompactionStreamingModel implements Model {
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming model request');
-      }
-
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        yield {
+    const model = new ScriptedModel([
+      modelStream([
+        {
           type: 'model',
           event: { type: 'response.output_item.added', item: compaction },
-        } as StreamEvent;
-        yield {
+        } as StreamEvent,
+        {
           type: 'response_done',
           response: {
             id: 'resp-compaction-stream',
@@ -415,13 +442,13 @@ describe('Runner.run (streaming)', () => {
             },
             output: [compaction, fakeModelMessage('streamed done')],
           },
-        } as StreamEvent;
-      }
-    }
+        } as StreamEvent,
+      ]),
+    ]);
 
     const agent = new Agent({
       name: 'StreamingCompactionAgent',
-      model: new CompactionStreamingModel(),
+      model,
     });
     const result = await run(agent, 'hi', { stream: true });
 
@@ -457,13 +484,9 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('does not persist input for a malformed terminal compaction item', async () => {
-    class MalformedCompactionStreamingModel implements Model {
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming model request');
-      }
-
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        yield {
+    const model = new ScriptedModel([
+      modelStream([
+        {
           type: 'response_done',
           response: {
             id: 'resp-malformed-compaction-stream',
@@ -480,9 +503,9 @@ describe('Runner.run (streaming)', () => {
               },
             ],
           },
-        } as StreamEvent;
-      }
-    }
+        } as StreamEvent,
+      ]),
+    ]);
 
     const addItems = vi.fn(async (_items: AgentInputItem[]) => {});
     const clearSession = vi.fn(async () => {});
@@ -499,7 +522,7 @@ describe('Runner.run (streaming)', () => {
     };
     const agent = new Agent({
       name: 'MalformedStreamingCompactionAgent',
-      model: new MalformedCompactionStreamingModel(),
+      model,
     });
     const defaultErrorHandler = vi.fn(() => ({
       finalOutput: 'not used',
@@ -521,40 +544,6 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
-    class QueueStreamingModel implements Model {
-      constructor(private readonly responses: ModelResponse[]) {}
-
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        const response = this.responses.shift();
-        if (!response) {
-          throw new Error('No response found');
-        }
-        return response;
-      }
-
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(request);
-        const output = response.output.map((item) =>
-          protocol.OutputModelItem.parse(item),
-        );
-        yield {
-          type: 'response_done',
-          response: {
-            id: response.responseId ?? 'resp-stream-tool-search',
-            usage: {
-              requests: response.usage.requests,
-              inputTokens: response.usage.inputTokens,
-              outputTokens: response.usage.outputTokens,
-              totalTokens: response.usage.totalTokens,
-            },
-            output,
-          },
-        } satisfies StreamEvent;
-      }
-    }
-
     const getShippingEta = tool({
       name: 'get_shipping_eta',
       description: 'Look up a shipping ETA.',
@@ -566,24 +555,30 @@ describe('Runner.run (streaming)', () => {
     });
     const agent = new Agent({
       name: 'StreamingShippingAgent',
-      model: new QueueStreamingModel([
-        {
-          output: [
-            {
-              type: 'function_call',
-              id: 'fc_shipping_eta',
-              callId: 'call_shipping_eta',
-              name: 'get_shipping_eta',
-              status: 'completed',
-              arguments: JSON.stringify({ trackingNumber: 'ZX-123' }),
-            } as protocol.FunctionCallItem,
-          ],
-          usage: new Usage(),
-        },
-        {
-          output: [fakeModelMessage('The package arrives tomorrow.')],
-          usage: new Usage(),
-        },
+      model: new ScriptedModel([
+        parsedTerminalModelStream(
+          {
+            output: [
+              {
+                type: 'function_call',
+                id: 'fc_shipping_eta',
+                callId: 'call_shipping_eta',
+                name: 'get_shipping_eta',
+                status: 'completed',
+                arguments: JSON.stringify({ trackingNumber: 'ZX-123' }),
+              } as protocol.FunctionCallItem,
+            ],
+            usage: new Usage(),
+          },
+          'resp-stream-tool-search',
+        ),
+        parsedTerminalModelStream(
+          {
+            output: [fakeModelMessage('The package arrives tomorrow.')],
+            usage: new Usage(),
+          },
+          'resp-stream-tool-search',
+        ),
       ]),
       tools: [getShippingEta],
       toolUseBehavior: 'run_llm_again',
@@ -609,58 +604,28 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('streams through missing function tool errors when opted in', async () => {
-    class RecordingStreamingModel implements Model {
-      readonly requests: ModelRequest[] = [];
-
-      constructor(private readonly responses: ModelResponse[]) {}
-
-      async getResponse(request: ModelRequest): Promise<ModelResponse> {
-        this.requests.push(request);
-        const response = this.responses.shift();
-        if (!response) {
-          throw new Error('No response found');
-        }
-        return response;
-      }
-
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(request);
-        yield {
-          type: 'response_done',
-          response: {
-            id: response.responseId ?? 'resp-stream-missing-tool',
-            usage: {
-              requests: response.usage.requests,
-              inputTokens: response.usage.inputTokens,
-              outputTokens: response.usage.outputTokens,
-              totalTokens: response.usage.totalTokens,
+    const model = new ScriptedModel([
+      parsedTerminalModelStream(
+        {
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: 'missing_tool',
+              callId: 'call_missing',
+              arguments: '{}',
             },
-            output: response.output.map((item) =>
-              protocol.OutputModelItem.parse(item),
-            ),
-          },
-        } satisfies StreamEvent;
-      }
-    }
-
-    const model = new RecordingStreamingModel([
-      {
-        output: [
-          {
-            ...TEST_MODEL_FUNCTION_CALL,
-            name: 'missing_tool',
-            callId: 'call_missing',
-            arguments: '{}',
-          },
-        ],
-        usage: new Usage(),
-      },
-      {
-        output: [fakeModelMessage('stream recovered')],
-        usage: new Usage(),
-      },
+          ],
+          usage: new Usage(),
+        },
+        'resp-stream-missing-tool',
+      ),
+      parsedTerminalModelStream(
+        {
+          output: [fakeModelMessage('stream recovered')],
+          usage: new Usage(),
+        },
+        'resp-stream-missing-tool',
+      ),
     ]);
     const agent = new Agent({
       name: 'StreamingMissingToolAgent',
@@ -675,8 +640,8 @@ describe('Runner.run (streaming)', () => {
 
     await result.completed;
     expect(result.finalOutput).toBe('stream recovered');
-    expect(model.requests).toHaveLength(2);
-    const secondInput = model.requests[1].input as AgentInputItem[];
+    expect(model.calls).toHaveLength(2);
+    const secondInput = model.calls[1].request.input as AgentInputItem[];
     expect(secondInput).toContainEqual({
       type: 'function_call_result',
       name: 'missing_tool',
@@ -690,38 +655,20 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('streams a redacted invalid-argument output back to the model', async () => {
-    class InvalidArgumentStreamingModel implements Model {
-      readonly requests: ModelRequest[] = [];
-
-      constructor(private readonly responses: ModelResponse[]) {}
-
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming model request');
+    class InvalidArgumentStreamingModel extends ScriptedModel {
+      constructor(responses: ModelResponse[]) {
+        super(
+          responses.map((response) =>
+            parsedTerminalModelStream(
+              response,
+              response.responseId ?? 'resp-stream-invalid-argument',
+            ),
+          ),
+        );
       }
 
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        this.requests.push(request);
-        const response = this.responses.shift();
-        if (!response) {
-          throw new Error('No response found');
-        }
-        yield {
-          type: 'response_done',
-          response: {
-            id: response.responseId ?? 'resp-stream-invalid-argument',
-            usage: {
-              requests: response.usage.requests,
-              inputTokens: response.usage.inputTokens,
-              outputTokens: response.usage.outputTokens,
-              totalTokens: response.usage.totalTokens,
-            },
-            output: response.output.map((item) =>
-              protocol.OutputModelItem.parse(item),
-            ),
-          },
-        } satisfies StreamEvent;
+      get requests(): readonly Readonly<ModelRequest>[] {
+        return this.calls.map((call) => call.request);
       }
     }
 
@@ -771,15 +718,9 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('does not retain invalid arguments in streamed Runner errors', async () => {
-    class InvalidArgumentThrowingStreamModel implements Model {
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming model request');
-      }
-
-      async *getStreamedResponse(
-        _request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        yield {
+    const model = new ScriptedModel([
+      modelStream([
+        {
           type: 'response_done',
           response: {
             id: 'resp-stream-invalid-argument-error',
@@ -796,15 +737,15 @@ describe('Runner.run (streaming)', () => {
               }),
             ],
           },
-        } satisfies StreamEvent;
-      }
-    }
+        } satisfies StreamEvent,
+      ]),
+    ]);
 
     const secret = 'SECRET_STREAMED_RUN_STATE_123';
     vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
     const agent = new Agent({
       name: 'StreamingInvalidArgumentStateAgent',
-      model: new InvalidArgumentThrowingStreamModel(),
+      model,
       tools: [
         tool({
           name: 'test',
@@ -1004,34 +945,14 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('emits agent_updated_stream_event with new agent on handoff', async () => {
-    class SimpleStreamingModel implements Model {
-      constructor(private resp: ModelResponse) {}
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return this.resp;
-      }
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'r',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: this.resp.output,
-          },
-        } as any;
-      }
-    }
-
     const agentB = new Agent({
       name: 'B',
-      model: new SimpleStreamingModel({
-        output: [fakeModelMessage('done B')],
-        usage: new Usage(),
-      }),
+      model: new ScriptedModel([
+        terminalModelStream(
+          { output: [fakeModelMessage('done B')], usage: new Usage() },
+          'r',
+        ),
+      ]),
     });
 
     const callItem: FunctionCallItem = {
@@ -1045,10 +966,9 @@ describe('Runner.run (streaming)', () => {
 
     const agentA = new Agent({
       name: 'A',
-      model: new SimpleStreamingModel({
-        output: [callItem],
-        usage: new Usage(),
-      }),
+      model: new ScriptedModel([
+        terminalModelStream({ output: [callItem], usage: new Usage() }, 'r'),
+      ]),
       handoffs: [handoff(agentB)],
     });
 
@@ -1067,41 +987,23 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('streams only the accepted handoff when multiple handoffs are emitted', async () => {
-    class SimpleStreamingModel implements Model {
-      constructor(private resp: ModelResponse) {}
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return this.resp;
-      }
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'r',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: this.resp.output,
-          },
-        } as any;
-      }
-    }
-
     const agentB = new Agent({
       name: 'B',
-      model: new SimpleStreamingModel({
-        output: [fakeModelMessage('done B')],
-        usage: new Usage(),
-      }),
+      model: new ScriptedModel([
+        terminalModelStream(
+          { output: [fakeModelMessage('done B')], usage: new Usage() },
+          'r',
+        ),
+      ]),
     });
     const agentC = new Agent({
       name: 'C',
-      model: new SimpleStreamingModel({
-        output: [fakeModelMessage('done C')],
-        usage: new Usage(),
-      }),
+      model: new ScriptedModel([
+        terminalModelStream(
+          { output: [fakeModelMessage('done C')], usage: new Usage() },
+          'r',
+        ),
+      ]),
     });
     const handoffToB = handoff(agentB);
     const handoffToC = handoff(agentC);
@@ -1123,10 +1025,12 @@ describe('Runner.run (streaming)', () => {
     };
     const agentA = new Agent({
       name: 'A',
-      model: new SimpleStreamingModel({
-        output: [acceptedCall, ignoredCall],
-        usage: new Usage(),
-      }),
+      model: new ScriptedModel([
+        terminalModelStream(
+          { output: [acceptedCall, ignoredCall], usage: new Usage() },
+          'r',
+        ),
+      ]),
       handoffs: [handoffToB, handoffToC],
     });
 
@@ -1163,34 +1067,14 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('emits agent_end lifecycle event for streaming agents', async () => {
-    class SimpleStreamingModel implements Model {
-      constructor(private resp: ModelResponse) {}
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return this.resp;
-      }
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'r',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: this.resp.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'TestAgent',
-      model: new SimpleStreamingModel({
-        output: [fakeModelMessage('Final output')],
-        usage: new Usage(),
-      }),
+      model: new ScriptedModel([
+        terminalModelStream(
+          { output: [fakeModelMessage('Final output')], usage: new Usage() },
+          'r',
+        ),
+      ]),
     });
 
     // Track agent_end events on both the agent and runner
@@ -1227,34 +1111,14 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('emits turn input on agent_start during streaming runs', async () => {
-    class LifecycleStreamingModel implements Model {
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return {
-          output: [fakeModelMessage('Final output')],
-          usage: new Usage(),
-        };
-      }
-
-      async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'r_lifecycle',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: [fakeModelMessage('Final output')],
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'StreamLifecycleAgent',
-      model: new LifecycleStreamingModel(),
+      model: new ScriptedModel([
+        terminalModelStream(
+          { output: [fakeModelMessage('Final output')], usage: new Usage() },
+          'r_lifecycle',
+        ),
+      ]),
     });
     const runner = new Runner();
 
@@ -1289,55 +1153,42 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('applies reasoningItemIdPolicy to follow-up streamed turn input', async () => {
-    class RequestRecordingStreamingModel implements Model {
-      readonly requests: ModelRequest[] = [];
-      #callCount = 0;
-
-      async getResponse(request: ModelRequest): Promise<ModelResponse> {
-        this.requests.push(request);
-        if (this.#callCount++ === 0) {
-          return {
-            output: [
-              {
-                type: 'reasoning',
-                id: 'rs_stream',
-                content: [{ type: 'input_text', text: 'reasoning trace' }],
-              } satisfies protocol.ReasoningItem,
-              {
-                type: 'function_call',
-                id: 'fc_stream',
-                callId: 'call_stream',
-                name: 'echo_tool',
-                status: 'completed',
-                arguments: '{}',
-              } satisfies protocol.FunctionCallItem,
-            ],
-            usage: new Usage(),
-          };
-        }
-        return {
-          output: [fakeModelMessage('stream done')],
-          usage: new Usage(),
-        };
+    class RequestRecordingStreamingModel extends ScriptedModel {
+      constructor() {
+        super([
+          parsedTerminalModelStream(
+            {
+              output: [
+                {
+                  type: 'reasoning',
+                  id: 'rs_stream',
+                  content: [{ type: 'input_text', text: 'reasoning trace' }],
+                } satisfies protocol.ReasoningItem,
+                {
+                  type: 'function_call',
+                  id: 'fc_stream',
+                  callId: 'call_stream',
+                  name: 'echo_tool',
+                  status: 'completed',
+                  arguments: '{}',
+                } satisfies protocol.FunctionCallItem,
+              ],
+              usage: new Usage(),
+            },
+            'stream_1',
+          ),
+          parsedTerminalModelStream(
+            {
+              output: [fakeModelMessage('stream done')],
+              usage: new Usage(),
+            },
+            'stream_2',
+          ),
+        ]);
       }
 
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(request);
-        yield {
-          type: 'response_done',
-          response: {
-            id: `stream_${this.#callCount}`,
-            usage: {
-              requests: 1,
-              inputTokens: response.usage.inputTokens,
-              outputTokens: response.usage.outputTokens,
-              totalTokens: response.usage.totalTokens,
-            },
-            output: response.output,
-          },
-        } as any;
+      get requests(): readonly Readonly<ModelRequest>[] {
+        return this.calls.map((call) => call.request);
       }
     }
 
@@ -1399,37 +1250,12 @@ describe('Runner.run (streaming)', () => {
       usage: new Usage({ inputTokens: 20, outputTokens: 10, totalTokens: 30 }),
     };
 
-    class MultiTurnStreamingModel implements Model {
-      #callCount = 0;
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        const current = this.#callCount++;
-        return current === 0 ? firstResponse : secondResponse;
-      }
-
-      async *getStreamedResponse(
-        req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(req);
-        yield {
-          type: 'response_done',
-          response: {
-            id: `r_${this.#callCount}`,
-            usage: {
-              requests: 1,
-              inputTokens: response.usage.inputTokens,
-              outputTokens: response.usage.outputTokens,
-              totalTokens: response.usage.totalTokens,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'UsageTracker',
-      model: new MultiTurnStreamingModel(),
+      model: new ScriptedModel([
+        terminalModelStream(firstResponse, 'r_1'),
+        terminalModelStream(secondResponse, 'r_2'),
+      ]),
       tools: [testTool],
     });
 
@@ -1490,36 +1316,13 @@ describe('Runner.run (streaming)', () => {
       },
     ];
 
-    class ExpensiveStreamingModel implements Model {
-      #callCount = 0;
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return responses[this.#callCount++] ?? responses[responses.length - 1];
-      }
-
-      async *getStreamedResponse(
-        req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(req);
-        yield {
-          type: 'response_done',
-          response: {
-            id: `r_${this.#callCount}`,
-            usage: {
-              requests: 1,
-              inputTokens: response.usage.inputTokens,
-              outputTokens: response.usage.outputTokens,
-              totalTokens: response.usage.totalTokens,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'ExpensiveAgent',
-      model: new ExpensiveStreamingModel(),
+      model: new ScriptedModel(
+        responses.map((response, index) =>
+          terminalModelStream(response, `r_${index + 1}`),
+        ),
+      ),
       tools: [testTool],
     });
 
@@ -1578,40 +1381,29 @@ describe('Runner.run (streaming)', () => {
         );
       });
 
-    class DelayedStreamingModel implements Model {
-      constructor(private readonly delayMs: number) {}
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return {
-          output: [fakeModelMessage('final')],
-          usage: new Usage(),
-        };
-      }
-
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        yield { type: 'output_text_delta', delta: 'hello' } as any;
-        await waitWithAbort(this.delayMs, request.signal);
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'delayed',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: [fakeModelMessage('final')],
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'SlowStream',
-      model: new DelayedStreamingModel(400),
+      model: new ScriptedModel([
+        modelStreamResponder((call) =>
+          (async function* () {
+            yield { type: 'output_text_delta', delta: 'hello' } as StreamEvent;
+            await waitWithAbort(400, call.request.signal);
+            yield {
+              type: 'response_done',
+              response: {
+                id: 'delayed',
+                usage: {
+                  requests: 1,
+                  inputTokens: 0,
+                  outputTokens: 0,
+                  totalTokens: 0,
+                },
+                output: [fakeModelMessage('final')],
+              },
+            } as StreamEvent;
+          })(),
+        ),
+      ]),
     });
 
     const result = await run(agent, 'go', { stream: true });
@@ -1643,36 +1435,34 @@ describe('Runner.run (streaming)', () => {
       releaseModel = resolve;
     });
 
-    class SettlingStreamingModel implements Model {
-      async getResponse(): Promise<ModelResponse> {
-        throw new Error('Unexpected non-streaming model request');
-      }
-
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        yield { type: 'output_text_delta', delta: 'hello' } as StreamEvent;
-        if (!request.signal) {
-          throw new Error('Expected an abort signal');
-        }
-        if (!request.signal.aborted) {
-          await new Promise<void>((resolve) => {
-            request.signal?.addEventListener('abort', () => resolve(), {
-              once: true,
-            });
-          });
-        }
-        markAbortObserved?.();
-        await modelReleased;
-        const error = new Error('Aborted');
-        error.name = 'AbortError';
-        throw error;
-      }
-    }
-
     const agent = new Agent({
       name: 'SettlingStream',
-      model: new SettlingStreamingModel(),
+      model: new ScriptedModel([
+        modelStreamResponder((call) =>
+          (async function* () {
+            yield {
+              type: 'output_text_delta',
+              delta: 'hello',
+            } as StreamEvent;
+            const signal = call.request.signal;
+            if (!signal) {
+              throw new Error('Expected an abort signal');
+            }
+            if (!signal.aborted) {
+              await new Promise<void>((resolve) => {
+                signal.addEventListener('abort', () => resolve(), {
+                  once: true,
+                });
+              });
+            }
+            markAbortObserved?.();
+            await modelReleased;
+            const error = new Error('Aborted');
+            error.name = 'AbortError';
+            throw error;
+          })(),
+        ),
+      ]),
     });
     const result = await run(agent, 'go', { stream: true });
     const reader = (result.toStream() as any).getReader();
@@ -1726,32 +1516,6 @@ describe('Runner.run (streaming)', () => {
       streamStarted = resolve;
     });
 
-    class SlowFirstEventStreamingModel implements Model {
-      async getResponse(): Promise<ModelResponse> {
-        throw new Error('not used');
-      }
-
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        streamStarted?.();
-        await waitWithAbort(500, request.signal);
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'resp-delayed',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: [fakeModelMessage('should not reach')],
-          },
-        } as any;
-      }
-    }
-
     const markSpy = vi.spyOn(
       ServerConversationTracker.prototype,
       'markInputAsSent',
@@ -1759,7 +1523,27 @@ describe('Runner.run (streaming)', () => {
 
     const agent = new Agent({
       name: 'AbortBeforeFirstEvent',
-      model: new SlowFirstEventStreamingModel(),
+      model: new ScriptedModel([
+        modelStreamResponder((call) =>
+          (async function* () {
+            streamStarted?.();
+            await waitWithAbort(500, call.request.signal);
+            yield {
+              type: 'response_done',
+              response: {
+                id: 'resp-delayed',
+                usage: {
+                  requests: 1,
+                  inputTokens: 0,
+                  outputTokens: 0,
+                  totalTokens: 0,
+                },
+                output: [fakeModelMessage('should not reach')],
+              },
+            } as StreamEvent;
+          })(),
+        ),
+      ]),
     });
     const runner = new Runner();
 
@@ -1816,38 +1600,12 @@ describe('Runner.run (streaming)', () => {
       usage: new Usage(),
     };
 
-    class BlockingStreamModel implements Model {
-      #callCount = 0;
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return this.#callCount === 0 ? toolResponse : finalMessageResponse;
-      }
-
-      async *getStreamedResponse(
-        _req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const currentCall = this.#callCount++;
-        const response =
-          currentCall === 0 ? toolResponse : finalMessageResponse;
-        yield {
-          type: 'response_done',
-          response: {
-            id: `resp-${currentCall}`,
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'BlockingAgent',
-      model: new BlockingStreamModel(),
+      model: new ScriptedModel([
+        terminalModelStream(toolResponse, 'resp-0'),
+        terminalModelStream(finalMessageResponse, 'resp-1'),
+      ]),
       tools: [blockingTool],
     });
 
@@ -2270,38 +2028,38 @@ describe('Runner.run (streaming)', () => {
     const nestedModelStarted = new Promise<void>((resolve) => {
       markNestedModelStarted = resolve;
     });
-    const nestedModel: Model = {
-      async getResponse() {
-        throw new Error('Unexpected non-streaming nested model request');
-      },
-      async *getStreamedResponse(request) {
-        markNestedModelStarted?.();
-        if (!request.signal) {
-          throw new Error('Expected nested model abort signal');
-        }
-        if (!request.signal.aborted) {
-          await new Promise<void>((resolve) => {
-            request.signal!.addEventListener('abort', () => resolve(), {
-              once: true,
+    const nestedModel = new ScriptedModel([
+      modelStreamResponder((call) =>
+        (async function* () {
+          markNestedModelStarted?.();
+          const signal = call.request.signal;
+          if (!signal) {
+            throw new Error('Expected nested model abort signal');
+          }
+          if (!signal.aborted) {
+            await new Promise<void>((resolve) => {
+              signal.addEventListener('abort', () => resolve(), {
+                once: true,
+              });
             });
-          });
-        }
-        request.signal.throwIfAborted();
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'unexpected-nested-response',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
+          }
+          signal.throwIfAborted();
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'unexpected-nested-response',
+              usage: {
+                requests: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              output: [fakeModelMessage('unexpected nested completion')],
             },
-            output: [fakeModelMessage('unexpected nested completion')],
-          },
-        } as StreamEvent;
-      },
-    };
+          } as StreamEvent;
+        })(),
+      ),
+    ]);
     const nestedAgent = new Agent({
       name: 'NestedStreamingAgent',
       model: nestedModel,
@@ -2374,26 +2132,15 @@ describe('Runner.run (streaming)', () => {
         };
       }),
     };
-    const nestedModel: Model = {
-      async getResponse() {
-        throw new Error('Unexpected non-streaming nested model request');
-      },
-      async *getStreamedResponse() {
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'nested-final-response',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: [fakeModelMessage('nested final output')],
-          },
-        } as StreamEvent;
-      },
-    };
+    const nestedModel = new ScriptedModel([
+      terminalModelStream(
+        {
+          output: [fakeModelMessage('nested final output')],
+          usage: new Usage(),
+        },
+        'nested-final-response',
+      ),
+    ]);
     const nestedAgent = new Agent({
       name: 'CommittedNestedStreamingAgent',
       model: nestedModel,
@@ -2667,37 +2414,12 @@ describe('Runner.run (streaming)', () => {
       usage: new Usage(),
     };
 
-    class SimpleStreamingModel implements Model {
-      #callCount = 0;
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        const current = this.#callCount++;
-        return current === 0 ? firstResponse : secondResponse;
-      }
-
-      async *getStreamedResponse(
-        req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(req);
-        yield {
-          type: 'response_done',
-          response: {
-            id: `r_${this.#callCount}`,
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'StreamTurnCounter',
-      model: new SimpleStreamingModel(),
+      model: new ScriptedModel([
+        terminalModelStream(firstResponse, 'r_1'),
+        terminalModelStream(secondResponse, 'r_2'),
+      ]),
       tools: [testTool],
       toolUseBehavior: 'run_llm_again',
     });
@@ -2740,40 +2462,13 @@ describe('Runner.run (streaming)', () => {
       },
     ];
 
-    class LongStreamingModel implements Model {
-      #callCount = 0;
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        const response = responses[this.#callCount++];
-        if (!response) {
-          throw new Error('No response found');
-        }
-        return response;
-      }
-
-      async *getStreamedResponse(
-        req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(req);
-        yield {
-          type: 'response_done',
-          response: {
-            id: `r_${this.#callCount}`,
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'NoMaxTurnsStream',
-      model: new LongStreamingModel(),
+      model: new ScriptedModel(
+        responses.map((response, index) =>
+          terminalModelStream(response, `r_${index + 1}`),
+        ),
+      ),
       tools: [testTool],
       toolUseBehavior: 'run_llm_again',
     });
@@ -2792,8 +2487,11 @@ describe('Runner.run (streaming)', () => {
   it('handles maxTurns errors with an error handler', async () => {
     const agent = new Agent({
       name: 'MaxTurnsHandlerStream',
-      model: new FakeModel([
-        { output: [fakeModelMessage('nope')], usage: new Usage() },
+      model: new ScriptedModel([
+        modelResponse({
+          output: [fakeModelMessage('nope')],
+          usage: new Usage(),
+        }),
       ]),
     });
     const result = await run(agent, 'x', {
@@ -2838,7 +2536,7 @@ describe('Runner.run (streaming)', () => {
     });
     const agent = new Agent({
       name: 'Pending error-handler guardrail stream',
-      model: new FakeModel([]),
+      model: new ScriptedModel([]),
       outputGuardrails: [
         {
           name: 'suspend error-handler output',
@@ -2872,37 +2570,19 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('handles model refusal errors with an error handler', async () => {
-    class RefusalStreamingModel implements Model {
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return {
+    const model = new ScriptedModel([
+      terminalModelStream(
+        {
           output: [fakeModelRefusal('I cannot help with that request.')],
           usage: new Usage(),
-        };
-      }
-
-      async *getStreamedResponse(
-        req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(req);
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'r_refusal',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
+        },
+        'r_refusal',
+      ),
+    ]);
 
     const agent = new Agent({
       name: 'RefusalHandlerStream',
-      model: new RefusalStreamingModel(),
+      model,
     });
     const result = await run(agent, 'x', {
       stream: true,
@@ -2932,38 +2612,20 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('handles invalid final output errors with an error handler', async () => {
-    class InvalidFinalOutputStreamingModel implements Model {
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return {
+    const model = new ScriptedModel([
+      terminalModelStream(
+        {
           output: [fakeModelMessage('not valid json')],
           usage: new Usage(),
-        };
-      }
-
-      async *getStreamedResponse(
-        req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response = await this.getResponse(req);
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'r_invalid_final_output',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
+        },
+        'r_invalid_final_output',
+      ),
+    ]);
 
     const agent = new Agent({
       name: 'InvalidFinalOutputHandlerStream',
       outputType: z.object({ summary: z.string() }),
-      model: new InvalidFinalOutputStreamingModel(),
+      model,
     });
     const result = await run(agent, 'x', {
       stream: true,
@@ -3001,37 +2663,6 @@ describe('Runner.run (streaming)', () => {
       execute: async ({ city }) => `Weather in ${city}`,
     });
 
-    class ApprovalStreamingModel implements Model {
-      constructor(private readonly responses: ModelResponse[]) {}
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        const response = this.responses.shift();
-        if (!response) {
-          throw new Error('No response found');
-        }
-        return response;
-      }
-
-      async *getStreamedResponse(
-        req: ModelRequest,
-      ): AsyncIterable<protocol.StreamEvent> {
-        const response = await this.getResponse(req);
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'approval-stream',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as protocol.StreamEvent;
-      }
-    }
-
     const modelResponses: ModelResponse[] = [
       {
         output: [
@@ -3052,7 +2683,11 @@ describe('Runner.run (streaming)', () => {
 
     const agent = new Agent({
       name: 'ApprovalStreamResume',
-      model: new ApprovalStreamingModel(modelResponses),
+      model: new ScriptedModel(
+        modelResponses.map((response) =>
+          terminalModelStream(response, 'approval-stream'),
+        ),
+      ),
       tools: [approvalTool],
       toolUseBehavior: 'run_llm_again',
     });
@@ -3111,38 +2746,12 @@ describe('Runner.run (streaming)', () => {
       usage: new Usage(),
     };
 
-    class SequencedStreamModel implements Model {
-      #turn = 0;
-
-      async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-        return this.#turn === 0 ? firstTurnResponse : secondTurnResponse;
-      }
-
-      async *getStreamedResponse(
-        _req: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const response =
-          this.#turn === 0 ? firstTurnResponse : secondTurnResponse;
-        this.#turn += 1;
-        yield {
-          type: 'response_done',
-          response: {
-            id: `resp-${this.#turn}`,
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'SequencedAgent',
-      model: new SequencedStreamModel(),
+      model: new ScriptedModel([
+        terminalModelStream(firstTurnResponse, 'resp-1'),
+        terminalModelStream(secondTurnResponse, 'resp-2'),
+      ]),
       tools: [sequenceTool],
     });
 
@@ -3168,58 +2777,54 @@ describe('Runner.run (streaming)', () => {
   describe('server-managed conversation state', () => {
     type Turn = { output: protocol.ModelItem[]; responseId?: string };
 
-    class TrackingStreamingModel implements Model {
-      public requests: ModelRequest[] = [];
-      public firstRequest: ModelRequest | undefined;
-      public lastRequest: ModelRequest | undefined;
+    class TrackingStreamingModel extends ScriptedModel {
+      public requests: ModelRequest[];
 
-      constructor(private readonly turns: Turn[]) {}
-
-      private recordRequest(request: ModelRequest) {
-        const clonedInput: string | AgentInputItem[] =
-          typeof request.input === 'string'
-            ? request.input
-            : (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[]);
-
-        const recorded: ModelRequest = {
-          ...request,
-          input: clonedInput,
-        };
-
-        this.requests.push(recorded);
-        this.lastRequest = recorded;
-        this.firstRequest ??= recorded;
+      constructor(turns: Turn[]) {
+        const requests: ModelRequest[] = [];
+        super(
+          turns.map((turn) =>
+            modelStreamResponder((call) => {
+              const recorded: ModelRequest = {
+                ...call.request,
+                input:
+                  typeof call.request.input === 'string'
+                    ? call.request.input
+                    : (JSON.parse(
+                        JSON.stringify(call.request.input),
+                      ) as AgentInputItem[]),
+              };
+              requests.push(recorded);
+              const responseId = turn.responseId ?? `resp-${requests.length}`;
+              return [
+                {
+                  type: 'response_done',
+                  response: {
+                    id: responseId,
+                    usage: {
+                      requests: 1,
+                      inputTokens: 0,
+                      outputTokens: 0,
+                      totalTokens: 0,
+                    },
+                    output: JSON.parse(
+                      JSON.stringify(turn.output),
+                    ) as protocol.ModelItem[],
+                  },
+                } as StreamEvent,
+              ];
+            }),
+          ),
+        );
+        this.requests = requests;
       }
 
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Not implemented');
+      get firstRequest(): ModelRequest | undefined {
+        return this.requests[0];
       }
 
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        this.recordRequest(request);
-        const turn = this.turns.shift();
-        if (!turn) {
-          throw new Error('No response configured');
-        }
-
-        const responseId = turn.responseId ?? `resp-${this.requests.length}`;
-        yield {
-          type: 'response_done',
-          response: {
-            id: responseId,
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: JSON.parse(
-              JSON.stringify(turn.output),
-            ) as protocol.ModelItem[],
-          },
-        } as StreamEvent;
+      get lastRequest(): ModelRequest | undefined {
+        return this.requests.at(-1);
       }
     }
 
@@ -3411,25 +3016,13 @@ describe('Runner.run (streaming)', () => {
     });
 
     it('does not mark streaming inputs as sent when the stream fails before any events', async () => {
-      /* eslint-disable require-yield */
-      class ThrowingStreamingModel implements Model {
-        async getResponse(): Promise<ModelResponse> {
-          throw new Error('not used');
-        }
-
-        async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-          throw new Error('stream failure');
-        }
-      }
-      /* eslint-enable require-yield */
-
       const markSpy = vi.spyOn(
         ServerConversationTracker.prototype,
         'markInputAsSent',
       );
       const agent = new Agent({
         name: 'StreamFail',
-        model: new ThrowingStreamingModel(),
+        model: new ScriptedModel([modelError(new Error('stream failure'))]),
       });
       const runner = new Runner();
 
@@ -3612,58 +3205,65 @@ describe('Runner.run (streaming)', () => {
     });
 
     it('replays managed handoff acknowledgements when resuming before streamed response completion', async () => {
-      class AbortAfterAckStreamingModel implements Model {
-        public requests: ModelRequest[] = [];
-        private attempt = 0;
+      class AbortAfterAckStreamingModel extends ScriptedModel {
+        readonly requests: ModelRequest[];
 
-        async getResponse(): Promise<ModelResponse> {
-          throw new Error('not used');
-        }
-
-        async *getStreamedResponse(
-          request: ModelRequest,
-        ): AsyncIterable<StreamEvent> {
-          this.requests.push({
-            ...request,
-            input: Array.isArray(request.input)
-              ? (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[])
-              : request.input,
-          });
-          this.attempt += 1;
-
-          if (this.attempt === 1) {
-            yield { type: 'output_text_delta', delta: 'ack' } as any;
-            const abortError = new Error('aborted');
-            (abortError as Error & { name: string }).name = 'AbortError';
-            const signal = request.signal as AbortSignal | undefined;
-            await new Promise((_resolve, reject) => {
-              if (signal?.aborted) {
-                reject(abortError);
-                return;
-              }
-              const onAbort = () => {
-                signal?.removeEventListener('abort', onAbort);
-                reject(abortError);
-              };
-              signal?.addEventListener('abort', onAbort, { once: true });
+        constructor() {
+          const requests: ModelRequest[] = [];
+          const record = (request: Readonly<ModelRequest>) => {
+            requests.push({
+              ...request,
+              input: Array.isArray(request.input)
+                ? (JSON.parse(
+                    JSON.stringify(request.input),
+                  ) as AgentInputItem[])
+                : request.input,
             });
-            yield* [] as any;
-            return;
-          }
-
-          yield {
-            type: 'response_done',
-            response: {
-              id: 'resp-b-final',
-              usage: {
-                requests: 1,
-                inputTokens: 0,
-                outputTokens: 0,
-                totalTokens: 0,
-              },
-              output: [fakeModelMessage('done B')],
-            },
-          } as any;
+          };
+          super([
+            modelStreamResponder((call) =>
+              (async function* () {
+                record(call.request);
+                yield {
+                  type: 'output_text_delta',
+                  delta: 'ack',
+                } as StreamEvent;
+                const abortError = new Error('aborted');
+                abortError.name = 'AbortError';
+                const signal = call.request.signal;
+                await new Promise((_resolve, reject) => {
+                  if (signal?.aborted) {
+                    reject(abortError);
+                    return;
+                  }
+                  const onAbort = () => {
+                    signal?.removeEventListener('abort', onAbort);
+                    reject(abortError);
+                  };
+                  signal?.addEventListener('abort', onAbort, { once: true });
+                });
+              })(),
+            ),
+            modelStreamResponder((call) => {
+              record(call.request);
+              return [
+                {
+                  type: 'response_done',
+                  response: {
+                    id: 'resp-b-final',
+                    usage: {
+                      requests: 1,
+                      inputTokens: 0,
+                      outputTokens: 0,
+                      totalTokens: 0,
+                    },
+                    output: [fakeModelMessage('done B')],
+                  },
+                } as StreamEvent,
+              ];
+            }),
+          ]);
+          this.requests = requests;
         }
       }
 
@@ -4155,18 +3755,7 @@ describe('Runner.run (streaming)', () => {
       }),
     };
     const streamError = new Error('model stream failed after compaction');
-    let capturedRequest: ModelRequest | undefined;
-    const model: Model = {
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw streamError;
-      },
-      getStreamedResponse(request: ModelRequest): AsyncIterable<StreamEvent> {
-        capturedRequest = request;
-        return new RejectingStreamingModel(streamError).getStreamedResponse(
-          request,
-        );
-      },
-    };
+    const model = new ScriptedModel([modelError(streamError)]);
     const agent = new Agent({ name: 'StreamCompactedInputFailure', model });
     const result = await new Runner().run(
       agent,
@@ -4178,7 +3767,7 @@ describe('Runner.run (streaming)', () => {
       'model stream failed after compaction',
     );
 
-    expect(capturedRequest?.input).toEqual([compaction, retainedInput]);
+    expect(model.firstCall?.request.input).toEqual([compaction, retainedInput]);
     expect(sessionItems).toEqual([compaction, retainedInput]);
   });
 
@@ -4436,34 +4025,15 @@ describe('Runner.run (streaming)', () => {
       },
     };
 
-    class TrackingStreamingModel implements Model {
-      calls = 0;
-
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('not implemented');
-      }
-
-      async *getStreamedResponse(
-        _request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        this.calls++;
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'stream-response',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: [protocol.OutputModelItem.parse(fakeModelMessage('done'))],
-          },
-        } satisfies StreamEvent;
-      }
-    }
-
-    const model = new TrackingStreamingModel();
+    const model = new ScriptedModel([
+      terminalModelStream(
+        {
+          output: [protocol.OutputModelItem.parse(fakeModelMessage('done'))],
+          usage: new Usage(),
+        },
+        'stream-response',
+      ),
+    ]);
     const agent = new Agent({
       name: 'StreamingParallelGuardrailFailure',
       model,
@@ -4483,7 +4053,7 @@ describe('Runner.run (streaming)', () => {
     );
     await errorThrown;
     await new Promise((resolve) => setTimeout(resolve, 0));
-    const callsBeforeSiblingFinished = model.calls;
+    const callsBeforeSiblingFinished = model.calls.length;
     const settledBeforeSiblingFinished = completionSettled;
     releaseSlowGuardrail();
 
@@ -4492,7 +4062,7 @@ describe('Runner.run (streaming)', () => {
     );
     expect(callsBeforeSiblingFinished).toBe(0);
     expect(settledBeforeSiblingFinished).toBe(false);
-    expect(model.calls).toBe(0);
+    expect(model.calls).toHaveLength(0);
     expect(result.currentTurn).toBe(0);
     expect(result.inputGuardrailResults.map((r) => r.guardrail.name)).toEqual([
       'slow-parallel-guardrail',
@@ -4517,38 +4087,29 @@ describe('Runner.run (streaming)', () => {
       },
     };
 
-    class TrackingStreamingModel implements Model {
-      calls = 0;
-
-      async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('not implemented');
-      }
-
-      async *getStreamedResponse(
-        _request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        this.calls++;
-        markModelStarted();
-        await guardrailFailing;
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'late-guardrail-response',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
+    const model = new ScriptedModel([
+      modelStreamResponder(() =>
+        (async function* () {
+          markModelStarted();
+          await guardrailFailing;
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'late-guardrail-response',
+              usage: {
+                requests: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              output: [
+                protocol.OutputModelItem.parse(fakeModelMessage('unused')),
+              ],
             },
-            output: [
-              protocol.OutputModelItem.parse(fakeModelMessage('unused')),
-            ],
-          },
-        } satisfies StreamEvent;
-      }
-    }
-
-    const model = new TrackingStreamingModel();
+          } satisfies StreamEvent;
+        })(),
+      ),
+    ]);
     const agent = new Agent({
       name: 'LateStreamingParallelGuardrailFailure',
       model,
@@ -4560,7 +4121,7 @@ describe('Runner.run (streaming)', () => {
     await expect(result.completed).rejects.toBeInstanceOf(
       GuardrailExecutionError,
     );
-    expect(model.calls).toBe(1);
+    expect(model.calls).toHaveLength(1);
     expect(result.currentTurn).toBe(1);
     expect(result.state._currentTurn).toBe(1);
 
@@ -4576,7 +4137,7 @@ describe('Runner.run (streaming)', () => {
     );
     expect(resumed.currentTurn).toBe(1);
     expect(resumed.state._currentTurn).toBe(1);
-    expect(model.calls).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('persists streaming input through the blocked result save when an output guardrail trips', async () => {
@@ -4680,7 +4241,7 @@ describe('Runner.run (streaming)', () => {
     });
     const agent = new Agent({
       name: 'Pre-aborted final output resume',
-      model: new FakeModel([]),
+      model: new ScriptedModel([]),
       outputGuardrails: [
         {
           name: 'should not run after pre-abort',
@@ -4802,37 +4363,9 @@ describe('Runner.run (streaming)', () => {
   });
 
   it('resumes a cancelled in-progress turn without double-counting turns', async () => {
-    class HangingStreamingModel implements Model {
-      async getResponse(): Promise<ModelResponse> {
-        throw new Error('unused');
-      }
-
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const abortError = new Error('aborted');
-        (abortError as any).name = 'AbortError';
-        const signal = (request as any).signal as AbortSignal | undefined;
-        await new Promise((_resolve, reject) => {
-          if (signal?.aborted) {
-            reject(abortError);
-            return;
-          }
-          const onAbort = () => {
-            signal?.removeEventListener('abort', onAbort);
-            reject(abortError);
-          };
-          signal?.addEventListener('abort', onAbort, { once: true });
-        });
-
-        // Keep the generator shape for the streaming contract while intentionally yielding nothing.
-        yield* [] as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'ResumeAfterCancel',
-      model: new HangingStreamingModel(),
+      model: new ScriptedModel([abortingHangingStream()]),
     });
     const runner = new Runner();
 
@@ -4850,10 +4383,12 @@ describe('Runner.run (streaming)', () => {
     const serialized = streaming.state.toString();
     const restored = await RunState.fromString(agent, serialized);
 
-    agent.model = new ImmediateStreamingModel({
-      output: [fakeModelMessage('resumed')],
-      usage: new Usage(),
-    });
+    agent.model = new ScriptedModel([
+      modelResponse({
+        output: [fakeModelMessage('resumed')],
+        usage: new Usage(),
+      }),
+    ]);
 
     const resumed = await runner.run(agent, restored);
 
@@ -4964,43 +4499,41 @@ describe('Runner.run (streaming)', () => {
   it.each(['non-plain', 'cyclic', 'throwing getter'] as const)(
     'ignores %s raw usage from a terminal model event',
     async (variant) => {
-      class InvalidRawUsageStreamingModel implements Model {
-        async getResponse(): Promise<ModelResponse> {
-          throw new Error('Unexpected call to getResponse');
-        }
-
-        async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-          const response: Record<string, unknown> = {
-            id: 'r',
-            usage: {
-              requests: 1,
-              inputTokens: 1,
-              outputTokens: 1,
-              totalTokens: 2,
-            },
-            output: [fakeModelMessage('done')],
-          };
-          if (variant === 'throwing getter') {
-            Object.defineProperty(response, 'rawUsage', {
-              enumerable: true,
-              get() {
-                throw new Error('raw usage is unavailable');
+      const model = new ScriptedModel([
+        modelStreamResponder(() =>
+          (async function* () {
+            const response: Record<string, unknown> = {
+              id: 'r',
+              usage: {
+                requests: 1,
+                inputTokens: 1,
+                outputTokens: 1,
+                totalTokens: 2,
               },
-            });
-          } else if (variant === 'cyclic') {
-            const rawUsage: Record<string, unknown> = {};
-            rawUsage.self = rawUsage;
-            response.rawUsage = rawUsage;
-          } else {
-            response.rawUsage = new Map([['input_tokens', 1]]);
-          }
-          yield { type: 'response_done', response } as any;
-        }
-      }
+              output: [fakeModelMessage('done')],
+            };
+            if (variant === 'throwing getter') {
+              Object.defineProperty(response, 'rawUsage', {
+                enumerable: true,
+                get() {
+                  throw new Error('raw usage is unavailable');
+                },
+              });
+            } else if (variant === 'cyclic') {
+              const rawUsage: Record<string, unknown> = {};
+              rawUsage.self = rawUsage;
+              response.rawUsage = rawUsage;
+            } else {
+              response.rawUsage = new Map([['input_tokens', 1]]);
+            }
+            yield { type: 'response_done', response } as any;
+          })(),
+        ),
+      ]);
 
       const agent = new Agent({
         name: 'InvalidRawUsage',
-        model: new InvalidRawUsageStreamingModel(),
+        model,
         modelSettings: { preserveRawUsage: true },
       });
       const result = await run(agent, 'hello', { stream: true });
@@ -5027,34 +4560,28 @@ describe('Runner.run (streaming)', () => {
       }),
     };
 
-    class ExpectGuardrailBeforeStreamModel implements Model {
-      getResponse(_request: ModelRequest): Promise<ModelResponse> {
-        throw new Error('Unexpected call to getResponse');
-      }
-
-      async *getStreamedResponse(
-        _request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        expect(guardrailFinished).toBe(true);
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'stream1',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: [fakeModelMessage('ok')],
-          },
-        } satisfies StreamEvent;
-      }
-    }
-
     const agent = new Agent({
       name: 'BlockingStreamAgent',
-      model: new ExpectGuardrailBeforeStreamModel(),
+      model: new ScriptedModel([
+        modelStreamResponder(() => {
+          expect(guardrailFinished).toBe(true);
+          return [
+            {
+              type: 'response_done',
+              response: {
+                id: 'stream1',
+                usage: {
+                  requests: 1,
+                  inputTokens: 0,
+                  outputTokens: 0,
+                  totalTokens: 0,
+                },
+                output: [fakeModelMessage('ok')],
+              },
+            } satisfies StreamEvent,
+          ];
+        }),
+      ]),
       inputGuardrails: [guardrail],
     });
 
@@ -5072,56 +4599,35 @@ describe('Runner.run (streaming)', () => {
   });
 });
 
-class ImmediateStreamingModel implements Model {
-  constructor(private readonly response: ModelResponse) {}
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    return this.response;
-  }
-
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const usage = this.response.usage;
-    const output = this.response.output.map((item) =>
-      protocol.OutputModelItem.parse(item),
-    );
-    yield {
-      type: 'response_done',
-      response: {
-        id: this.response.responseId ?? 'r',
-        requestId: this.response.requestId,
-        usage: {
-          requests: usage.requests,
-          inputTokens: usage.inputTokens,
-          outputTokens: usage.outputTokens,
-          totalTokens: usage.totalTokens,
-        },
-        rawUsage: this.response.rawUsage,
-        output,
-      },
-    } satisfies StreamEvent;
+class ImmediateStreamingModel extends ScriptedModel {
+  constructor(response: ModelResponse) {
+    super([
+      modelStream([
+        {
+          type: 'response_done',
+          response: {
+            id: response.responseId ?? 'r',
+            requestId: response.requestId,
+            usage: {
+              requests: response.usage.requests,
+              inputTokens: response.usage.inputTokens,
+              outputTokens: response.usage.outputTokens,
+              totalTokens: response.usage.totalTokens,
+            },
+            rawUsage: response.rawUsage,
+            output: response.output.map((item) =>
+              protocol.OutputModelItem.parse(item),
+            ),
+          },
+        } satisfies StreamEvent,
+      ]),
+    ]);
   }
 }
 
-class RejectingStreamingModel implements Model {
-  constructor(private readonly error: Error) {}
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    throw this.error;
-  }
-
-  getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
-    const error = this.error;
-    return {
-      [Symbol.asyncIterator]() {
-        return {
-          async next() {
-            throw error;
-          },
-        } satisfies AsyncIterator<StreamEvent>;
-      },
-    } satisfies AsyncIterable<StreamEvent>;
+class RejectingStreamingModel extends ScriptedModel {
+  constructor(error: Error) {
+    super([modelError(error)]);
   }
 }
 
@@ -5137,39 +4643,16 @@ function createSessionMock(): Session {
 
 // A streaming model that returns one queued ModelResponse per turn, mirroring
 // the QueueStreamingModel used elsewhere in this file.
-class QueuedTurnStreamingModel implements Model {
-  calls = 0;
-
-  constructor(private readonly responses: ModelResponse[]) {}
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    this.calls++;
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response found');
-    }
-    return response;
-  }
-
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const response = await this.getResponse(request);
-    yield {
-      type: 'response_done',
-      response: {
-        id: response.responseId ?? 'resp-current-turn',
-        usage: {
-          requests: response.usage.requests,
-          inputTokens: response.usage.inputTokens,
-          outputTokens: response.usage.outputTokens,
-          totalTokens: response.usage.totalTokens,
-        },
-        output: response.output.map((item) =>
-          protocol.OutputModelItem.parse(item),
+class QueuedTurnStreamingModel extends ScriptedModel {
+  constructor(responses: ModelResponse[]) {
+    super(
+      responses.map((response) =>
+        parsedTerminalModelStream(
+          response,
+          response.responseId ?? 'resp-current-turn',
         ),
-      },
-    } satisfies StreamEvent;
+      ),
+    );
   }
 }
 
@@ -5224,7 +4707,7 @@ describe('StreamedRunResult.currentTurn (streamed runs)', () => {
     // currentTurn is written only once a turn is ADMITTED, so it stays 0 here.
     const agent = new Agent({
       name: 'MaxTurnsZeroAgent',
-      model: new FakeModel(),
+      model: new ScriptedModel(),
     });
 
     const result = await run(agent, 'go', { stream: true, maxTurns: 0 });
@@ -5266,7 +4749,7 @@ describe('StreamedRunResult.currentTurn (streamed runs)', () => {
     const result = await run(agent, 'x', { stream: true });
     await expect(result.completed).rejects.toBeInstanceOf(UserError);
 
-    expect(model.calls).toBe(0);
+    expect(model.calls).toHaveLength(0);
     expect(result.currentTurn).toBe(0);
     expect(result.state._currentTurn).toBe(0);
 
@@ -5281,7 +4764,7 @@ describe('StreamedRunResult.currentTurn (streamed runs)', () => {
     expect(resumed.finalOutput).toEqual({ value: 'ok' });
     expect(resumed.currentTurn).toBe(1);
     expect(resumed.state._currentTurn).toBe(1);
-    expect(model.calls).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('preserves an in-progress turn when resumed request serialization fails', async () => {
@@ -5307,7 +4790,7 @@ describe('StreamedRunResult.currentTurn (streamed runs)', () => {
     });
     await expect(result.completed).rejects.toBeInstanceOf(UserError);
 
-    expect(model.calls).toBe(0);
+    expect(model.calls).toHaveLength(0);
     expect(result.currentTurn).toBe(1);
     expect(result.state._currentTurn).toBe(1);
     expect(result.state._currentTurnInProgress).toBe(true);
@@ -5326,7 +4809,7 @@ describe('StreamedRunResult.currentTurn (streamed runs)', () => {
     expect(resumed.finalOutput).toEqual({ value: 'ok' });
     expect(resumed.currentTurn).toBe(1);
     expect(resumed.state._currentTurn).toBe(1);
-    expect(model.calls).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('reports 0 when a blocking input guardrail trips before any model request', async () => {
@@ -5364,35 +4847,9 @@ describe('StreamedRunResult.currentTurn (streamed runs)', () => {
   it('carries the turn count into a resumed streamed run instead of restarting at 0', async () => {
     // A run resumed from a serialized state has already spent turns; restarting the
     // public counter at 0 would under-report them for the rest of the run.
-    class HangingStreamingModel implements Model {
-      async getResponse(): Promise<ModelResponse> {
-        throw new Error('unused');
-      }
-
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<StreamEvent> {
-        const abortError = new Error('aborted');
-        (abortError as any).name = 'AbortError';
-        const signal = (request as any).signal as AbortSignal | undefined;
-        await new Promise((_resolve, reject) => {
-          if (signal?.aborted) {
-            reject(abortError);
-            return;
-          }
-          const onAbort = () => {
-            signal?.removeEventListener('abort', onAbort);
-            reject(abortError);
-          };
-          signal?.addEventListener('abort', onAbort, { once: true });
-        });
-        yield* [] as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'ResumeTurnCountAgent',
-      model: new HangingStreamingModel(),
+      model: new ScriptedModel([abortingHangingStream()]),
     });
     const runner = new Runner();
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -70,11 +70,10 @@ import {
 import logger from '../src/logger';
 import { getGlobalTraceProvider } from '../src/tracing/provider';
 import {
-  FakeModel,
   fakeModelRefusal,
   fakeModelMessageWithRefusal,
   fakeModelMessage,
-  FakeModelProvider,
+  ScriptedModelProvider,
   FakeTracingExporter,
   TEST_MODEL_MESSAGE,
   TEST_MODEL_RESPONSE_BASIC,
@@ -90,6 +89,12 @@ import {
   ModelRequest,
   ModelSettings,
 } from '../src/model';
+import {
+  ScriptedModel,
+  modelError,
+  modelResponder,
+  modelResponse,
+} from '../src/testing';
 
 const PROGRAMMATIC_TOOL_CALLING_TOOL: HostedTool = {
   type: 'hosted_tool',
@@ -115,10 +120,51 @@ function getRequestInputItems(request: ModelRequest): AgentInputItem[] {
   return Array.isArray(request.input) ? request.input : [];
 }
 
+function cloneModelRequest(request: Readonly<ModelRequest>): ModelRequest {
+  return {
+    ...request,
+    input: Array.isArray(request.input)
+      ? (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[])
+      : request.input,
+  };
+}
+
+function createReasoningPolicyModel(options: {
+  reasoningId: string;
+  functionId: string;
+  callId: string;
+  toolName: string;
+}): ScriptedModel {
+  return new ScriptedModel([
+    modelResponse({
+      output: [
+        {
+          type: 'reasoning',
+          id: options.reasoningId,
+          content: [{ type: 'input_text', text: 'reasoning trace' }],
+        } satisfies protocol.ReasoningItem,
+        {
+          type: 'function_call',
+          id: options.functionId,
+          callId: options.callId,
+          name: options.toolName,
+          status: 'completed',
+          arguments: '{}',
+        } satisfies protocol.FunctionCallItem,
+      ],
+      usage: new Usage(),
+    }),
+    modelResponse({
+      output: [fakeModelMessage('done')],
+      usage: new Usage(),
+    }),
+  ]);
+}
+
 describe('Runner.run', () => {
   beforeAll(() => {
     setTracingDisabled(true);
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
 
   describe('basic', () => {
@@ -141,8 +187,8 @@ describe('Runner.run', () => {
       const flagSpy = vi
         .spyOn(logger, 'dontLogToolData', 'get')
         .mockReturnValue(true);
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -150,11 +196,11 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('recovered')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const getResponseSpy = vi.spyOn(model, 'getResponse');
       const agent = new Agent({
@@ -195,8 +241,8 @@ describe('Runner.run', () => {
         const flagSpy = vi
           .spyOn(logger, 'dontLogToolData', 'get')
           .mockReturnValue(dontLogToolData);
-        const model = new FakeModel([
-          {
+        const model = new ScriptedModel([
+          modelResponse({
             output: [
               {
                 ...TEST_MODEL_FUNCTION_CALL,
@@ -204,7 +250,7 @@ describe('Runner.run', () => {
               },
             ],
             usage: new Usage(),
-          },
+          }),
         ]);
         const structuredTool = tool({
           name: 'test',
@@ -272,15 +318,15 @@ describe('Runner.run', () => {
           return 'cancelled after cleanup';
         },
       });
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [{ ...TEST_MODEL_FUNCTION_CALL }],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('unexpected second response')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const getResponseSpy = vi.spyOn(model, 'getResponse');
       const agent = new Agent({
@@ -329,11 +375,11 @@ describe('Runner.run', () => {
           return 'unexpected tool output';
         },
       });
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [{ ...TEST_MODEL_FUNCTION_CALL }],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'AbortReasonAgent',
@@ -412,8 +458,8 @@ describe('Runner.run', () => {
           return 'sibling complete';
         },
       });
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -429,7 +475,7 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'ParallelCancellationAgent',
@@ -534,8 +580,8 @@ describe('Runner.run', () => {
           button: 'left',
         },
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -546,7 +592,7 @@ describe('Runner.run', () => {
             computerCall,
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'ParallelActionCancellationAgent',
@@ -638,8 +684,8 @@ describe('Runner.run', () => {
           ],
         },
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -650,7 +696,7 @@ describe('Runner.run', () => {
             computerCall,
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'SiblingCategoryFailureAgent',
@@ -751,8 +797,8 @@ describe('Runner.run', () => {
           { type: 'move', x: 3, y: 4 },
         ],
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -763,7 +809,7 @@ describe('Runner.run', () => {
             computerCall,
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'BatchedComputerApprovalFailureAgent',
@@ -829,8 +875,8 @@ describe('Runner.run', () => {
           ],
         },
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -841,7 +887,7 @@ describe('Runner.run', () => {
             computerCall,
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'PostInvocationDrainAgent',
@@ -961,8 +1007,8 @@ describe('Runner.run', () => {
         status: 'completed',
         action: { type: 'screenshot' },
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -980,7 +1026,7 @@ describe('Runner.run', () => {
             secondComputerCall,
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'FunctionFailureStopsComputerAgent',
@@ -1112,8 +1158,8 @@ describe('Runner.run', () => {
           ],
         },
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -1137,7 +1183,7 @@ describe('Runner.run', () => {
             computerCall,
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'RejectedSafetyCheckCancellationAgent',
@@ -1217,8 +1263,8 @@ describe('Runner.run', () => {
       });
       const shell = new FakeShell();
       const editor = new FakeEditor();
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -1250,7 +1296,7 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'MixedActionCancellationAgent',
@@ -1340,8 +1386,8 @@ describe('Runner.run', () => {
         parameters: z.object({ test: z.string() }),
         execute: queuedExecute,
       });
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -1357,7 +1403,7 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'QueuedCancellationAgent',
@@ -1412,15 +1458,15 @@ describe('Runner.run', () => {
           return 'approved tool cleanup complete';
         },
       });
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [{ ...TEST_MODEL_FUNCTION_CALL }],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('unexpected second response')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const getResponseSpy = vi.spyOn(model, 'getResponse');
       const agent = new Agent({
@@ -1500,8 +1546,8 @@ describe('Runner.run', () => {
           return 'approved sibling complete';
         },
       });
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -1517,7 +1563,7 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'ApprovedSiblingCancellationAgent',
@@ -1607,7 +1653,9 @@ describe('Runner.run', () => {
     });
 
     it('rejects an invalid per-run tool name collision policy before model calls', async () => {
-      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const model = new ScriptedModel([
+        modelResponse(TEST_MODEL_RESPONSE_BASIC),
+      ]);
       const getResponse = vi.spyOn(model, 'getResponse');
       const agent = new Agent({ name: 'Invalid policy agent', model });
 
@@ -1622,7 +1670,9 @@ describe('Runner.run', () => {
     });
 
     it('rejects a null per-run tool name collision policy before model calls', async () => {
-      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const model = new ScriptedModel([
+        modelResponse(TEST_MODEL_RESPONSE_BASIC),
+      ]);
       const getResponse = vi.spyOn(model, 'getResponse');
       const agent = new Agent({ name: 'Null policy agent', model });
 
@@ -1637,7 +1687,9 @@ describe('Runner.run', () => {
     });
 
     it('keeps the default provider lazy until a string model needs it', async () => {
-      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const model = new ScriptedModel([
+        modelResponse(TEST_MODEL_RESPONSE_BASIC),
+      ]);
       const provider = {
         getModel: vi.fn(() => model),
       } satisfies ModelProvider;
@@ -1655,19 +1707,25 @@ describe('Runner.run', () => {
 
         expect(provider.getModel).toHaveBeenCalledWith('default-model');
       } finally {
-        setDefaultModelProvider(new FakeModelProvider());
+        setDefaultModelProvider(new ScriptedModelProvider());
       }
     });
 
     it("keeps a runner's resolved default provider stable", async () => {
       const firstProvider = {
         getModel: vi.fn(
-          () => new FakeModel([{ ...TEST_MODEL_RESPONSE_BASIC }]),
+          () =>
+            new ScriptedModel([
+              modelResponse({ ...TEST_MODEL_RESPONSE_BASIC }),
+            ]),
         ),
       } satisfies ModelProvider;
       const laterProvider = {
         getModel: vi.fn(
-          () => new FakeModel([{ ...TEST_MODEL_RESPONSE_BASIC }]),
+          () =>
+            new ScriptedModel([
+              modelResponse({ ...TEST_MODEL_RESPONSE_BASIC }),
+            ]),
         ),
       } satisfies ModelProvider;
       setDefaultModelProvider(firstProvider);
@@ -1685,12 +1743,14 @@ describe('Runner.run', () => {
         expect(firstProvider.getModel).toHaveBeenCalledTimes(2);
         expect(laterProvider.getModel).not.toHaveBeenCalled();
       } finally {
-        setDefaultModelProvider(new FakeModelProvider());
+        setDefaultModelProvider(new ScriptedModelProvider());
       }
     });
 
     it('does not require a modelProvider when the selected model is a Model object', async () => {
-      const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+      const model = new ScriptedModel([
+        modelResponse(TEST_MODEL_RESPONSE_BASIC),
+      ]);
       const provider = {
         getModel: vi.fn(() => {
           throw new Error('default provider should not be used');
@@ -1708,7 +1768,7 @@ describe('Runner.run', () => {
 
         expect(provider.getModel).not.toHaveBeenCalled();
       } finally {
-        setDefaultModelProvider(new FakeModelProvider());
+        setDefaultModelProvider(new ScriptedModelProvider());
       }
     });
 
@@ -1744,17 +1804,14 @@ describe('Runner.run', () => {
     });
 
     it('returns missing function tool errors to the model when opted in', async () => {
-      class RecordingModel extends FakeModel {
-        readonly requests: ModelRequest[] = [];
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          return super.getResponse(request);
+      class RecordingModel extends ScriptedModel {
+        get requests(): readonly Readonly<ModelRequest>[] {
+          return this.calls.map((call) => call.request);
         }
       }
 
       const model = new RecordingModel([
-        {
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -1764,11 +1821,11 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('recovered')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'MissingToolAgent',
@@ -1799,17 +1856,14 @@ describe('Runner.run', () => {
     });
 
     it('uses toolErrorFormatter for missing function tool errors', async () => {
-      class RecordingModel extends FakeModel {
-        readonly requests: ModelRequest[] = [];
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          return super.getResponse(request);
+      class RecordingModel extends ScriptedModel {
+        get requests(): readonly Readonly<ModelRequest>[] {
+          return this.calls.map((call) => call.request);
         }
       }
 
       const model = new RecordingModel([
-        {
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -1819,11 +1873,11 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('formatter recovered')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const seenKinds: string[] = [];
       const agent = new Agent({
@@ -1859,17 +1913,14 @@ describe('Runner.run', () => {
     });
 
     it('redacts hostile tool-not-found formatter errors and keeps the fallback result', async () => {
-      class RecordingModel extends FakeModel {
-        readonly requests: ModelRequest[] = [];
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          return super.getResponse(request);
+      class RecordingModel extends ScriptedModel {
+        get requests(): readonly Readonly<ModelRequest>[] {
+          return this.calls.map((call) => call.request);
         }
       }
 
       const model = new RecordingModel([
-        {
+        modelResponse({
           output: [
             {
               ...TEST_MODEL_FUNCTION_CALL,
@@ -1879,11 +1930,11 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('formatter fallback recovered')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'MissingToolFormatterFallbackAgent',
@@ -1933,7 +1984,7 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'ReusedNestedStateAgent',
         instructions: 'Finish the run.',
-        model: new FakeModel([TEST_MODEL_RESPONSE_BASIC]),
+        model: new ScriptedModel([modelResponse(TEST_MODEL_RESPONSE_BASIC)]),
       });
       const nestedState = new RunState(new RunContext(), 'input', agent, 1);
       nestedState._agentToolInvocation = {
@@ -1957,7 +2008,7 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'ReusedInMemoryNestedStateAgent',
         instructions: 'Finish the run.',
-        model: new FakeModel([TEST_MODEL_RESPONSE_BASIC]),
+        model: new ScriptedModel([modelResponse(TEST_MODEL_RESPONSE_BASIC)]),
       });
       const nestedState = new RunState(new RunContext(), 'input', agent, 1);
       nestedState._agentToolInvocation = {
@@ -2034,13 +2085,9 @@ describe('Runner.run', () => {
     });
 
     it('rejects custom client tool_search parameters without execute before calling the model', async () => {
-      const getResponse = vi.fn().mockResolvedValue(TEST_MODEL_RESPONSE_BASIC);
-      const model: Model = {
-        getResponse,
-        async *getStreamedResponse() {
-          yield* [];
-        },
-      };
+      const model = new ScriptedModel([
+        modelResponse(TEST_MODEL_RESPONSE_BASIC),
+      ]);
       const agent = new Agent({
         name: 'ClientToolSearchValidationAgent',
         model,
@@ -2073,7 +2120,7 @@ describe('Runner.run', () => {
       await expect(runPromise).rejects.toThrow(
         /require toolSearchTool\(\{ execution: "client", execute \}\)/,
       );
-      expect(getResponse).not.toHaveBeenCalled();
+      expect(model.calls).toHaveLength(0);
     });
 
     it('loads runtime tools from custom client tool_search execute callbacks across turns', async () => {
@@ -2108,8 +2155,8 @@ describe('Runner.run', () => {
         },
         execute,
       );
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'tool_search_call',
@@ -2124,8 +2171,8 @@ describe('Runner.run', () => {
             } as protocol.ToolSearchCallItem,
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [
             {
               type: 'function_call',
@@ -2137,11 +2184,11 @@ describe('Runner.run', () => {
             } as protocol.FunctionCallItem,
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('Account loaded.')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'CustomClientToolSearchAgent',
@@ -2201,8 +2248,8 @@ describe('Runner.run', () => {
         },
         execute,
       );
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'tool_search_call',
@@ -2217,8 +2264,8 @@ describe('Runner.run', () => {
             } as protocol.ToolSearchCallItem,
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [
             {
               type: 'function_call',
@@ -2230,11 +2277,11 @@ describe('Runner.run', () => {
             } as protocol.FunctionCallItem,
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('Account loaded.')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'SerializedCustomClientToolSearchAgent',
@@ -2295,7 +2342,7 @@ describe('Runner.run', () => {
       } as const;
       const agent = new Agent({
         name: 'MissingExecutorToolSearchAgent',
-        model: new FakeModel(),
+        model: new ScriptedModel(),
         tools: [toolSearch as any],
       });
       const state = new RunState(new RunContext(), 'hello', agent, 10);
@@ -2365,7 +2412,7 @@ describe('Runner.run', () => {
       });
       const agent = new Agent({
         name: 'BuiltInClientToolSearchResumeAgent',
-        model: new FakeModel(),
+        model: new ScriptedModel(),
         tools: [getShippingEta],
       });
       const state = new RunState(new RunContext(), 'hello', agent, 10);
@@ -2432,8 +2479,8 @@ describe('Runner.run', () => {
         deferLoading: true,
         execute: async () => 'tomorrow',
       });
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'function_call',
@@ -2445,11 +2492,11 @@ describe('Runner.run', () => {
             } as protocol.FunctionCallItem,
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('The package arrives tomorrow.')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'ShippingAgent',
@@ -2484,8 +2531,8 @@ describe('Runner.run', () => {
     });
 
     it('exposes aggregated usage on run results', async () => {
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('hi there')],
           usage: new Usage({
             requests: 1,
@@ -2494,7 +2541,7 @@ describe('Runner.run', () => {
             totalTokens: 5,
           }),
           responseId: 'usage-res',
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'UsageAgent',
@@ -2518,11 +2565,11 @@ describe('Runner.run', () => {
     });
 
     it('emits turn input on agent_start lifecycle hooks', async () => {
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('Acknowledged')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'LifecycleInputAgent',
@@ -2553,16 +2600,10 @@ describe('Runner.run', () => {
     });
 
     it('applies toolChoice updates from agent_tool_end before the next model call', async () => {
-      class ToolChoiceTrackingModel implements Model {
-        requests: ModelRequest[] = [];
-        private callCount = 0;
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          this.callCount += 1;
-
-          if (this.callCount === 1) {
-            return {
+      class ToolChoiceTrackingModel extends ScriptedModel {
+        constructor() {
+          super([
+            modelResponse({
               output: [
                 {
                   ...TEST_MODEL_FUNCTION_CALL,
@@ -2573,20 +2614,16 @@ describe('Runner.run', () => {
                 },
               ],
               usage: new Usage(),
-            };
-          }
-
-          return {
-            output: [fakeModelMessage('finished')],
-            usage: new Usage(),
-          };
+            }),
+            modelResponse({
+              output: [fakeModelMessage('finished')],
+              usage: new Usage(),
+            }),
+          ]);
         }
 
-        async *getStreamedResponse(
-          _request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          yield* [];
-          throw new Error('Not implemented');
+        get requests(): readonly ModelRequest[] {
+          return this.calls.map((call) => call.request);
         }
       }
 
@@ -2611,13 +2648,10 @@ describe('Runner.run', () => {
     });
 
     it('continues Programmatic Tool Calling through nested calls and program output', async () => {
-      class ProgrammaticToolCallingModel implements Model {
-        requests: ModelRequest[] = [];
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          if (this.requests.length === 1) {
-            return {
+      class ProgrammaticToolCallingModel extends ScriptedModel {
+        constructor() {
+          super([
+            modelResponse({
               output: [
                 {
                   type: 'program',
@@ -2644,10 +2678,8 @@ describe('Runner.run', () => {
                 },
               ],
               usage: new Usage(),
-            };
-          }
-          if (this.requests.length === 2) {
-            return {
+            }),
+            modelResponse({
               output: [
                 {
                   type: 'program_output',
@@ -2658,17 +2690,16 @@ describe('Runner.run', () => {
                 },
               ],
               usage: new Usage(),
-            };
-          }
-          return {
-            output: [fakeModelMessage('Program completed.')],
-            usage: new Usage(),
-          };
+            }),
+            modelResponse({
+              output: [fakeModelMessage('Program completed.')],
+              usage: new Usage(),
+            }),
+          ]);
         }
 
-        async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-          yield* [];
-          throw new Error('Not implemented');
+        get requests(): readonly ModelRequest[] {
+          return this.calls.map((call) => call.request);
         }
       }
 
@@ -2743,8 +2774,8 @@ describe('Runner.run', () => {
       });
       const agent = new Agent({
         name: 'PromptProgramAgent',
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'program',
@@ -2766,8 +2797,8 @@ describe('Runner.run', () => {
               },
             ],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [
               {
                 type: 'program_output',
@@ -2779,7 +2810,7 @@ describe('Runner.run', () => {
               fakeModelMessage('Prompt program completed.'),
             ],
             usage: new Usage(),
-          },
+          }),
         ]),
         prompt: { promptId: 'pmpt_programmatic_tool_calling' },
         tools: [lookup],
@@ -2800,8 +2831,8 @@ describe('Runner.run', () => {
     it('rejects prompt-supplied Programmatic Tool Calling when tools are explicitly disabled', async () => {
       const agent = new Agent({
         name: 'PromptProgramAgent',
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'program',
@@ -2812,7 +2843,7 @@ describe('Runner.run', () => {
               },
             ],
             usage: new Usage(),
-          },
+          }),
         ]),
         prompt: { promptId: 'pmpt_programmatic_tool_calling' },
         tools: [],
@@ -2824,11 +2855,11 @@ describe('Runner.run', () => {
     });
 
     it('sholuld handle structured output', async () => {
-      const fakeModel = new FakeModel([
-        {
+      const fakeModel = new ScriptedModel([
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
           output: [fakeModelMessage('{"city": "San Francisco"}')],
-        },
+        }),
       ]);
 
       const runner = new Runner();
@@ -2949,26 +2980,31 @@ describe('Runner.run', () => {
     });
 
     it('propagates model errors', async () => {
-      const agent = new Agent({ name: 'Fail', model: new FakeModel() });
+      const agent = new Agent({
+        name: 'Fail',
+        model: new ScriptedModel([
+          modelError(new Error('Scripted model failure')),
+        ]),
+      });
 
-      await expect(run(agent, 'fail')).rejects.toThrow('No response found');
+      await expect(run(agent, 'fail')).rejects.toThrow(
+        'Scripted model failure',
+      );
     });
 
     it('sets overridePromptModel when agent supplies a prompt and explicit model', async () => {
-      class CapturingModel implements Model {
-        lastRequest?: ModelRequest;
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.lastRequest = request;
-          return {
-            output: [fakeModelMessage('override')],
-            usage: new Usage(),
-          };
+      class CapturingModel extends ScriptedModel {
+        constructor() {
+          super([
+            modelResponse({
+              output: [fakeModelMessage('override')],
+              usage: new Usage(),
+            }),
+          ]);
         }
-        async *getStreamedResponse(
-          _request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          yield* [];
-          throw new Error('Not implemented');
+
+        get lastRequest(): Readonly<ModelRequest> | undefined {
+          return this.lastCall?.request;
         }
       }
 
@@ -2988,22 +3024,18 @@ describe('Runner.run', () => {
     });
 
     it('serializes GA computer tools without requiring display metadata', async () => {
-      class CapturingModel implements Model {
-        lastRequest?: ModelRequest;
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.lastRequest = request;
-          return {
-            output: [fakeModelMessage('computer ok')],
-            usage: new Usage(),
-          };
+      class CapturingModel extends ScriptedModel {
+        constructor() {
+          super([
+            modelResponse({
+              output: [fakeModelMessage('computer ok')],
+              usage: new Usage(),
+            }),
+          ]);
         }
 
-        async *getStreamedResponse(
-          _request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          yield* [];
-          throw new Error('Not implemented');
+        get lastRequest(): Readonly<ModelRequest> | undefined {
+          return this.lastCall?.request;
         }
       }
 
@@ -3076,8 +3108,11 @@ describe('Runner.run', () => {
     });
 
     it('emits agent_end once when final output comes from tool results', async () => {
-      const model = new FakeModel([
-        { output: [{ ...TEST_MODEL_FUNCTION_CALL }], usage: new Usage() },
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        }),
       ]);
       const agent = new Agent({
         name: 'ToolAgent',
@@ -3119,8 +3154,11 @@ describe('Runner.run', () => {
       const computer = computerTool({
         computer: { create, dispose },
       });
-      const model = new FakeModel([
-        { output: [fakeModelMessage('done')], usage: new Usage() },
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
       ]);
       const agent = new Agent({
         name: 'ComputerAgent',
@@ -3162,12 +3200,15 @@ describe('Runner.run', () => {
         callId: 'call-1',
         arguments: '{}',
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [functionCall, fakeModelMessage('pending')],
           usage: new Usage(),
-        },
-        { output: [fakeModelMessage('all done')], usage: new Usage() },
+        }),
+        modelResponse({
+          output: [fakeModelMessage('all done')],
+          usage: new Usage(),
+        }),
       ]);
 
       const agent = new Agent({
@@ -3195,9 +3236,15 @@ describe('Runner.run', () => {
       const computer = computerTool({
         computer: computerInstance,
       });
-      const model = new FakeModel([
-        { output: [fakeModelMessage('done once')], usage: new Usage() },
-        { output: [fakeModelMessage('done twice')], usage: new Usage() },
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [fakeModelMessage('done once')],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done twice')],
+          usage: new Usage(),
+        }),
       ]);
       const agent = new Agent({
         name: 'ComputerAgent',
@@ -3227,8 +3274,11 @@ describe('Runner.run', () => {
 
       const agentB = new Agent({
         name: 'HandoffB',
-        model: new FakeModel([
-          { output: [fakeModelMessage('done B')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('done B')],
+            usage: new Usage(),
+          }),
         ]),
         tools: [toolB],
       });
@@ -3243,7 +3293,9 @@ describe('Runner.run', () => {
       };
       const agentA = new Agent({
         name: 'HandoffA',
-        model: new FakeModel([{ output: [callItem], usage: new Usage() }]),
+        model: new ScriptedModel([
+          modelResponse({ output: [callItem], usage: new Usage() }),
+        ]),
         handoffs: [handoffToB],
         tools: [toolA],
       });
@@ -3278,12 +3330,15 @@ describe('Runner.run', () => {
         callId: 'call-1',
         arguments: '{}',
       };
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [functionCall, fakeModelMessage('pending')],
           usage: new Usage(),
-        },
-        { output: [fakeModelMessage('all done')], usage: new Usage() },
+        }),
+        modelResponse({
+          output: [fakeModelMessage('all done')],
+          usage: new Usage(),
+        }),
       ]);
 
       const agent = new Agent({
@@ -3316,34 +3371,28 @@ describe('Runner.run', () => {
   });
 
   describe('additional scenarios', () => {
-    class StreamingModel extends FakeModel {
+    class StreamingModel extends ScriptedModel {
       constructor(resp: protocol.AssistantMessageItem) {
-        super([{ output: [resp], usage: new Usage() }]);
-        this._resp = resp;
-      }
-      private _resp: protocol.AssistantMessageItem;
-      override async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-        yield {
-          type: 'output_text_delta',
-          delta: 'hi',
-          providerData: {},
-        } as any;
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'r1',
-            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-            output: [this._resp],
-          },
-        } as any;
+        super(
+          Array.from({ length: 3 }, (_, index) =>
+            modelResponse({
+              output: [resp],
+              usage: new Usage(),
+              responseId: `r${index + 1}`,
+            }),
+          ),
+        );
       }
     }
 
     it('resumes from serialized RunState', async () => {
       const agent = new Agent({
         name: 'Resume',
-        model: new FakeModel([
-          { output: [fakeModelMessage('hi')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('hi')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const first = await run(agent, 'hi');
@@ -3357,8 +3406,11 @@ describe('Runner.run', () => {
     it('resumes from schema 1.0 RunState', async () => {
       const agent = new Agent({
         name: 'ResumeV1',
-        model: new FakeModel([
-          { output: [fakeModelMessage('hi')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('hi')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const first = await run(agent, 'hi');
@@ -3381,8 +3433,11 @@ describe('Runner.run', () => {
       const provider = getGlobalTraceProvider();
       const agent = new Agent({
         name: 'ResumeTraceOverrides',
-        model: new FakeModel([
-          { output: [fakeModelMessage('hi')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('hi')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const runner = new Runner({
@@ -3431,8 +3486,11 @@ describe('Runner.run', () => {
         const provider = getGlobalTraceProvider();
         const agent = new Agent({
           name: 'ResumeAmbientTrace',
-          model: new FakeModel([
-            { output: [fakeModelMessage('hi')], usage: new Usage() },
+          model: new ScriptedModel([
+            modelResponse({
+              output: [fakeModelMessage('hi')],
+              usage: new Usage(),
+            }),
           ]),
         });
         const state = new RunState(new RunContext(), 'hi', agent, 1);
@@ -3496,7 +3554,10 @@ describe('Runner.run', () => {
       });
       const agent = new Agent({
         name: 'Guard',
-        model: new FakeModel([firstResponse, secondResponse]),
+        model: new ScriptedModel([
+          modelResponse(firstResponse),
+          modelResponse(secondResponse),
+        ]),
         tools: [TEST_TOOL],
       });
       const result = await runner.run(agent, 'start');
@@ -3516,23 +3577,18 @@ describe('Runner.run', () => {
         }),
       };
 
-      class ExpectGuardrailFirstModel implements Model {
-        calls = 0;
-
-        async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-          this.calls++;
-          expect(guardrailCompleted).toBe(true);
-          return {
-            output: [fakeModelMessage('done')],
-            usage: new Usage(),
-          };
+      class ExpectGuardrailFirstModel extends ScriptedModel {
+        constructor() {
+          super([
+            modelResponder(() => {
+              expect(guardrailCompleted).toBe(true);
+              return {
+                output: [fakeModelMessage('done')],
+                usage: new Usage(),
+              };
+            }),
+          ]);
         }
-
-        /* eslint-disable require-yield */
-        async *getStreamedResponse(_request: ModelRequest) {
-          throw new Error('not implemented');
-        }
-        /* eslint-enable require-yield */
       }
 
       const agent = new Agent({
@@ -3577,22 +3633,15 @@ describe('Runner.run', () => {
         },
       };
 
-      class TrackingModel implements Model {
-        calls = 0;
-
-        async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-          this.calls++;
-          return {
-            output: [fakeModelMessage('should not run')],
-            usage: new Usage(),
-          };
+      class TrackingModel extends ScriptedModel {
+        constructor() {
+          super([
+            modelResponse({
+              output: [fakeModelMessage('should not run')],
+              usage: new Usage(),
+            }),
+          ]);
         }
-
-        /* eslint-disable require-yield */
-        async *getStreamedResponse(_request: ModelRequest) {
-          throw new Error('not implemented');
-        }
-        /* eslint-enable require-yield */
       }
 
       const model = new TrackingModel();
@@ -3614,14 +3663,14 @@ describe('Runner.run', () => {
       );
       await errorThrown;
       await new Promise((resolve) => setTimeout(resolve, 0));
-      const callsBeforeSiblingFinished = model.calls;
+      const callsBeforeSiblingFinished = model.calls.length;
       const settledBeforeSiblingFinished = runSettled;
       releaseSlowGuardrail();
 
       await expect(runPromise).rejects.toBeInstanceOf(GuardrailExecutionError);
       expect(callsBeforeSiblingFinished).toBe(0);
       expect(settledBeforeSiblingFinished).toBe(false);
-      expect(model.calls).toBe(0);
+      expect(model.calls).toHaveLength(0);
     });
 
     it('retains an admitted turn when a parallel guardrail fails after the model starts', async () => {
@@ -3642,24 +3691,19 @@ describe('Runner.run', () => {
         },
       };
 
-      class TrackingModel implements Model {
-        calls = 0;
-
-        async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-          this.calls++;
-          markModelStarted();
-          await guardrailFailing;
-          return {
-            output: [fakeModelMessage('unused')],
-            usage: new Usage(),
-          };
+      class TrackingModel extends ScriptedModel {
+        constructor() {
+          super([
+            modelResponder(async () => {
+              markModelStarted();
+              await guardrailFailing;
+              return {
+                output: [fakeModelMessage('unused')],
+                usage: new Usage(),
+              };
+            }),
+          ]);
         }
-
-        /* eslint-disable require-yield */
-        async *getStreamedResponse(_request: ModelRequest) {
-          throw new Error('not implemented');
-        }
-        /* eslint-enable require-yield */
       }
 
       const model = new TrackingModel();
@@ -3678,7 +3722,7 @@ describe('Runner.run', () => {
 
       expect(caughtError).toBeInstanceOf(GuardrailExecutionError);
       const guardrailError = caughtError as GuardrailExecutionError;
-      expect(model.calls).toBe(1);
+      expect(model.calls).toHaveLength(1);
       expect(guardrailError.state?._currentTurn).toBe(1);
 
       const restored = await RunState.fromString(
@@ -3697,15 +3741,15 @@ describe('Runner.run', () => {
       expect((resumedError as MaxTurnsExceededError).state?._currentTurn).toBe(
         1,
       );
-      expect(model.calls).toBe(1);
+      expect(model.calls).toHaveLength(1);
     });
 
     it('throws InputGuardrailTripwireTriggered when parallel guardrail trips with structured output and model returns non-JSON', async () => {
-      const fakeModel = new FakeModel([
-        {
+      const fakeModel = new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('I am sorry, this is plain text not JSON')],
           usage: new Usage(),
-        },
+        }),
       ]);
 
       const agent = new Agent({
@@ -3734,11 +3778,11 @@ describe('Runner.run', () => {
 
     it('keeps the current agent span attached when an input guardrail trips', async () => {
       setTracingDisabled(false);
-      const fakeModel = new FakeModel([
-        {
+      const fakeModel = new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('plain text')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'GuardrailSpan',
@@ -3778,8 +3822,11 @@ describe('Runner.run', () => {
       });
       const agent = new Agent({
         name: 'Out',
-        model: new FakeModel([
-          { output: [fakeModelMessage('hi')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('hi')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const result = await runner.run(agent, 'input');
@@ -3814,8 +3861,11 @@ describe('Runner.run', () => {
       });
       const agent = new Agent({
         name: 'Out',
-        model: new FakeModel([
-          { output: [fakeModelMessage('hi')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('hi')],
+            usage: new Usage(),
+          }),
         ]),
       });
       let caughtError: unknown;
@@ -3846,8 +3896,11 @@ describe('Runner.run', () => {
       });
       const agent = new Agent({
         name: 'Out',
-        model: new FakeModel([
-          { output: [fakeModelMessage('x')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('x')],
+            usage: new Usage(),
+          }),
         ]),
       });
       await expect(runner.run(agent, 'input')).rejects.toBeInstanceOf(
@@ -3899,7 +3952,7 @@ describe('Runner.run', () => {
       ];
       const agent = new Agent({
         name: 'Out',
-        model: new FakeModel(responses),
+        model: new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [queryPerson],
       });
 
@@ -3961,7 +4014,7 @@ describe('Runner.run', () => {
       };
       const agent = new Agent({
         name: 'Tool',
-        model: new FakeModel([first, second]),
+        model: new ScriptedModel([modelResponse(first), modelResponse(second)]),
         tools: [TEST_TOOL],
       });
       const result = await run(agent, 'do');
@@ -3975,8 +4028,11 @@ describe('Runner.run', () => {
     it('switches agents via handoff', async () => {
       const agentB = new Agent({
         name: 'B',
-        model: new FakeModel([
-          { output: [fakeModelMessage('done B')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('done B')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const callItem: protocol.FunctionCallItem = {
@@ -3989,7 +4045,9 @@ describe('Runner.run', () => {
       };
       const agentA = new Agent({
         name: 'A',
-        model: new FakeModel([{ output: [callItem], usage: new Usage() }]),
+        model: new ScriptedModel([
+          modelResponse({ output: [callItem], usage: new Usage() }),
+        ]),
         handoffs: [handoff(agentB)],
       });
       const runner = new Runner();
@@ -4025,14 +4083,20 @@ describe('Runner.run', () => {
 
       const agentB = new Agent({
         name: 'B',
-        model: new FakeModel([
-          { output: [fakeModelMessage('done B')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('done B')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const agentC = new Agent({
         name: 'C',
-        model: new FakeModel([
-          { output: [fakeModelMessage('done C')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('done C')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const handoffToB = handoff(agentB);
@@ -4056,8 +4120,11 @@ describe('Runner.run', () => {
       const session = new RecordingSession();
       const agentA = new Agent({
         name: 'A',
-        model: new FakeModel([
-          { output: [acceptedCall, ignoredCall], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [acceptedCall, ignoredCall],
+            usage: new Usage(),
+          }),
         ]),
         handoffs: [handoffToB, handoffToC],
       });
@@ -4120,13 +4187,13 @@ describe('Runner.run', () => {
       };
       const agent = new Agent({
         name: 'Record',
-        model: new FakeModel([first, second]),
+        model: new ScriptedModel([modelResponse(first), modelResponse(second)]),
         tools: [TEST_TOOL],
       });
       const result = await run(agent, 'go');
       expect(result.state._modelResponses).toHaveLength(2);
-      expect(result.state._modelResponses[0]).toBe(first);
-      expect(result.state._modelResponses[1]).toBe(second);
+      expect(result.state._modelResponses[0]).toStrictEqual(first);
+      expect(result.state._modelResponses[1]).toStrictEqual(second);
     });
 
     it('records one model response per turn for streaming runs', async () => {
@@ -4147,32 +4214,9 @@ describe('Runner.run', () => {
         output: [fakeModelMessage('final')],
         usage: new Usage(),
       };
-      class SimpleStreamingModel implements Model {
-        constructor(private resps: ModelResponse[]) {}
-        async getResponse(_req: ModelRequest): Promise<ModelResponse> {
-          const r = this.resps.shift();
-          if (!r) {
-            throw new Error('No response found');
-          }
-          return r;
-        }
-        async *getStreamedResponse(
-          req: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          const r = await this.getResponse(req);
-          yield {
-            type: 'response_done',
-            response: {
-              id: 'r',
-              usage: {
-                requests: 1,
-                inputTokens: 0,
-                outputTokens: 0,
-                totalTokens: 0,
-              },
-              output: r.output,
-            },
-          } as any;
+      class SimpleStreamingModel extends ScriptedModel {
+        constructor(responses: ModelResponse[]) {
+          super(responses.map(modelResponse));
         }
       }
       const agent = new Agent({
@@ -4191,8 +4235,11 @@ describe('Runner.run', () => {
     it('max turn exceeded throws', async () => {
       const agent = new Agent({
         name: 'Max',
-        model: new FakeModel([
-          { output: [fakeModelMessage('nope')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('nope')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const error = await run(agent, 'x', { maxTurns: 0 }).catch((err) => err);
@@ -4202,22 +4249,17 @@ describe('Runner.run', () => {
     });
 
     it('rolls back a turn when request serialization fails before the model call', async () => {
-      class TrackingModel extends FakeModel {
-        calls = 0;
-
-        override async getResponse(
-          request: ModelRequest,
-        ): Promise<ModelResponse> {
-          this.calls++;
-          return await super.getResponse(request);
+      class TrackingModel extends ScriptedModel {
+        get callCount(): number {
+          return this.calls.length;
         }
       }
 
       const model = new TrackingModel([
-        {
+        modelResponse({
           output: [fakeModelMessage('{"value":"ok"}')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent: Agent<any, any> = new Agent({
         name: 'RequestSerializationFailure',
@@ -4229,7 +4271,7 @@ describe('Runner.run', () => {
       const error = await run(agent, state).catch((caught) => caught);
 
       expect(error).toBeInstanceOf(UserError);
-      expect(model.calls).toBe(0);
+      expect(model.callCount).toBe(0);
       expect(state._currentTurn).toBe(0);
 
       const restored = await RunState.fromString(agent, state.toString());
@@ -4238,26 +4280,21 @@ describe('Runner.run', () => {
 
       expect(resumed.finalOutput).toEqual({ value: 'ok' });
       expect(resumed.state._currentTurn).toBe(1);
-      expect(model.calls).toBe(1);
+      expect(model.callCount).toBe(1);
     });
 
     it('preserves an in-progress turn when resumed request serialization fails', async () => {
-      class TrackingModel extends FakeModel {
-        calls = 0;
-
-        override async getResponse(
-          request: ModelRequest,
-        ): Promise<ModelResponse> {
-          this.calls++;
-          return await super.getResponse(request);
+      class TrackingModel extends ScriptedModel {
+        get callCount(): number {
+          return this.calls.length;
         }
       }
 
       const model = new TrackingModel([
-        {
+        modelResponse({
           output: [fakeModelMessage('{"value":"ok"}')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent: Agent<any, any> = new Agent({
         name: 'ResumedRequestSerializationFailure',
@@ -4274,7 +4311,7 @@ describe('Runner.run', () => {
       );
 
       expect(error).toBeInstanceOf(UserError);
-      expect(model.calls).toBe(0);
+      expect(model.callCount).toBe(0);
       expect(restored._currentTurn).toBe(1);
       expect(restored._currentTurnInProgress).toBe(true);
 
@@ -4284,7 +4321,7 @@ describe('Runner.run', () => {
 
       expect(resumed.finalOutput).toEqual({ value: 'ok' });
       expect(resumed.state._currentTurn).toBe(1);
-      expect(model.calls).toBe(1);
+      expect(model.callCount).toBe(1);
     });
 
     it('does not enforce maxTurns when maxTurns is null', async () => {
@@ -4301,9 +4338,12 @@ describe('Runner.run', () => {
       }));
       const agent = new Agent({
         name: 'NoMaxTurns',
-        model: new FakeModel([
-          ...toolResponses,
-          { output: [fakeModelMessage('done')], usage: new Usage() },
+        model: new ScriptedModel([
+          ...toolResponses.map(modelResponse),
+          modelResponse({
+            output: [fakeModelMessage('done')],
+            usage: new Usage(),
+          }),
         ]),
         tools: [TEST_TOOL],
       });
@@ -4343,7 +4383,7 @@ describe('Runner.run', () => {
       ];
       const agent = new Agent({
         name: 'NoMaxTurnsResume',
-        model: new FakeModel(responses),
+        model: new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [TEST_TOOL],
       });
       const error = await run(agent, 'x', { maxTurns: 1 }).catch((err) => err);
@@ -4365,8 +4405,11 @@ describe('Runner.run', () => {
     it('max turn handler returns final output', async () => {
       const agent = new Agent({
         name: 'MaxSummary',
-        model: new FakeModel([
-          { output: [fakeModelMessage('nope')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('nope')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const result = await run(agent, 'x', {
@@ -4384,8 +4427,11 @@ describe('Runner.run', () => {
     it('max turn handler can skip history updates', async () => {
       const agent = new Agent({
         name: 'MaxSummaryNoHistory',
-        model: new FakeModel([
-          { output: [fakeModelMessage('nope')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('nope')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const result = await run(agent, 'x', {
@@ -4404,11 +4450,11 @@ describe('Runner.run', () => {
     it('throws model refusal errors instead of retrying refusal-only messages', async () => {
       const agent = new Agent({
         name: 'Refusal',
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelRefusal('I cannot help with that request.')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       await expect(run(agent, 'x', { maxTurns: 3 })).rejects.toMatchObject({
@@ -4421,11 +4467,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'StructuredRefusalError',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelRefusal('I cannot help with that request.')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       await expect(run(agent, 'x')).rejects.toBeInstanceOf(ModelRefusalError);
@@ -4434,8 +4480,8 @@ describe('Runner.run', () => {
     it('uses assistant text when a message also contains refusal content', async () => {
       const agent = new Agent({
         name: 'MixedTextRefusal',
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               fakeModelMessageWithRefusal(
                 'valid answer',
@@ -4443,7 +4489,7 @@ describe('Runner.run', () => {
               ),
             ],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       const result = await run(agent, 'x');
@@ -4454,8 +4500,8 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'MixedStructuredRefusal',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               fakeModelMessageWithRefusal(
                 '{"summary":"valid answer"}',
@@ -4463,7 +4509,7 @@ describe('Runner.run', () => {
               ),
             ],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       const result = await run(agent, 'x');
@@ -4474,11 +4520,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'StructuredRefusal',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelRefusal('I cannot help with that request.')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       const result = await run(agent, 'x', {
@@ -4502,11 +4548,11 @@ describe('Runner.run', () => {
     it('model refusal handler can skip history updates', async () => {
       const agent = new Agent({
         name: 'RefusalNoHistory',
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelRefusal('I cannot help with that request.')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       const result = await run(agent, 'x', {
@@ -4524,11 +4570,11 @@ describe('Runner.run', () => {
     it('default error handler can handle model refusals', async () => {
       const agent = new Agent({
         name: 'DefaultRefusal',
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelRefusal('I cannot help with that request.')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       const result = await run(agent, 'x', {
@@ -4546,11 +4592,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'InvalidStructuredOutput',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4561,11 +4607,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'InvalidStructuredOutputHandler',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4592,11 +4638,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'InvalidStructuredOutputNoHistory',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4617,11 +4663,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'InvalidStructuredOutputDeclined',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4638,11 +4684,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'InvalidStructuredOutputBadFallback',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4661,11 +4707,11 @@ describe('Runner.run', () => {
       const agent = new Agent({
         name: 'DefaultInvalidStructuredOutput',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4687,22 +4733,13 @@ describe('Runner.run', () => {
     ])(
       'empty structured output handler avoids another model turn for $name',
       async ({ output }) => {
-        class CountingModel implements Model {
-          public requests: ModelRequest[] = [];
-
-          constructor(private responses: ModelResponse[]) {}
-
-          async getResponse(request: ModelRequest): Promise<ModelResponse> {
-            this.requests.push(request);
-            const response = this.responses.shift();
-            if (!response) {
-              throw new Error('No response found');
-            }
-            return response;
+        class CountingModel extends ScriptedModel {
+          constructor(responses: ModelResponse[]) {
+            super(responses.map(modelResponse));
           }
 
-          getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
-            throw new Error('Not implemented');
+          get requests(): readonly ModelRequest[] {
+            return this.calls.map((call) => call.request);
           }
         }
 
@@ -4751,8 +4788,8 @@ describe('Runner.run', () => {
         name: 'InvalidStructuredOutputAfterTool',
         outputType: z.object({ summary: z.string() }),
         tools: [recordSideEffect],
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -4765,12 +4802,12 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -4783,11 +4820,11 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [fakeModelMessage('{"summary":"unexpected retry"}')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4807,11 +4844,11 @@ describe('Runner.run', () => {
       const nestedAgent = new Agent({
         name: 'NestedRecoverer',
         outputType: z.object({ summary: z.string() }),
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('not valid json')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       const nestedTool = nestedAgent.asTool({
@@ -4828,8 +4865,8 @@ describe('Runner.run', () => {
       const parentAgent = new Agent({
         name: 'ParentAgent',
         tools: [nestedTool],
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -4842,11 +4879,11 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [fakeModelMessage('parent done')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -4881,9 +4918,8 @@ describe('Runner.run', () => {
 
       const agent = new Agent({
         name: 'TurnCounter',
-        model: new FakeModel([
-          // First call: tool call
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -4896,9 +4932,11 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          // Second call: should be blocked by maxTurns=1
-          { output: [fakeModelMessage('second')], usage: new Usage() },
+          }),
+          modelResponse({
+            output: [fakeModelMessage('second')],
+            usage: new Usage(),
+          }),
         ]),
         tools: [testTool],
         toolUseBehavior: 'run_llm_again',
@@ -4924,9 +4962,8 @@ describe('Runner.run', () => {
 
       const agent = new Agent({
         name: 'ResumeTurnCounter',
-        model: new FakeModel([
-          // First post-interruption call: should NOT advance turn (still turn 1)
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -4939,9 +4976,11 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          // Second call: SHOULD advance turn to 2, then maxTurns=1 should throw
-          { output: [fakeModelMessage('second')], usage: new Usage() },
+          }),
+          modelResponse({
+            output: [fakeModelMessage('second')],
+            usage: new Usage(),
+          }),
         ]),
         tools: [testTool],
         toolUseBehavior: 'run_llm_again',
@@ -4985,8 +5024,8 @@ describe('Runner.run', () => {
         execute: async ({ city }) => `Weather in ${city}`,
       });
 
-      const model = new FakeModel([
-        {
+      const model = new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'function_call',
@@ -4999,8 +5038,11 @@ describe('Runner.run', () => {
             } as protocol.FunctionCallItem,
           ],
           usage: new Usage(),
-        },
-        { output: [fakeModelMessage('All set.')], usage: new Usage() },
+        }),
+        modelResponse({
+          output: [fakeModelMessage('All set.')],
+          usage: new Usage(),
+        }),
       ]);
 
       const agent = new Agent({
@@ -5027,8 +5069,11 @@ describe('Runner.run', () => {
       setTraceProcessors([new BatchTraceProcessor(new FakeTracingExporter())]);
       const agent = new Agent({
         name: 'NoIG',
-        model: new FakeModel([
-          { output: [fakeModelMessage('ok')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('ok')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const result = await run(agent, 'hi');
@@ -5041,8 +5086,11 @@ describe('Runner.run', () => {
       setTracingDisabled(false);
       const agent = new Agent({
         name: 'NoOG',
-        model: new FakeModel([
-          { output: [fakeModelMessage('ok')], usage: new Usage() },
+        model: new ScriptedModel([
+          modelResponse({
+            output: [fakeModelMessage('ok')],
+            usage: new Usage(),
+          }),
         ]),
       });
       const spy = vi.spyOn(agent, 'processFinalOutput');
@@ -5078,44 +5126,12 @@ describe('Runner.run', () => {
     });
 
     it('uses runner-level reasoningItemIdPolicy when building follow-up turn input', async () => {
-      class RequestRecordingModel implements Model {
-        readonly requests: ModelRequest[] = [];
-        #callCount = 0;
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          if (this.#callCount++ === 0) {
-            return {
-              output: [
-                {
-                  type: 'reasoning',
-                  id: 'rs_first',
-                  content: [{ type: 'input_text', text: 'reasoning trace' }],
-                } satisfies protocol.ReasoningItem,
-                {
-                  type: 'function_call',
-                  id: 'fc_first',
-                  callId: 'call_first',
-                  name: 'echo_tool',
-                  status: 'completed',
-                  arguments: '{}',
-                } satisfies protocol.FunctionCallItem,
-              ],
-              usage: new Usage(),
-            };
-          }
-          return {
-            output: [fakeModelMessage('done')],
-            usage: new Usage(),
-          };
-        }
-
-        getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
-          throw new Error('Not implemented');
-        }
-      }
-
-      const model = new RequestRecordingModel();
+      const model = createReasoningPolicyModel({
+        reasoningId: 'rs_first',
+        functionId: 'fc_first',
+        callId: 'call_first',
+        toolName: 'echo_tool',
+      });
       const echoTool = tool({
         name: 'echo_tool',
         description: 'Echoes a static payload.',
@@ -5133,10 +5149,10 @@ describe('Runner.run', () => {
 
       const result = await runner.run(agent, 'hello');
       expect(result.finalOutput).toBe('done');
-      expect(model.requests).toHaveLength(2);
+      expect(model.calls).toHaveLength(2);
 
       const secondRequestReasoning = getRequestInputItems(
-        model.requests[1],
+        model.calls[1].request,
       ).find(
         (item): item is protocol.ReasoningItem => item.type === 'reasoning',
       );
@@ -5151,44 +5167,12 @@ describe('Runner.run', () => {
     });
 
     it('allows per-run reasoningItemIdPolicy to override runner defaults', async () => {
-      class RequestRecordingModel implements Model {
-        readonly requests: ModelRequest[] = [];
-        #callCount = 0;
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          if (this.#callCount++ === 0) {
-            return {
-              output: [
-                {
-                  type: 'reasoning',
-                  id: 'rs_override',
-                  content: [{ type: 'input_text', text: 'reasoning trace' }],
-                } satisfies protocol.ReasoningItem,
-                {
-                  type: 'function_call',
-                  id: 'fc_override',
-                  callId: 'call_override',
-                  name: 'echo_tool',
-                  status: 'completed',
-                  arguments: '{}',
-                } satisfies protocol.FunctionCallItem,
-              ],
-              usage: new Usage(),
-            };
-          }
-          return {
-            output: [fakeModelMessage('done')],
-            usage: new Usage(),
-          };
-        }
-
-        getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
-          throw new Error('Not implemented');
-        }
-      }
-
-      const model = new RequestRecordingModel();
+      const model = createReasoningPolicyModel({
+        reasoningId: 'rs_override',
+        functionId: 'fc_override',
+        callId: 'call_override',
+        toolName: 'echo_tool',
+      });
       const echoTool = tool({
         name: 'echo_tool',
         description: 'Echoes a static payload.',
@@ -5209,7 +5193,7 @@ describe('Runner.run', () => {
       });
 
       const secondRequestReasoning = getRequestInputItems(
-        model.requests[1],
+        model.calls[1].request,
       ).find(
         (item): item is protocol.ReasoningItem => item.type === 'reasoning',
       );
@@ -5218,44 +5202,12 @@ describe('Runner.run', () => {
     });
 
     it('passes reasoningItemIdPolicy through the run() helper', async () => {
-      class RequestRecordingModel implements Model {
-        readonly requests: ModelRequest[] = [];
-        #callCount = 0;
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          if (this.#callCount++ === 0) {
-            return {
-              output: [
-                {
-                  type: 'reasoning',
-                  id: 'rs_helper',
-                  content: [{ type: 'input_text', text: 'reasoning trace' }],
-                } satisfies protocol.ReasoningItem,
-                {
-                  type: 'function_call',
-                  id: 'fc_helper',
-                  callId: 'call_helper',
-                  name: 'echo_tool',
-                  status: 'completed',
-                  arguments: '{}',
-                } satisfies protocol.FunctionCallItem,
-              ],
-              usage: new Usage(),
-            };
-          }
-          return {
-            output: [fakeModelMessage('done')],
-            usage: new Usage(),
-          };
-        }
-
-        getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
-          throw new Error('Not implemented');
-        }
-      }
-
-      const model = new RequestRecordingModel();
+      const model = createReasoningPolicyModel({
+        reasoningId: 'rs_helper',
+        functionId: 'fc_helper',
+        callId: 'call_helper',
+        toolName: 'echo_tool',
+      });
       const echoTool = tool({
         name: 'echo_tool',
         description: 'Echoes a static payload.',
@@ -5273,7 +5225,7 @@ describe('Runner.run', () => {
       });
 
       const secondRequestReasoning = getRequestInputItems(
-        model.requests[1],
+        model.calls[1].request,
       ).find(
         (item): item is protocol.ReasoningItem => item.type === 'reasoning',
       );
@@ -5282,44 +5234,12 @@ describe('Runner.run', () => {
     });
 
     it('uses serialized reasoningItemIdPolicy when resuming without override', async () => {
-      class RequestRecordingModel implements Model {
-        readonly requests: ModelRequest[] = [];
-        #callCount = 0;
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          if (this.#callCount++ === 0) {
-            return {
-              output: [
-                {
-                  type: 'reasoning',
-                  id: 'rs_resume',
-                  content: [{ type: 'input_text', text: 'reasoning trace' }],
-                } satisfies protocol.ReasoningItem,
-                {
-                  type: 'function_call',
-                  id: 'fc_resume',
-                  callId: 'call_resume',
-                  name: 'approval_tool',
-                  status: 'completed',
-                  arguments: '{}',
-                } satisfies protocol.FunctionCallItem,
-              ],
-              usage: new Usage(),
-            };
-          }
-          return {
-            output: [fakeModelMessage('done')],
-            usage: new Usage(),
-          };
-        }
-
-        getStreamedResponse(_request: ModelRequest): AsyncIterable<any> {
-          throw new Error('Not implemented');
-        }
-      }
-
-      const model = new RequestRecordingModel();
+      const model = createReasoningPolicyModel({
+        reasoningId: 'rs_resume',
+        functionId: 'fc_resume',
+        callId: 'call_resume',
+        toolName: 'approval_tool',
+      });
       const approvalTool = tool({
         name: 'approval_tool',
         description: 'Requires approval before execution.',
@@ -5348,9 +5268,9 @@ describe('Runner.run', () => {
       const resumedRun = await run(agent, restoredState, { maxTurns: 1 });
 
       expect(resumedRun.finalOutput).toBe('done');
-      expect(model.requests).toHaveLength(2);
+      expect(model.calls).toHaveLength(2);
       const secondRequestReasoning = getRequestInputItems(
-        model.requests[1],
+        model.calls[1].request,
       ).find(
         (item): item is protocol.ReasoningItem => item.type === 'reasoning',
       );
@@ -5411,23 +5331,18 @@ describe('Runner.run', () => {
         }
       }
 
-      class RecordingModel extends FakeModel {
-        lastRequest: ModelRequest | undefined;
-
-        override async getResponse(
-          request: ModelRequest,
-        ): Promise<ModelResponse> {
-          this.lastRequest = request;
-          return super.getResponse(request);
+      class RecordingModel extends ScriptedModel {
+        get lastRequest(): Readonly<ModelRequest> | undefined {
+          return this.lastCall?.request;
         }
       }
 
       it('uses session history and stores run results', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('response')],
-          },
+          }),
         ]);
         const agent = new Agent({ name: 'SessionAgent', model });
         const historyItem = fakeModelMessage(
@@ -5457,7 +5372,7 @@ describe('Runner.run', () => {
         const firstPart = Array.isArray(savedAssistant.content)
           ? (savedAssistant.content[0] as { providerData?: unknown })
           : undefined;
-        expect(firstPart?.providerData).toEqual({ annotations: [] });
+        expect(firstPart?.providerData).toBeUndefined();
       });
 
       it('persists accepted tool results before surfacing cancellation', async () => {
@@ -5481,11 +5396,11 @@ describe('Runner.run', () => {
             return 'completed tool result';
           },
         });
-        const model = new FakeModel([
-          {
+        const model = new ScriptedModel([
+          modelResponse({
             output: [{ ...TEST_MODEL_FUNCTION_CALL }],
             usage: new Usage(),
-          },
+          }),
         ]);
         const agent = new Agent({
           name: 'SessionCancellationAgent',
@@ -5534,15 +5449,15 @@ describe('Runner.run', () => {
             return 'completed tool result';
           },
         });
-        const model = new FakeModel([
-          {
+        const model = new ScriptedModel([
+          modelResponse({
             output: [{ ...TEST_MODEL_FUNCTION_CALL }],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [fakeModelMessage('resumed response')],
             usage: new Usage(),
-          },
+          }),
         ]);
         const agent = new Agent({
           name: 'SessionCancellationResumeAgent',
@@ -5607,11 +5522,11 @@ describe('Runner.run', () => {
         });
         const agentB = new Agent({
           name: 'SessionCancellationHandoffTarget',
-          model: new FakeModel([
-            {
+          model: new ScriptedModel([
+            modelResponse({
               output: [fakeModelMessage('handoff response')],
               usage: new Usage(),
-            },
+            }),
           ]),
         });
         const onHandoff = vi.fn();
@@ -5626,15 +5541,15 @@ describe('Runner.run', () => {
         };
         const agentA = new Agent({
           name: 'SessionCancellationHandoffSource',
-          model: new FakeModel([
-            {
+          model: new ScriptedModel([
+            modelResponse({
               output: [{ ...TEST_MODEL_FUNCTION_CALL }, handoffCall],
               usage: new Usage(),
-            },
-            {
+            }),
+            modelResponse({
               output: [fakeModelMessage('resumed source response')],
               usage: new Usage(),
-            },
+            }),
           ]),
           tools: [abortableTool],
           handoffs: [handoffToB],
@@ -5692,10 +5607,10 @@ describe('Runner.run', () => {
         }
 
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('response')],
-          },
+          }),
         ]);
         const agent = new Agent({ name: 'SessionReasoningAgent', model });
         const session = new ReasoningPreservingSession([
@@ -5721,10 +5636,10 @@ describe('Runner.run', () => {
 
       it('allows list inputs with session history and no session input callback', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('list response')],
-          },
+          }),
         ]);
         const agent = new Agent({ name: 'ListSession', model });
         const historyItem = user('History stays');
@@ -5750,10 +5665,10 @@ describe('Runner.run', () => {
 
       it('allows list inputs when session input callback is provided', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('response')],
-          },
+          }),
         ]);
         const agent = new Agent({ name: 'SessionCallbackAgent', model });
         const sessionHistory: AgentInputItem[] = [
@@ -5797,10 +5712,10 @@ describe('Runner.run', () => {
 
       it('supports async session input callback', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('response')],
-          },
+          }),
         ]);
         const agent = new Agent({ name: 'AsyncSessionCallback', model });
         const session = new MemorySession([
@@ -5826,10 +5741,10 @@ describe('Runner.run', () => {
 
       it('persists transformed session input from callback', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('session response')],
-          },
+          }),
         ]);
         const agent = new Agent({ name: 'SessionTransform', model });
         const session = new MemorySession();
@@ -5863,40 +5778,41 @@ describe('Runner.run', () => {
       });
 
       it('does not persist duplicate user input when a model retry succeeds in the same run', async () => {
-        class RetryRecordingModel extends FakeModel {
-          requests: ModelRequest[] = [];
-          attempts = 0;
+        class RetryRecordingModel extends ScriptedModel {
+          readonly requests: ModelRequest[];
 
-          override async getResponse(
-            request: ModelRequest,
-          ): Promise<ModelResponse> {
-            this.requests.push({
-              ...request,
-              input: Array.isArray(request.input)
-                ? (JSON.parse(
-                    JSON.stringify(request.input),
-                  ) as AgentInputItem[])
-                : request.input,
-            });
-            this.attempts += 1;
+          constructor(response: ModelResponse) {
+            const requests: ModelRequest[] = [];
+            const record = (request: Readonly<ModelRequest>) => {
+              requests.push(cloneModelRequest(request));
+            };
+            super([
+              modelResponder((call) => {
+                record(call.request);
+                const error = new Error('temporary failure') as Error & {
+                  statusCode?: number;
+                };
+                error.statusCode = 503;
+                throw error;
+              }),
+              modelResponder((call) => {
+                record(call.request);
+                return response;
+              }),
+            ]);
+            this.requests = requests;
+          }
 
-            if (this.attempts === 1) {
-              const error = new Error('temporary failure');
-              (error as Error & { statusCode?: number }).statusCode = 503;
-              throw error;
-            }
-
-            return await super.getResponse(request);
+          get attempts(): number {
+            return this.calls.length;
           }
         }
 
-        const model = new RetryRecordingModel([
-          {
-            ...TEST_MODEL_RESPONSE_BASIC,
-            output: [fakeModelMessage('retry response')],
-            usage: new Usage({ requests: 1 }),
-          },
-        ]);
+        const model = new RetryRecordingModel({
+          ...TEST_MODEL_RESPONSE_BASIC,
+          output: [fakeModelMessage('retry response')],
+          usage: new Usage({ requests: 1 }),
+        });
         const agent = new Agent({
           name: 'RetrySessionAgent',
           model,
@@ -5935,10 +5851,10 @@ describe('Runner.run', () => {
 
       it('does not duplicate history when callback clones entries', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('clone response')],
-          },
+          }),
         ]);
         const history = [user('Existing history item')];
         const session = new MemorySession(history);
@@ -5976,11 +5892,14 @@ describe('Runner.run', () => {
         async ({ stream }) => {
           const model = stream
             ? new StreamingModel(fakeModelMessage('assistant'))
-            : new FakeModel(
-                Array.from({ length: 3 }, (_, turn) => ({
-                  ...TEST_MODEL_RESPONSE_BASIC,
-                  output: [fakeModelMessage(`assistant ${turn}`)],
-                })),
+            : new ScriptedModel(
+                Array.from(
+                  Array.from({ length: 3 }, (_, turn) => ({
+                    ...TEST_MODEL_RESPONSE_BASIC,
+                    output: [fakeModelMessage(`assistant ${turn}`)],
+                  })),
+                  modelResponse,
+                ),
               );
           const agent = new Agent({ name: 'RepeatedHistorySession', model });
           const session = new MemorySession();
@@ -6024,10 +5943,10 @@ describe('Runner.run', () => {
 
       it('persists reordered new items ahead of matching history', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('reordered response')],
-          },
+          }),
         ]);
         const historyMessage = user('Repeatable message');
         const newMessage = user('Repeatable message');
@@ -6053,10 +5972,10 @@ describe('Runner.run', () => {
 
       it('persists binary payloads that share prefixes with history', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('binary response')],
-          },
+          }),
         ]);
         const historyPayload = new Uint8Array(32);
         const newPayload = new Uint8Array(32);
@@ -6106,10 +6025,10 @@ describe('Runner.run', () => {
 
       it('throws when session input callback returns invalid data', async () => {
         const model = new RecordingModel([
-          {
+          modelResponse({
             ...TEST_MODEL_RESPONSE_BASIC,
             output: [fakeModelMessage('response')],
-          },
+          }),
         ]);
         const agent = new Agent({ name: 'InvalidCallback', model });
         const session = new MemorySession([user('history')]);
@@ -6136,15 +6055,15 @@ describe('Runner.run', () => {
           providerData: { source: 'openai' },
         } as protocol.FunctionCallItem;
 
-        const model = new FakeModel([
-          {
+        const model = new ScriptedModel([
+          modelResponse({
             output: [functionCall],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [fakeModelMessage('Weather retrieved.')],
             usage: new Usage(),
-          },
+          }),
         ]);
 
         const weatherTool = tool({
@@ -6205,11 +6124,11 @@ describe('Runner.run', () => {
           },
         } as protocol.HostedToolCallItem;
 
-        const model = new FakeModel([
-          {
+        const model = new ScriptedModel([
+          modelResponse({
             output: [hostedCall],
             usage: new Usage(),
-          },
+          }),
         ]);
 
         const hostedTool = hostedMcpTool({
@@ -6270,9 +6189,8 @@ describe('Runner.run', () => {
           execute: async ({ city }) => `Sunny, 72°F in ${city}`,
         });
 
-        const model = new FakeModel([
-          // First response: tool call that requires approval
-          {
+        const model = new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -6285,12 +6203,11 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          // Second response: after approval, final answer
-          {
+          }),
+          modelResponse({
             output: [fakeModelMessage('The weather is sunny in Oakland.')],
             usage: new Usage(),
-          },
+          }),
         ]);
 
         const agent = new Agent({
@@ -6364,9 +6281,8 @@ describe('Runner.run', () => {
           execute: async ({ city }) => `12:00PM in ${city}`,
         });
 
-        const model = new FakeModel([
-          // First response: tool call that requires approval.
-          {
+        const model = new ScriptedModel([
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -6379,9 +6295,8 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          // Second response: after approval, request another tool call without approval.
-          {
+          }),
+          modelResponse({
             output: [
               {
                 type: 'function_call',
@@ -6394,14 +6309,13 @@ describe('Runner.run', () => {
               } as protocol.FunctionCallItem,
             ],
             usage: new Usage(),
-          },
-          // Third response: final answer after tool results are available.
-          {
+          }),
+          modelResponse({
             output: [
               fakeModelMessage('It is sunny in Oakland and it is noon.'),
             ],
             usage: new Usage(),
-          },
+          }),
         ]);
 
         const agent = new Agent({
@@ -6453,53 +6367,28 @@ describe('Runner.run', () => {
   });
 
   describe('callModelInputFilter', () => {
-    class FilterTrackingModel extends FakeModel {
-      lastRequest?: ModelRequest;
-
-      override async getResponse(
-        request: ModelRequest,
-      ): Promise<ModelResponse> {
-        this.lastRequest = request;
-        return await super.getResponse(request);
+    class FilterTrackingModel extends ScriptedModel {
+      get lastRequest(): Readonly<ModelRequest> | undefined {
+        return this.lastCall?.request;
       }
     }
 
-    class FilterStreamingModel implements Model {
-      lastRequest?: ModelRequest;
-
-      constructor(private readonly response: ModelResponse) {}
-
-      async getResponse(request: ModelRequest): Promise<ModelResponse> {
-        this.lastRequest = request;
-        return this.response;
+    class FilterStreamingModel extends ScriptedModel {
+      constructor(response: ModelResponse) {
+        super([modelResponse({ ...response, responseId: 'stream-filter' })]);
       }
 
-      async *getStreamedResponse(
-        request: ModelRequest,
-      ): AsyncIterable<protocol.StreamEvent> {
-        this.lastRequest = request;
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'stream-filter',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: this.response.output,
-          },
-        } as protocol.StreamEvent;
+      get lastRequest(): Readonly<ModelRequest> | undefined {
+        return this.lastCall?.request;
       }
     }
 
     it('modifies model input for non-streaming runs', async () => {
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
           output: [fakeModelMessage('filtered result')],
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'FilterAgent',
@@ -6534,10 +6423,10 @@ describe('Runner.run', () => {
 
     it('keeps duplicate calls before their outputs in non-streaming runs', async () => {
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
           output: [fakeModelMessage('deduplicated result')],
-        },
+        }),
       ]);
       const agent = new Agent({ name: 'DeduplicateCallAgent', model });
       const oldCall: protocol.FunctionCallItem = {
@@ -6576,7 +6465,7 @@ describe('Runner.run', () => {
         execute: async () => 'done',
       });
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           output: [
             {
               type: 'function_call',
@@ -6586,11 +6475,11 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('done')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'LaterInjectionAgent',
@@ -6647,10 +6536,10 @@ describe('Runner.run', () => {
 
     it('persists an earlier duplicate explicitly selected by the filter', async () => {
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           output: [fakeModelMessage('done')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({ name: 'EarlierDuplicateAgent', model });
       const oldCall: protocol.FunctionCallItem = {
@@ -6690,10 +6579,10 @@ describe('Runner.run', () => {
 
     it('persists a repeated current clone separately from equal-content history', async () => {
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           output: [fakeModelMessage('done')],
           usage: new Usage(),
-        },
+        }),
       ]);
       const agent = new Agent({ name: 'RepeatedCurrentCloneAgent', model });
       const sameMessage = user('same');
@@ -6817,9 +6706,9 @@ describe('Runner.run', () => {
 
     it('does not mutate run history when filter mutates input items', async () => {
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'HistoryFilterAgent',
@@ -6894,9 +6783,9 @@ describe('Runner.run', () => {
       }
 
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'FilterSessionAgent',
@@ -6964,9 +6853,9 @@ describe('Runner.run', () => {
       }
 
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'EmptyFilterAgent',
@@ -7026,9 +6915,15 @@ describe('Runner.run', () => {
         }
       }
 
-      const model = new FakeModel([
-        { output: [fakeModelMessage('first turn')], usage: new Usage() },
-        { output: [fakeModelMessage('second turn')], usage: new Usage() },
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [fakeModelMessage('first turn')],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('second turn')],
+          usage: new Usage(),
+        }),
       ]);
 
       const agent = new Agent({ name: 'PersistCounterAgent', model });
@@ -7059,8 +6954,11 @@ describe('Runner.run', () => {
     });
 
     it('does not double-count turns when resuming an in-progress turn', async () => {
-      const model = new FakeModel([
-        { output: [fakeModelMessage('done')], usage: new Usage() },
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
       ]);
 
       const agent = new Agent({ name: 'TurnResumeAgent', model });
@@ -7104,9 +7002,15 @@ describe('Runner.run', () => {
         }
       }
 
-      const model = new FakeModel([
-        { output: [{ ...TEST_MODEL_FUNCTION_CALL }], usage: new Usage() },
-        { output: [fakeModelMessage('second turn')], usage: new Usage() },
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('second turn')],
+          usage: new Usage(),
+        }),
       ]);
 
       const agent = new Agent({
@@ -7162,9 +7066,15 @@ describe('Runner.run', () => {
         }
       }
 
-      const model = new FakeModel([
-        { output: [{ ...TEST_MODEL_FUNCTION_CALL }], usage: new Usage() },
-        { output: [fakeModelMessage('second turn')], usage: new Usage() },
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [{ ...TEST_MODEL_FUNCTION_CALL }],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('second turn')],
+          usage: new Usage(),
+        }),
       ]);
 
       const agent = new Agent({
@@ -7227,9 +7137,9 @@ describe('Runner.run', () => {
       }
 
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'PrependedFilterAgent',
@@ -7258,9 +7168,9 @@ describe('Runner.run', () => {
 
     it('throws when filter returns invalid data', async () => {
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'InvalidFilterAgent',
@@ -7280,9 +7190,9 @@ describe('Runner.run', () => {
 
     it('prefers per-run callModelInputFilter over runner config', async () => {
       const model = new FilterTrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
-        },
+        }),
       ]);
       const agent = new Agent({
         name: 'OverrideFilterAgent',
@@ -7324,20 +7234,20 @@ describe('Runner.run', () => {
     });
 
     it('allows callModelInputFilter to override omitted reasoning IDs', async () => {
-      class ReasoningTrackingModel extends FakeModel {
-        requests: ModelRequest[] = [];
+      class ReasoningTrackingModel extends ScriptedModel {
+        readonly requests: ModelRequest[];
 
-        override async getResponse(
-          request: ModelRequest,
-        ): Promise<ModelResponse> {
-          const cloned: ModelRequest = {
-            ...request,
-            input: Array.isArray(request.input)
-              ? (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[])
-              : request.input,
-          };
-          this.requests.push(cloned);
-          return await super.getResponse(request);
+        constructor(responses: ModelResponse[]) {
+          const requests: ModelRequest[] = [];
+          super(
+            responses.map((response) =>
+              modelResponder((call) => {
+                requests.push(cloneModelRequest(call.request));
+                return response;
+              }),
+            ),
+          );
+          this.requests = requests;
         }
       }
 
@@ -7412,30 +7322,20 @@ describe('Runner.run', () => {
     });
 
     it('keeps server conversation tracking aligned with filtered inputs', async () => {
-      class ConversationTrackingModel implements Model {
-        requests: ModelRequest[] = [];
+      class ConversationTrackingModel extends ScriptedModel {
+        readonly requests: ModelRequest[];
 
-        constructor(private readonly responses: ModelResponse[]) {}
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          const cloned: ModelRequest = {
-            ...request,
-            input: Array.isArray(request.input)
-              ? (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[])
-              : request.input,
-          };
-          this.requests.push(cloned);
-          const response = this.responses.shift();
-          if (!response) {
-            throw new Error('No response configured');
-          }
-          return response;
-        }
-
-        getStreamedResponse(
-          _request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          throw new Error('Not implemented');
+        constructor(responses: ModelResponse[]) {
+          const requests: ModelRequest[] = [];
+          super(
+            responses.map((response) =>
+              modelResponder((call) => {
+                requests.push(cloneModelRequest(call.request));
+                return response;
+              }),
+            ),
+          );
+          this.requests = requests;
         }
       }
 
@@ -7523,30 +7423,20 @@ describe('Runner.run', () => {
     });
 
     it('stops requeuing sanitized inputs when filters replace them', async () => {
-      class RedactionTrackingModel implements Model {
-        requests: ModelRequest[] = [];
+      class RedactionTrackingModel extends ScriptedModel {
+        readonly requests: ModelRequest[];
 
-        constructor(private readonly responses: ModelResponse[]) {}
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          const cloned: ModelRequest = {
-            ...request,
-            input: Array.isArray(request.input)
-              ? (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[])
-              : request.input,
-          };
-          this.requests.push(cloned);
-          const response = this.responses.shift();
-          if (!response) {
-            throw new Error('No response configured');
-          }
-          return response;
-        }
-
-        getStreamedResponse(
-          _request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          throw new Error('Not implemented');
+        constructor(responses: ModelResponse[]) {
+          const requests: ModelRequest[] = [];
+          super(
+            responses.map((response) =>
+              modelResponder((call) => {
+                requests.push(cloneModelRequest(call.request));
+                return response;
+              }),
+            ),
+          );
+          this.requests = requests;
         }
       }
 
@@ -7639,30 +7529,20 @@ describe('Runner.run', () => {
     });
 
     it('does not requeue filtered tool outputs in server-managed conversations', async () => {
-      class ConversationTrackingModel implements Model {
-        requests: ModelRequest[] = [];
+      class ConversationTrackingModel extends ScriptedModel {
+        readonly requests: ModelRequest[];
 
-        constructor(private readonly responses: ModelResponse[]) {}
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          const cloned: ModelRequest = {
-            ...request,
-            input: Array.isArray(request.input)
-              ? (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[])
-              : request.input,
-          };
-          this.requests.push(cloned);
-          const response = this.responses.shift();
-          if (!response) {
-            throw new Error('No response configured');
-          }
-          return response;
-        }
-
-        getStreamedResponse(
-          _request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          throw new Error('Not implemented');
+        constructor(responses: ModelResponse[]) {
+          const requests: ModelRequest[] = [];
+          super(
+            responses.map((response) =>
+              modelResponder((call) => {
+                requests.push(cloneModelRequest(call.request));
+                return response;
+              }),
+            ),
+          );
+          this.requests = requests;
         }
       }
 
@@ -7762,29 +7642,9 @@ describe('Runner.run', () => {
     });
 
     it('preserves providerData when saving streaming session items', async () => {
-      class MetadataStreamingModel implements Model {
-        constructor(private readonly response: ModelResponse) {}
-
-        async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-          return this.response;
-        }
-
-        async *getStreamedResponse(
-          _request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          yield {
-            type: 'response_done',
-            response: {
-              id: 'meta-stream',
-              usage: {
-                requests: 1,
-                inputTokens: 0,
-                outputTokens: 0,
-                totalTokens: 0,
-              },
-              output: this.response.output,
-            },
-          } as protocol.StreamEvent;
+      class MetadataStreamingModel extends ScriptedModel {
+        constructor(response: ModelResponse) {
+          super([modelResponse({ ...response, responseId: 'meta-stream' })]);
         }
       }
 
@@ -7854,18 +7714,13 @@ describe('Runner.run', () => {
   });
 
   describe('gpt-5 default model adjustments', () => {
-    class InspectableModel extends FakeModel {
-      lastRequest: ModelRequest | undefined;
-
+    class InspectableModel extends ScriptedModel {
       constructor(response: ModelResponse) {
-        super([response]);
+        super([modelResponse(response)]);
       }
 
-      override async getResponse(
-        request: ModelRequest,
-      ): Promise<ModelResponse> {
-        this.lastRequest = request;
-        return await super.getResponse(request);
+      get lastRequest(): Readonly<ModelRequest> | undefined {
+        return this.lastCall?.request;
       }
     }
 
@@ -8031,8 +7886,6 @@ describe('Runner.run', () => {
   });
 
   describe('server-managed conversation state', () => {
-    type TurnResponse = ModelResponse;
-
     class RecordingSession implements Session {
       public added: AgentInputItem[][] = [];
 
@@ -8057,42 +7910,28 @@ describe('Runner.run', () => {
       }
     }
 
-    class TrackingModel implements Model {
-      public requests: ModelRequest[] = [];
-      public firstRequest: ModelRequest | undefined;
-      public lastRequest: ModelRequest | undefined;
+    class TrackingModel extends ScriptedModel {
+      public requests: ModelRequest[];
 
-      constructor(private readonly responses: TurnResponse[]) {}
-
-      private recordRequest(request: ModelRequest) {
-        const clonedInput: string | AgentInputItem[] =
-          typeof request.input === 'string'
-            ? request.input
-            : (JSON.parse(JSON.stringify(request.input)) as AgentInputItem[]);
-
-        const recorded: ModelRequest = {
-          ...request,
-          input: clonedInput,
-        };
-
-        this.requests.push(recorded);
-        this.lastRequest = recorded;
-        this.firstRequest ??= recorded;
+      constructor(responses: Array<ReturnType<typeof modelResponse>>) {
+        const requests: ModelRequest[] = [];
+        super(
+          responses.map((step) =>
+            modelResponder((call) => {
+              requests.push(cloneModelRequest(call.request));
+              return step.response;
+            }),
+          ),
+        );
+        this.requests = requests;
       }
 
-      async getResponse(request: ModelRequest): Promise<ModelResponse> {
-        this.recordRequest(request);
-        const response = this.responses.shift();
-        if (!response) {
-          throw new Error('No response configured');
-        }
-        return response;
+      get firstRequest(): ModelRequest | undefined {
+        return this.requests[0];
       }
 
-      getStreamedResponse(
-        _request: ModelRequest,
-      ): AsyncIterable<protocol.StreamEvent> {
-        throw new Error('Not implemented');
+      get lastRequest(): ModelRequest | undefined {
+        return this.requests.at(-1);
       }
     }
 
@@ -8125,21 +7964,15 @@ describe('Runner.run', () => {
     });
 
     it('marks server-managed inputs as sent only after a successful response', async () => {
-      /* eslint-disable require-yield */
-      class SingleResponseModel implements Model {
-        public readonly requests: ModelRequest[] = [];
-        constructor(private readonly response: ModelResponse) {}
-
-        async getResponse(request: ModelRequest): Promise<ModelResponse> {
-          this.requests.push(request);
-          return this.response;
+      class SingleResponseModel extends ScriptedModel {
+        constructor(response: ModelResponse) {
+          super([modelResponse(response)]);
         }
 
-        async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-          throw new Error('not used');
+        get requests(): readonly ModelRequest[] {
+          return this.calls.map((call) => call.request);
         }
       }
-      /* eslint-enable require-yield */
 
       const markSpy = vi.spyOn(
         ServerConversationTracker.prototype,
@@ -8165,25 +7998,13 @@ describe('Runner.run', () => {
     });
 
     it('does not mark server inputs as sent when the model call fails before sending', async () => {
-      /* eslint-disable require-yield */
-      class ThrowingModel implements Model {
-        async getResponse(): Promise<ModelResponse> {
-          throw new Error('boom');
-        }
-
-        async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-          throw new Error('not used');
-        }
-      }
-      /* eslint-enable require-yield */
-
       const markSpy = vi.spyOn(
         ServerConversationTracker.prototype,
         'markInputAsSent',
       );
       const agent = new Agent({
         name: 'MarkFailure',
-        model: new ThrowingModel(),
+        model: new ScriptedModel([modelError(new Error('boom'))]),
       });
       const runner = new Runner();
 
@@ -8199,10 +8020,10 @@ describe('Runner.run', () => {
 
     it('skips persisting turns when the server manages conversation history via conversationId', async () => {
       const model = new TrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
           output: [fakeModelMessage('response')],
-        },
+        }),
       ]);
       const agent = new Agent({ name: 'ServerManagedConversation', model });
       // Deliberately combine session with conversationId to ensure callbacks and state helpers remain usable without duplicating remote history.
@@ -8220,10 +8041,10 @@ describe('Runner.run', () => {
 
     it('skips persisting turns when the server manages conversation history via previousResponseId', async () => {
       const model = new TrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
           output: [fakeModelMessage('response')],
-        },
+        }),
       ]);
       const agent = new Agent({ name: 'ServerManagedPrevious', model });
       // Deliberately combine session with previousResponseId to ensure we honor server-side transcripts while keeping session utilities available.
@@ -8241,10 +8062,10 @@ describe('Runner.run', () => {
 
     it('preserves user input when the session callback only reuses history with conversationId', async () => {
       const model = new TrackingModel([
-        {
+        modelResponse({
           ...TEST_MODEL_RESPONSE_BASIC,
           output: [fakeModelMessage('response')],
-        },
+        }),
       ]);
       const agent = new Agent({ name: 'ServerManagedReuse', model });
       const persistedHistory: AgentInputItem[] = [
@@ -8289,15 +8110,19 @@ describe('Runner.run', () => {
 
     it('only sends new items when using conversationId across turns', async () => {
       const model = new TrackingModel([
-        buildResponse(
-          [fakeModelMessage('a_message'), buildToolCall('call-1', 'foo')],
-          'resp-1',
+        modelResponse(
+          buildResponse(
+            [fakeModelMessage('a_message'), buildToolCall('call-1', 'foo')],
+            'resp-1',
+          ),
         ),
-        buildResponse(
-          [fakeModelMessage('b_message'), buildToolCall('call-2', 'bar')],
-          'resp-2',
+        modelResponse(
+          buildResponse(
+            [fakeModelMessage('b_message'), buildToolCall('call-2', 'bar')],
+            'resp-2',
+          ),
         ),
-        buildResponse([fakeModelMessage('done')], 'resp-3'),
+        modelResponse(buildResponse([fakeModelMessage('done')], 'resp-3')),
       ]);
 
       const agent = new Agent({
@@ -8346,20 +8171,17 @@ describe('Runner.run', () => {
     });
 
     it('does not retry a failed server-managed request before the server ack is recorded', async () => {
-      class RetryTrackingModel extends TrackingModel {
-        attempts = 0;
+      class RetryTrackingModel extends ScriptedModel {
+        constructor() {
+          const error = new Error('temporary conversation failure') as Error & {
+            statusCode?: number;
+          };
+          error.statusCode = 503;
+          super([modelError(error)]);
+        }
 
-        override async getResponse(
-          request: ModelRequest,
-        ): Promise<ModelResponse> {
-          this.attempts += 1;
-          if (this.attempts === 1) {
-            this['recordRequest'](request);
-            const error = new Error('temporary conversation failure');
-            (error as Error & { statusCode?: number }).statusCode = 503;
-            throw error;
-          }
-          return await super.getResponse(request);
+        get requests(): readonly Readonly<ModelRequest>[] {
+          return this.calls.map((call) => call.request);
         }
       }
 
@@ -8367,10 +8189,7 @@ describe('Runner.run', () => {
         ServerConversationTracker.prototype,
         'markInputAsSent',
       );
-      const model = new RetryTrackingModel([
-        buildResponse([buildToolCall('call-retry', 'foo')], 'resp-retry-1'),
-        buildResponse([fakeModelMessage('done')], 'resp-retry-2'),
-      ]);
+      const model = new RetryTrackingModel();
 
       const agent = new Agent({
         name: 'RetryConversationAgent',
@@ -8403,11 +8222,13 @@ describe('Runner.run', () => {
 
     it('only sends new items and updates previousResponseId across turns', async () => {
       const model = new TrackingModel([
-        buildResponse(
-          [fakeModelMessage('a_message'), buildToolCall('call-1', 'foo')],
-          'resp-789',
+        modelResponse(
+          buildResponse(
+            [fakeModelMessage('a_message'), buildToolCall('call-1', 'foo')],
+            'resp-789',
+          ),
         ),
-        buildResponse([fakeModelMessage('done')], 'resp-900'),
+        modelResponse(buildResponse([fakeModelMessage('done')], 'resp-900')),
       ]);
 
       const agent = new Agent({
@@ -8439,10 +8260,10 @@ describe('Runner.run', () => {
 
     it('acknowledges ignored handoffs when continuing a managed previousResponseId run', async () => {
       const agentBModel = new TrackingModel([
-        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+        modelResponse(buildResponse([fakeModelMessage('done B')], 'resp-b')),
       ]);
       const agentCModel = new TrackingModel([
-        buildResponse([fakeModelMessage('done C')], 'resp-c'),
+        modelResponse(buildResponse([fakeModelMessage('done C')], 'resp-c')),
       ]);
       const agentB = new Agent({
         name: 'ManagedB',
@@ -8473,7 +8294,7 @@ describe('Runner.run', () => {
       const agentA = new Agent({
         name: 'ManagedA',
         model: new TrackingModel([
-          buildResponse([acceptedCall, ignoredCall], 'resp-a'),
+          modelResponse(buildResponse([acceptedCall, ignoredCall], 'resp-a')),
         ]),
         handoffs: [handoffToB, handoffToC],
       });
@@ -8505,10 +8326,10 @@ describe('Runner.run', () => {
 
     it('rejects an ignored handoff that reuses a committed callId', async () => {
       const agentBModel = new TrackingModel([
-        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+        modelResponse(buildResponse([fakeModelMessage('done B')], 'resp-b')),
       ]);
       const agentCModel = new TrackingModel([
-        buildResponse([fakeModelMessage('done C')], 'resp-c'),
+        modelResponse(buildResponse([fakeModelMessage('done C')], 'resp-c')),
       ]);
       const agentB = new Agent({
         name: 'ManagedReuseB',
@@ -8540,8 +8361,12 @@ describe('Runner.run', () => {
       const agentA = new Agent({
         name: 'ManagedReuseA',
         model: new TrackingModel([
-          buildResponse([buildToolCall(reusedCallId, 'warmup')], 'resp-tool'),
-          buildResponse([acceptedCall, ignoredCall], 'resp-handoff'),
+          modelResponse(
+            buildResponse([buildToolCall(reusedCallId, 'warmup')], 'resp-tool'),
+          ),
+          modelResponse(
+            buildResponse([acceptedCall, ignoredCall], 'resp-handoff'),
+          ),
         ]),
         tools: [serverTool],
         handoffs: [handoffToB, handoffToC],
@@ -8561,7 +8386,7 @@ describe('Runner.run', () => {
 
     it('replays pending managed handoff acknowledgements when resuming in non-stream mode', async () => {
       const agentBModel = new TrackingModel([
-        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+        modelResponse(buildResponse([fakeModelMessage('done B')], 'resp-b')),
       ]);
       const agentB = new Agent({
         name: 'ManagedResumeNonStreamB',
@@ -8570,7 +8395,7 @@ describe('Runner.run', () => {
       const agentC = new Agent({
         name: 'ManagedResumeNonStreamC',
         model: new TrackingModel([
-          buildResponse([fakeModelMessage('done C')], 'resp-c'),
+          modelResponse(buildResponse([fakeModelMessage('done C')], 'resp-c')),
         ]),
       });
       const handoffToB = handoff(agentB);
@@ -8664,10 +8489,10 @@ describe('Runner.run', () => {
 
     it('does not append ignored handoff acknowledgements after removeAllTools filters the handoff input', async () => {
       const agentBModel = new TrackingModel([
-        buildResponse([fakeModelMessage('done B')], 'resp-b'),
+        modelResponse(buildResponse([fakeModelMessage('done B')], 'resp-b')),
       ]);
       const agentCModel = new TrackingModel([
-        buildResponse([fakeModelMessage('done C')], 'resp-c'),
+        modelResponse(buildResponse([fakeModelMessage('done C')], 'resp-c')),
       ]);
       const agentB = new Agent({
         name: 'ManagedFilteredB',
@@ -8700,7 +8525,7 @@ describe('Runner.run', () => {
       const agentA = new Agent({
         name: 'ManagedFilteredA',
         model: new TrackingModel([
-          buildResponse([acceptedCall, ignoredCall], 'resp-a'),
+          modelResponse(buildResponse([acceptedCall, ignoredCall], 'resp-a')),
         ]),
         handoffs: [handoffToB, handoffToC],
       });
@@ -8721,18 +8546,22 @@ describe('Runner.run', () => {
         environment: { type: 'container_auto' },
       });
       const model = new TrackingModel([
-        buildResponse(
-          [
-            {
-              type: 'shell_call',
-              callId: 'call-shell-1',
-              status: 'completed',
-              action: { commands: ['echo hi'] },
-            } satisfies protocol.ShellCallItem,
-          ],
-          'resp-shell-1',
+        modelResponse(
+          buildResponse(
+            [
+              {
+                type: 'shell_call',
+                callId: 'call-shell-1',
+                status: 'completed',
+                action: { commands: ['echo hi'] },
+              } satisfies protocol.ShellCallItem,
+            ],
+            'resp-shell-1',
+          ),
         ),
-        buildResponse([fakeModelMessage('done')], 'resp-shell-2'),
+        modelResponse(
+          buildResponse([fakeModelMessage('done')], 'resp-shell-2'),
+        ),
       ]);
 
       const agent = new Agent({
@@ -8763,25 +8592,33 @@ describe('Runner.run', () => {
         environment: { type: 'container_auto' },
       });
       const model = new TrackingModel([
-        buildResponse(
-          [
-            {
-              type: 'shell_call',
-              callId: 'call-shell-1',
-              status: 'completed',
-              action: { commands: ['echo hi'] },
-            } satisfies protocol.ShellCallItem,
-          ],
-          'resp-shell-1',
+        modelResponse(
+          buildResponse(
+            [
+              {
+                type: 'shell_call',
+                callId: 'call-shell-1',
+                status: 'completed',
+                action: { commands: ['echo hi'] },
+              } satisfies protocol.ShellCallItem,
+            ],
+            'resp-shell-1',
+          ),
         ),
-        buildResponse([fakeModelMessage('done')], 'resp-shell-2'),
-        buildResponse(
-          [fakeModelMessage('continued from result')],
-          'resp-shell-3',
+        modelResponse(
+          buildResponse([fakeModelMessage('done')], 'resp-shell-2'),
         ),
-        buildResponse(
-          [fakeModelMessage('continued from state')],
-          'resp-shell-4',
+        modelResponse(
+          buildResponse(
+            [fakeModelMessage('continued from result')],
+            'resp-shell-3',
+          ),
+        ),
+        modelResponse(
+          buildResponse(
+            [fakeModelMessage('continued from state')],
+            'resp-shell-4',
+          ),
         ),
       ]);
 
@@ -8822,18 +8659,22 @@ describe('Runner.run', () => {
         environment: { type: 'container_auto' },
       });
       const model = new TrackingModel([
-        buildResponse(
-          [
-            {
-              type: 'shell_call',
-              callId: 'call-shell-pending',
-              status: 'in_progress',
-              action: { commands: ['echo hi'] },
-            } satisfies protocol.ShellCallItem,
-          ],
-          'resp-shell-pending-1',
+        modelResponse(
+          buildResponse(
+            [
+              {
+                type: 'shell_call',
+                callId: 'call-shell-pending',
+                status: 'in_progress',
+                action: { commands: ['echo hi'] },
+              } satisfies protocol.ShellCallItem,
+            ],
+            'resp-shell-pending-1',
+          ),
         ),
-        buildResponse([fakeModelMessage('done')], 'resp-shell-pending-2'),
+        modelResponse(
+          buildResponse([fakeModelMessage('done')], 'resp-shell-pending-2'),
+        ),
       ]);
 
       const agent = new Agent({
@@ -8862,30 +8703,28 @@ describe('Runner.run', () => {
     });
 
     it('does not retry a failed previousResponseId request before the server ack is recorded', async () => {
-      class RetryTrackingModel extends TrackingModel {
-        attempts = 0;
+      class RetryTrackingModel extends ScriptedModel {
+        readonly error: Error & { statusCode?: number };
 
-        override async getResponse(
-          request: ModelRequest,
-        ): Promise<ModelResponse> {
-          this.attempts += 1;
-          if (this.attempts === 1) {
-            this['recordRequest'](request);
-            const error = new Error('temporary previousResponseId failure');
-            (error as Error & { statusCode?: number }).statusCode = 503;
-            throw error;
-          }
-          return await super.getResponse(request);
+        constructor() {
+          const error = new Error(
+            'temporary previousResponseId failure',
+          ) as Error & { statusCode?: number };
+          error.statusCode = 503;
+          super([modelError(error)]);
+          this.error = error;
+        }
+
+        get requests(): readonly Readonly<ModelRequest>[] {
+          return this.calls.map((call) => call.request);
+        }
+
+        get attempts(): number {
+          return this.calls.length;
         }
       }
 
-      const model = new RetryTrackingModel([
-        buildResponse(
-          [buildToolCall('call-prev-retry', 'foo')],
-          'resp-prev-retry-1',
-        ),
-        buildResponse([fakeModelMessage('done')], 'resp-prev-retry-2'),
-      ]);
+      const model = new RetryTrackingModel();
 
       const agent = new Agent({
         name: 'RetryPreviousResponseAgent',
@@ -8915,34 +8754,23 @@ describe('Runner.run', () => {
     });
 
     it('does not retry a streamed server-managed request before the server ack is recorded', async () => {
-      /* eslint-disable require-yield */
-      class RetryStreamingTrackingModel implements Model {
-        public requests: ModelRequest[] = [];
-        attempts = 0;
-
-        async getResponse(): Promise<ModelResponse> {
-          throw new Error('not used');
+      class RetryStreamingTrackingModel extends ScriptedModel {
+        constructor() {
+          const error = new Error(
+            'temporary streamed conversation failure',
+          ) as Error & { statusCode?: number };
+          error.statusCode = 503;
+          super([modelError(error)]);
         }
 
-        async *getStreamedResponse(
-          request: ModelRequest,
-        ): AsyncIterable<protocol.StreamEvent> {
-          this.requests.push({
-            ...request,
-            input:
-              typeof request.input === 'string'
-                ? request.input
-                : (JSON.parse(
-                    JSON.stringify(request.input),
-                  ) as AgentInputItem[]),
-          });
-          this.attempts += 1;
-          const error = new Error('temporary streamed conversation failure');
-          (error as Error & { statusCode?: number }).statusCode = 503;
-          throw error;
+        get requests(): readonly Readonly<ModelRequest>[] {
+          return this.calls.map((call) => call.request);
+        }
+
+        get attempts(): number {
+          return this.calls.length;
         }
       }
-      /* eslint-enable require-yield */
 
       const model = new RetryStreamingTrackingModel();
       const markSpy = vi.spyOn(
@@ -8991,8 +8819,10 @@ describe('Runner.run', () => {
       });
 
       const model = new TrackingModel([
-        buildResponse([buildToolCall('call-approved', 'foo')], 'resp-1'),
-        buildResponse([fakeModelMessage('done')], 'resp-2'),
+        modelResponse(
+          buildResponse([buildToolCall('call-approved', 'foo')], 'resp-1'),
+        ),
+        modelResponse(buildResponse([fakeModelMessage('done')], 'resp-2')),
       ]);
 
       const agent = new Agent({
@@ -9051,11 +8881,15 @@ describe('Runner.run', () => {
       };
 
       const model = new TrackingModel([
-        buildResponse(
-          [buildToolCall('call-approved', 'foo'), missingToolCall],
-          'resp-mixed-missing-1',
+        modelResponse(
+          buildResponse(
+            [buildToolCall('call-approved', 'foo'), missingToolCall],
+            'resp-mixed-missing-1',
+          ),
         ),
-        buildResponse([fakeModelMessage('done')], 'resp-mixed-missing-2'),
+        modelResponse(
+          buildResponse([fakeModelMessage('done')], 'resp-mixed-missing-2'),
+        ),
       ]);
 
       const agent = new Agent({
@@ -9113,8 +8947,10 @@ describe('Runner.run', () => {
       });
 
       const model = new TrackingModel([
-        buildResponse([buildToolCall('call-prev', 'foo')], 'resp-prev-1'),
-        buildResponse([fakeModelMessage('done')], 'resp-prev-2'),
+        modelResponse(
+          buildResponse([buildToolCall('call-prev', 'foo')], 'resp-prev-1'),
+        ),
+        modelResponse(buildResponse([fakeModelMessage('done')], 'resp-prev-2')),
       ]);
 
       const agent = new Agent({
@@ -9161,9 +8997,19 @@ describe('Runner.run', () => {
         execute: async ({ test }) => `result:${test}`,
       });
       const model = new TrackingModel([
-        buildResponse([buildToolCall('call-serialized-1', 'first')], 'resp-1'),
-        buildResponse([buildToolCall('call-serialized-2', 'second')], 'resp-2'),
-        buildResponse([fakeModelMessage('done')], 'resp-3'),
+        modelResponse(
+          buildResponse(
+            [buildToolCall('call-serialized-1', 'first')],
+            'resp-1',
+          ),
+        ),
+        modelResponse(
+          buildResponse(
+            [buildToolCall('call-serialized-2', 'second')],
+            'resp-2',
+          ),
+        ),
+        modelResponse(buildResponse([fakeModelMessage('done')], 'resp-3')),
       ]);
       const agent = new Agent({
         name: 'SerializedConsecutiveApprovalAgent',
@@ -9226,9 +9072,13 @@ describe('Runner.run', () => {
         },
       });
       const model = new TrackingModel([
-        buildResponse([buildMcpApproval('approval-1')], 'resp-mcp-1'),
-        buildResponse([buildMcpApproval('approval-2')], 'resp-mcp-2'),
-        buildResponse([fakeModelMessage('done')], 'resp-mcp-3'),
+        modelResponse(
+          buildResponse([buildMcpApproval('approval-1')], 'resp-mcp-1'),
+        ),
+        modelResponse(
+          buildResponse([buildMcpApproval('approval-2')], 'resp-mcp-2'),
+        ),
+        modelResponse(buildResponse([fakeModelMessage('done')], 'resp-mcp-3')),
       ]);
       const agent = new Agent({
         name: 'ConsecutiveHostedMcpApprovalAgent',
@@ -9276,8 +9126,12 @@ describe('Runner.run', () => {
       });
 
       const model = new TrackingModel([
-        buildResponse([buildToolCall('call-repeat', 'foo')], 'resp-repeat-1'),
-        buildResponse([fakeModelMessage('done')], 'resp-repeat-2'),
+        modelResponse(
+          buildResponse([buildToolCall('call-repeat', 'foo')], 'resp-repeat-1'),
+        ),
+        modelResponse(
+          buildResponse([fakeModelMessage('done')], 'resp-repeat-2'),
+        ),
       ]);
 
       const agent = new Agent({
@@ -9319,8 +9173,12 @@ describe('Runner.run', () => {
       });
 
       const model = new TrackingModel([
-        buildResponse([buildToolCall('call-extra', 'foo')], 'resp-extra-1'),
-        buildResponse([fakeModelMessage('done')], 'resp-extra-2'),
+        modelResponse(
+          buildResponse([buildToolCall('call-extra', 'foo')], 'resp-extra-1'),
+        ),
+        modelResponse(
+          buildResponse([fakeModelMessage('done')], 'resp-extra-2'),
+        ),
       ]);
 
       const agent = new Agent({
@@ -9398,11 +9256,15 @@ describe('Runner.run', () => {
       } as protocol.HostedToolCallItem;
 
       const model = new TrackingModel([
-        buildResponse(
-          [mcpApprovalCall, buildToolCall('call-mixed', 'foo')],
-          'resp-mixed-1',
+        modelResponse(
+          buildResponse(
+            [mcpApprovalCall, buildToolCall('call-mixed', 'foo')],
+            'resp-mixed-1',
+          ),
         ),
-        buildResponse([fakeModelMessage('still waiting')], 'resp-mixed-2'),
+        modelResponse(
+          buildResponse([fakeModelMessage('still waiting')], 'resp-mixed-2'),
+        ),
       ]);
 
       const agent = new Agent({
@@ -9475,8 +9337,10 @@ describe('Runner.run', () => {
       } as protocol.HostedToolCallItem;
 
       const model = new TrackingModel([
-        buildResponse([mcpApprovalCall], 'resp-mcp-reject-1'),
-        buildResponse([fakeModelMessage('done')], 'resp-mcp-reject-2'),
+        modelResponse(buildResponse([mcpApprovalCall], 'resp-mcp-reject-1')),
+        modelResponse(
+          buildResponse([fakeModelMessage('done')], 'resp-mcp-reject-2'),
+        ),
       ]);
 
       const agent = new Agent({
@@ -9528,11 +9392,13 @@ describe('Runner.run', () => {
 
     it('sends full history when no server-managed state is provided', async () => {
       const model = new TrackingModel([
-        buildResponse(
-          [fakeModelMessage('a_message'), buildToolCall('call-1', 'foo')],
-          'resp-789',
+        modelResponse(
+          buildResponse(
+            [fakeModelMessage('a_message'), buildToolCall('call-1', 'foo')],
+            'resp-789',
+          ),
         ),
-        buildResponse([fakeModelMessage('done')], 'resp-900'),
+        modelResponse(buildResponse([fakeModelMessage('done')], 'resp-900')),
       ]);
 
       const agent = new Agent({
@@ -9565,14 +9431,9 @@ describe('Runner.run', () => {
   });
 
   describe('inline compaction items', () => {
-    class RecordingModel extends FakeModel {
-      readonly requests: ModelRequest[] = [];
-
-      override async getResponse(
-        request: ModelRequest,
-      ): Promise<ModelResponse> {
-        this.requests.push(request);
-        return super.getResponse(request);
+    class RecordingModel extends ScriptedModel {
+      get requests(): readonly Readonly<ModelRequest>[] {
+        return this.calls.map((call) => call.request);
       }
     }
 
@@ -9592,7 +9453,7 @@ describe('Runner.run', () => {
         execute: async () => 'tool result payload',
       });
       const model = new RecordingModel([
-        {
+        modelResponse({
           output: [
             COMPACTION_ITEM,
             {
@@ -9603,8 +9464,11 @@ describe('Runner.run', () => {
             },
           ],
           usage: new Usage(),
-        },
-        { output: [fakeModelMessage('done')], usage: new Usage() },
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
       ]);
       const agent = new Agent({
         name: 'CompactionAgent',
@@ -9642,11 +9506,14 @@ describe('Runner.run', () => {
       });
       const clearSession = vi.spyOn(session, 'clearSession');
       const model = new RecordingModel([
-        {
+        modelResponse({
           output: [COMPACTION_ITEM, fakeModelMessage('first turn done')],
           usage: new Usage(),
-        },
-        { output: [fakeModelMessage('second turn done')], usage: new Usage() },
+        }),
+        modelResponse({
+          output: [fakeModelMessage('second turn done')],
+          usage: new Usage(),
+        }),
       ]);
       const agent = new Agent({
         name: 'SessionCompactionAgent',
@@ -9687,13 +9554,13 @@ describe('Runner.run', () => {
     });
 
     it("returns the agent's model when it is a Model instance and no override is provided", () => {
-      const fakeModel = new FakeModel();
+      const fakeModel = new ScriptedModel();
       const result = selectModel(fakeModel, undefined);
       expect(result).toBe(fakeModel);
     });
 
     it("returns the agent's model when it is a Model instance even when an override is provided", () => {
-      const fakeModel = new FakeModel();
+      const fakeModel = new ScriptedModel();
       const result = selectModel(fakeModel, MODEL_B);
       expect(result).toBe(fakeModel);
     });

--- a/packages/agents-core/test/run.toolGuardrailState.test.ts
+++ b/packages/agents-core/test/run.toolGuardrailState.test.ts
@@ -3,12 +3,8 @@ import { z } from 'zod';
 import {
   Agent,
   MaxTurnsExceededError,
-  Model,
-  ModelRequest,
-  ModelResponse,
   RunContext,
   RunState,
-  StreamEvent,
   ToolCallError,
   ToolGuardrailFunctionOutputFactory,
   ToolInputGuardrailTripwireTriggered,
@@ -23,52 +19,21 @@ import {
 } from '../src';
 import { attachRunStateToError } from '../src/runner/errorHandlers';
 import * as protocol from '../src/types/protocol';
+import { ScriptedModel, modelResponse } from '../src/testing';
 
 type GuardrailKind = 'input' | 'output';
 
-class QueuedToolCallModel implements Model {
-  readonly #outputs: ModelResponse['output'][];
-  #responseCount = 0;
-
+class QueuedToolCallModel extends ScriptedModel {
   constructor(turns: number) {
-    this.#outputs = Array.from({ length: turns }, (_, index) => [
-      functionToolCall(index + 1),
-    ]);
-  }
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    return this.#nextResponse();
-  }
-
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const response = this.#nextResponse();
-    yield {
-      type: 'response_done',
-      response: {
-        id: response.responseId,
-        usage: {
-          requests: response.usage.requests,
-          inputTokens: response.usage.inputTokens,
-          outputTokens: response.usage.outputTokens,
-          totalTokens: response.usage.totalTokens,
-        },
-        output: response.output,
-      },
-    } as StreamEvent;
-  }
-
-  #nextResponse(): ModelResponse {
-    const output = this.#outputs.shift();
-    if (!output) {
-      throw new Error('No queued model output');
-    }
-    return {
-      output,
-      usage: new Usage(),
-      responseId: `response-${++this.#responseCount}`,
-    };
+    super(
+      Array.from({ length: turns }, (_, index) =>
+        modelResponse({
+          output: [functionToolCall(index + 1)],
+          usage: new Usage(),
+          responseId: `response-${index + 1}`,
+        }),
+      ),
+    );
   }
 }
 

--- a/packages/agents-core/test/runState.compatibility.test.ts
+++ b/packages/agents-core/test/runState.compatibility.test.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { Agent } from '../src/agent';
-import type { Model, ModelRequest, ModelResponse } from '../src/model';
+import type { ModelRequest, ModelResponse } from '../src/model';
 import { Runner } from '../src/run';
 import {
   CURRENT_SCHEMA_VERSION,
@@ -15,6 +15,7 @@ import {
 import { setDefaultModelProvider } from '../src/providers';
 import { tool } from '../src/tool';
 import { Usage } from '../src/usage';
+import { ScriptedModel, modelResponse } from '../src/testing';
 
 type FixtureRecord = {
   scenario: string;
@@ -65,23 +66,15 @@ const fixtureRoot = join(
 );
 const manifest = readJson<CorpusManifest>('sources.json');
 
-class QueueModel implements Model {
-  readonly requests: ModelRequest[] = [];
-
-  constructor(private readonly outputs: ModelResponse['output'][]) {}
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(request);
-    const output = this.outputs.shift();
-    if (!output) {
-      throw new Error('No queued compatibility-test model output.');
-    }
-    return { output, usage: new Usage() };
+class QueueModel extends ScriptedModel {
+  constructor(outputs: ModelResponse['output'][]) {
+    super(
+      outputs.map((output) => modelResponse({ output, usage: new Usage() })),
+    );
   }
 
-  async *getStreamedResponse(): AsyncIterable<never> {
-    yield* [];
-    throw new Error('Compatibility tests do not stream.');
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
@@ -301,18 +294,13 @@ describe('historical RunState compatibility corpus', () => {
   it.each(manifest.negativeFixtures.filter((fixture) => fixture.expectedError))(
     'rejects negative fixture $scenario before side effects',
     async (fixture) => {
-      let modelCalls = 0;
       let toolCalls = 0;
-      const model: Model = {
-        async getResponse() {
-          modelCalls += 1;
-          return { output: [message('unexpected')], usage: new Usage() };
-        },
-        async *getStreamedResponse() {
-          yield* [];
-          throw new Error('Compatibility tests do not stream.');
-        },
-      };
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [message('unexpected')],
+          usage: new Usage(),
+        }),
+      ]);
       const agent = new Agent({
         name: 'HistoricalAgent',
         model,
@@ -332,7 +320,7 @@ describe('historical RunState compatibility corpus', () => {
       await expect(
         RunState.fromString(agent, readFixture(fixture.path)),
       ).rejects.toThrow(fixture.expectedError);
-      expect(modelCalls).toBe(0);
+      expect(model.calls).toHaveLength(0);
       expect(toolCalls).toBe(0);
     },
   );

--- a/packages/agents-core/test/runState.pendingInput.test.ts
+++ b/packages/agents-core/test/runState.pendingInput.test.ts
@@ -12,7 +12,7 @@ import {
   tool,
   type AgentInputItem,
 } from '../src';
-import type { Model, ModelRequest, ModelResponse } from '../src/model';
+import type { ModelRequest, ModelResponse } from '../src/model';
 import { RunContext } from '../src/runContext';
 import { RunToolApprovalItem } from '../src/items';
 import { MemorySession } from '../src/memory/memorySession';
@@ -20,147 +20,105 @@ import type { Session } from '../src/memory/session';
 import type * as protocol from '../src/types/protocol';
 import { Usage } from '../src/usage';
 import { fakeModelMessage, fakeModelRefusal } from './stubs';
+import {
+  ScriptedModel,
+  modelError,
+  modelResponder,
+  modelResponse,
+  modelStream,
+  modelStreamResponder,
+} from '../src/testing';
 
-class RecordingModel implements Model {
-  readonly requests: ModelRequest[] = [];
-
-  constructor(private readonly responses: ModelResponse[]) {}
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(structuredClone(request));
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response found');
-    }
-    return response;
+class RecordingModel extends ScriptedModel {
+  constructor(responses: ModelResponse[]) {
+    super(responses.map(modelResponse));
   }
 
-  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-    yield* [];
-    throw new Error('Not implemented');
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
-class FailOnceModel implements Model {
-  readonly requests: ModelRequest[] = [];
-  private failed = false;
-
-  constructor(private readonly response: ModelResponse) {}
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(structuredClone(request));
-    if (!this.failed) {
-      this.failed = true;
-      throw new Error('model request failed');
-    }
-    return this.response;
+class FailOnceModel extends ScriptedModel {
+  constructor(response: ModelResponse) {
+    super([
+      modelError(new Error('model request failed')),
+      modelResponse(response),
+    ]);
   }
 
-  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-    yield* [];
-    throw new Error('Not implemented');
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
-class FailingAcceptedStreamModel implements Model {
-  streamCalls = 0;
-
-  async getResponse(): Promise<ModelResponse> {
-    throw new Error('Not implemented');
-  }
-
-  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-    this.streamCalls += 1;
-    yield {
-      type: 'output_text_delta',
-      delta: 'accepted',
-      providerData: {},
-    } as protocol.StreamEvent;
-    throw new Error('stream failed after acceptance');
-  }
-}
-
-class RecordingStreamModel implements Model {
-  readonly requests: ModelRequest[] = [];
-
-  constructor(private readonly responses: ModelResponse[]) {}
-
-  async getResponse(): Promise<ModelResponse> {
-    throw new Error('Not implemented');
-  }
-
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<protocol.StreamEvent> {
-    this.requests.push(structuredClone(request));
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response found');
-    }
-    yield {
-      type: 'response_done',
-      response: {
-        id: response.responseId,
-        requestId: response.requestId,
-        usage: {
-          requests: response.usage.requests,
-          inputTokens: response.usage.inputTokens,
-          outputTokens: response.usage.outputTokens,
-          totalTokens: response.usage.totalTokens,
-        },
-        output: response.output,
-      },
-    } as protocol.StreamEvent;
-  }
-}
-
-class AbortBeforeEventStreamModel implements Model {
-  streamCalls = 0;
-  started!: Promise<void>;
-  private markStarted!: () => void;
-
+class FailingAcceptedStreamModel extends ScriptedModel {
   constructor() {
-    this.started = new Promise<void>((resolve) => {
-      this.markStarted = resolve;
-    });
+    super([
+      modelStream(
+        (async function* () {
+          yield {
+            type: 'output_text_delta',
+            delta: 'accepted',
+            providerData: {},
+          } as protocol.StreamEvent;
+          throw new Error('stream failed after acceptance');
+        })(),
+      ),
+    ]);
   }
 
-  async getResponse(): Promise<ModelResponse> {
-    throw new Error('Not implemented');
-  }
-
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<protocol.StreamEvent> {
-    this.streamCalls += 1;
-    this.markStarted();
-    await new Promise<void>((_resolve, reject) => {
-      const abort = () => {
-        const error = new Error('aborted before first event');
-        error.name = 'AbortError';
-        reject(error);
-      };
-      if (request.signal?.aborted) {
-        abort();
-        return;
-      }
-      request.signal?.addEventListener('abort', abort, { once: true });
-    });
-    yield* [];
+  get streamCalls(): number {
+    return this.calls.filter((call) => call.streamed).length;
   }
 }
 
-class NeverCalledStreamModel implements Model {
-  streamCalls = 0;
-
-  async getResponse(): Promise<ModelResponse> {
-    throw new Error('Not implemented');
+class RecordingStreamModel extends ScriptedModel {
+  constructor(responses: ModelResponse[]) {
+    super(responses.map(modelResponse));
   }
 
-  async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-    this.streamCalls += 1;
-    yield* [];
-    throw new Error('Model should not be called');
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
+  }
+}
+
+class AbortBeforeEventStreamModel extends ScriptedModel {
+  readonly started: Promise<void>;
+  constructor() {
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    super([
+      modelResponder(async (call) => {
+        markStarted();
+        await new Promise<void>((_resolve, reject) => {
+          const abort = () => {
+            const error = new Error('aborted before first event');
+            error.name = 'AbortError';
+            reject(error);
+          };
+          if (call.request.signal?.aborted) {
+            abort();
+            return;
+          }
+          call.request.signal?.addEventListener('abort', abort, { once: true });
+        });
+        return [];
+      }),
+    ]);
+    this.started = started;
+  }
+
+  get streamCalls(): number {
+    return this.calls.filter((call) => call.streamed).length;
+  }
+}
+
+class NeverCalledStreamModel extends ScriptedModel {
+  get streamCalls(): number {
+    return this.calls.filter((call) => call.streamed).length;
   }
 }
 
@@ -648,25 +606,18 @@ describe('RunState pending input', () => {
       return { tripwireTriggered: false, outputInfo: {} };
     });
 
-    class ParallelGuardrailModel implements Model {
-      async getResponse(): Promise<ModelResponse> {
-        expect(guardrailCompleted).toBe(false);
-        markModelStarted();
-        return {
-          output: [fakeModelMessage('done')],
-          usage: new Usage(),
-        };
-      }
-
-      async *getStreamedResponse(): AsyncIterable<protocol.StreamEvent> {
-        yield* [];
-        throw new Error('Not implemented');
-      }
-    }
-
     const agent = new Agent({
       name: 'parallel-pending-guardrail',
-      model: new ParallelGuardrailModel(),
+      model: new ScriptedModel([
+        modelResponder(() => {
+          expect(guardrailCompleted).toBe(false);
+          markModelStarted();
+          return {
+            output: [fakeModelMessage('done')],
+            usage: new Usage(),
+          };
+        }),
+      ]),
     });
     const state = createResumableState(agent);
     state.addInput('guard in parallel');
@@ -710,27 +661,28 @@ describe('RunState pending input', () => {
           responseId: `local-guardrail-${modelCalls}`,
         };
       };
-      const model: Model = {
-        async getResponse() {
-          return nextResponse();
-        },
-        async *getStreamedResponse() {
-          const response = nextResponse();
-          yield {
-            type: 'response_done',
-            response: {
-              id: response.responseId,
-              usage: {
-                requests: response.usage.requests,
-                inputTokens: response.usage.inputTokens,
-                outputTokens: response.usage.outputTokens,
-                totalTokens: response.usage.totalTokens,
-              },
-              output: response.output,
-            },
-          } as protocol.StreamEvent;
-        },
-      };
+      const nextStep = () =>
+        stream
+          ? modelStreamResponder(() => {
+              const response = nextResponse();
+              return [
+                {
+                  type: 'response_done',
+                  response: {
+                    id: response.responseId,
+                    usage: {
+                      requests: response.usage.requests,
+                      inputTokens: response.usage.inputTokens,
+                      outputTokens: response.usage.outputTokens,
+                      totalTokens: response.usage.totalTokens,
+                    },
+                    output: response.output,
+                  },
+                } as protocol.StreamEvent,
+              ];
+            })
+          : modelResponder(() => nextResponse());
+      const model = new ScriptedModel([nextStep(), nextStep()]);
       const guardrail = vi
         .fn(async () => ({ tripwireTriggered: false, outputInfo: {} }))
         .mockImplementationOnce(async () => {
@@ -762,7 +714,7 @@ describe('RunState pending input', () => {
         ).rejects.toBeInstanceOf(InputGuardrailTripwireTriggered);
       }
 
-      expect(modelCalls).toBe(1);
+      expect(model.calls).toHaveLength(1);
       expect(guardrail).toHaveBeenCalledTimes(1);
       expect(state.pendingInput).toEqual([message('guard local staged input')]);
       expect(
@@ -802,24 +754,16 @@ describe('RunState pending input', () => {
     const modelFailed = new Promise<void>((resolve) => {
       markModelFailed = resolve;
     });
-    let modelCalls = 0;
-    const model: Model = {
-      async getResponse() {
-        modelCalls += 1;
-        if (modelCalls === 1) {
-          markModelFailed();
-          throw new Error('model failed before guardrail completion');
-        }
-        return {
-          output: [fakeModelMessage('done')],
-          usage: new Usage(),
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-        throw new Error('Not implemented');
-      },
-    };
+    const model = new ScriptedModel([
+      modelResponder(() => {
+        markModelFailed();
+        throw new Error('model failed before guardrail completion');
+      }),
+      modelResponse({
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      }),
+    ]);
     const guardrail = vi.fn(async () => {
       await guardrailCanFinish;
       return { tripwireTriggered: false, outputInfo: {} };
@@ -862,7 +806,7 @@ describe('RunState pending input', () => {
 
     const completed = await runner.run(agent, state, { session });
     expect(completed.finalOutput).toBe('done');
-    expect(modelCalls).toBe(2);
+    expect(model.calls).toHaveLength(2);
     expect(guardrail).toHaveBeenCalledTimes(1);
     expect(await session.getItems()).toEqual([
       message('persist after guardrail success'),
@@ -886,16 +830,12 @@ describe('RunState pending input', () => {
         outputInfo: { reason: 'blocked after model failure' },
       };
     });
-    const model: Model = {
-      async getResponse() {
+    const model = new ScriptedModel([
+      modelResponder(() => {
         markModelFailed();
         throw new ModelRefusalError('refused before guardrail completion');
-      },
-      async *getStreamedResponse() {
-        yield* [];
-        throw new Error('Not implemented');
-      },
-    };
+      }),
+    ]);
     const agent = new Agent({ name: 'guardrail-before-refusal', model });
     const state = createResumableState(agent);
     state.addInput('guard before fallback');
@@ -1048,35 +988,34 @@ describe('RunState pending input', () => {
     'retries a failed local admission write before the $label model request',
     async ({ stream }) => {
       const session = new FailOnceSession();
-      let modelCalls = 0;
       const response: ModelResponse = {
         output: [fakeModelMessage('done')],
         usage: new Usage(),
       };
-      const model: Model = {
-        async getResponse() {
-          modelCalls += 1;
-          expect(session.addAttempts).toBe(2);
-          return response;
-        },
-        async *getStreamedResponse() {
-          modelCalls += 1;
-          expect(session.addAttempts).toBe(2);
-          yield {
-            type: 'response_done',
-            response: {
-              id: 'response-local-session-retry',
-              usage: {
-                requests: response.usage.requests,
-                inputTokens: response.usage.inputTokens,
-                outputTokens: response.usage.outputTokens,
-                totalTokens: response.usage.totalTokens,
-              },
-              output: response.output,
-            },
-          } as protocol.StreamEvent;
-        },
-      };
+      const step = stream
+        ? modelStreamResponder(() => {
+            expect(session.addAttempts).toBe(2);
+            return [
+              {
+                type: 'response_done',
+                response: {
+                  id: 'response-local-session-retry',
+                  usage: {
+                    requests: response.usage.requests,
+                    inputTokens: response.usage.inputTokens,
+                    outputTokens: response.usage.outputTokens,
+                    totalTokens: response.usage.totalTokens,
+                  },
+                  output: response.output,
+                },
+              } as protocol.StreamEvent,
+            ];
+          })
+        : modelResponder(() => {
+            expect(session.addAttempts).toBe(2);
+            return response;
+          });
+      const model = new ScriptedModel([step]);
       const agent = new Agent({ name: 'local-session-retry', model });
       const state = createResumableState(agent);
       state.addInput('retry durable input');
@@ -1094,7 +1033,7 @@ describe('RunState pending input', () => {
         );
       }
 
-      expect(modelCalls).toBe(0);
+      expect(model.calls).toHaveLength(0);
       expect(session.addAttempts).toBe(1);
       expect(state.pendingInput).toEqual([]);
       expect(
@@ -1113,7 +1052,7 @@ describe('RunState pending input', () => {
         expect(completed.finalOutput).toBe('done');
       }
 
-      expect(modelCalls).toBe(1);
+      expect(model.calls).toHaveLength(1);
       expect(await session.getItems()).toEqual([
         message('retry durable input'),
         fakeModelMessage('done'),
@@ -1167,20 +1106,12 @@ describe('RunState pending input', () => {
   ])(
     'fails closed after a server-managed request reports $label',
     async ({ advice, conversationId, previousResponseId }) => {
-      let modelCalls = 0;
-      const model: Model = {
-        async getResponse() {
-          modelCalls += 1;
-          throw new Error('request may have been accepted');
-        },
-        getRetryAdvice() {
-          return { suggested: false, ...advice };
-        },
-        async *getStreamedResponse() {
-          yield* [];
-          throw new Error('Not implemented');
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(new Error('request may have been accepted'), {
+          suggested: false,
+          ...advice,
+        }),
+      ]);
       const agent = new Agent({ name: 'unsafe-server-failure', model });
       const state = createResumableState(agent);
       state.setConversationContext(conversationId, previousResponseId);
@@ -1203,36 +1134,23 @@ describe('RunState pending input', () => {
       await expect(run(agent, restored, options)).rejects.toThrow(
         /accepted model response could not be processed/i,
       );
-      expect(modelCalls).toBe(1);
+      expect(model.calls).toHaveLength(1);
     },
   );
 
   it('keeps server-managed input replayable when the application approves an unsafe retry', async () => {
-    let modelCalls = 0;
-    const model: Model = {
-      async getResponse() {
-        modelCalls += 1;
-        if (modelCalls === 1) {
-          throw new Error('request may have been accepted');
-        }
-        return {
-          output: [fakeModelMessage('done')],
-          usage: new Usage(),
-          responseId: 'approved-retry-response',
-        };
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          replaySafety: 'unsafe',
-          responseStarted: true,
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-        throw new Error('Not implemented');
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('request may have been accepted'), {
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      }),
+      modelResponse({
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+        responseId: 'approved-retry-response',
+      }),
+    ]);
     const agent = new Agent({
       name: 'approved-unsafe-server-retry',
       model,
@@ -1253,7 +1171,7 @@ describe('RunState pending input', () => {
     });
 
     expect(result.finalOutput).toBe('done');
-    expect(modelCalls).toBe(2);
+    expect(model.calls).toHaveLength(2);
     expect(state.pendingInput).toEqual([]);
     expect(
       state._generatedItems.filter((item) => item instanceof RunInputItem),
@@ -1262,24 +1180,13 @@ describe('RunState pending input', () => {
 
   it('fails closed when an approved unsafe retry is aborted before the next attempt', async () => {
     const controller = new AbortController();
-    let modelCalls = 0;
-    const model: Model = {
-      async getResponse() {
-        modelCalls += 1;
-        throw new Error('request may have been accepted');
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          replaySafety: 'unsafe',
-          responseStarted: true,
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-        throw new Error('Not implemented');
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('request may have been accepted'), {
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      }),
+    ]);
     const agent = new Agent({
       name: 'aborted-approved-unsafe-server-retry',
       model,
@@ -1304,7 +1211,7 @@ describe('RunState pending input', () => {
         signal: controller.signal,
       }),
     ).rejects.toMatchObject({ name: 'AbortError' });
-    expect(modelCalls).toBe(1);
+    expect(model.calls).toHaveLength(1);
     expect(state.pendingInput).toEqual([]);
     expect(
       state._generatedItems.filter((item) => item instanceof RunInputItem),
@@ -1320,7 +1227,7 @@ describe('RunState pending input', () => {
         conversationId: 'aborted-approved-retry-conversation',
       }),
     ).rejects.toThrow(/accepted model response could not be processed/i);
-    expect(modelCalls).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('preserves input appended while a server-managed request is in flight', async () => {
@@ -1340,29 +1247,26 @@ describe('RunState pending input', () => {
       arguments: '{}',
     };
     const requests: ModelRequest[] = [];
-    const model: Model = {
-      async getResponse(request) {
-        requests.push(structuredClone(request));
-        if (requests.length === 1) {
-          markFirstRequestStarted();
-          await firstRequestCanFinish;
-          return {
-            output: [functionCall],
-            usage: new Usage(),
-            responseId: 'append-first-response',
-          };
-        }
+    const model = new ScriptedModel([
+      modelResponder(async (call) => {
+        requests.push(structuredClone(call.request) as ModelRequest);
+        markFirstRequestStarted();
+        await firstRequestCanFinish;
+        return {
+          output: [functionCall],
+          usage: new Usage(),
+          responseId: 'append-first-response',
+        };
+      }),
+      modelResponder((call) => {
+        requests.push(structuredClone(call.request) as ModelRequest);
         return {
           output: [fakeModelMessage('done')],
           usage: new Usage(),
           responseId: 'append-second-response',
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-        throw new Error('Not implemented');
-      },
-    };
+      }),
+    ]);
     const continueTurn = tool({
       name: 'continue_turn',
       description: 'Continues the current run.',
@@ -2153,15 +2057,10 @@ describe('RunState pending input', () => {
       'shared refusal',
       createResumableState(errorStateAgent),
     );
-    const model: Model = {
-      async getResponse() {
-        throw sharedError;
-      },
-      async *getStreamedResponse() {
-        yield* [];
-        throw new Error('Not implemented');
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(sharedError),
+      modelError(sharedError),
+    ]);
     const agent = new Agent({ name: 'shared-refusal-error', model });
     let handlerCalls = 0;
     const options = {
@@ -2525,32 +2424,17 @@ describe('RunState pending input', () => {
   });
 
   it('keeps one local occurrence across an explicitly approved unsafe replay', async () => {
-    let attempts = 0;
-    const requestInputs: AgentInputItem[][] = [];
-    const model: Model = {
-      async getResponse(request) {
-        attempts += 1;
-        requestInputs.push(structuredClone(request.input as AgentInputItem[]));
-        if (attempts === 1) {
-          throw new Error('request may have been accepted');
-        }
-        return {
-          output: [fakeModelMessage('done')],
-          usage: new Usage(),
-        };
-      },
-      getRetryAdvice() {
-        return {
-          suggested: false,
-          replaySafety: 'unsafe',
-          responseStarted: true,
-        };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-        throw new Error('Not implemented');
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('request may have been accepted'), {
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      }),
+      modelResponse({
+        output: [fakeModelMessage('done')],
+        usage: new Usage(),
+      }),
+    ]);
     const agent = new Agent({
       name: 'unsafe-replay-pending-input',
       model,
@@ -2569,8 +2453,8 @@ describe('RunState pending input', () => {
     const completed = await run(agent, state, { session });
 
     expect(completed.finalOutput).toBe('done');
-    expect(attempts).toBe(2);
-    expect(requestInputs[0]).toEqual(requestInputs[1]);
+    expect(model.calls).toHaveLength(2);
+    expect(model.calls[0].request.input).toEqual(model.calls[1].request.input);
     expect(
       state._generatedItems.filter((item) => item instanceof RunInputItem),
     ).toHaveLength(1);
@@ -2645,20 +2529,12 @@ describe('RunState pending input', () => {
   ])(
     'fails closed before the first server-managed stream event after $label',
     async ({ advice, conversationId, previousResponseId }) => {
-      let streamCalls = 0;
-      const model: Model = {
-        async getResponse() {
-          throw new Error('Not implemented');
-        },
-        async *getStreamedResponse() {
-          streamCalls += 1;
-          yield* [];
-          throw new Error('stream request may have been accepted');
-        },
-        getRetryAdvice() {
-          return { suggested: false, ...advice };
-        },
-      };
+      const model = new ScriptedModel([
+        modelError(new Error('stream request may have been accepted'), {
+          suggested: false,
+          ...advice,
+        }),
+      ]);
       const agent = new Agent({ name: 'unsafe-server-stream', model });
       const state = createResumableState(agent);
       state.setConversationContext(conversationId, previousResponseId);
@@ -2685,25 +2561,17 @@ describe('RunState pending input', () => {
       await expect(run(agent, restored, options)).rejects.toThrow(
         /accepted model response could not be processed/i,
       );
-      expect(streamCalls).toBe(1);
+      expect(model.calls).toHaveLength(1);
     },
   );
 
   it('keeps staged input replayable after a provider-safe pre-event stream failure', async () => {
-    let streamCalls = 0;
-    const model: Model = {
-      async getResponse() {
-        throw new Error('Not implemented');
-      },
-      async *getStreamedResponse() {
-        streamCalls += 1;
-        yield* [];
-        throw new Error('safe stream failure');
-      },
-      getRetryAdvice() {
-        return { suggested: false, replaySafety: 'safe' };
-      },
-    };
+    const model = new ScriptedModel([
+      modelError(new Error('safe stream failure'), {
+        suggested: false,
+        replaySafety: 'safe',
+      }),
+    ]);
     const agent = new Agent({ name: 'safe-server-stream', model });
     const state = createResumableState(agent);
     state.setConversationContext('safe-stream-conversation');
@@ -2720,7 +2588,7 @@ describe('RunState pending input', () => {
     expect(
       state._generatedItems.filter((item) => item instanceof RunInputItem),
     ).toHaveLength(0);
-    expect(streamCalls).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('checkpoints server acceptance before surfacing a parallel staged-input guardrail failure', async () => {
@@ -2732,22 +2600,19 @@ describe('RunState pending input', () => {
     const modelStarted = new Promise<void>((resolve) => {
       markModelStarted = resolve;
     });
-    let streamCalls = 0;
-    const model: Model = {
-      async getResponse() {
-        throw new Error('Not implemented');
-      },
-      async *getStreamedResponse() {
-        streamCalls += 1;
-        markModelStarted();
-        await firstEventCanArrive;
-        yield {
-          type: 'output_text_delta',
-          delta: 'accepted but guarded',
-          providerData: {},
-        } as protocol.StreamEvent;
-      },
-    };
+    const model = new ScriptedModel([
+      modelStreamResponder(() =>
+        (async function* () {
+          markModelStarted();
+          await firstEventCanArrive;
+          yield {
+            type: 'output_text_delta',
+            delta: 'accepted but guarded',
+            providerData: {},
+          } as protocol.StreamEvent;
+        })(),
+      ),
+    ]);
     const agent = new Agent({ name: 'accepted-guardrail-stream', model });
     const state = createResumableState(agent);
     state.setConversationContext('accepted-guardrail-conversation');
@@ -2806,7 +2671,7 @@ describe('RunState pending input', () => {
         conversationId: 'accepted-guardrail-conversation',
       }),
     ).rejects.toThrow(/accepted model response could not be processed/i);
-    expect(streamCalls).toBe(1);
+    expect(model.calls).toHaveLength(1);
   });
 
   it('treats an explicit server-managed stream abort as an unsafe accepted request', async () => {

--- a/packages/agents-core/test/runner/conversation.test.ts
+++ b/packages/agents-core/test/runner/conversation.test.ts
@@ -6,11 +6,11 @@ import { RunContext } from '../../src/runContext';
 import { applyCallModelInputFilter } from '../../src/runner/conversation';
 import type { AgentInputItem } from '../../src/types';
 import { UserError } from '../../src/errors';
-import { FakeModelProvider } from '../stubs';
+import { ScriptedModelProvider } from '../stubs';
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 const makeAgent = (name: string) =>

--- a/packages/agents-core/test/runner/guardrails.test.ts
+++ b/packages/agents-core/test/runner/guardrails.test.ts
@@ -22,11 +22,11 @@ import {
 } from '../../src/errors';
 import { Usage } from '../../src/usage';
 import { RunMessageOutputItem } from '../../src/items';
-import { FakeModelProvider } from '../stubs';
+import { ScriptedModelProvider } from '../stubs';
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 type AnyAgent = Agent<unknown, AgentOutputType<unknown>>;

--- a/packages/agents-core/test/runner/modelOutputs.test.ts
+++ b/packages/agents-core/test/runner/modelOutputs.test.ts
@@ -40,7 +40,7 @@ import {
 import { Usage } from '../../src/usage';
 import {
   FakeEditor,
-  FakeModelProvider,
+  ScriptedModelProvider,
   FakeShell,
   TEST_AGENT,
   TEST_MODEL_FUNCTION_CALL,
@@ -53,7 +53,7 @@ import { z } from 'zod';
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 const PROGRAMMATIC_TOOL_CALLING_TOOL: HostedTool = {

--- a/packages/agents-core/test/runner/modelPreparation.test.ts
+++ b/packages/agents-core/test/runner/modelPreparation.test.ts
@@ -28,39 +28,15 @@ import { FUNCTION_TOOL_NAMESPACE } from '../../src/toolIdentity';
 import { prepareAgentArtifacts } from '../../src/runner/modelPreparation';
 import { withTrace } from '../../src/tracing/context';
 import {
-  FakeModel,
   TEST_MODEL_FUNCTION_CALL,
   TEST_MODEL_RESPONSE_BASIC,
-  FakeModelProvider,
+  ScriptedModelProvider,
 } from '../stubs';
+import { ScriptedModel, modelResponse } from '../../src/testing';
 
-class RecordingModel extends FakeModel {
-  readonly requests: ModelRequest[] = [];
-
-  override async getResponse(request: ModelRequest) {
-    this.requests.push(request);
-    return super.getResponse(request);
-  }
-
-  override async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<protocol.StreamEvent> {
-    const response = await this.getResponse(request);
-    yield {
-      type: 'response_done',
-      response: {
-        id: response.responseId ?? 'recording-response',
-        usage: {
-          requests: response.usage.requests,
-          inputTokens: response.usage.inputTokens,
-          outputTokens: response.usage.outputTokens,
-          totalTokens: response.usage.totalTokens,
-        },
-        output: response.output.map((item) =>
-          protocol.OutputModelItem.parse(item),
-        ),
-      },
-    };
+class RecordingModel extends ScriptedModel {
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
@@ -98,7 +74,7 @@ async function expectRejectedBeforeModelRequest(args: {
   expectedMessage: string;
   policy?: ToolNameCollisionPolicy;
 }): Promise<void> {
-  const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+  const model = new RecordingModel([modelResponse(TEST_MODEL_RESPONSE_BASIC)]);
   const agent = new Agent({
     name: 'Collision agent',
     model,
@@ -119,7 +95,7 @@ async function expectRejectedBeforeModelRequest(args: {
 
 describe('model-visible tool name validation', () => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 
   beforeEach(() => {
     vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(false);
@@ -138,7 +114,9 @@ describe('model-visible tool name validation', () => {
     async (stream) => {
       const secretToolName = 'SECRET_COLLISION_TRACE';
       const processor = new RecordingTracingProcessor();
-      const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+      const model = new RecordingModel([
+        modelResponse(TEST_MODEL_RESPONSE_BASIC),
+      ]);
       const agent = new Agent({
         name: 'Trace collision agent',
         model,
@@ -214,7 +192,9 @@ describe('model-visible tool name validation', () => {
     const bare = functionTool('lookup');
     const deferred = functionTool('lookup');
     deferred.deferLoading = true;
-    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new RecordingModel([
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
+    ]);
     const agent = new Agent({
       name: 'Category-aware function agent',
       model,
@@ -274,7 +254,9 @@ describe('model-visible tool name validation', () => {
   });
 
   it('warns by default and exposes only the last function tool', async () => {
-    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new RecordingModel([
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
+    ]);
     const agent = new Agent({
       name: 'Last function wins agent',
       model,
@@ -302,7 +284,7 @@ describe('model-visible tool name validation', () => {
     const firstExecute = vi.fn(async () => 'first');
     const secondExecute = vi.fn(async () => 'second');
     const model = new RecordingModel([
-      {
+      modelResponse({
         output: [
           {
             ...TEST_MODEL_FUNCTION_CALL,
@@ -311,8 +293,8 @@ describe('model-visible tool name validation', () => {
           },
         ],
         usage: new Usage(),
-      },
-      TEST_MODEL_RESPONSE_BASIC,
+      }),
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
     ]);
     const agent = new Agent({
       name: 'Dispatch winner agent',
@@ -341,7 +323,9 @@ describe('model-visible tool name validation', () => {
       toolNameOverride: 'duplicate',
       toolDescriptionOverride: 'Second handoff',
     });
-    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new RecordingModel([
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
+    ]);
     const agent = new Agent({
       name: 'Handoff wins agent',
       model,
@@ -372,7 +356,9 @@ describe('model-visible tool name validation', () => {
       toolNameOverride: 'handoff_duplicate',
       isEnabled: false,
     });
-    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new RecordingModel([
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
+    ]);
     const agent = new Agent({
       name: 'Filtered capabilities agent',
       model,
@@ -398,7 +384,9 @@ describe('model-visible tool name validation', () => {
   it('filters disabled runtime-loaded function tools before validation', async () => {
     const configured = functionTool('lookup');
     const disabledRuntime = functionTool('lookup', false);
-    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new RecordingModel([
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
+    ]);
     const agent = new Agent({
       name: 'Runtime filtering agent',
       model,
@@ -472,7 +460,9 @@ describe('model-visible tool name validation', () => {
       description: 'Billing tools',
       tools: [functionTool('lookup')],
     });
-    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new RecordingModel([
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
+    ]);
     const dottedHandoff = handoff(new Agent({ name: 'Dotted target' }), {
       toolNameOverride: 'crm.lookup',
     });
@@ -500,7 +490,7 @@ describe('model-visible tool name validation', () => {
     const duplicateHandoff = handoff(new Agent({ name: 'Stream target' }), {
       toolNameOverride: 'duplicate',
     });
-    const model = new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new ScriptedModel([modelResponse(TEST_MODEL_RESPONSE_BASIC)]);
     const getResponse = vi.spyOn(model, 'getResponse');
     const getStreamedResponse = vi.spyOn(model, 'getStreamedResponse');
     const agent = new Agent({
@@ -545,7 +535,9 @@ describe('model-visible tool name validation', () => {
 
   it('redacts warning details while keeping remediation actionable', async () => {
     vi.spyOn(logger, 'dontLogToolData', 'get').mockReturnValue(true);
-    const model = new RecordingModel([TEST_MODEL_RESPONSE_BASIC]);
+    const model = new RecordingModel([
+      modelResponse(TEST_MODEL_RESPONSE_BASIC),
+    ]);
     const agent = new Agent({
       name: 'Redacted warning agent',
       model,

--- a/packages/agents-core/test/runner/modelSettings.test.ts
+++ b/packages/agents-core/test/runner/modelSettings.test.ts
@@ -10,11 +10,11 @@ import {
   maybeResetToolChoice,
 } from '../../src/runner/modelSettings';
 import { AgentToolUseTracker } from '../../src/runner/toolUseTracker';
-import { FakeModelProvider } from '../stubs';
+import { ScriptedModelProvider } from '../stubs';
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 describe('maybeResetToolChoice', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -50,12 +50,12 @@ import { Usage, RequestUsage } from '../../src/usage';
 import { z } from 'zod';
 import type { AgentInputItem, UnknownContext } from '../../src/types';
 import * as protocol from '../../src/types/protocol';
-import { FakeModelProvider, TEST_AGENT, fakeModelMessage } from '../stubs';
+import { ScriptedModelProvider, TEST_AGENT, fakeModelMessage } from '../stubs';
 import logger from '../../src/logger';
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 async function expectLoggerWarnings<T>(

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -73,7 +73,7 @@ import {
   TEST_MODEL_MESSAGE,
   TEST_MODEL_RESPONSE_WITH_FUNCTION,
   TEST_TOOL,
-  FakeModelProvider,
+  ScriptedModelProvider,
   FakeShell,
   FakeEditor,
 } from '../stubs';
@@ -187,7 +187,7 @@ function getEndedHandoffSpan(processor: RecordingProcessor): Span<any> {
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 describe('getToolCallOutputItem', () => {
@@ -940,7 +940,7 @@ describe('AgentToolUseTracker', () => {
 
 describe('executeComputerActions', () => {
   it('runs action and returns screenshot output', async () => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
     const fakeComputer = {
       environment: 'mac',
       dimensions: [1, 1] as [number, number],

--- a/packages/agents-core/test/runner/turnResolution.test.ts
+++ b/packages/agents-core/test/runner/turnResolution.test.ts
@@ -36,7 +36,7 @@ import {
 import { Usage } from '../../src/usage';
 import {
   FakeEditor,
-  FakeModelProvider,
+  ScriptedModelProvider,
   FakeShell,
   TEST_AGENT,
   TEST_MODEL_RESPONSE_BASIC,
@@ -52,7 +52,7 @@ import type { UnknownContext } from '../../src/types';
 
 beforeAll(() => {
   setTracingDisabled(true);
-  setDefaultModelProvider(new FakeModelProvider());
+  setDefaultModelProvider(new ScriptedModelProvider());
 });
 
 describe('resolveTurnAfterModelResponse', () => {
@@ -60,7 +60,7 @@ describe('resolveTurnAfterModelResponse', () => {
   let state: RunState<any, any>;
 
   beforeAll(() => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
 
   beforeEach(() => {

--- a/packages/agents-core/test/sandboxCapabilities.test.ts
+++ b/packages/agents-core/test/sandboxCapabilities.test.ts
@@ -9,6 +9,7 @@ import {
   shell,
   StaticCompactionPolicy,
 } from '../src/sandbox';
+import { scriptedSandboxSession } from '../src/testing';
 
 describe('Compaction', () => {
   it('uses a static threshold when configured', () => {
@@ -413,12 +414,14 @@ describe('Memory', () => {
   });
 
   it('renders memory read prompts from the sandbox summary file', async () => {
-    const capability = memory({ generate: false }).bind({
-      state: { manifest: new Manifest() },
-      pathExists: async (path: string) => path === 'memories/memory_summary.md',
-      readFile: async () =>
-        new TextEncoder().encode('Use pnpm for package commands.'),
-    });
+    const session = scriptedSandboxSession([
+      { method: 'pathExists', result: true },
+      {
+        method: 'readFile',
+        result: new TextEncoder().encode('Use pnpm for package commands.'),
+      },
+    ]);
+    const capability = memory({ generate: false }).bind(session);
 
     const instructions = await capability.instructions(new Manifest());
 
@@ -427,28 +430,24 @@ describe('Memory', () => {
     expect(instructions).toContain(
       'Memory is writable. You are authorized to edit memories/MEMORY.md',
     );
+    session.assertComplete();
   });
 
   it('omits memory read prompts when no summary exists', async () => {
-    const capability = memory({ generate: false }).bind({
-      state: { manifest: new Manifest() },
-      pathExists: async () => false,
-      readFile: async () => {
-        throw new Error('must not be called');
-      },
-    });
+    const session = scriptedSandboxSession([
+      { method: 'pathExists', result: false },
+    ]);
+    const capability = memory({ generate: false }).bind(session);
 
     await expect(capability.instructions(new Manifest())).resolves.toBeNull();
+    session.assertComplete();
   });
 
   it('can read memory summaries through shell-only sessions', async () => {
-    const capability = memory({
-      read: { liveUpdate: false },
-      generate: false,
-    }).bind({
-      state: { manifest: new Manifest() },
-      execCommand: async () =>
-        [
+    const session = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        result: [
           'Chunk ID: abc123',
           'Wall time: 0.0001 seconds',
           'Process exited with code 0',
@@ -457,7 +456,12 @@ describe('Memory', () => {
           'Remember to run node --test.',
           '__OPENAI_AGENTS_MEMORY_SUMMARY_END__',
         ].join('\n'),
-    });
+      },
+    ]);
+    const capability = memory({
+      read: { liveUpdate: false },
+      generate: false,
+    }).bind(session);
 
     const instructions = await capability.instructions(new Manifest());
 
@@ -465,5 +469,6 @@ describe('Memory', () => {
     expect(instructions).toContain(
       'Never update memories. You can only read them.',
     );
+    session.assertComplete();
   });
 });

--- a/packages/agents-core/test/sandboxMemoryGeneration.test.ts
+++ b/packages/agents-core/test/sandboxMemoryGeneration.test.ts
@@ -38,7 +38,12 @@ import {
 } from '../src/sandbox/memory/rollouts';
 import { SandboxMemoryStorage } from '../src/sandbox/memory/storage';
 import { Usage } from '../src/usage';
-import { FakeModel, FakeModelProvider, fakeModelMessage } from './stubs';
+import { ScriptedModelProvider, fakeModelMessage } from './stubs';
+import {
+  ScriptedModel,
+  modelResponse,
+  scriptedSandboxSession,
+} from '../src/testing';
 
 const PROGRAMMATIC_TOOL_CALLING_TOOL: HostedTool = {
   type: 'hosted_tool',
@@ -52,8 +57,8 @@ class MemoryPhaseModelProvider implements ModelProvider {
   async getModel(modelName: string): Promise<Model> {
     this.calls.push(modelName);
     if (modelName === 'phase-one-model') {
-      return new FakeModel([
-        {
+      return new ScriptedModel([
+        modelResponse({
           output: [
             fakeModelMessage(
               JSON.stringify({
@@ -64,49 +69,47 @@ class MemoryPhaseModelProvider implements ModelProvider {
             ),
           ],
           usage: new Usage(),
-        },
+        }),
       ]);
     }
     if (modelName === 'phase-two-model') {
-      return new FakeModel([
-        {
+      return new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('Consolidated memory.')],
           usage: new Usage(),
-        },
+        }),
       ]);
     }
     throw new Error(`Unexpected model lookup: ${modelName}`);
   }
 }
 
-class RecordingFakeModel extends FakeModel {
-  readonly requests: Parameters<Model['getResponse']>[0][] = [];
-
-  override async getResponse(
-    request: Parameters<Model['getResponse']>[0],
-  ): ReturnType<Model['getResponse']> {
-    this.requests.push(request);
-    return await super.getResponse(request);
+class RecordingModel extends ScriptedModel {
+  get requests(): readonly Readonly<Parameters<Model['getResponse']>[0]>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
 function createNoopMemoryGenerationConfig(count = 1) {
   return {
-    phaseOneModel: new FakeModel(
-      Array.from({ length: count }, () => ({
-        output: [
-          fakeModelMessage(
-            JSON.stringify({
-              rollout_summary: '',
-              rollout_slug: '',
-              raw_memory: '',
-            }),
-          ),
-        ],
-        usage: new Usage(),
-      })),
+    phaseOneModel: new ScriptedModel(
+      Array.from(
+        Array.from({ length: count }, () => ({
+          output: [
+            fakeModelMessage(
+              JSON.stringify({
+                rollout_summary: '',
+                rollout_slug: '',
+                raw_memory: '',
+              }),
+            ),
+          ],
+          usage: new Usage(),
+        })),
+        modelResponse,
+      ),
     ),
-    phaseTwoModel: new FakeModel([]),
+    phaseTwoModel: new ScriptedModel([]),
   };
 }
 
@@ -253,56 +256,18 @@ class MemorySession implements SandboxSessionLike<SandboxSessionState> {
   }
 }
 
-class ShellReadOnlySession implements SandboxSessionLike<SandboxSessionState> {
-  readonly execCalls: ExecCommandArgs[] = [];
-  state: SandboxSessionState = {
-    manifest: new Manifest(),
-  };
-
-  constructor(private readonly content: string) {}
-
-  async execCommand(args: ExecCommandArgs): Promise<string> {
-    this.execCalls.push(args);
-    return (
-      'Process exited with code 0\n' +
-      'Output:\n' +
-      `__OPENAI_AGENTS_MEMORY_READ_BEGIN__\n${this.content}` +
-      '__OPENAI_AGENTS_MEMORY_READ_STATUS__0' +
-      '__OPENAI_AGENTS_MEMORY_READ_END__'
-    );
-  }
-}
-
-class ShellAppendSession implements SandboxSessionLike<SandboxSessionState> {
-  readonly execCalls: ExecCommandArgs[] = [];
-  state: SandboxSessionState = {
-    manifest: new Manifest(),
-  };
-
-  async execCommand(args: ExecCommandArgs): Promise<string> {
-    this.execCalls.push(args);
-    return 'Process exited with code 0\nOutput:\n';
-  }
-}
-
-class BrokenShellReadSession implements SandboxSessionLike<SandboxSessionState> {
-  state: SandboxSessionState = {
-    manifest: new Manifest(),
-  };
-
-  async execCommand(_args: ExecCommandArgs): Promise<string> {
-    return 'Process exited with code 0\nOutput:\nread failed before markers';
-  }
-}
-
-class MissingShellReadSession implements SandboxSessionLike<SandboxSessionState> {
-  state: SandboxSessionState = {
-    manifest: new Manifest(),
-  };
-
-  async execCommand(_args: ExecCommandArgs): Promise<string> {
-    return 'Process exited with code 0\nOutput:\n__OPENAI_AGENTS_MEMORY_READ_MISSING__';
-  }
+function scriptedShellReadSession(content: string) {
+  return scriptedSandboxSession([
+    {
+      method: 'execCommand',
+      result:
+        'Process exited with code 0\n' +
+        'Output:\n' +
+        `__OPENAI_AGENTS_MEMORY_READ_BEGIN__\n${content}` +
+        '__OPENAI_AGENTS_MEMORY_READ_STATUS__0' +
+        '__OPENAI_AGENTS_MEMORY_READ_END__',
+    },
+  ]);
 }
 
 class MemorySnapshotClient {
@@ -326,28 +291,10 @@ class MemorySnapshotClient {
   }
 }
 
-class ReadFileOnlyMissingSession implements SandboxSessionLike<SandboxSessionState> {
-  state: SandboxSessionState = {
-    manifest: new Manifest(),
-  };
-
-  async readFile(args: { path: string }): Promise<string> {
-    const error = new Error(`Missing file: ${args.path}`) as Error & {
-      code: string;
-    };
-    error.code = 'ENOENT';
-    throw error;
-  }
-
-  async materializeEntry(args: MaterializeEntryArgs): Promise<void> {
-    this.state.manifest = new Manifest({
-      ...this.state.manifest,
-      entries: {
-        ...this.state.manifest.entries,
-        [args.path]: args.entry,
-      },
-    });
-  }
+function missingFileError(path: string): Error & { code: string } {
+  const error = new Error(`Missing file: ${path}`) as Error & { code: string };
+  error.code = 'ENOENT';
+  return error;
 }
 
 function sha256(value: string): string {
@@ -356,7 +303,7 @@ function sha256(value: string): string {
 
 describe('Sandbox memory generation', () => {
   beforeEach(() => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
 
   it('validates Python-compatible rollout ids', () => {
@@ -701,8 +648,8 @@ describe('Sandbox memory generation', () => {
 
   it('persists rollout artifacts and invokes consolidation during cleanup', async () => {
     const session = new MemorySession();
-    const phaseOneModel = new RecordingFakeModel([
-      {
+    const phaseOneModel = new RecordingModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -713,19 +660,19 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new RecordingFakeModel([
-      {
+    const phaseTwoModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const agentModel = new FakeModel([
-      {
+    const agentModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
@@ -810,8 +757,8 @@ describe('Sandbox memory generation', () => {
       memory: memory({
         read: false,
         generate: {
-          phaseOneModel: new FakeModel([]),
-          phaseTwoModel: new FakeModel([]),
+          phaseOneModel: new ScriptedModel([]),
+          phaseTwoModel: new ScriptedModel([]),
         },
       }),
       runAgent,
@@ -843,8 +790,8 @@ describe('Sandbox memory generation', () => {
 
   it('flushes generated memory before serializing owned sessions', async () => {
     const client = new MemorySnapshotClient();
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -855,21 +802,21 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated serialized memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       capabilities: [
         memory({
@@ -895,8 +842,8 @@ describe('Sandbox memory generation', () => {
 
   it('flushes and continues recording memory on a reused provided session', async () => {
     const session = new MemorySession();
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -907,8 +854,8 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -919,29 +866,29 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated first memory.')],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('Consolidated second memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('first done')],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('second done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       capabilities: [
         memory({
@@ -981,8 +928,8 @@ describe('Sandbox memory generation', () => {
     const session = new MemorySession();
     const agent = new SandboxAgent({
       name: 'sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'reasoning',
@@ -995,7 +942,7 @@ describe('Sandbox memory generation', () => {
             fakeModelMessage('ASSISTANT_KEEP'),
           ],
           usage: new Usage(),
-        },
+        }),
       ]),
       capabilities: [
         memory({
@@ -1047,8 +994,8 @@ describe('Sandbox memory generation', () => {
     const session = new MemorySession();
     const agent = new SandboxAgent({
       name: 'sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'program',
@@ -1067,7 +1014,7 @@ describe('Sandbox memory generation', () => {
             fakeModelMessage('Program completed.'),
           ],
           usage: new Usage(),
-        },
+        }),
       ]),
       tools: [PROGRAMMATIC_TOOL_CALLING_TOOL],
       capabilities: [
@@ -1105,18 +1052,18 @@ describe('Sandbox memory generation', () => {
     const session = new MemorySession();
     const nonSandboxAgent = new Agent({
       name: 'non-sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('done outside sandbox')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
     const handoffToNonSandbox = handoff(nonSandboxAgent);
     const sandboxAgent = new SandboxAgent({
       name: 'sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'function_call',
@@ -1128,7 +1075,7 @@ describe('Sandbox memory generation', () => {
             },
           ],
           usage: new Usage(),
-        },
+        }),
       ]),
       handoffs: [handoffToNonSandbox],
       capabilities: [
@@ -1153,8 +1100,8 @@ describe('Sandbox memory generation', () => {
     session.state.manifest = new Manifest({
       root: '/repo',
     });
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1165,19 +1112,19 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const agentModel = new FakeModel([
-      {
+    const agentModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
@@ -1208,11 +1155,11 @@ describe('Sandbox memory generation', () => {
   it('uses the invoking Runner model provider for memory generation phases', async () => {
     const session = new MemorySession();
     const provider = new MemoryPhaseModelProvider();
-    const agentModel = new FakeModel([
-      {
+    const agentModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
@@ -1263,8 +1210,8 @@ describe('Sandbox memory generation', () => {
       },
       async clearSession() {},
     };
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1275,19 +1222,19 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const agentModel = new FakeModel([
-      {
+    const agentModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
@@ -1329,8 +1276,8 @@ describe('Sandbox memory generation', () => {
       },
       async clearSession() {},
     };
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1341,19 +1288,19 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const agentModel = new FakeModel([
-      {
+    const agentModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
@@ -1386,15 +1333,15 @@ describe('Sandbox memory generation', () => {
     const session = new MemorySession();
     const agent = new SandboxAgent({
       name: 'sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('first')],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('second')],
           usage: new Usage(),
-        },
+        }),
       ]),
       capabilities: [
         memory({
@@ -1436,21 +1383,29 @@ describe('Sandbox memory generation', () => {
   });
 
   it('appends rollout JSONL with shell append when direct reads are unavailable', async () => {
-    const session = new ShellAppendSession();
+    const session = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        result: 'Process exited with code 0\nOutput:\n',
+      },
+    ]);
     const storage = new SandboxMemoryStorage({ session });
 
     await storage.appendJsonl('sessions/large.jsonl', { next: true });
 
-    expect(session.execCalls).toHaveLength(1);
-    expect(session.execCalls[0]?.cmd).toContain(
+    const [call] = session.calls;
+    expect(call?.method).toBe('execCommand');
+    const [args] = call?.args ?? [];
+    expect((args as ExecCommandArgs).cmd).toContain(
       "printf '%s\\n' '{\"next\":true}' >> 'sessions/large.jsonl'",
     );
-    expect(session.execCalls[0]?.cmd).not.toContain(
+    expect((args as ExecCommandArgs).cmd).not.toContain(
       "cat 'sessions/large.jsonl'",
     );
-    expect(session.execCalls[0]?.cmd).not.toContain(
+    expect((args as ExecCommandArgs).cmd).not.toContain(
       "head -c 1000000 'sessions/large.jsonl'",
     );
+    session.assertComplete();
   });
 
   it('serializes concurrent rollout JSONL appends to the same file', async () => {
@@ -1499,22 +1454,24 @@ describe('Sandbox memory generation', () => {
   });
 
   it('preserves exact shell-read text without synthetic marker newlines', async () => {
-    const session = new ShellReadOnlySession('  leading\ntrailing');
+    const session = scriptedShellReadSession('  leading\ntrailing');
     const storage = new SandboxMemoryStorage({ session });
 
     await expect(storage.readText('memories/raw.txt')).resolves.toBe(
       '  leading\ntrailing',
     );
-    expect(session.execCalls[0]?.cmd).toContain(
+    const [args] = session.calls[0]?.args ?? [];
+    expect((args as ExecCommandArgs).cmd).toContain(
       "printf '%s' '__OPENAI_AGENTS_MEMORY_READ_END__'",
     );
-    expect(session.execCalls[0]?.cmd).not.toContain(
+    expect((args as ExecCommandArgs).cmd).not.toContain(
       "printf '\\n%s\\n' '__OPENAI_AGENTS_MEMORY_READ_END__'",
     );
+    session.assertComplete();
   });
 
   it('does not treat memory content as exec truncation metadata', async () => {
-    const session = new ShellReadOnlySession(
+    const session = scriptedShellReadSession(
       'Original token count: 123\nmemory content',
     );
     const storage = new SandboxMemoryStorage({ session });
@@ -1522,22 +1479,37 @@ describe('Sandbox memory generation', () => {
     await expect(storage.readText('memories/raw.txt')).resolves.toBe(
       'Original token count: 123\nmemory content',
     );
+    session.assertComplete();
   });
 
   it('treats explicit shell-read missing markers as absent files', async () => {
-    const session = new MissingShellReadSession();
+    const session = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        result:
+          'Process exited with code 0\nOutput:\n__OPENAI_AGENTS_MEMORY_READ_MISSING__',
+      },
+    ]);
     const storage = new SandboxMemoryStorage({ session });
 
     await expect(storage.readText('memories/missing.txt')).resolves.toBeNull();
+    session.assertComplete();
   });
 
   it('fails shell-backed reads when framing markers are missing', async () => {
-    const session = new BrokenShellReadSession();
+    const session = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        result:
+          'Process exited with code 0\nOutput:\nread failed before markers',
+      },
+    ]);
     const storage = new SandboxMemoryStorage({ session });
 
     await expect(storage.readText('memories/raw.txt')).rejects.toThrow(
       'Failed to read memory file "memories/raw.txt" from shell output.',
     );
+    session.assertComplete();
   });
 
   it('hydrates memory from an external store and mirrors writes back', async () => {
@@ -1572,7 +1544,22 @@ describe('Sandbox memory generation', () => {
   });
 
   it('falls back to the external store when direct sandbox reads miss', async () => {
-    const session = new ReadFileOnlyMissingSession();
+    const session = scriptedSandboxSession([
+      {
+        method: 'readFile',
+        error: missingFileError('memories/raw_memories/rollout.md'),
+      },
+      {
+        method: 'readFile',
+        error: missingFileError('sessions/from-store.jsonl'),
+      },
+      { method: 'materializeEntry', result: undefined },
+      {
+        method: 'readFile',
+        error: missingFileError('sessions/from-store.jsonl'),
+      },
+      { method: 'materializeEntry', result: undefined },
+    ]);
     const store = new InMemoryMemoryStore();
     await store.write(
       'memories/raw_memories/rollout.md',
@@ -1591,13 +1578,14 @@ describe('Sandbox memory generation', () => {
         (await store.read('sessions/from-store.jsonl'))!,
       ),
     ).toBe(`${JSON.stringify({ turn: 1 })}\n${JSON.stringify({ turn: 2 })}\n`);
+    session.assertComplete();
   });
 
   it('uses runner group id and generated fallback rollout ids when no session id exists', async () => {
     const groupedSession = new MemorySession();
     const fallbackSession = new MemorySession();
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1608,8 +1596,8 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1621,17 +1609,17 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated grouped memory.')],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('Consolidated fallback memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const createAgent = (model: Model) =>
       new SandboxAgent({
@@ -1650,11 +1638,11 @@ describe('Sandbox memory generation', () => {
 
     await new Runner({ groupId: 'runner-group' }).run(
       createAgent(
-        new FakeModel([
-          {
+        new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('done')],
             usage: new Usage(),
-          },
+          }),
         ]),
       ),
       'Remember group fallback.',
@@ -1668,11 +1656,11 @@ describe('Sandbox memory generation', () => {
 
     await run(
       createAgent(
-        new FakeModel([
-          {
+        new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('done')],
             usage: new Usage(),
-          },
+          }),
         ]),
       ),
       'Remember generated fallback.',
@@ -1691,8 +1679,8 @@ describe('Sandbox memory generation', () => {
 
   it('supports multiple independent memory layouts in one sandbox session', async () => {
     const session = new MemorySession();
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1703,8 +1691,8 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1715,17 +1703,17 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated agent A memory.')],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('Consolidated agent B memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const createAgent = (
       name: string,
@@ -1734,11 +1722,11 @@ describe('Sandbox memory generation', () => {
     ) =>
       new SandboxAgent({
         name,
-        model: new FakeModel([
-          {
+        model: new ScriptedModel([
+          modelResponse({
             output: [fakeModelMessage('done')],
             usage: new Usage(),
-          },
+          }),
         ]),
         capabilities: [
           memory({
@@ -1785,8 +1773,8 @@ describe('Sandbox memory generation', () => {
       needsApproval: true,
       execute: async () => 'approved',
     });
-    const phaseOneModel = new RecordingFakeModel([
-      {
+    const phaseOneModel = new RecordingModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1797,18 +1785,18 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [
             {
               type: 'function_call',
@@ -1820,7 +1808,7 @@ describe('Sandbox memory generation', () => {
             },
           ],
           usage: new Usage(),
-        },
+        }),
       ]),
       tools: [approvalTool],
       capabilities: [
@@ -1848,8 +1836,8 @@ describe('Sandbox memory generation', () => {
 
   it('skips phase two when phase one returns a no-op extraction', async () => {
     const session = new MemorySession();
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1860,14 +1848,14 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new FakeModel([]);
-    const agentModel = new FakeModel([
-      {
+    const phaseTwoModel = new ScriptedModel([]);
+    const agentModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',
@@ -1932,8 +1920,8 @@ describe('Sandbox memory generation', () => {
         2,
       )}\n`,
     );
-    const phaseOneModel = new FakeModel([
-      {
+    const phaseOneModel = new ScriptedModel([
+      modelResponse({
         output: [
           fakeModelMessage(
             JSON.stringify({
@@ -1944,19 +1932,19 @@ describe('Sandbox memory generation', () => {
           ),
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const phaseTwoModel = new RecordingFakeModel([
-      {
+    const phaseTwoModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('Consolidated memory.')],
         usage: new Usage(),
-      },
+      }),
     ]);
-    const agentModel = new FakeModel([
-      {
+    const agentModel = new ScriptedModel([
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const agent = new SandboxAgent({
       name: 'sandbox',

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -100,13 +100,15 @@ import type {
 } from '../src/sandbox';
 import { Usage } from '../src/usage';
 import * as protocol from '../src/types/protocol';
-import {
-  FakeModel,
-  FakeModelProvider,
-  FakeShell,
-  fakeModelMessage,
-} from './stubs';
+import { ScriptedModelProvider, FakeShell, fakeModelMessage } from './stubs';
 import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
+import {
+  ScriptedModel,
+  modelResponder,
+  modelResponse,
+  modelStreamResponder,
+  scriptedSandboxSession,
+} from '../src/testing';
 
 class StubEditor implements Editor {
   async createFile(
@@ -128,49 +130,41 @@ class StubEditor implements Editor {
   }
 }
 
-class RecordingFakeModel extends FakeModel {
-  public readonly requests: ModelRequest[] = [];
-
-  override async getResponse(request: ModelRequest) {
-    this.requests.push(request);
-    return await super.getResponse(request);
+class RecordingModel extends ScriptedModel {
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
-class RecordingStreamingModel implements Model {
-  public readonly requests: ModelRequest[] = [];
-
-  constructor(private readonly responses: ModelResponse[]) {}
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    throw new Error('Use getStreamedResponse for this test model.');
+class RecordingStreamingModel extends ScriptedModel {
+  constructor(responses: ModelResponse[]) {
+    super(
+      responses.map((response) =>
+        modelStreamResponder((call) => [
+          {
+            type: 'response_done',
+            response: {
+              id: `stream-${call.index}`,
+              usage: {
+                requests: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              output: response.output,
+            },
+          } as protocol.StreamEvent,
+        ]),
+      ),
+    );
   }
 
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<protocol.StreamEvent> {
-    this.requests.push(request);
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response found');
-    }
-    yield {
-      type: 'response_done',
-      response: {
-        id: `stream-${this.requests.length}`,
-        usage: {
-          requests: 1,
-          inputTokens: 0,
-          outputTokens: 0,
-          totalTokens: 0,
-        },
-        output: response.output,
-      },
-    } as protocol.StreamEvent;
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
-class OpenAIChatCompletionsModel extends RecordingFakeModel {}
+class OpenAIChatCompletionsModel extends RecordingModel {}
 
 class RecordingTracingProcessor implements TracingProcessor {
   public readonly tracesStarted: Trace[] = [];
@@ -1073,7 +1067,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'ClonedPendingInputAgent',
         model,
@@ -1130,7 +1124,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'CloningContextPersistenceAgent',
         model,
@@ -1222,7 +1216,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'CloningPrefixPersistenceAgent',
         model,
@@ -1277,7 +1271,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'CloningHistoryPrefixPersistenceAgent',
         model,
@@ -1335,7 +1329,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'RedactingCloningContextPersistenceAgent',
         model,
@@ -1375,7 +1369,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'RewritingCurrentCloningContextPersistenceAgent',
         model,
@@ -1424,7 +1418,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'ReplacingHistoryCloningContextPersistenceAgent',
         model,
@@ -1469,7 +1463,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'PrependingCloningContextPersistenceAgent',
         model,
@@ -1527,7 +1521,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'PrependingEqualCloningContextPersistenceAgent',
         model,
@@ -1586,7 +1580,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'ReplacingCurrentContextPersistenceAgent',
         model,
@@ -1657,7 +1651,7 @@ describe('sandbox runner integration', () => {
       ];
       const model = stream
         ? new RecordingStreamingModel(responses)
-        : new RecordingFakeModel(responses);
+        : new RecordingModel(Array.from(responses, modelResponse));
       const agent = new SandboxAgent({
         name: 'LaterClonedContextPersistenceAgent',
         model,
@@ -1749,7 +1743,7 @@ describe('sandbox runner integration', () => {
       ];
       const model = stream
         ? new RecordingStreamingModel(responses)
-        : new RecordingFakeModel(responses);
+        : new RecordingModel(Array.from(responses, modelResponse));
       const agent = new SandboxAgent({
         name: 'SubsetClonedContextPersistenceAgent',
         model,
@@ -1834,7 +1828,7 @@ describe('sandbox runner integration', () => {
       ];
       const model = stream
         ? new RecordingStreamingModel(responses)
-        : new RecordingFakeModel(responses);
+        : new RecordingModel(Array.from(responses, modelResponse));
       const agent = new Agent({
         name: 'RepeatedFilterInjectionAgent',
         model,
@@ -1881,7 +1875,7 @@ describe('sandbox runner integration', () => {
       };
       const model = stream
         ? new RecordingStreamingModel([response])
-        : new RecordingFakeModel([response]);
+        : new RecordingModel([modelResponse(response)]);
       const agent = new SandboxAgent({
         name: 'CompactionPersistenceAgent',
         model,
@@ -1962,7 +1956,7 @@ describe('sandbox runner integration', () => {
       ];
       const model = stream
         ? new RecordingStreamingModel(responses)
-        : new RecordingFakeModel(responses);
+        : new RecordingModel(Array.from(responses, modelResponse));
       const agent = new SandboxAgent({
         name: 'LaterCompactionPersistenceAgent',
         model,
@@ -2010,7 +2004,7 @@ describe('sandbox runner integration', () => {
 
   beforeAll(() => {
     setTracingDisabled(true);
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
   });
 
   afterEach(() => {
@@ -2020,19 +2014,19 @@ describe('sandbox runner integration', () => {
   });
 
   it('requires RunConfig.sandbox when execution reaches a SandboxAgent', async () => {
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
       model: sandboxModel,
     });
     const handoffToSandbox = handoff(sandboxAgent);
-    const rootModel = new RecordingFakeModel([
-      {
+    const rootModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             id: 'handoff-1',
@@ -2044,7 +2038,7 @@ describe('sandbox runner integration', () => {
           },
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
     const rootAgent = new Agent({
       name: 'RootAgent',
@@ -2059,11 +2053,11 @@ describe('sandbox runner integration', () => {
 
   it('hands off from a plain agent to a sandbox agent and prepares sandbox instructions', async () => {
     const client = new FakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -2071,8 +2065,8 @@ describe('sandbox runner integration', () => {
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const handoffToSandbox = handoff(sandboxAgent);
-    const rootModel = new RecordingFakeModel([
-      {
+    const rootModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             id: 'handoff-1',
@@ -2084,7 +2078,7 @@ describe('sandbox runner integration', () => {
           },
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
     const rootAgent = new Agent({
       name: 'RootAgent',
@@ -2108,11 +2102,11 @@ describe('sandbox runner integration', () => {
 
   it('does not pass an implicit default manifest when creating sessions', async () => {
     const client = new FakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -2155,11 +2149,11 @@ describe('sandbox runner integration', () => {
     ] as const) {
       const sandboxAgent = new SandboxAgent({
         name: `SandboxWorker-${name}`,
-        model: new RecordingFakeModel([
-          {
+        model: new RecordingModel([
+          modelResponse({
             output: [fakeModelMessage(`${name} sandbox done`)],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -2271,8 +2265,8 @@ describe('sandbox runner integration', () => {
       parameters: z.object({}),
       execute: async () => 'tool result',
     });
-    const model = new RecordingFakeModel([
-      {
+    const model = new RecordingModel([
+      modelResponse({
         output: [
           {
             type: 'compaction',
@@ -2288,8 +2282,11 @@ describe('sandbox runner integration', () => {
           } as protocol.FunctionCallItem,
         ],
         usage: new Usage(),
-      },
-      { output: [fakeModelMessage('sandbox done')], usage: new Usage() },
+      }),
+      modelResponse({
+        output: [fakeModelMessage('sandbox done')],
+        usage: new Usage(),
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -2315,15 +2312,15 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const samplingRecorder = new SamplingRecorderCapability();
     const runConfigModel = Object.assign(
-      new RecordingFakeModel([
-        {
+      new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       { model: 'gpt-5-mini' },
     ) satisfies Model;
@@ -2350,11 +2347,11 @@ describe('sandbox runner integration', () => {
   it('passes string RunConfig model names into sandbox capability sampling', async () => {
     const client = new FakeSandboxClient();
     const samplingRecorder = new SamplingRecorderCapability();
-    const runConfigModel = new RecordingFakeModel([
-      {
+    const runConfigModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -2385,10 +2382,10 @@ describe('sandbox runner integration', () => {
   it('resolves string RunConfig models before adding default sandbox tools', async () => {
     const client = new FakeSandboxClient();
     const chatModel = new OpenAIChatCompletionsModel([
-      {
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const runner = new Runner({
       model: 'chat-model',
@@ -2419,11 +2416,11 @@ describe('sandbox runner integration', () => {
 
   it('preserves resolved model instances for string sandbox agent models', async () => {
     const client = new FakeSandboxClient();
-    const responsesModel = new RecordingFakeModel([
-      {
+    const responsesModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const runner = new Runner({
       modelProvider: {
@@ -2454,15 +2451,15 @@ describe('sandbox runner integration', () => {
   it('uses the sandbox agent model before runner defaults for capability sampling', async () => {
     const client = new FakeSandboxClient();
     const samplingRecorder = new SamplingRecorderCapability();
-    const runConfigModel = Object.assign(new RecordingFakeModel([]), {
+    const runConfigModel = Object.assign(new RecordingModel([]), {
       model: 'runner-model',
     }) satisfies Model;
     const agentModel = Object.assign(
-      new RecordingFakeModel([
-        {
+      new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       { model: 'agent-model' },
     ) satisfies Model;
@@ -2485,18 +2482,18 @@ describe('sandbox runner integration', () => {
       model: 'agent-model',
       modelInstance: agentModel,
     });
-    expect((runConfigModel as RecordingFakeModel).requests).toHaveLength(0);
+    expect((runConfigModel as RecordingModel).requests).toHaveLength(0);
   });
 
   it('processes capability manifests before creating sandbox sessions', async () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       capabilities: [
         filesystem(),
@@ -2529,18 +2526,18 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('nested sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       capabilities: [],
     });
     const outerAgent = new Agent({
       name: 'OuterAgent',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [
             {
               id: 'call-1',
@@ -2552,11 +2549,11 @@ describe('sandbox runner integration', () => {
             } as any,
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('outer done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       tools: [
         sandboxAgent.asTool({
@@ -2587,11 +2584,11 @@ describe('sandbox runner integration', () => {
     const liveSession = client.makeSession(liveSessionState);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: new Manifest({
         entries: {
@@ -2720,11 +2717,11 @@ describe('sandbox runner integration', () => {
     const liveSession = client.makeSession(liveSessionState);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: new Manifest({
         entries: {
@@ -2758,11 +2755,11 @@ describe('sandbox runner integration', () => {
 
   it('passes run-level snapshot and resource settings through sandbox client options', async () => {
     const client = new FakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -2808,15 +2805,15 @@ describe('sandbox runner integration', () => {
     const plainClient = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('sandbox done again')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
@@ -2842,11 +2839,11 @@ describe('sandbox runner integration', () => {
     const client = new DefaultSnapshotFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
@@ -2869,11 +2866,11 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: new Manifest({ root: '/workspace' }),
       runAs: { name: ' sandbox-user ' },
@@ -2905,11 +2902,11 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: manifest,
       runAs: 'sandbox-user',
@@ -2981,7 +2978,7 @@ describe('sandbox runner integration', () => {
       };
       const sandboxAgent = new SandboxAgent({
         name: 'SandboxWorker',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
         defaultManifest: manifest,
       });
 
@@ -2998,7 +2995,7 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         environment: {
           TOKEN: {
@@ -3038,15 +3035,15 @@ describe('sandbox runner integration', () => {
 
   it('serializes sandbox session state and resumes it on the next run', async () => {
     const client = new ManifestSerializingFakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('turn one')],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('turn two')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -3165,7 +3162,7 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         extraPathGrants: [
           {
@@ -3251,7 +3248,7 @@ describe('sandbox runner integration', () => {
     });
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: trustedManifest,
     });
     const sessionState: FakeSandboxSessionState = {
@@ -3292,7 +3289,7 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const runState = new RunState<
       unknown,
@@ -3381,7 +3378,7 @@ describe('sandbox runner integration', () => {
       });
       const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
         name: 'SandboxWorker',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
         defaultManifest: trustedManifest,
       });
       const runState = new RunState<
@@ -3415,7 +3412,7 @@ describe('sandbox runner integration', () => {
     Object.defineProperty(client, 'backendId', { value: 'docker' });
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         environment: {
           SECRET_ENV: {
@@ -3474,7 +3471,7 @@ describe('sandbox runner integration', () => {
     Object.defineProperty(client, 'backendId', { value: 'docker' });
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const sessionState: FakeSandboxSessionState = {
       manifest: new Manifest({
@@ -3516,11 +3513,11 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: new Manifest({
         entries: {
@@ -3605,11 +3602,11 @@ describe('sandbox runner integration', () => {
     const client = new RuntimeEnvironmentFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       defaultManifest: new Manifest({
         environment: {
@@ -3655,8 +3652,8 @@ describe('sandbox runner integration', () => {
         return 'approved';
       },
     });
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             type: 'function_call',
@@ -3676,11 +3673,11 @@ describe('sandbox runner integration', () => {
           } satisfies protocol.FunctionCallItem,
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -3723,7 +3720,7 @@ describe('sandbox runner integration', () => {
     Object.defineProperty(client, 'resume', {
       value: undefined,
     });
-    const sandboxModel = new RecordingFakeModel([]);
+    const sandboxModel = new RecordingModel([]);
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
       model: sandboxModel,
@@ -3770,7 +3767,7 @@ describe('sandbox runner integration', () => {
 
   it('rejects unsupported serialized sandbox session state versions', async () => {
     const client = new FakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([]);
+    const sandboxModel = new RecordingModel([]);
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
       model: sandboxModel,
@@ -4550,8 +4547,8 @@ describe('sandbox runner integration', () => {
 
   it('resets required tool choice after a sandbox agent uses a tool', async () => {
     const client = new FakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             id: 'tool-1',
@@ -4563,11 +4560,11 @@ describe('sandbox runner integration', () => {
           },
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -4592,8 +4589,8 @@ describe('sandbox runner integration', () => {
 
   it('resets required tool choice after a sandbox agent uses a shell tool', async () => {
     const client = new FakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             id: 'shell-1',
@@ -4606,11 +4603,11 @@ describe('sandbox runner integration', () => {
           },
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -4634,11 +4631,11 @@ describe('sandbox runner integration', () => {
   });
 
   it('allows reserved function tool names returned from sandbox capabilities', async () => {
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -4677,8 +4674,8 @@ describe('sandbox runner integration', () => {
       parameters: z.object({}).strict(),
       execute: async () => 'tool result',
     });
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             id: 'fc_sandbox_tool',
@@ -4690,11 +4687,11 @@ describe('sandbox runner integration', () => {
           } satisfies protocol.FunctionCallItem,
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -5038,7 +5035,7 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
@@ -5124,11 +5121,11 @@ describe('sandbox runner integration', () => {
 
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -5166,20 +5163,20 @@ describe('sandbox runner integration', () => {
       const waitForClosePeers = createSandboxBarrier(2);
       const agentA = new SandboxAgent({
         name: `Parallel Sandbox Worker A ${includeTaskAndTurnSpans}`,
-        model: new RecordingFakeModel([
-          {
+        model: new RecordingModel([
+          modelResponse({
             output: [fakeModelMessage('sandbox A done')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
       const agentB = new SandboxAgent({
         name: `Parallel Sandbox Worker B ${includeTaskAndTurnSpans}`,
-        model: new RecordingFakeModel([
-          {
+        model: new RecordingModel([
+          modelResponse({
             output: [fakeModelMessage('sandbox B done')],
             usage: new Usage(),
-          },
+          }),
         ]),
       });
 
@@ -5272,8 +5269,8 @@ describe('sandbox runner integration', () => {
     const createAgent = (label: string) =>
       new SandboxAgent({
         name: `Parallel sandbox capability agent ${label}`,
-        model: new RecordingFakeModel([
-          {
+        model: new RecordingModel([
+          modelResponse({
             output: [
               {
                 id: `tool-${label}`,
@@ -5285,11 +5282,11 @@ describe('sandbox runner integration', () => {
               },
             ],
             usage: new Usage(),
-          },
-          {
+          }),
+          modelResponse({
             output: [fakeModelMessage(`sandbox ${label} done`)],
             usage: new Usage(),
-          },
+          }),
         ]),
         capabilities: [
           shell({
@@ -5360,11 +5357,11 @@ describe('sandbox runner integration', () => {
       };
       return new SandboxAgent({
         name: `Parallel sandbox memory agent ${label}`,
-        model: new RecordingFakeModel([
-          {
+        model: new RecordingModel([
+          modelResponse({
             output: [fakeModelMessage(`sandbox ${label} done`)],
             usage: new Usage(),
-          },
+          }),
         ]),
         capabilities: [
           shell(),
@@ -5411,8 +5408,8 @@ describe('sandbox runner integration', () => {
     setTracingDisabled(false);
     const sandboxAgent = new SandboxAgent({
       name: 'Tracing-disabled sandbox agent',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [
             {
               id: 'tool-disabled',
@@ -5424,11 +5421,11 @@ describe('sandbox runner integration', () => {
             },
           ],
           usage: new Usage(),
-        },
-        {
+        }),
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
       capabilities: [shell()],
     });
@@ -5444,22 +5441,19 @@ describe('sandbox runner integration', () => {
 
   it('rejects concurrent reuse of the same SandboxAgent across runs', async () => {
     let releaseFirstRun: (() => void) | undefined;
-    const blockingModel = {
-      async getResponse(request: ModelRequest) {
+    const blockingModel = new ScriptedModel([
+      modelResponder(async (call) => {
         await new Promise<void>((resolve) => {
           releaseFirstRun = resolve;
         });
         return {
           output: [
-            fakeModelMessage(String(request.systemInstructions ?? 'done')),
+            fakeModelMessage(String(call.request.systemInstructions ?? 'done')),
           ],
           usage: new Usage(),
         };
-      },
-      async *getStreamedResponse() {
-        yield* [];
-      },
-    };
+      }),
+    ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
       model: blockingModel,
@@ -5490,11 +5484,11 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -5515,11 +5509,11 @@ describe('sandbox runner integration', () => {
     });
     const firstAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const secondAgent = new SandboxAgent({
       name: 'SandboxReviewer',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -5561,11 +5555,11 @@ describe('sandbox runner integration', () => {
     const client = new StartableFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -5593,7 +5587,7 @@ describe('sandbox runner integration', () => {
     const clientOptions = { resumeAs: 'current-user' };
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
@@ -5665,11 +5659,11 @@ describe('sandbox runner integration', () => {
     client.startCalls.length = 0;
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -5690,11 +5684,11 @@ describe('sandbox runner integration', () => {
     });
     const firstAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const secondAgent = new SandboxAgent({
       name: 'SandboxReviewer',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -5734,11 +5728,11 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const startingAgent = new Agent({
       name: 'Router',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     }) as Agent<unknown, AgentOutputType>;
     const firstAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'RuntimeWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         entries: {
           'first.txt': {
@@ -5750,7 +5744,7 @@ describe('sandbox runner integration', () => {
     });
     const secondAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'RuntimeWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         entries: {
           'second.txt': {
@@ -5802,11 +5796,11 @@ describe('sandbox runner integration', () => {
     const client = new RedactedHostPathSerializedResumeFakeSandboxClient();
     const startingAgent = new Agent({
       name: 'Router',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     }) as Agent<unknown, AgentOutputType>;
     const firstAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'RuntimeWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         extraPathGrants: [
           {
@@ -5819,7 +5813,7 @@ describe('sandbox runner integration', () => {
     });
     const secondAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'RuntimeWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         extraPathGrants: [
           {
@@ -5887,11 +5881,11 @@ describe('sandbox runner integration', () => {
     });
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -5914,11 +5908,11 @@ describe('sandbox runner integration', () => {
     const client = new ShutdownOnlyFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -5939,18 +5933,20 @@ describe('sandbox runner integration', () => {
 
   it('keeps lifecycle preStop when managed pre-stop hooks are installed', async () => {
     const calls: string[] = [];
-    const session: SandboxSessionLike<FakeSandboxSessionState> = {
-      state: {
-        manifest: new Manifest(),
-        sessionId: 'session-1',
+    const session = scriptedSandboxSession([
+      {
+        method: 'preStop',
+        respond: (call) => {
+          calls.push(`preStop:${call.args[0]?.reason}`);
+        },
       },
-      preStop: async (options) => {
-        calls.push(`preStop:${options?.reason}`);
+      {
+        method: 'close',
+        respond: () => {
+          calls.push('close');
+        },
       },
-      close: async () => {
-        calls.push('close');
-      },
-    };
+    ]);
 
     registerSandboxPreStopHook(session, () => {
       calls.push('hook');
@@ -5959,45 +5955,43 @@ describe('sandbox runner integration', () => {
     await cleanupSandboxSession(session);
 
     expect(calls).toEqual(['hook', 'preStop:cleanup', 'close']);
+    session.assertComplete();
   });
 
   it('passes preserveOwnedSessions through standardized lifecycle cleanup', async () => {
-    const calls: unknown[] = [];
-    const session: SandboxSessionLike<FakeSandboxSessionState> = {
-      state: {
-        manifest: new Manifest(),
-        sessionId: 'session-1',
+    const session = scriptedSandboxSession([
+      {
+        method: 'shutdown',
+        match: (options) => {
+          expect(options).toEqual({
+            reason: 'cleanup',
+            preserveOwnedSessions: true,
+          });
+        },
+        result: undefined,
       },
-      shutdown: async (options) => {
-        calls.push(options);
-      },
-    };
+    ]);
 
     await cleanupSandboxSession(session, { preserveOwnedSessions: true });
 
-    expect(calls).toEqual([
-      {
-        reason: 'cleanup',
-        preserveOwnedSessions: true,
-      },
-    ]);
+    session.assertComplete();
   });
 
   it('runs managed provider pre-stop hooks before serialization', async () => {
     const calls: string[] = [];
     const providerHooks = new Set<() => Promise<void> | void>();
-    const session: SandboxSessionLike<FakeSandboxSessionState> = {
-      state: {
-        manifest: new Manifest(),
-        sessionId: 'session-1',
+    const session = scriptedSandboxSession([
+      {
+        method: 'registerPreStopHook',
+        respond: (call) => {
+          const hook = call.args[0];
+          providerHooks.add(hook);
+          return () => {
+            providerHooks.delete(hook);
+          };
+        },
       },
-      registerPreStopHook: (hook) => {
-        providerHooks.add(hook);
-        return () => {
-          providerHooks.delete(hook);
-        };
-      },
-    };
+    ]);
 
     const unregister = registerSandboxPreStopHook(session, () => {
       calls.push('hook');
@@ -6014,23 +6008,24 @@ describe('sandbox runner integration', () => {
 
     unregister();
     expect(providerHooks.size).toBe(0);
+    session.assertComplete();
   });
 
   it('cleans up sessions that only expose provider pre-stop hooks', async () => {
     const calls: string[] = [];
     const providerHooks = new Set<() => Promise<void> | void>();
-    const session: SandboxSessionLike<FakeSandboxSessionState> = {
-      state: {
-        manifest: new Manifest(),
-        sessionId: 'session-1',
+    const session = scriptedSandboxSession([
+      {
+        method: 'registerPreStopHook',
+        respond: (call) => {
+          const hook = call.args[0];
+          providerHooks.add(hook);
+          return () => {
+            providerHooks.delete(hook);
+          };
+        },
       },
-      registerPreStopHook: (hook) => {
-        providerHooks.add(hook);
-        return () => {
-          providerHooks.delete(hook);
-        };
-      },
-    };
+    ]);
 
     registerSandboxPreStopHook(session, () => {
       calls.push('hook');
@@ -6039,17 +6034,18 @@ describe('sandbox runner integration', () => {
     await cleanupSandboxSession(session);
 
     expect(calls).toEqual(['hook']);
+    session.assertComplete();
   });
 
   it('runs standardized lifecycle cleanup hooks in order', async () => {
     const client = new StandardLifecycleFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -6088,11 +6084,11 @@ describe('sandbox runner integration', () => {
     const client = new FailingStopLifecycleFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -6135,11 +6131,11 @@ describe('sandbox runner integration', () => {
     );
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [fakeModelMessage('sandbox done')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -6161,7 +6157,7 @@ describe('sandbox runner integration', () => {
     );
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -6249,8 +6245,8 @@ describe('sandbox runner integration', () => {
       execute: async () => 'approved',
       needsApproval: true,
     });
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             id: 'approval-1',
@@ -6262,11 +6258,11 @@ describe('sandbox runner integration', () => {
           } as any,
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -6315,8 +6311,8 @@ describe('sandbox runner integration', () => {
 
   it('rebinds interrupted sandbox capability tools after resuming a closed preserved session', async () => {
     const client = new ClosedHandleSerializedResumeFakeSandboxClient();
-    const sandboxModel = new RecordingFakeModel([
-      {
+    const sandboxModel = new RecordingModel([
+      modelResponse({
         output: [
           {
             id: 'shell-approval-1',
@@ -6328,11 +6324,11 @@ describe('sandbox runner integration', () => {
           } satisfies protocol.FunctionCallItem,
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('sandbox done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
@@ -6397,8 +6393,8 @@ describe('sandbox runner integration', () => {
     });
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [
             {
               id: 'approval-1',
@@ -6410,7 +6406,7 @@ describe('sandbox runner integration', () => {
             } as any,
           ],
           usage: new Usage(),
-        },
+        }),
       ]),
       tools: [approvalTool],
       toolUseBehavior: 'stop_on_first_tool',
@@ -6445,7 +6441,7 @@ describe('sandbox runner integration', () => {
   it('clears preserved sandbox state for non-sandbox interruption resumes without a client', async () => {
     const plainAgent = new Agent({
       name: 'PlainAgent',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     }) as Agent<unknown, AgentOutputType>;
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
       new RunContext(),
@@ -6513,12 +6509,12 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const plainAgent = new Agent({
       name: 'PlainAgent',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     }) as Agent<unknown, AgentOutputType>;
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
       new RunContext(),
@@ -6584,17 +6580,17 @@ describe('sandbox runner integration', () => {
     );
     const firstSandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'FirstSandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const secondSandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SecondSandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const plainAgent = new Agent({
       name: 'PlainAgent',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     }) as Agent<unknown, AgentOutputType>;
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
       new RunContext(),
@@ -6679,12 +6675,12 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const plainAgent = new Agent({
       name: 'PlainAgent',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     }) as Agent<unknown, AgentOutputType>;
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
       new RunContext(),
@@ -6762,7 +6758,7 @@ describe('sandbox runner integration', () => {
     const client = new FakeSandboxClient();
     const plainAgent = new Agent({
       name: 'PlainAgent',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     }) as Agent<unknown, AgentOutputType>;
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
       new RunContext(),
@@ -6836,7 +6832,7 @@ describe('sandbox runner integration', () => {
   it('preserves sandbox state when interruption resume setup cannot adopt preserved sessions', async () => {
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
@@ -6908,7 +6904,7 @@ describe('sandbox runner integration', () => {
     const client = new NonPersistentFakeSandboxClient();
     const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({ root: '/workspace' }),
     });
     const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
@@ -6990,8 +6986,8 @@ describe('sandbox runner integration', () => {
     });
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([
-        {
+      model: new RecordingModel([
+        modelResponse({
           output: [
             {
               id: 'approval-1',
@@ -7003,7 +6999,7 @@ describe('sandbox runner integration', () => {
             } as any,
           ],
           usage: new Usage(),
-        },
+        }),
       ]),
       tools: [approvalTool],
       defaultManifest: new Manifest({ root: '/workspace' }),
@@ -7136,7 +7132,7 @@ describe('sandbox runner integration', () => {
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         root: '/workspace',
         entries: {
@@ -7426,7 +7422,7 @@ describe('sandbox runner integration', () => {
       const applyManifest = vi.fn();
       const sandboxAgent = new SandboxAgent({
         name: 'SandboxWorker',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
         defaultManifest: manifest,
       });
       const providedSession: SandboxSessionLike<FakeSandboxSessionState> = {
@@ -7478,7 +7474,7 @@ describe('sandbox runner integration', () => {
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: manifest,
     });
     const providedSession: SandboxSessionLike<FakeSandboxSessionState> = {
@@ -7521,7 +7517,7 @@ describe('sandbox runner integration', () => {
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: manifest,
     });
     const providedSession: SandboxSessionLike<FakeSandboxSessionState> = {
@@ -7574,7 +7570,7 @@ describe('sandbox runner integration', () => {
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: trustedManifest,
     });
     const providedSession: SandboxSessionLike<FakeSandboxSessionState> = {
@@ -7639,7 +7635,7 @@ describe('sandbox runner integration', () => {
       const applyManifest = vi.fn();
       const sandboxAgent = new SandboxAgent({
         name: 'SandboxWorker',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
         defaultManifest: manifest,
       });
       const providedSession: SandboxSessionLike<FakeSandboxSessionState> = {
@@ -7673,7 +7669,7 @@ describe('sandbox runner integration', () => {
   it('bases implicit provided-session manifests on the live session root', async () => {
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       capabilities: [new ManifestFileCapability()],
     });
     const state: FakeSandboxSessionState = {
@@ -7722,7 +7718,7 @@ describe('sandbox runner integration', () => {
   it('applies metadata-only manifest deltas to provided sessions', async () => {
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         root: '/workspace',
         extraPathGrants: [{ path: '/tmp/data', readOnly: true }],
@@ -7775,7 +7771,7 @@ describe('sandbox runner integration', () => {
   it('applies missing nested manifest entries to a provided session', async () => {
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         root: '/workspace',
         entries: {
@@ -7845,7 +7841,7 @@ describe('sandbox runner integration', () => {
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         root: '/workspace',
         entries: {
@@ -7906,7 +7902,7 @@ describe('sandbox runner integration', () => {
     const materializeEntry = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         root: '/workspace',
         entries: {
@@ -7977,7 +7973,7 @@ describe('sandbox runner integration', () => {
     const applyManifest = vi.fn();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: new Manifest({
         root: '/workspace',
         environment: {
@@ -8050,7 +8046,7 @@ describe('sandbox runner integration', () => {
     });
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8133,7 +8129,7 @@ describe('sandbox runner integration', () => {
     const manifest = new Manifest();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8192,7 +8188,7 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8258,7 +8254,7 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8335,12 +8331,12 @@ describe('sandbox runner integration', () => {
       }).withInContainerMountCredentialExposureAcknowledged('remote');
       const firstAgent = new SandboxAgent({
         name: 'SandboxWorker',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
         defaultManifest: trustedManifest,
       });
       const secondAgent = new SandboxAgent({
         name: 'SandboxReviewer',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
         defaultManifest: trustedManifest,
       });
       const state = new RunState<unknown, Agent<unknown, any>>(
@@ -8473,7 +8469,7 @@ describe('sandbox runner integration', () => {
       }).withInContainerMountCredentialExposureAcknowledged('remote');
       const sandboxAgent = new SandboxAgent({
         name: 'SandboxWorker',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
       });
       const state = new RunState<unknown, Agent<unknown, any>>(
         new RunContext(),
@@ -8579,7 +8575,7 @@ describe('sandbox runner integration', () => {
     });
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8695,7 +8691,7 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8758,7 +8754,7 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountBroadCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8809,7 +8805,7 @@ describe('sandbox runner integration', () => {
     });
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8865,7 +8861,7 @@ describe('sandbox runner integration', () => {
     const client = new RevalidatingLiveProcessFakeSandboxClient([true, false]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -8929,7 +8925,7 @@ describe('sandbox runner integration', () => {
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9032,7 +9028,7 @@ describe('sandbox runner integration', () => {
     const client = new DockerRejectingManifestEntriesFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9104,7 +9100,7 @@ describe('sandbox runner integration', () => {
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9172,7 +9168,7 @@ describe('sandbox runner integration', () => {
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9231,7 +9227,7 @@ describe('sandbox runner integration', () => {
     const client = new FailingBeforeLiveCleanupFakeSandboxClient(2);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9297,7 +9293,7 @@ describe('sandbox runner integration', () => {
     ]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9341,7 +9337,7 @@ describe('sandbox runner integration', () => {
     const client = new FailingLiveCleanupFakeSandboxClient([true, true, true]);
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9412,7 +9408,7 @@ describe('sandbox runner integration', () => {
     (client as unknown as { resume?: undefined }).resume = undefined;
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9464,7 +9460,7 @@ describe('sandbox runner integration', () => {
     const client = new RecoverableCloseFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9507,11 +9503,11 @@ describe('sandbox runner integration', () => {
     const client = new DelayedSelectiveCloseFailureFakeSandboxClient();
     const firstSandboxAgent = new SandboxAgent({
       name: 'FirstSandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const secondSandboxAgent = new SandboxAgent({
       name: 'SecondSandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9570,7 +9566,7 @@ describe('sandbox runner integration', () => {
     client.shouldFailClose = false;
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9622,7 +9618,7 @@ describe('sandbox runner integration', () => {
     const client = new SerializedShutdownOnlyFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9660,7 +9656,7 @@ describe('sandbox runner integration', () => {
     const client = new SerializedResumeFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9732,7 +9728,7 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: manifest,
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
@@ -9787,7 +9783,7 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
       defaultManifest: manifest,
     });
     const manager = new SandboxRuntimeManager({
@@ -9817,7 +9813,7 @@ describe('sandbox runner integration', () => {
     }).withInContainerMountCredentialExposureAcknowledged('remote');
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9884,7 +9880,7 @@ describe('sandbox runner integration', () => {
     const client = new SerializedResumeFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -9930,7 +9926,7 @@ describe('sandbox runner integration', () => {
     const client = new SerializedResumeFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -10012,7 +10008,7 @@ describe('sandbox runner integration', () => {
     );
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),
@@ -10062,7 +10058,7 @@ describe('sandbox runner integration', () => {
       }
       const sandboxAgent = new SandboxAgent({
         name: 'SandboxWorker',
-        model: new RecordingFakeModel([]),
+        model: new RecordingModel([]),
       });
       const state = new RunState<unknown, Agent<unknown, any>>(
         new RunContext(),
@@ -10122,7 +10118,7 @@ describe('sandbox runner integration', () => {
     const client = new NonPersistentFakeSandboxClient();
     const sandboxAgent = new SandboxAgent({
       name: 'SandboxWorker',
-      model: new RecordingFakeModel([]),
+      model: new RecordingModel([]),
     });
     const state = new RunState<unknown, Agent<unknown, any>>(
       new RunContext(),

--- a/packages/agents-core/test/sandboxRuntime.test.ts
+++ b/packages/agents-core/test/sandboxRuntime.test.ts
@@ -18,6 +18,7 @@ import { applyManifestToProvidedSession } from '../src/sandbox/runtime/providedS
 import { renderRemoteMountPolicyInstructions } from '../src/sandbox/runtime/prompts';
 import { DockerSandboxSession } from '../src/sandbox/sandboxes/docker';
 import { mergeManifestDelta } from '../src/sandbox/internal';
+import { ScriptedModel } from '../src/testing';
 
 class TestCapability extends Capability {
   public readonly type: string;
@@ -79,25 +80,9 @@ class StubEditor implements Editor {
   }
 }
 
-class OpenAIChatCompletionsModel {
-  async getResponse() {
-    throw new Error('not used');
-  }
+class OpenAIChatCompletionsModel extends ScriptedModel {}
 
-  async *getStreamedResponse() {
-    yield* [];
-  }
-}
-
-class OpenAIResponsesModel {
-  async getResponse() {
-    throw new Error('not used');
-  }
-
-  async *getStreamedResponse() {
-    yield* [];
-  }
-}
+class OpenAIResponsesModel extends ScriptedModel {}
 
 function sessionWithManifest(manifest: Manifest): SandboxSessionLike {
   return {

--- a/packages/agents-core/test/sandboxSkills.test.ts
+++ b/packages/agents-core/test/sandboxSkills.test.ts
@@ -7,68 +7,16 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   skills,
   type Entry,
-  type MaterializeEntryArgs,
-  type SandboxSession,
-  type SandboxSessionState,
   Manifest,
   SandboxSkillsConfigError,
   SandboxWorkspaceReadNotFoundError,
 } from '../src/sandbox';
 import { localDirLazySkillSource } from '../src/sandbox/local';
-
-class FakeSkillsSession implements SandboxSession {
-  readonly state: SandboxSessionState;
-  readonly existingPaths = new Set<string>();
-  readonly materializeCalls: MaterializeEntryArgs[] = [];
-  readonly files = new Map<string, string | Uint8Array>();
-
-  constructor(manifest: Manifest = new Manifest()) {
-    this.state = {
-      manifest,
-    };
-  }
-
-  async pathExists(path: string): Promise<boolean> {
-    return this.existingPaths.has(path);
-  }
-
-  async materializeEntry(args: MaterializeEntryArgs): Promise<void> {
-    this.materializeCalls.push(args);
-    this.existingPaths.add(`${args.path}/SKILL.md`);
-  }
-
-  async listDir(args: { path: string }) {
-    const childNames = new Set<string>();
-    for (const path of this.files.keys()) {
-      if (!path.startsWith(`${args.path}/`)) {
-        continue;
-      }
-      const childName = path.slice(args.path.length + 1).split('/')[0];
-      if (childName) {
-        childNames.add(childName);
-      }
-    }
-    return [...childNames].sort().map((name) => ({
-      name,
-      path: `${args.path}/${name}`,
-      type: 'dir' as const,
-    }));
-  }
-
-  async readFile(args: { path: string }): Promise<string | Uint8Array> {
-    const content = this.files.get(args.path);
-    if (typeof content === 'undefined') {
-      throw new SandboxWorkspaceReadNotFoundError(
-        `file not found: ${args.path}`,
-      );
-    }
-    return content;
-  }
-}
+import { scriptedSandboxSession } from '../src/testing';
 
 describe('Skills', () => {
   it('requires exactly one source', () => {
@@ -286,7 +234,11 @@ describe('Skills', () => {
         ],
       },
     });
-    const session = new FakeSkillsSession();
+    const session = scriptedSandboxSession([
+      { method: 'pathExists', result: false },
+      { method: 'materializeEntry', result: undefined },
+      { method: 'pathExists', result: true },
+    ]);
     capability.bind(session);
 
     const tools = capability.tools();
@@ -312,16 +264,20 @@ describe('Skills', () => {
       skill_name: 'dynamic-skill',
       path: '.agents/dynamic-skill',
     });
-    expect(session.materializeCalls).toEqual([
-      {
-        path: '.agents/dynamic-skill',
-        entry: {
-          type: 'local_dir',
-          src: 'skills/dynamic-skill',
+    expect(session.calls[1]).toMatchObject({
+      method: 'materializeEntry',
+      args: [
+        {
+          path: '.agents/dynamic-skill',
+          entry: {
+            type: 'local_dir',
+            src: 'skills/dynamic-skill',
+          },
+          runAs: undefined,
         },
-        runAs: undefined,
-      },
-    ]);
+      ],
+    });
+    session.assertComplete();
   });
 
   it('discovers lazy local directory skill metadata from SKILL.md frontmatter', async () => {
@@ -354,7 +310,11 @@ describe('Skills', () => {
         '- spreadsheet-review: Review spreadsheets quickly (file: .agents/sheet-tools)',
       );
 
-      const session = new FakeSkillsSession(manifest);
+      const session = scriptedSandboxSession([
+        { method: 'pathExists', result: false },
+        { method: 'materializeEntry', result: undefined },
+      ]);
+      session.state.manifest = manifest;
       capability.bind(session);
       const [tool] = capability.tools();
 
@@ -368,16 +328,20 @@ describe('Skills', () => {
         skill_name: 'spreadsheet-review',
         path: '.agents/sheet-tools',
       });
-      expect(session.materializeCalls).toEqual([
-        {
-          path: '.agents/sheet-tools',
-          entry: {
-            type: 'local_dir',
-            src: `${skillsRoot}/sheet-tools`,
+      expect(session.calls[1]).toMatchObject({
+        method: 'materializeEntry',
+        args: [
+          {
+            path: '.agents/sheet-tools',
+            entry: {
+              type: 'local_dir',
+              src: `${skillsRoot}/sheet-tools`,
+            },
+            runAs: undefined,
           },
-          runAs: undefined,
-        },
-      ]);
+        ],
+      });
+      session.assertComplete();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -540,7 +504,10 @@ describe('Skills', () => {
           baseDir: root,
         }),
       });
-      const session = new FakeSkillsSession();
+      const session = scriptedSandboxSession([
+        { method: 'pathExists', result: false },
+        { method: 'materializeEntry', result: undefined },
+      ]);
       capability.bind(session);
       const [tool] = capability.tools();
 
@@ -554,16 +521,20 @@ describe('Skills', () => {
         skill_name: 'relative-skill',
         path: '.agents/relative-skill',
       });
-      expect(session.materializeCalls).toEqual([
-        {
-          path: '.agents/relative-skill',
-          entry: {
-            type: 'local_dir',
-            src: `${root}/skills/relative-skill`,
+      expect(session.calls[1]).toMatchObject({
+        method: 'materializeEntry',
+        args: [
+          {
+            path: '.agents/relative-skill',
+            entry: {
+              type: 'local_dir',
+              src: `${root}/skills/relative-skill`,
+            },
+            runAs: undefined,
           },
-          runAs: undefined,
-        },
-      ]);
+        ],
+      });
+      session.assertComplete();
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -576,17 +547,28 @@ describe('Skills', () => {
         children: {},
       },
     });
-    const session = new FakeSkillsSession();
-    session.files.set(
-      '.agents/sheet-tools/SKILL.md',
-      [
-        '---',
-        'name: "spreadsheet-review"',
-        "description: 'Review spreadsheets quickly'",
-        '---',
-        '# Spreadsheet review',
-      ].join('\n'),
-    );
+    const session = scriptedSandboxSession([
+      {
+        method: 'listDir',
+        result: [
+          {
+            name: 'sheet-tools',
+            path: '.agents/sheet-tools',
+            type: 'dir',
+          },
+        ],
+      },
+      {
+        method: 'readFile',
+        result: [
+          '---',
+          'name: "spreadsheet-review"',
+          "description: 'Review spreadsheets quickly'",
+          '---',
+          '# Spreadsheet review',
+        ].join('\n'),
+      },
+    ]);
     capability.bind(session);
 
     const instructions = await capability.instructions(new Manifest());
@@ -594,45 +576,59 @@ describe('Skills', () => {
     expect(instructions).toContain(
       '- spreadsheet-review: Review spreadsheets quickly (file: .agents/sheet-tools)',
     );
+    session.assertComplete();
   });
 
   it('ignores missing skill directories while preserving access failures', async () => {
     const capability = skills({ from: { type: 'dir', children: {} } });
-    const session = new FakeSkillsSession();
+    const denied = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    const session = scriptedSandboxSession([
+      {
+        method: 'listDir',
+        error: new SandboxWorkspaceReadNotFoundError('missing skill directory'),
+      },
+      { method: 'listDir', error: denied },
+    ]);
+    session.readFile = async () => 'unused';
     capability.bind(session);
 
-    vi.spyOn(session, 'listDir').mockRejectedValueOnce(
-      new SandboxWorkspaceReadNotFoundError('missing skill directory'),
-    );
     await expect(capability.instructions(new Manifest())).resolves.toContain(
       '.agents',
     );
 
-    const denied = Object.assign(new Error('Permission denied'), {
-      code: 'EACCES',
-    });
-    vi.spyOn(session, 'listDir').mockRejectedValueOnce(denied);
     await expect(capability.instructions(new Manifest())).rejects.toBe(denied);
+    session.assertComplete();
   });
 
   it('skips missing skill files without suppressing unreadable files', async () => {
     const capability = skills({ from: { type: 'dir', children: {} } });
-    const session = new FakeSkillsSession();
-    session.files.set('.agents/blocked/SKILL.md', '# Placeholder');
+    const denied = Object.assign(new Error('Permission denied'), {
+      code: 'EACCES',
+    });
+    const directory = {
+      name: 'blocked',
+      path: '.agents/blocked',
+      type: 'dir' as const,
+    };
+    const session = scriptedSandboxSession([
+      { method: 'listDir', result: [directory] },
+      {
+        method: 'readFile',
+        error: new SandboxWorkspaceReadNotFoundError('missing skill file'),
+      },
+      { method: 'listDir', result: [directory] },
+      { method: 'readFile', error: denied },
+    ]);
     capability.bind(session);
 
-    vi.spyOn(session, 'readFile').mockRejectedValueOnce(
-      new SandboxWorkspaceReadNotFoundError('missing skill file'),
-    );
     await expect(capability.instructions(new Manifest())).resolves.toContain(
       '.agents',
     );
 
-    const denied = Object.assign(new Error('Permission denied'), {
-      code: 'EACCES',
-    });
-    vi.spyOn(session, 'readFile').mockRejectedValueOnce(denied);
     await expect(capability.instructions(new Manifest())).rejects.toBe(denied);
+    session.assertComplete();
   });
 
   it('does not materialize lazy skills when their existence cannot be determined', async () => {
@@ -642,11 +638,15 @@ describe('Skills', () => {
         index: [{ name: 'dynamic-skill', description: 'dynamic' }],
       },
     });
-    const session = new FakeSkillsSession();
     const denied = Object.assign(new Error('Permission denied'), {
       code: 'EACCES',
     });
-    vi.spyOn(session, 'pathExists').mockRejectedValue(denied);
+    const session = scriptedSandboxSession([
+      { method: 'pathExists', error: denied },
+    ]);
+    session.materializeEntry = async () => {
+      throw new Error('materializeEntry must not be called');
+    };
     capability.bind(session);
 
     await expect(
@@ -655,7 +655,8 @@ describe('Skills', () => {
         JSON.stringify({ skill_name: 'dynamic-skill' }),
       ),
     ).resolves.toContain('Permission denied');
-    expect(session.materializeCalls).toEqual([]);
+    expect(session.calls.map((call) => call.method)).toEqual(['pathExists']);
+    session.assertComplete();
   });
 
   it('renders lazy loading guidance for lazy skill sources', async () => {
@@ -698,7 +699,10 @@ describe('Skills', () => {
         },
       ],
     });
-    const session = new FakeSkillsSession();
+    const session = scriptedSandboxSession([
+      { method: 'pathExists', result: false },
+      { method: 'materializeEntry', result: undefined },
+    ]);
     capability.bind(session);
 
     const instructions = await capability.instructions(new Manifest());
@@ -716,6 +720,7 @@ describe('Skills', () => {
       skill_name: 'dynamic-skill',
       path: '.agents/dynamic-skill',
     });
+    session.assertComplete();
   });
 
   it('materializes lazy skills from GitRepo subpaths', async () => {
@@ -735,7 +740,10 @@ describe('Skills', () => {
         ],
       },
     });
-    const session = new FakeSkillsSession();
+    const session = scriptedSandboxSession([
+      { method: 'pathExists', result: false },
+      { method: 'materializeEntry', result: undefined },
+    ]);
     capability.bind(session);
 
     const tools = capability.tools();
@@ -744,17 +752,21 @@ describe('Skills', () => {
       JSON.stringify({ skill_name: 'dynamic-skill' }),
     );
 
-    expect(session.materializeCalls).toEqual([
-      {
-        path: '.agents/dynamic-skill',
-        entry: {
-          type: 'git_repo',
-          repo: 'openai/skills',
-          ref: 'main',
-          subpath: 'bundled/dynamic-skill',
+    expect(session.calls[1]).toMatchObject({
+      method: 'materializeEntry',
+      args: [
+        {
+          path: '.agents/dynamic-skill',
+          entry: {
+            type: 'git_repo',
+            repo: 'openai/skills',
+            ref: 'main',
+            subpath: 'bundled/dynamic-skill',
+          },
+          runAs: undefined,
         },
-        runAs: undefined,
-      },
-    ]);
+      ],
+    });
+    session.assertComplete();
   });
 });

--- a/packages/agents-core/test/sandboxTools.test.ts
+++ b/packages/agents-core/test/sandboxTools.test.ts
@@ -2,17 +2,17 @@ import { describe, expect, it, vi } from 'vitest';
 import type { ApplyPatchOperation, ApplyPatchResult, Editor } from '../src';
 import { RunContext } from '../src';
 import {
-  ExecCommandArgs,
   filesystem,
   Manifest,
   shell,
   prepareSandboxAgent,
   SandboxAgent,
-  type SandboxSession,
-  type SandboxSessionState,
-  type ViewImageArgs,
-  type WriteStdinArgs,
 } from '../src/sandbox';
+import {
+  ScriptedModel,
+  scriptedSandboxSession,
+  type ScriptedSandboxInput,
+} from '../src/testing';
 
 class FakeEditor implements Editor {
   readonly calls: ApplyPatchOperation[] = [];
@@ -39,86 +39,19 @@ class FakeEditor implements Editor {
   }
 }
 
-class FakeResponsesModel {
-  async getResponse() {
-    throw new Error('not used');
-  }
+class FakeResponsesModel extends ScriptedModel {}
 
-  async *getStreamedResponse() {
-    yield* [];
-  }
-}
+class FakeChatCompletionsModel extends ScriptedModel {}
 
-class FakeChatCompletionsModel {
-  async getResponse() {
-    throw new Error('not used');
-  }
-
-  async *getStreamedResponse() {
-    yield* [];
-  }
-}
-
-type FakeSessionState = SandboxSessionState & {
-  sessionId?: string;
-};
-
-class FakeSandboxSession implements SandboxSession<FakeSessionState> {
-  readonly state: FakeSessionState;
-  readonly editor = new FakeEditor();
-  readonly createEditorCalls: Array<string | undefined> = [];
-  readonly execCommandCalls: ExecCommandArgs[] = [];
-  readonly writeStdinCalls: WriteStdinArgs[] = [];
-  readonly viewImageCalls: ViewImageArgs[] = [];
-  private readonly pty: boolean;
-
-  constructor(args: { manifest?: Manifest; pty?: boolean } = {}) {
-    this.state = {
-      manifest: args.manifest ?? new Manifest(),
-    };
-    this.pty = args.pty ?? false;
-  }
-
-  createEditor(runAs?: string): Editor {
-    this.createEditorCalls.push(runAs);
-    return this.editor;
-  }
-
-  async execCommand(args: ExecCommandArgs): Promise<string> {
-    this.execCommandCalls.push(args);
-    return 'exec ok';
-  }
-
-  async writeStdin(args: WriteStdinArgs): Promise<string> {
-    this.writeStdinCalls.push(args);
-    return 'stdin ok';
-  }
-
-  async viewImage(args: ViewImageArgs) {
-    this.viewImageCalls.push(args);
-    return {
-      type: 'image' as const,
-      image: {
-        data: Uint8Array.from([137, 80, 78, 71]),
-        mediaType: 'image/png',
-      },
-    };
-  }
-
-  supportsPty(): boolean {
-    return this.pty;
-  }
-}
-
-class FailingViewImageSandboxSession extends FakeSandboxSession {
-  constructor(private readonly error: Error) {
-    super();
-  }
-
-  override async viewImage(args: ViewImageArgs): Promise<never> {
-    this.viewImageCalls.push(args);
-    throw this.error;
-  }
+function scriptedFilesystemSession(
+  viewImageSteps: readonly ScriptedSandboxInput<'viewImage'>[] = [],
+) {
+  const editor = new FakeEditor();
+  const session = scriptedSandboxSession([
+    { method: 'createEditor', result: editor },
+    ...viewImageSteps,
+  ]);
+  return { editor, session };
 }
 
 describe('sandbox shell tools', () => {
@@ -141,7 +74,9 @@ describe('sandbox shell tools', () => {
 
   it('exposes exec_command for non-PTY sessions and preserves snake_case schemas', async () => {
     const capability = shell();
-    const session = new FakeSandboxSession();
+    const session = scriptedSandboxSession([
+      { method: 'execCommand', result: 'exec ok' },
+    ]);
     capability.bind(session).bindRunAs('sandbox-user');
 
     const tools = capability.tools();
@@ -188,23 +123,33 @@ describe('sandbox shell tools', () => {
     );
 
     expect(result).toBe('exec ok');
-    expect(session.execCommandCalls).toEqual([
-      {
-        cmd: 'pwd',
-        workdir: 'src/project',
-        shell: '/bin/bash',
-        login: false,
-        tty: true,
-        yieldTimeMs: 1500,
-        maxOutputTokens: 128,
-        runAs: 'sandbox-user',
-      },
+    expect(session.calls).toEqual([
+      expect.objectContaining({
+        method: 'execCommand',
+        args: [
+          {
+            cmd: 'pwd',
+            workdir: 'src/project',
+            shell: '/bin/bash',
+            login: false,
+            tty: true,
+            yieldTimeMs: 1500,
+            maxOutputTokens: 128,
+            runAs: 'sandbox-user',
+          },
+        ],
+      }),
     ]);
+    session.assertComplete();
   });
 
   it('adds write_stdin for PTY sessions and preserves snake_case schemas', async () => {
     const capability = shell();
-    const session = new FakeSandboxSession({ pty: true });
+    const session = scriptedSandboxSession([
+      { method: 'supportsPty', result: true },
+      { method: 'writeStdin', result: 'stdin ok' },
+    ]);
+    session.execCommand = async () => 'unused';
     capability.bind(session);
 
     const tools = capability.tools();
@@ -242,14 +187,21 @@ describe('sandbox shell tools', () => {
     );
 
     expect(result).toBe('stdin ok');
-    expect(session.writeStdinCalls).toEqual([
-      {
-        sessionId: 1337,
-        chars: 'hello',
-        yieldTimeMs: 25,
-        maxOutputTokens: 64,
-      },
+    expect(session.calls).toEqual([
+      expect.objectContaining({ method: 'supportsPty', args: [] }),
+      expect.objectContaining({
+        method: 'writeStdin',
+        args: [
+          {
+            sessionId: 1337,
+            chars: 'hello',
+            yieldTimeMs: 25,
+            maxOutputTokens: 64,
+          },
+        ],
+      }),
     ]);
+    session.assertComplete();
   });
 });
 
@@ -262,7 +214,18 @@ describe('sandbox filesystem tools', () => {
 
   it('exposes native view_image and apply_patch after binding to a responses model', async () => {
     const capability = filesystem();
-    const session = new FakeSandboxSession();
+    const { session } = scriptedFilesystemSession([
+      {
+        method: 'viewImage',
+        result: {
+          type: 'image',
+          image: {
+            data: Uint8Array.from([137, 80, 78, 71]),
+            mediaType: 'image/png',
+          },
+        },
+      },
+    ]);
     capability
       .bind(session)
       .bindRunAs('sandbox-user')
@@ -274,7 +237,10 @@ describe('sandbox filesystem tools', () => {
       'view_image',
       'apply_patch',
     ]);
-    expect(session.createEditorCalls).toEqual(['sandbox-user']);
+    expect(session.calls[0]).toMatchObject({
+      method: 'createEditor',
+      args: ['sandbox-user'],
+    });
 
     const result = await (tools[0] as any).invoke(
       new RunContext(),
@@ -288,19 +254,21 @@ describe('sandbox filesystem tools', () => {
         mediaType: 'image/png',
       },
     });
-    expect(session.viewImageCalls).toEqual([
-      {
-        path: 'images/example.png',
-        runAs: 'sandbox-user',
-      },
-    ]);
+    expect(session.calls[1]).toMatchObject({
+      method: 'viewImage',
+      args: [{ path: 'images/example.png', runAs: 'sandbox-user' }],
+    });
+    session.assertComplete();
   });
 
   it('returns model-readable view_image errors', async () => {
     const capability = filesystem();
-    const session = new FailingViewImageSandboxSession(
-      new Error('Unsupported image format for view_image: notes.txt'),
-    );
+    const { session } = scriptedFilesystemSession([
+      {
+        method: 'viewImage',
+        error: new Error('Unsupported image format for view_image: notes.txt'),
+      },
+    ]);
     capability
       .bind(session)
       .bindRunAs('sandbox-user')
@@ -313,12 +281,11 @@ describe('sandbox filesystem tools', () => {
     );
 
     expect(result).toBe('image path `notes.txt` is not a supported image file');
-    expect(session.viewImageCalls).toEqual([
-      {
-        path: 'notes.txt',
-        runAs: 'sandbox-user',
-      },
-    ]);
+    expect(session.calls[1]).toMatchObject({
+      method: 'viewImage',
+      args: [{ path: 'notes.txt', runAs: 'sandbox-user' }],
+    });
+    session.assertComplete();
   });
 
   it.each([
@@ -333,7 +300,9 @@ describe('sandbox filesystem tools', () => {
     'classifies view_image failures for model consumption: %s',
     async (message, expected) => {
       const capability = filesystem();
-      const session = new FailingViewImageSandboxSession(new Error(message));
+      const { session } = scriptedFilesystemSession([
+        { method: 'viewImage', error: new Error(message) },
+      ]);
       capability
         .bind(session)
         .bindModel('gpt-4o', new FakeChatCompletionsModel() as any);
@@ -345,36 +314,54 @@ describe('sandbox filesystem tools', () => {
       );
 
       expect(result).toBe(expected);
+      session.assertComplete();
     },
   );
 
   it('renders every supported view_image result for text transports', async () => {
     const capability = filesystem();
-    const session = new FakeSandboxSession();
-    const viewImage = vi.spyOn(session, 'viewImage') as any;
-    viewImage
-      .mockResolvedValueOnce('openai-file-reference')
-      .mockResolvedValueOnce({
-        type: 'image',
-        image: 'data:image/png;base64,a',
-      })
-      .mockResolvedValueOnce({
-        type: 'image',
-        image: { url: 'https://example.com/image.png' },
-      })
-      .mockResolvedValueOnce({
-        type: 'image',
-        image: { fileId: 'file_123' },
-      })
-      .mockResolvedValueOnce({
-        type: 'image',
-        image: { data: 'YWJj' },
-      })
-      .mockResolvedValueOnce({
-        type: 'image',
-        image: { data: Uint8Array.from([97, 98, 99]) },
-      })
-      .mockResolvedValueOnce({ type: 'image', image: null });
+    const { session } = scriptedFilesystemSession([
+      { method: 'viewImage', result: 'openai-file-reference' as any },
+      {
+        method: 'viewImage',
+        result: {
+          type: 'image',
+          image: 'data:image/png;base64,a',
+        },
+      },
+      {
+        method: 'viewImage',
+        result: {
+          type: 'image',
+          image: { url: 'https://example.com/image.png' },
+        },
+      },
+      {
+        method: 'viewImage',
+        result: {
+          type: 'image',
+          image: { fileId: 'file_123' },
+        },
+      },
+      {
+        method: 'viewImage',
+        result: {
+          type: 'image',
+          image: { data: 'YWJj' },
+        },
+      },
+      {
+        method: 'viewImage',
+        result: {
+          type: 'image',
+          image: { data: Uint8Array.from([97, 98, 99]) },
+        },
+      },
+      {
+        method: 'viewImage',
+        result: { type: 'image', image: null } as any,
+      },
+    ]);
     capability
       .bind(session)
       .bindModel('gpt-4o', new FakeChatCompletionsModel() as any);
@@ -399,6 +386,7 @@ describe('sandbox filesystem tools', () => {
     await expect(invoke()).resolves.toBe(
       'No image data was returned by the sandbox session.',
     );
+    session.assertComplete();
   });
 
   it('requires filesystem sessions to provide editor and image handlers', async () => {
@@ -410,8 +398,7 @@ describe('sandbox filesystem tools', () => {
       'Filesystem sandbox sessions must provide createEditor().',
     );
 
-    const session = new FakeSandboxSession();
-    (session as any).viewImage = undefined;
+    const { session } = scriptedFilesystemSession();
     const noViewImage = filesystem();
     noViewImage
       .bind(session)
@@ -426,6 +413,7 @@ describe('sandbox filesystem tools', () => {
     ).resolves.toContain(
       'Filesystem sandbox sessions must provide viewImage().',
     );
+    session.assertComplete();
   });
 
   it('allows callers to configure the filesystem tool set', () => {
@@ -433,16 +421,30 @@ describe('sandbox filesystem tools', () => {
       configureTools: (tools) =>
         tools.filter((candidate) => candidate.name === 'view_image'),
     });
-    capability.bind(new FakeSandboxSession());
+    const { session } = scriptedFilesystemSession();
+    session.viewImage = async () => ({ type: 'image' });
+    capability.bind(session);
 
     expect(capability.tools().map((candidate) => candidate.name)).toEqual([
       'view_image',
     ]);
+    session.assertComplete();
   });
 
   it('exposes function fallbacks after binding to a chat-completions model', async () => {
     const capability = filesystem();
-    const session = new FakeSandboxSession();
+    const { editor, session } = scriptedFilesystemSession([
+      {
+        method: 'viewImage',
+        result: {
+          type: 'image',
+          image: {
+            data: Uint8Array.from([137, 80, 78, 71]),
+            mediaType: 'image/png',
+          },
+        },
+      },
+    ]);
     capability
       .bind(session)
       .bindRunAs('sandbox-user')
@@ -462,12 +464,10 @@ describe('sandbox filesystem tools', () => {
     );
 
     expect(imageResult).toBe('data:image/png;base64,iVBORw==');
-    expect(session.viewImageCalls).toEqual([
-      {
-        path: 'images/example.png',
-        runAs: 'sandbox-user',
-      },
-    ]);
+    expect(session.calls[1]).toMatchObject({
+      method: 'viewImage',
+      args: [{ path: 'images/example.png', runAs: 'sandbox-user' }],
+    });
 
     const patch = [
       '*** Begin Patch',
@@ -487,7 +487,7 @@ describe('sandbox filesystem tools', () => {
     );
 
     expect(patchResult).toBe('created\nupdated\ndeleted');
-    expect(session.editor.calls).toEqual([
+    expect(editor.calls).toEqual([
       {
         type: 'create_file',
         path: 'created.txt',
@@ -504,6 +504,7 @@ describe('sandbox filesystem tools', () => {
         path: 'obsolete.txt',
       },
     ]);
+    session.assertComplete();
   });
 
   it.each([
@@ -554,7 +555,7 @@ describe('sandbox filesystem tools', () => {
     'returns model-readable apply_patch input errors',
     async (input, error) => {
       const capability = filesystem();
-      const session = new FakeSandboxSession();
+      const { editor, session } = scriptedFilesystemSession();
       capability
         .bind(session)
         .bindModel('gpt-4o', new FakeChatCompletionsModel() as any);
@@ -563,7 +564,8 @@ describe('sandbox filesystem tools', () => {
       await expect(
         (applyPatch as any).invoke(new RunContext(), input),
       ).resolves.toContain(error);
-      expect(session.editor.calls).toEqual([]);
+      expect(editor.calls).toEqual([]);
+      session.assertComplete();
     },
   );
 
@@ -614,7 +616,7 @@ describe('sandbox filesystem tools', () => {
     'accepts supported structured apply_patch input forms',
     async (input, path) => {
       const capability = filesystem();
-      const session = new FakeSandboxSession();
+      const { editor, session } = scriptedFilesystemSession();
       capability
         .bind(session)
         .bindModel('gpt-4o', new FakeChatCompletionsModel() as any);
@@ -623,15 +625,16 @@ describe('sandbox filesystem tools', () => {
       await expect(
         (applyPatch as any).invoke(new RunContext(), input),
       ).resolves.toBe('created');
-      expect(session.editor.calls).toEqual([
+      expect(editor.calls).toEqual([
         expect.objectContaining({ type: 'create_file', path }),
       ]);
+      session.assertComplete();
     },
   );
 
   it('returns model-readable editor failures', async () => {
     const capability = filesystem();
-    const session = new FakeSandboxSession();
+    const { editor, session } = scriptedFilesystemSession();
     capability
       .bind(session)
       .bindModel('gpt-4o', new FakeChatCompletionsModel() as any);
@@ -641,7 +644,7 @@ describe('sandbox filesystem tools', () => {
       path: 'notes.txt',
       diff: '+hello\n',
     });
-    const createFile = vi.spyOn(session.editor, 'createFile');
+    const createFile = vi.spyOn(editor, 'createFile');
 
     createFile.mockRejectedValueOnce(new Error('permission denied'));
     await expect(
@@ -665,13 +668,12 @@ describe('sandbox filesystem tools', () => {
     await expect(
       (applyPatch as any).invoke(new RunContext(), input),
     ).resolves.toBe('Patch applied.');
+    session.assertComplete();
   });
 
   it('accepts move-only freeform apply_patch updates', async () => {
-    const session = new FakeSandboxSession({
-      manifest: new Manifest({ root: '/workspace' }),
-      pty: true,
-    });
+    const { editor, session } = scriptedFilesystemSession();
+    session.state.manifest = new Manifest({ root: '/workspace' });
     const capability = filesystem();
     capability.bind(session);
     const tools = capability.tools();
@@ -688,7 +690,7 @@ describe('sandbox filesystem tools', () => {
     );
 
     expect(patchResult).toBe('updated');
-    expect(session.editor.calls).toEqual([
+    expect(editor.calls).toEqual([
       {
         type: 'update_file',
         path: 'old.txt',
@@ -696,15 +698,22 @@ describe('sandbox filesystem tools', () => {
         moveTo: 'new.txt',
       },
     ]);
+    session.assertComplete();
   });
 });
 
 describe('prepareSandboxAgent tool wiring', () => {
   it('adds bound capability tools to the execution agent', () => {
-    const session = new FakeSandboxSession({
-      manifest: new Manifest({ root: '/workspace' }),
-      pty: true,
-    });
+    const editor = new FakeEditor();
+    const session = scriptedSandboxSession([
+      { method: 'createEditor', result: editor },
+      { method: 'createEditor', result: editor },
+      { method: 'supportsPty', result: true },
+    ]);
+    session.execCommand = async () => 'unused';
+    session.writeStdin = async () => 'unused';
+    session.viewImage = async () => ({ type: 'image' });
+    session.state.manifest = new Manifest({ root: '/workspace' });
     const prepared = prepareSandboxAgent({
       agent: new SandboxAgent({
         name: 'sandbox',
@@ -720,5 +729,6 @@ describe('prepareSandboxAgent tool wiring', () => {
       'exec_command',
       'write_stdin',
     ]);
+    session.assertComplete();
   });
 });

--- a/packages/agents-core/test/stubs.ts
+++ b/packages/agents-core/test/stubs.ts
@@ -1,11 +1,7 @@
 import { z } from 'zod';
 import { Agent } from '../src/agent';
-import {
-  Model,
-  ModelProvider,
-  ModelRequest,
-  ModelResponse,
-} from '../src/model';
+import { Model, ModelProvider, ModelResponse } from '../src/model';
+import { ScriptedModel, assistantMessage, modelResponse } from '../src/testing';
 import { tool } from '../src/tool';
 import type { Computer } from '../src/computer';
 import type { Environment } from '../src/computer';
@@ -20,35 +16,11 @@ import * as protocol from '../src/types/protocol';
 import { Usage } from '../src/usage';
 import { Span, Trace, TracingExporter } from '../src';
 
-export const TEST_MODEL_MESSAGE: protocol.AssistantMessageItem = {
-  id: '123',
-  status: 'completed' as const,
-  type: 'message' as const,
-  role: 'assistant' as const,
-  content: [
-    {
-      type: 'output_text' as const,
-      text: 'Hello World',
-      providerData: {
-        annotations: [],
-      },
-    },
-  ],
-};
+export const TEST_MODEL_MESSAGE: protocol.AssistantMessageItem =
+  assistantMessage('Hello World', { id: '123' });
 
 export function fakeModelMessage(text: string): protocol.AssistantMessageItem {
-  return {
-    ...TEST_MODEL_MESSAGE,
-    content: [
-      {
-        type: 'output_text' as const,
-        text,
-        providerData: {
-          annotations: [],
-        },
-      },
-    ],
-  };
+  return assistantMessage(text, { id: TEST_MODEL_MESSAGE.id });
 }
 
 export function fakeModelRefusal(
@@ -154,28 +126,9 @@ export class FakeComputer implements Computer {
   async wait(): Promise<void> {}
 }
 
-export class FakeModel implements Model {
-  constructor(private _responses: ModelResponse[] = []) {}
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    const response = this._responses.shift();
-    if (!response) {
-      throw new Error('No response found');
-    }
-    return response;
-  }
-
-  /* eslint-disable require-yield */
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<protocol.StreamEvent> {
-    throw new Error('Not implemented');
-  }
-}
-
-export class FakeModelProvider implements ModelProvider {
+export class ScriptedModelProvider implements ModelProvider {
   async getModel(_name: string): Promise<Model> {
-    return new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
+    return new ScriptedModel([modelResponse(TEST_MODEL_RESPONSE_BASIC)]);
   }
 }
 

--- a/packages/agents-core/test/taskTurnTracing.test.ts
+++ b/packages/agents-core/test/taskTurnTracing.test.ts
@@ -26,8 +26,6 @@ import {
   withGenerationSpan,
   withTrace,
   withTraceContext,
-  type Model,
-  type ModelRequest,
   type ModelResponse,
   type MCPServer,
   type OpenAIResponsesCompactionResult,
@@ -39,8 +37,17 @@ import { defaultProcessor } from '../src/tracing/processor';
 import { mergeAgentToolRunConfig } from '../src/agentToolRunConfig';
 import { SandboxRuntimeManager } from '../src/sandbox/runtime';
 import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
-import { fakeModelMessage, FakeModel } from './stubs';
+import { fakeModelMessage } from './stubs';
 import logger from '../src/logger';
+import {
+  ScriptedModel,
+  modelError,
+  modelResponder,
+  modelResponse,
+  modelStream,
+  modelStreamResponder,
+  type RecordedModelCall,
+} from '../src/testing';
 
 class RecordingProcessor implements TracingProcessor {
   readonly spansStarted: Span<any>[] = [];
@@ -60,102 +67,89 @@ class RecordingProcessor implements TracingProcessor {
   async forceFlush(): Promise<void> {}
 }
 
-class StreamingModel implements Model {
-  private readonly responses: ModelResponse[];
-
+class StreamingModel extends ScriptedModel {
   constructor(response: ModelResponse | ModelResponse[]) {
-    this.responses = Array.isArray(response) ? [...response] : [response];
-  }
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    throw new Error('Use getStreamedResponse for this model.');
-  }
-
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No response found.');
-    }
-    yield {
-      type: 'response_done',
-      response: {
-        id: 'stream-response',
-        output: response.output,
-        usage: response.usage,
-      },
-    } as StreamEvent;
+    const responses = Array.isArray(response) ? response : [response];
+    super(
+      responses.map((item) =>
+        modelStream([
+          {
+            type: 'response_done',
+            response: {
+              id: 'stream-response',
+              output: item.output,
+              usage: item.usage,
+            },
+          } as StreamEvent,
+        ]),
+      ),
+    );
   }
 }
 
-class FailingModel implements Model {
-  constructor(private readonly error: Error) {}
-
-  async getResponse(): Promise<ModelResponse> {
-    throw this.error;
-  }
-
-  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-    throw this.error;
-    yield* [] as StreamEvent[];
+class FailingModel extends ScriptedModel {
+  constructor(error: Error) {
+    super([modelError(error)]);
   }
 }
 
-class HangingStreamingModel implements Model {
-  async getResponse(): Promise<ModelResponse> {
-    throw new Error('Use getStreamedResponse for this model.');
-  }
-
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const abortError = new Error('aborted');
-    abortError.name = 'AbortError';
-    const signal = request.signal;
-    await new Promise((_resolve, reject) => {
-      if (signal?.aborted) {
-        reject(abortError);
-        return;
-      }
-      signal?.addEventListener('abort', () => reject(abortError), {
-        once: true,
-      });
-    });
-    yield* [] as StreamEvent[];
+class HangingStreamingModel extends ScriptedModel {
+  constructor() {
+    super([
+      modelStreamResponder((call) =>
+        (async function* () {
+          const abortError = new Error('aborted');
+          abortError.name = 'AbortError';
+          const signal = call.request.signal;
+          await new Promise((_resolve, reject) => {
+            if (signal?.aborted) {
+              reject(abortError);
+              return;
+            }
+            signal?.addEventListener('abort', () => reject(abortError), {
+              once: true,
+            });
+          });
+          yield* [] as StreamEvent[];
+        })(),
+      ),
+    ]);
   }
 }
 
-class AbortReconciliationUsageModel implements Model {
-  async getResponse(): Promise<ModelResponse> {
-    return responseWithSpecificUsage(7, 3);
-  }
-
-  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
-    yield {
-      type: 'model',
-      event: {
-        type: 'response.created',
-        response: { id: 'response-before-abort' },
-      },
-    } as StreamEvent;
-    yield {
-      type: 'model',
-      event: {
-        type: 'response.output_item.done',
-        item: {
-          type: 'function_call',
-          id: 'function-call-before-abort',
-          call_id: 'call-before-abort',
-          name: 'slow_tool',
-          arguments: '{}',
-          status: 'completed',
-        },
-      },
-    } as StreamEvent;
-    const abortError = new Error('aborted');
-    abortError.name = 'AbortError';
-    throw abortError;
+class AbortReconciliationUsageModel extends ScriptedModel {
+  constructor() {
+    super([
+      modelStreamResponder(() =>
+        (async function* () {
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.created',
+              response: { id: 'response-before-abort' },
+            },
+          } as StreamEvent;
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.output_item.done',
+              item: {
+                type: 'function_call',
+                id: 'function-call-before-abort',
+                call_id: 'call-before-abort',
+                name: 'slow_tool',
+                arguments: '{}',
+                status: 'completed',
+              },
+            },
+          } as StreamEvent;
+          const abortError = new Error('aborted');
+          abortError.name = 'AbortError';
+          throw abortError;
+        })(),
+      ),
+      modelResponse(responseWithSpecificUsage(7, 3)),
+    ]);
   }
 }
 
@@ -208,113 +202,91 @@ function createBarrier(participantCount: number) {
   };
 }
 
-class CoordinatedModel implements Model {
-  private readonly responses: ModelResponse[];
-  private callCount = 0;
-
+class CoordinatedModel extends ScriptedModel {
   constructor(
     response: ModelResponse | ModelResponse[],
-    private readonly waitForPeers: () => Promise<void>,
-    private readonly waitBeforeResponse?: Promise<void>,
+    waitForPeers: () => Promise<void>,
+    waitBeforeResponse?: Promise<void>,
   ) {
-    this.responses = Array.isArray(response) ? [...response] : [response];
-  }
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    if (this.callCount === 0) {
-      await this.waitForPeers();
-      await this.waitBeforeResponse;
-    }
-    this.callCount += 1;
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No coordinated response found.');
-    }
-    return response;
-  }
-
-  getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
-    throw new Error('Streaming is not supported by this model.');
+    const responses = Array.isArray(response) ? response : [response];
+    super(
+      responses.map((item, index) =>
+        index === 0
+          ? modelResponder(async () => {
+              await waitForPeers();
+              await waitBeforeResponse;
+              return item;
+            })
+          : modelResponse(item),
+      ),
+    );
   }
 }
 
-class CoordinatedTracingModel implements Model {
-  constructor(
-    private readonly label: string,
-    private readonly waitForPeers: () => Promise<void>,
-  ) {}
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    return withGenerationSpan(
-      async () => {
-        await this.waitForPeers();
-        return responseWithoutUsage();
-      },
-      { data: { model: this.label } },
-      request._internal?.tracingParent,
-    );
-  }
-
-  getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
-    throw new Error('Streaming is not supported by this model.');
+class CoordinatedTracingModel extends ScriptedModel {
+  constructor(label: string, waitForPeers: () => Promise<void>) {
+    super([
+      modelResponder((call) =>
+        withGenerationSpan(
+          async () => {
+            await waitForPeers();
+            return responseWithoutUsage();
+          },
+          { data: { model: label } },
+          call.request._internal?.tracingParent,
+        ),
+      ),
+    ]);
   }
 }
 
-class RetryingTracingModel implements Model {
-  private attempts = 0;
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    return withGenerationSpan(
-      async () => {
-        this.attempts += 1;
-        if (this.attempts === 1) {
-          const error = new Error('Rate limited');
-          (error as Error & { statusCode?: number }).statusCode = 429;
-          throw error;
-        }
-        return responseWithSpecificUsage(7, 3);
-      },
-      { data: { model: `retry-attempt-${this.attempts + 1}` } },
-      request._internal?.tracingParent,
-    );
-  }
-
-  getStreamedResponse(_request: ModelRequest): AsyncIterable<StreamEvent> {
-    throw new Error('Streaming is not supported by this model.');
-  }
-}
-
-class CoordinatedStreamingTracingModel implements Model {
-  constructor(
-    private readonly label: string,
-    private readonly waitForPeers: () => Promise<void>,
-  ) {}
-
-  async getResponse(): Promise<ModelResponse> {
-    throw new Error('Use getStreamedResponse for this model.');
-  }
-
-  async *getStreamedResponse(
-    request: ModelRequest,
-  ): AsyncIterable<StreamEvent> {
-    const span = createGenerationSpan(
-      { data: { model: this.label } },
-      request._internal?.tracingParent,
-    );
-    span.start();
-    try {
-      await this.waitForPeers();
-      yield {
-        type: 'response_done',
-        response: {
-          id: `stream-response-${this.label}`,
-          output: responseWithoutUsage().output,
-          usage: new Usage(),
+class RetryingTracingModel extends ScriptedModel {
+  constructor() {
+    let attempts = 0;
+    const respond = (call: RecordedModelCall) =>
+      withGenerationSpan(
+        async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            const error = new Error('Rate limited');
+            (error as Error & { statusCode?: number }).statusCode = 429;
+            throw error;
+          }
+          return responseWithSpecificUsage(7, 3);
         },
-      } as StreamEvent;
-    } finally {
-      span.end();
-    }
+        { data: { model: `retry-attempt-${attempts + 1}` } },
+        call.request._internal?.tracingParent,
+      );
+    super([modelResponder(respond), modelResponder(respond)]);
+  }
+}
+
+class CoordinatedStreamingTracingModel extends ScriptedModel {
+  constructor(label: string, waitForPeers: () => Promise<void>) {
+    super([
+      modelStreamResponder((call) =>
+        (async function* () {
+          const span = createGenerationSpan(
+            { data: { model: label } },
+            call.request._internal?.tracingParent,
+          );
+          span.start();
+          try {
+            await waitForPeers();
+            yield {
+              type: 'response_done',
+              response: {
+                id: `stream-response-${label}`,
+                output: responseWithoutUsage().output,
+                usage: new Usage(),
+              },
+            } as StreamEvent;
+          } finally {
+            span.end();
+          }
+        })(),
+      ),
+    ]);
   }
 }
 
@@ -447,7 +419,7 @@ function createNestedAgentToolScenario(
 ) {
   const nestedAgent = new Agent({
     name: 'Nested agent',
-    model: new FakeModel([responseWithUsage()]),
+    model: new ScriptedModel([modelResponse(responseWithUsage())]),
   });
   const nestedTool = nestedAgent.asTool({
     toolName: 'nested_agent',
@@ -465,9 +437,9 @@ function createNestedAgentToolScenario(
   });
   const outerAgent = new Agent({
     name: 'Outer agent',
-    model: new FakeModel([
-      agentToolCallResponse(nestedTool.name),
-      responseWithUsage(),
+    model: new ScriptedModel([
+      modelResponse(agentToolCallResponse(nestedTool.name)),
+      modelResponse(responseWithUsage()),
     ]),
     tools: [nestedTool],
   });
@@ -531,7 +503,7 @@ function responseWithoutUsage(): ModelResponse {
 function createApprovedAgentToolScenario(stream: boolean) {
   const nestedAgent = new Agent({
     name: 'Approved nested agent',
-    model: new FakeModel([responseWithUsage()]),
+    model: new ScriptedModel([modelResponse(responseWithUsage())]),
   });
   const nestedTool = nestedAgent.asTool({
     toolName: 'approved_nested_agent',
@@ -544,7 +516,9 @@ function createApprovedAgentToolScenario(stream: boolean) {
   ];
   const outerAgent = new Agent({
     name: 'Outer approval agent',
-    model: stream ? new StreamingModel(responses) : new FakeModel(responses),
+    model: stream
+      ? new StreamingModel(responses)
+      : new ScriptedModel(Array.from(responses, modelResponse)),
     tools: [nestedTool],
   });
   return outerAgent;
@@ -578,7 +552,7 @@ describe('runner task and turn tracing', () => {
   it('creates task and turn spans by default with Python-compatible usage', async () => {
     const agent = new Agent({
       name: 'Researcher',
-      model: new FakeModel([responseWithUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithUsage())]),
     });
     const runner = new Runner({ workflowName: 'Tracing parity workflow' });
 
@@ -645,7 +619,7 @@ describe('runner task and turn tracing', () => {
         name: 'Nested trace agent',
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       const runner = new Runner({ workflowName: 'Inner workflow' });
       let outerTraceId: string | undefined;
@@ -685,7 +659,7 @@ describe('runner task and turn tracing', () => {
         name: 'Restored workflow agent',
         model: stream
           ? new StreamingModel(responses)
-          : new FakeModel(responses),
+          : new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [approvalTool],
       });
       const firstRunner = new Runner({ workflowName: 'Stored workflow' });
@@ -736,7 +710,7 @@ describe('runner task and turn tracing', () => {
         name: 'Resume without trace agent',
         model: stream
           ? new StreamingModel(responses)
-          : new FakeModel(responses),
+          : new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [approvalTool],
       });
       const firstRunner = new Runner({ tracingDisabled: true });
@@ -778,7 +752,7 @@ describe('runner task and turn tracing', () => {
   it('omits only task and turn spans when explicitly disabled', async () => {
     const agent = new Agent({
       name: 'Researcher',
-      model: new FakeModel([responseWithUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithUsage())]),
     });
     const runner = new Runner({
       tracing: { includeTaskAndTurnSpans: false },
@@ -803,7 +777,7 @@ describe('runner task and turn tracing', () => {
         name: 'Researcher',
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       const runner = new Runner({ tracingDisabled: true });
 
@@ -829,9 +803,9 @@ describe('runner task and turn tracing', () => {
     });
     const agent = new Agent({
       name: 'Re-enabled tracing agent',
-      model: new FakeModel([
-        agentToolCallResponse(approvalTool.name),
-        responseWithoutUsage(),
+      model: new ScriptedModel([
+        modelResponse(agentToolCallResponse(approvalTool.name)),
+        modelResponse(responseWithoutUsage()),
       ]),
       tools: [approvalTool],
     });
@@ -876,7 +850,7 @@ describe('runner task and turn tracing', () => {
           : 'Globally re-enabled tracing agent',
         model: stream
           ? new StreamingModel(responses)
-          : new FakeModel(responses),
+          : new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [approvalTool],
       });
 
@@ -1041,9 +1015,11 @@ describe('runner task and turn tracing', () => {
     });
     const outerAgent = new Agent({
       name: 'Outer parallel agent',
-      model: new FakeModel([
-        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
-        responseWithoutUsage(),
+      model: new ScriptedModel([
+        modelResponse(
+          parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        ),
+        modelResponse(responseWithoutUsage()),
       ]),
       tools: [nestedToolA, nestedToolB],
     });
@@ -1190,9 +1166,11 @@ describe('runner task and turn tracing', () => {
     });
     const outerAgent = new Agent({
       name: 'Opt-out outer parallel agent',
-      model: new FakeModel([
-        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
-        responseWithoutUsage(),
+      model: new ScriptedModel([
+        modelResponse(
+          parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        ),
+        modelResponse(responseWithoutUsage()),
       ]),
       tools: [nestedToolA, nestedToolB],
     });
@@ -1244,11 +1222,11 @@ describe('runner task and turn tracing', () => {
     const waitForBothModels = createBarrier(2);
     const targetAgentA = new Agent({
       name: 'Nested handoff target A',
-      model: new FakeModel([responseWithoutUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithoutUsage())]),
     });
     const targetAgentB = new Agent({
       name: 'Nested handoff target B',
-      model: new FakeModel([responseWithoutUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithoutUsage())]),
     });
     const handoffA = handoff(targetAgentA);
     const handoffB = handoff(targetAgentB);
@@ -1278,9 +1256,11 @@ describe('runner task and turn tracing', () => {
     });
     const outerAgent = new Agent({
       name: 'Outer parallel handoff agent',
-      model: new FakeModel([
-        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
-        responseWithoutUsage(),
+      model: new ScriptedModel([
+        modelResponse(
+          parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        ),
+        modelResponse(responseWithoutUsage()),
       ]),
       tools: [nestedToolA, nestedToolB],
     });
@@ -1315,12 +1295,12 @@ describe('runner task and turn tracing', () => {
     );
     const nestedAgentA = new Agent({
       name: 'Nested MCP agent A',
-      model: new FakeModel([responseWithoutUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithoutUsage())]),
       mcpServers: [serverA],
     });
     const nestedAgentB = new Agent({
       name: 'Nested MCP agent B',
-      model: new FakeModel([responseWithoutUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithoutUsage())]),
       mcpServers: [serverB],
     });
     const nestedToolA = nestedAgentA.asTool({
@@ -1333,9 +1313,11 @@ describe('runner task and turn tracing', () => {
     });
     const outerAgent = new Agent({
       name: 'Outer parallel MCP agent',
-      model: new FakeModel([
-        parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
-        responseWithoutUsage(),
+      model: new ScriptedModel([
+        modelResponse(
+          parallelAgentToolCallResponse([nestedToolA.name, nestedToolB.name]),
+        ),
+        modelResponse(responseWithoutUsage()),
       ]),
       tools: [nestedToolA, nestedToolB],
     });
@@ -1374,9 +1356,11 @@ describe('runner task and turn tracing', () => {
     );
     const agent = new Agent({
       name: 'Parallel MCP tool agent',
-      model: new FakeModel([
-        parallelAgentToolCallResponse([serverA.toolName, serverB.toolName]),
-        responseWithoutUsage(),
+      model: new ScriptedModel([
+        modelResponse(
+          parallelAgentToolCallResponse([serverA.toolName, serverB.toolName]),
+        ),
+        modelResponse(responseWithoutUsage()),
       ]),
       mcpServers: [serverA, serverB],
     });
@@ -1432,9 +1416,9 @@ describe('runner task and turn tracing', () => {
       expect(preparedTool).toBeDefined();
       const agent = new Agent({
         name: 'MCP URL redaction agent',
-        model: new FakeModel([
-          agentToolCallResponse(preparedTool!.name),
-          responseWithoutUsage(),
+        model: new ScriptedModel([
+          modelResponse(agentToolCallResponse(preparedTool!.name)),
+          modelResponse(responseWithoutUsage()),
         ]),
         mcpServers: [server],
         mcpConfig: { includeServerInToolNames: true },
@@ -1980,7 +1964,7 @@ describe('runner task and turn tracing', () => {
     const runner = new Runner();
     const nonStreamingAgent = new Agent({
       name: 'Non-streaming compaction agent',
-      model: new FakeModel([responseWithUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithUsage())]),
     });
 
     await runner.run(nonStreamingAgent, 'hello', {
@@ -2023,7 +2007,7 @@ describe('runner task and turn tracing', () => {
           : 'Compaction failure agent',
         model: stream
           ? new StreamingModel(responseWithUsage())
-          : new FakeModel([responseWithUsage()]),
+          : new ScriptedModel([modelResponse(responseWithUsage())]),
       });
       const runner = new Runner();
       const session = new FailingCompactionSession();
@@ -2069,7 +2053,7 @@ describe('runner task and turn tracing', () => {
   it('marks the task span when non-streaming session writes fail', async () => {
     const agent = new Agent({
       name: 'Session write failure agent',
-      model: new FakeModel([responseWithUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithUsage())]),
     });
 
     const session = new FailingAddItemsSession();
@@ -2098,7 +2082,7 @@ describe('runner task and turn tracing', () => {
           : 'Sandbox cleanup failure agent',
         model: stream
           ? new StreamingModel(responseWithUsage())
-          : new FakeModel([responseWithUsage()]),
+          : new ScriptedModel([modelResponse(responseWithUsage())]),
       });
 
       try {
@@ -2142,7 +2126,7 @@ describe('runner task and turn tracing', () => {
           : 'Output guardrail tracing agent',
         model: stream
           ? new StreamingModel(responseWithoutUsage())
-          : new FakeModel([responseWithoutUsage()]),
+          : new ScriptedModel([modelResponse(responseWithoutUsage())]),
         outputGuardrails: [
           {
             name: 'delayed output guardrail',
@@ -2218,7 +2202,7 @@ describe('runner task and turn tracing', () => {
             ? new FailingModel(failureError)
             : stream
               ? new StreamingModel(response)
-              : new FakeModel([response]),
+              : new ScriptedModel([modelResponse(response)]),
         tools: failure === 'tool' ? [failingTool] : [],
         outputGuardrails:
           failure === 'guardrail'
@@ -2276,7 +2260,7 @@ describe('runner task and turn tracing', () => {
         outputType: z.object({ summary: z.string() }),
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       const runner = new Runner();
       const options = {
@@ -2324,7 +2308,7 @@ describe('runner task and turn tracing', () => {
         outputType: z.object({ summary: z.string() }),
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       let parserCalls = 0;
       agent.processFinalOutput = (output: string) => {
@@ -2397,7 +2381,7 @@ describe('runner task and turn tracing', () => {
         outputType: z.object({ summary: z.string() }),
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       agent.processFinalOutput = (output: string): never => {
         throw new Error(`Overridden parser rejected ${output}`);
@@ -2448,7 +2432,7 @@ describe('runner task and turn tracing', () => {
         outputType: z.object({ summary: z.string() }),
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       let parserCalls = 0;
       agent.processFinalOutput = (output: string) => {
@@ -2523,7 +2507,7 @@ describe('runner task and turn tracing', () => {
         outputType: z.object({ summary: z.string() }),
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
       });
       const handlerError = new Error('error handler failure');
       const options = {
@@ -2581,7 +2565,7 @@ describe('runner task and turn tracing', () => {
   it('uses invocation-local usage and a fresh agent span when resuming', async () => {
     const agent = new Agent({
       name: 'Resumed agent',
-      model: new FakeModel([responseWithUsage()]),
+      model: new ScriptedModel([modelResponse(responseWithUsage())]),
     });
     const state = new RunState(new RunContext(), 'hello', agent, 10);
     state._context.usage.add(
@@ -2636,7 +2620,7 @@ describe('runner task and turn tracing', () => {
           : 'Interrupted span agent',
         model: stream
           ? new StreamingModel(response)
-          : new FakeModel([response]),
+          : new ScriptedModel([modelResponse(response)]),
         tools: [approvalTool],
       });
 
@@ -2680,7 +2664,7 @@ describe('runner task and turn tracing', () => {
           : 'Opt-out interrupted span agent',
         model: stream
           ? new StreamingModel(responses)
-          : new FakeModel(responses),
+          : new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [approvalTool],
       });
       const runner = new Runner({
@@ -2749,7 +2733,9 @@ describe('runner task and turn tracing', () => {
           : 'Mixed-config approval agent',
         model: stream
           ? new StreamingModel([approvalResponse(approvalTool.name)])
-          : new FakeModel([approvalResponse(approvalTool.name)]),
+          : new ScriptedModel([
+              modelResponse(approvalResponse(approvalTool.name)),
+            ]),
         tools: [approvalTool],
       });
 
@@ -2831,7 +2817,7 @@ describe('runner task and turn tracing', () => {
           : 'Disable tracing on resume agent',
         model: stream
           ? new StreamingModel(responses)
-          : new FakeModel(responses),
+          : new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [approvalTool],
       });
       const firstRunner = new Runner({
@@ -2877,9 +2863,9 @@ describe('runner task and turn tracing', () => {
     });
     const agent = new Agent({
       name: 'Approval agent',
-      model: new FakeModel([
-        approvalResponse(approvalTool.name),
-        responseWithUsage(),
+      model: new ScriptedModel([
+        modelResponse(approvalResponse(approvalTool.name)),
+        modelResponse(responseWithUsage()),
       ]),
       tools: [approvalTool],
     });
@@ -2995,7 +2981,7 @@ describe('runner task and turn tracing', () => {
         name: agentName,
         model: stream
           ? new StreamingModel(responses)
-          : new FakeModel(responses),
+          : new ScriptedModel(Array.from(responses, modelResponse)),
         tools: [approvalTool],
       });
       const runner = new Runner();
@@ -3150,7 +3136,9 @@ describe('runner task and turn tracing', () => {
     });
     const agent = new Agent({
       name: 'Failing approval agent',
-      model: new FakeModel([approvalResponse(approvalTool.name)]),
+      model: new ScriptedModel([
+        modelResponse(approvalResponse(approvalTool.name)),
+      ]),
       tools: [approvalTool],
     });
     const runner = new Runner();

--- a/packages/agents-core/test/testing/scriptedModel.test.ts
+++ b/packages/agents-core/test/testing/scriptedModel.test.ts
@@ -1,0 +1,1075 @@
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Agent, run, tool, Usage } from '../../src';
+import type { ModelRequest, ModelResponse } from '../../src/model';
+import type { StreamEvent } from '../../src/types/protocol';
+import {
+  InvalidScriptedModelStepError,
+  ScriptedModel,
+  ScriptedModelRequestAbortedError,
+  assistantMessage,
+  functionCall,
+  modelError,
+  modelResponder,
+  modelResponse,
+  modelStream,
+  modelStreamResponder,
+  type RecordedModelCall,
+} from '../../src/testing';
+
+describe('ScriptedModel', () => {
+  it('drives a multi-turn tool workflow and records calls', async () => {
+    const weather = tool({
+      name: 'get_weather',
+      description: 'Gets the weather.',
+      parameters: z.object({ city: z.string() }),
+      execute: async ({ city }) => `${city}: sunny`,
+    });
+    const model = new ScriptedModel([
+      modelResponse([
+        functionCall('get_weather', { city: 'Tokyo' }, { callId: 'call_1' }),
+      ]),
+      modelResponse([assistantMessage('It is sunny.')]),
+    ]);
+    const agent = new Agent({
+      name: 'Weather assistant',
+      model,
+      tools: [weather],
+    });
+
+    const result = await run(agent, 'Weather in Tokyo?');
+
+    expect(result.finalOutput).toBe('It is sunny.');
+    expect(model.calls).toHaveLength(2);
+    expect(model.firstCall).toMatchObject({
+      index: 0,
+      streamed: false,
+      request: {
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: 'Weather in Tokyo?',
+          },
+        ],
+      },
+    });
+    expect(model.lastCall?.request.input).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'function_call_result' }),
+      ]),
+    );
+    expect(model.remainingSteps).toBe(0);
+    expect(() => model.assertComplete()).not.toThrow();
+  });
+
+  it('derives a response from the recorded call', async () => {
+    const model = new ScriptedModel([
+      modelResponder(async (call) => {
+        await Promise.resolve();
+        return [
+          assistantMessage(`call ${call.index}: ${String(call.request.input)}`),
+        ];
+      }),
+    ]);
+
+    const response = await model.getResponse(makeRequest('hello'));
+
+    expect(response.output).toEqual([assistantMessage('call 0: hello')]);
+    expect(response.responseId).toBe('scripted-response-1');
+  });
+
+  it('records request collections and model settings at call time', async () => {
+    class RuntimeToken {}
+    const policy = () => true;
+    const controller = new AbortController();
+    const input = [
+      { type: 'message', role: 'user', content: 'hello' },
+    ] as const;
+    const reasoning: NonNullable<ModelRequest['modelSettings']['reasoning']> = {
+      effort: 'high',
+    };
+    const cycle: { value: number; self?: unknown } = { value: 1 };
+    cycle.self = cycle;
+    const runtimeToken = new RuntimeToken();
+    const bytes = new Uint8Array([1, 2, 3]);
+    const ownProto = JSON.parse('{"__proto__":{"value":"snapshot"}}') as Record<
+      string,
+      unknown
+    >;
+    const providerData = {
+      nested: { value: 1 },
+      cycle,
+      aliases: [cycle],
+      runtimeToken,
+      bytes,
+      buffer: bytes.buffer,
+      ownProto,
+    };
+    const backoff = { initialDelayMs: 10 };
+    const serializedTool: ModelRequest['tools'][number] = {
+      type: 'function',
+      name: 'test_tool',
+      description: 'A test tool.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      strict: true,
+    };
+    const serializedHandoff: ModelRequest['handoffs'][number] = {
+      toolName: 'transfer_to_test',
+      toolDescription: 'Transfer to the test agent.',
+      inputJsonSchema: {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+      strictJsonSchema: true,
+    };
+    const modelSettings: ModelRequest['modelSettings'] = {
+      reasoning,
+      providerData,
+      retry: {
+        maxRetries: 1,
+        backoff,
+        policy,
+      },
+    };
+    const request: ModelRequest = {
+      ...makeRequest('unused'),
+      input: [...input],
+      modelSettings,
+      tools: [serializedTool],
+      handoffs: [serializedHandoff],
+      signal: controller.signal,
+    };
+    const model = new ScriptedModel([[assistantMessage('done')]]);
+
+    await model.getResponse(request);
+    request.input = [];
+    request.tools = [];
+    request.handoffs = [];
+    reasoning.effort = 'low';
+    providerData.nested.value = 2;
+    cycle.value = 2;
+    backoff.initialDelayMs = 20;
+    bytes[0] = 9;
+
+    expect(model.firstCall?.request.input).toEqual(input);
+    expect(model.firstCall?.request.modelSettings).toMatchObject({
+      reasoning: { effort: 'high' },
+      providerData: { nested: { value: 1 } },
+      retry: { maxRetries: 1, backoff: { initialDelayMs: 10 } },
+    });
+    expect(model.firstCall?.request.modelSettings.retry?.policy).toBe(policy);
+    expect(model.firstCall?.request.modelSettings).not.toBe(modelSettings);
+    const recordedProviderData = model.firstCall?.request.modelSettings
+      .providerData as typeof providerData;
+    expect(recordedProviderData.cycle.value).toBe(1);
+    expect(recordedProviderData.cycle.self).toBe(recordedProviderData.cycle);
+    expect(recordedProviderData.aliases[0]).toBe(recordedProviderData.cycle);
+    expect(recordedProviderData.runtimeToken).toBe(runtimeToken);
+    expect(recordedProviderData.bytes).not.toBe(bytes);
+    expect(recordedProviderData.bytes[0]).toBe(1);
+    expect(recordedProviderData.bytes.buffer).toBe(recordedProviderData.buffer);
+    expect(Object.getPrototypeOf(recordedProviderData.ownProto)).toBe(
+      Object.prototype,
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        recordedProviderData.ownProto,
+        '__proto__',
+      ),
+    ).toBe(true);
+    expect(recordedProviderData.ownProto.__proto__).toEqual({
+      value: 'snapshot',
+    });
+    expect(model.firstCall?.request.tools[0]).not.toBe(serializedTool);
+    expect(model.firstCall?.request.tools[0]).toStrictEqual(serializedTool);
+    expect(model.firstCall?.request.handoffs[0]).not.toBe(serializedHandoff);
+    expect(model.firstCall?.request.handoffs[0]).toStrictEqual(
+      serializedHandoff,
+    );
+    expect(model.firstCall?.request.signal).toBe(controller.signal);
+  });
+
+  it('detaches plain model settings from another JavaScript realm', async () => {
+    const providerData = runInNewContext(`
+      (() => {
+        class RuntimeToken {
+          value = 'identity';
+        }
+        const buffer = new ArrayBuffer(8);
+        const view = new DataView(buffer, 2, 3);
+        view.setUint8(0, 7);
+        return {
+          nested: { value: 1 },
+          runtimeToken: new RuntimeToken(),
+          view,
+        };
+      })()
+    `) as {
+      nested: { value: number };
+      runtimeToken: object;
+      view: DataView;
+    };
+    const runtimeToken = providerData.runtimeToken;
+    const model = new ScriptedModel([[assistantMessage('done')]]);
+
+    await model.getResponse(makeRequest('hello', undefined, { providerData }));
+    providerData.nested.value = 2;
+    providerData.view.setUint8(0, 8);
+
+    const recordedProviderData = model.firstCall?.request.modelSettings
+      .providerData as typeof providerData;
+    expect(recordedProviderData).not.toBe(providerData);
+    expect(recordedProviderData.nested).not.toBe(providerData.nested);
+    expect(recordedProviderData.nested.value).toBe(1);
+    expect(recordedProviderData.runtimeToken).toBe(runtimeToken);
+    expect(recordedProviderData.view).not.toBe(providerData.view);
+    expect(recordedProviderData.view.byteOffset).toBe(2);
+    expect(recordedProviderData.view.byteLength).toBe(3);
+    expect(recordedProviderData.view.getUint8(0)).toBe(7);
+  });
+
+  it('isolates canonical call history from responder and accessor mutations', async () => {
+    const providerData = {
+      nested: { value: 1 },
+      bytes: new Uint8Array([1, 2, 3]),
+    };
+    const model = new ScriptedModel([
+      modelResponder((call) => {
+        const exposed = call.request.modelSettings
+          .providerData as typeof providerData;
+        exposed.nested.value = 9;
+        exposed.bytes[0] = 9;
+        return [];
+      }),
+    ]);
+
+    await model.getResponse(makeRequest('hello', undefined, { providerData }));
+
+    const exposedCalls = [
+      model.calls[0],
+      model.firstCall,
+      model.lastCall,
+    ] as RecordedModelCall[];
+    for (const call of exposedCalls) {
+      const exposed = call.request.modelSettings
+        .providerData as typeof providerData;
+      exposed.nested.value = 8;
+      exposed.bytes[0] = 8;
+    }
+
+    for (const call of [model.calls[0], model.firstCall, model.lastCall]) {
+      const recorded = call?.request.modelSettings
+        .providerData as typeof providerData;
+      expect(recorded.nested.value).toBe(1);
+      expect(recorded.bytes[0]).toBe(1);
+    }
+  });
+
+  it('snapshots a complete non-streaming response when it is queued', async () => {
+    const response = {
+      output: [assistantMessage('hello')],
+      usage: new Usage({
+        requests: 1,
+        inputTokensDetails: [{ cachedTokens: 2 }],
+      }),
+      providerData: { nested: { value: 1 } },
+    };
+    const model = new ScriptedModel([modelResponse(response)]);
+
+    response.output[0] = assistantMessage('mutated');
+    response.usage.inputTokensDetails[0].cachedTokens = 9;
+    response.providerData.nested.value = 9;
+
+    const result = await model.getResponse(makeRequest('hello'));
+
+    expect(result).not.toBe(response);
+    expect(result.output).toEqual([assistantMessage('hello')]);
+    expect(result.usage.inputTokensDetails[0].cachedTokens).toBe(2);
+    expect(result.providerData).toEqual({ nested: { value: 1 } });
+  });
+
+  it('accepts direct responses in the constructor and enqueue', async () => {
+    const completeResponse = {
+      output: [assistantMessage('first')],
+      usage: new Usage(),
+      responseId: 'response_1',
+      providerData: { source: 'test' },
+    };
+    const output = [assistantMessage('second')];
+    const model = new ScriptedModel([completeResponse]);
+    model.enqueue(output);
+
+    await expect(
+      model.getResponse(makeRequest('first')),
+    ).resolves.toMatchObject(completeResponse);
+    await expect(
+      model.getResponse(makeRequest('second')),
+    ).resolves.toMatchObject({
+      output,
+      usage: { requests: 1 },
+      responseId: 'scripted-response-2',
+    });
+    expect(() => model.assertComplete()).not.toThrow();
+  });
+
+  it('preserves explicit zero usage and fills omitted shorthand usage', async () => {
+    const explicitUsage = new Usage({ requests: 0 });
+    const completeResponse = {
+      output: [assistantMessage('explicit')],
+      usage: explicitUsage,
+    };
+    const model = new ScriptedModel([
+      completeResponse,
+      [assistantMessage('shorthand')],
+    ]);
+
+    await expect(
+      model.getResponse(makeRequest('explicit')),
+    ).resolves.toMatchObject(completeResponse);
+    await expect(
+      model.getResponse(makeRequest('shorthand')),
+    ).resolves.toMatchObject({ usage: { requests: 1 } });
+  });
+
+  it('gates and snapshots raw usage across run modes', async () => {
+    for (const streamed of [false, true]) {
+      const rawUsage = { provider: { inputTokens: 3 } };
+      const response = {
+        output: [assistantMessage('hello')],
+        usage: new Usage({ requests: 1 }),
+        responseId: 'response_1',
+        rawUsage,
+      };
+      const model = new ScriptedModel([response, response]);
+      const disabledRequest = makeRequest('disabled', undefined, {
+        preserveRawUsage: false,
+      });
+      const enabledRequest = makeRequest('enabled', undefined, {
+        preserveRawUsage: true,
+      });
+
+      const disabled = streamed
+        ? getCompletedResponse(
+            await collectEvents(model.getStreamedResponse(disabledRequest)),
+          )
+        : await model.getResponse(disabledRequest);
+      const enabled = streamed
+        ? getCompletedResponse(
+            await collectEvents(model.getStreamedResponse(enabledRequest)),
+          )
+        : await model.getResponse(enabledRequest);
+
+      expect(disabled.rawUsage).toBeUndefined();
+      expect(enabled.rawUsage).toEqual({ provider: { inputTokens: 3 } });
+      expect(enabled.rawUsage).not.toBe(rawUsage);
+      rawUsage.provider.inputTokens = 99;
+      expect(enabled.rawUsage).toEqual({ provider: { inputTokens: 3 } });
+    }
+  });
+
+  it('uses call-time raw usage settings after an async response', async () => {
+    for (const streamed of [false, true]) {
+      for (const [initial, mutated] of [
+        [false, true],
+        [true, false],
+      ] as const) {
+        let release!: () => void;
+        let markStarted!: () => void;
+        const gate = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        const started = new Promise<void>((resolve) => {
+          markStarted = resolve;
+        });
+        const rawUsage = { provider: { inputTokens: 3 } };
+        const model = new ScriptedModel([
+          modelResponder(async () => {
+            markStarted();
+            await gate;
+            return {
+              output: [assistantMessage('hello')],
+              usage: new Usage({ requests: 1 }),
+              rawUsage,
+            };
+          }),
+        ]);
+        const request = makeRequest('hello', undefined, {
+          preserveRawUsage: initial,
+        });
+
+        const pending = streamed
+          ? collectEvents(model.getStreamedResponse(request))
+          : model.getResponse(request);
+        await started;
+        request.modelSettings.preserveRawUsage = mutated;
+        release();
+        const result = await pending;
+        const response = streamed
+          ? getCompletedResponse(result as StreamEvent[])
+          : (result as ModelResponse);
+
+        expect(response.rawUsage).toEqual(initial ? rawUsage : undefined);
+        if (initial) {
+          expect(response.rawUsage).not.toBe(rawUsage);
+        }
+      }
+    }
+  });
+
+  it('omits a throwing raw usage accessor without leaking its error', async () => {
+    for (const streamed of [false, true]) {
+      for (const preserveRawUsage of [false, true]) {
+        const response: ModelResponse = {
+          output: [assistantMessage('hello')],
+          usage: new Usage({ requests: 1 }),
+        };
+        Object.defineProperty(response, 'rawUsage', {
+          enumerable: true,
+          get() {
+            throw new Error('raw usage unavailable');
+          },
+        });
+        const model = new ScriptedModel([response]);
+        const request = makeRequest('hello', undefined, { preserveRawUsage });
+
+        const normalized = streamed
+          ? getCompletedResponse(
+              await collectEvents(model.getStreamedResponse(request)),
+            )
+          : await model.getResponse(request);
+
+        expect(normalized.output).toEqual([assistantMessage('hello')]);
+        expect(normalized.rawUsage).toBeUndefined();
+      }
+    }
+  });
+
+  it('reads an enabled raw usage accessor only once', async () => {
+    for (const streamed of [false, true]) {
+      let reads = 0;
+      const response: ModelResponse = {
+        output: [assistantMessage('hello')],
+        usage: new Usage({ requests: 1 }),
+        responseId: 'response_1',
+      };
+      Object.defineProperty(response, 'rawUsage', {
+        enumerable: true,
+        get() {
+          reads += 1;
+          if (reads > 1) {
+            throw new Error('raw usage read more than once');
+          }
+          return undefined;
+        },
+      });
+      const model = new ScriptedModel([response]);
+      const request = makeRequest('hello', undefined, {
+        preserveRawUsage: true,
+      });
+
+      const normalized = streamed
+        ? getCompletedResponse(
+            await collectEvents(model.getStreamedResponse(request)),
+          )
+        : await model.getResponse(request);
+
+      expect(reads).toBe(1);
+      expect(normalized.rawUsage).toBeUndefined();
+    }
+  });
+
+  it('assigns an ID when automatically streaming a response without one', async () => {
+    const usage = new Usage({ requests: 0 });
+    const model = new ScriptedModel([
+      {
+        output: [assistantMessage('hello')],
+        usage,
+      },
+    ]);
+
+    const completed = getCompletedResponse(
+      await collectEvents(model.getStreamedResponse(makeRequest('hello'))),
+    );
+
+    expect(completed.id).toBe('scripted-response-1');
+    expect(completed.usage.requests).toBe(0);
+  });
+
+  it('converts a response into normalized streaming events', async () => {
+    const response = {
+      output: [assistantMessage('hello', { id: 'message_1' })],
+      usage: new Usage({
+        requests: 1,
+        inputTokens: 2,
+        outputTokens: 1,
+        totalTokens: 3,
+      }),
+      responseId: 'response_1',
+      requestId: 'request_1',
+      providerData: { vendor: 'metadata' },
+    };
+    const directModel = new ScriptedModel([modelResponse(response)]);
+    const streamingModel = new ScriptedModel([
+      modelResponder(async () => response),
+    ]);
+
+    const directResponse = await directModel.getResponse(makeRequest('hello'));
+
+    const events: StreamEvent[] = [];
+    for await (const event of streamingModel.getStreamedResponse(
+      makeRequest('hello'),
+    )) {
+      events.push(event);
+    }
+
+    expect(directResponse.providerData).toEqual({ vendor: 'metadata' });
+    expect(events).toEqual([
+      { type: 'response_started' },
+      {
+        type: 'output_text_delta',
+        itemId: 'message_1',
+        delta: 'hello',
+      },
+      expect.objectContaining({
+        type: 'response_done',
+        response: expect.objectContaining({
+          id: 'response_1',
+          requestId: 'request_1',
+          usage: expect.objectContaining({ totalTokens: 3 }),
+          providerData: { vendor: 'metadata' },
+        }),
+      }),
+    ]);
+    expect(streamingModel.lastCall?.streamed).toBe(true);
+  });
+
+  it('checks abort signals before every automatic stream event', async () => {
+    const controller = new AbortController();
+    const model = new ScriptedModel([
+      modelResponse([
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            { type: 'output_text', text: 'first' },
+            { type: 'output_text', text: 'second' },
+          ],
+        },
+      ]),
+    ]);
+    const iterator = model
+      .getStreamedResponse(makeRequest('hello', controller.signal))
+      [Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: { type: 'response_started' },
+    });
+    await expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: {
+        type: 'output_text_delta',
+        delta: 'first',
+      },
+    });
+
+    controller.abort();
+
+    await expect(iterator.next()).rejects.toMatchObject({
+      name: 'AbortError',
+      callIndex: 0,
+    });
+  });
+
+  it.each([
+    { name: 'non-streaming', streamed: false },
+    { name: 'streaming', streamed: true },
+  ])(
+    'rechecks abort after $name response normalization',
+    async ({ streamed }) => {
+      const controller = new AbortController();
+      const response: ModelResponse = {
+        output: [assistantMessage('done')],
+        usage: new Usage(),
+      };
+      Object.defineProperty(response, 'rawUsage', {
+        enumerable: true,
+        get() {
+          controller.abort();
+          return { provider: 'test' };
+        },
+      });
+      const model = new ScriptedModel([modelResponse(response)]);
+      const request = makeRequest('hello', controller.signal, {
+        preserveRawUsage: true,
+      });
+
+      const result = streamed
+        ? collectEvents(model.getStreamedResponse(request))
+        : model.getResponse(request);
+
+      await expect(result).rejects.toMatchObject({
+        name: 'AbortError',
+        callIndex: 0,
+      });
+    },
+  );
+
+  it('assigns streamed steps and records calls in invocation order', async () => {
+    const model = new ScriptedModel([
+      modelResponse([assistantMessage('first')]),
+      modelResponse([assistantMessage('second')]),
+    ]);
+    const firstStream = model.getStreamedResponse(makeRequest('first call'));
+    const secondStream = model.getStreamedResponse(makeRequest('second call'));
+
+    expect(model.calls.map((call) => call.request.input)).toEqual([
+      'first call',
+      'second call',
+    ]);
+    expect(model.remainingSteps).toBe(0);
+
+    const secondEvents = await collectEvents(secondStream);
+    const firstEvents = await collectEvents(firstStream);
+
+    expect(getStreamText(firstEvents)).toBe('first');
+    expect(getStreamText(secondEvents)).toBe('second');
+  });
+
+  it('passes through a raw normalized stream', async () => {
+    const events: StreamEvent[] = [
+      { type: 'output_text_delta', delta: 'custom' },
+      {
+        type: 'response_done',
+        response: {
+          id: 'custom_response',
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          output: [assistantMessage('custom')],
+        },
+      } as StreamEvent,
+    ];
+    const model = new ScriptedModel([modelStream(events)]);
+    events[0] = { type: 'output_text_delta', delta: 'mutated' };
+    const done = events[1] as Extract<StreamEvent, { type: 'response_done' }>;
+    done.response.output = [assistantMessage('mutated')];
+
+    const received: StreamEvent[] = [];
+    for await (const event of model.getStreamedResponse(makeRequest('hello'))) {
+      received.push(event);
+    }
+
+    expect(received).toEqual([
+      { type: 'output_text_delta', delta: 'custom' },
+      {
+        type: 'response_done',
+        response: {
+          id: 'custom_response',
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          output: [assistantMessage('custom')],
+        },
+      },
+    ]);
+  });
+
+  it('derives a raw normalized stream from the recorded call', async () => {
+    const model = new ScriptedModel([
+      modelStreamResponder(async (call) => {
+        await Promise.resolve();
+        return (async function* () {
+          yield {
+            type: 'output_text_delta',
+            delta: `${call.index}:${String(call.request.input)}`,
+          } satisfies StreamEvent;
+          yield {
+            type: 'response_done',
+            response: {
+              id: 'dynamic-stream',
+              usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+              output: [assistantMessage('done')],
+            },
+          } as StreamEvent;
+        })();
+      }),
+    ]);
+
+    const events = await collectEvents(
+      model.getStreamedResponse(makeRequest('hello')),
+    );
+
+    expect(events[0]).toEqual({
+      type: 'output_text_delta',
+      delta: '0:hello',
+    });
+    expect(model.firstCall).toMatchObject({ index: 0, streamed: true });
+  });
+
+  it('propagates an error and supplies scripted retry advice', async () => {
+    const error = new Error('temporary failure');
+    const model = new ScriptedModel([
+      modelError(error, ({ attempt }) => ({
+        suggested: attempt === 1,
+        replaySafety: 'safe',
+      })),
+    ]);
+    const request = makeRequest('hello');
+
+    await expect(model.getResponse(request)).rejects.toBe(error);
+    await expect(
+      model.getRetryAdvice({
+        request,
+        error,
+        stream: false,
+        attempt: 1,
+      }),
+    ).resolves.toEqual({ suggested: true, replaySafety: 'safe' });
+  });
+
+  it('snapshots static retry advice when it is queued', async () => {
+    const error = new Error('temporary failure');
+    const retryAdvice = {
+      suggested: true,
+      replaySafety: 'safe' as const,
+      normalized: { isNetworkError: true },
+    };
+    const model = new ScriptedModel([modelError(error, retryAdvice)]);
+    const request = makeRequest('hello');
+
+    retryAdvice.suggested = false;
+    retryAdvice.normalized.isNetworkError = false;
+
+    await expect(model.getResponse(request)).rejects.toBe(error);
+    await expect(
+      model.getRetryAdvice({
+        request,
+        error,
+        stream: false,
+        attempt: 1,
+      }),
+    ).resolves.toEqual({
+      suggested: true,
+      replaySafety: 'safe',
+      normalized: { isNetworkError: true },
+    });
+  });
+
+  it('keeps retry advice scoped to each reused error step', async () => {
+    const error = new Error('shared failure');
+    const nonStreamingRequest = makeRequest('non-streaming');
+    const streamingRequest = makeRequest('streaming');
+    const missingAdviceRequest = makeRequest('missing advice');
+    const model = new ScriptedModel([
+      modelError(error, { suggested: false }),
+      modelError(error, { suggested: true, replaySafety: 'safe' }),
+      modelError(error),
+    ]);
+
+    const nonStreamingFailure = model.getResponse(nonStreamingRequest);
+    const streamingFailure = collectEvents(
+      model.getStreamedResponse(streamingRequest),
+    );
+    const missingAdviceFailure = model.getResponse(missingAdviceRequest);
+    await expect(nonStreamingFailure).rejects.toBe(error);
+    await expect(streamingFailure).rejects.toBe(error);
+    await expect(missingAdviceFailure).rejects.toBe(error);
+
+    await expect(
+      model.getRetryAdvice({
+        request: streamingRequest,
+        error,
+        stream: true,
+        attempt: 1,
+      }),
+    ).resolves.toEqual({ suggested: true, replaySafety: 'safe' });
+    await expect(
+      model.getRetryAdvice({
+        request: nonStreamingRequest,
+        error,
+        stream: false,
+        attempt: 1,
+      }),
+    ).resolves.toEqual({ suggested: false });
+    await expect(
+      model.getRetryAdvice({
+        request: missingAdviceRequest,
+        error,
+        stream: false,
+        attempt: 1,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('prioritizes exact request identity for reused errors', async () => {
+    const error = new Error('shared failure');
+    const sharedRequest = makeRequest('shared input');
+    const firstRequest = { ...sharedRequest };
+    const secondRequest = { ...sharedRequest };
+    const model = new ScriptedModel([
+      modelError(error, { suggested: false }),
+      modelError(error, { suggested: true }),
+    ]);
+
+    await Promise.allSettled([
+      model.getResponse(firstRequest),
+      model.getResponse(secondRequest),
+    ]);
+
+    await expect(
+      model.getRetryAdvice({
+        request: secondRequest,
+        error,
+        stream: false,
+        attempt: 1,
+      }),
+    ).resolves.toEqual({ suggested: true });
+    await expect(
+      model.getRetryAdvice({
+        request: firstRequest,
+        error,
+        stream: false,
+        attempt: 1,
+      }),
+    ).resolves.toEqual({ suggested: false });
+  });
+
+  it('rejects raw stream steps in non-streaming mode', async () => {
+    const model = new ScriptedModel([
+      modelStream([]),
+      modelStreamResponder(() => []),
+    ]);
+
+    await expect(model.getResponse(makeRequest('hello'))).rejects.toThrow(
+      InvalidScriptedModelStepError,
+    );
+    await expect(model.getResponse(makeRequest('hello'))).rejects.toThrow(
+      InvalidScriptedModelStepError,
+    );
+  });
+
+  it('validates scripted envelopes before a model call', () => {
+    expect(
+      () => new ScriptedModel([{ type: 'unknown' } as never]),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'InvalidScriptedModelStepError',
+        reason: 'unknown_step_type',
+        inputIndex: 0,
+        stepType: 'unknown',
+      }),
+    );
+    expect(
+      () => new ScriptedModel([{ type: 'responder' } as never]),
+    ).toThrowError(
+      expect.objectContaining({ reason: 'missing_responder', inputIndex: 0 }),
+    );
+    expect(
+      () =>
+        new ScriptedModel([{ output: [], usage: { requests: 1 } } as never]),
+    ).toThrowError(
+      expect.objectContaining({ reason: 'invalid_response', inputIndex: 0 }),
+    );
+
+    const model = new ScriptedModel();
+    expect(() =>
+      model.enqueue(modelResponse([assistantMessage('valid')]), {
+        type: 'stream',
+        events: undefined,
+      } as never),
+    ).toThrowError(
+      expect.objectContaining({ reason: 'invalid_stream', inputIndex: 1 }),
+    );
+    expect(model.remainingSteps).toBe(0);
+  });
+
+  it('validates responder responses with structured call details', async () => {
+    const model = new ScriptedModel([
+      modelResponder(() => ({ output: [], usage: {} }) as never),
+    ]);
+
+    await expect(model.getResponse(makeRequest('hello'))).rejects.toMatchObject(
+      {
+        name: 'InvalidScriptedModelStepError',
+        reason: 'invalid_response',
+        callIndex: 0,
+      },
+    );
+  });
+
+  it.each([
+    ['synchronous', () => ({})],
+    ['asynchronous', async () => ({})],
+  ])(
+    'validates %s stream responder results with structured call details',
+    async (_kind, respond) => {
+      const model = new ScriptedModel([modelStreamResponder(respond as never)]);
+
+      await expect(
+        collectEvents(model.getStreamedResponse(makeRequest('hello'))),
+      ).rejects.toMatchObject({
+        name: 'InvalidScriptedModelStepError',
+        reason: 'invalid_stream',
+        callIndex: 0,
+        stepType: 'stream_responder',
+      });
+    },
+  );
+
+  it('keeps call history indexing private and immutable', async () => {
+    const model = new ScriptedModel([modelResponse([]), modelResponse([])]);
+    await model.getResponse(makeRequest('first'));
+
+    const exposedCalls = model.calls as RecordedModelCall[];
+    expect(() => exposedCalls.pop()).toThrow(TypeError);
+    await model.getResponse(makeRequest('second'));
+
+    expect(model.calls.map((call) => call.index)).toEqual([0, 1]);
+  });
+
+  it('creates provider-neutral assistant messages', () => {
+    expect(assistantMessage('hello')).toEqual({
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'hello' }],
+    });
+  });
+
+  it('fails on unexpected calls and unconsumed steps', async () => {
+    const empty = new ScriptedModel();
+    await expect(empty.getResponse(makeRequest('hello'))).rejects.toMatchObject(
+      {
+        name: 'UnexpectedModelCallError',
+        callIndex: 0,
+        streamed: false,
+      },
+    );
+
+    const pending = new ScriptedModel([
+      modelResponse([assistantMessage('unused')]),
+    ]);
+    expect(() => pending.assertComplete()).toThrowError(
+      expect.objectContaining({
+        name: 'UnconsumedModelStepsError',
+        remainingSteps: 1,
+      }),
+    );
+  });
+
+  it('checks abort signals before consuming a step', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const model = new ScriptedModel([
+      modelResponse([assistantMessage('unused')]),
+    ]);
+
+    await expect(
+      model.getResponse(makeRequest('hello', controller.signal)),
+    ).rejects.toBeInstanceOf(ScriptedModelRequestAbortedError);
+    expect(model.remainingSteps).toBe(1);
+    expect(model.calls).toHaveLength(0);
+  });
+
+  it('checks abort signals before deferred stream step dispatch', async () => {
+    const controller = new AbortController();
+    const scriptedError = new Error('scripted failure');
+    const responder = vi.fn(() => []);
+    const errorModel = new ScriptedModel([modelError(scriptedError)]);
+    const responderModel = new ScriptedModel([modelStreamResponder(responder)]);
+    const errorStream = errorModel.getStreamedResponse(
+      makeRequest('error', controller.signal),
+    );
+    const responderStream = responderModel.getStreamedResponse(
+      makeRequest('responder', controller.signal),
+    );
+
+    controller.abort();
+
+    await expect(collectEvents(errorStream)).rejects.toBeInstanceOf(
+      ScriptedModelRequestAbortedError,
+    );
+    await expect(collectEvents(responderStream)).rejects.toBeInstanceOf(
+      ScriptedModelRequestAbortedError,
+    );
+    expect(responder).not.toHaveBeenCalled();
+  });
+
+  it('rechecks abort signals after awaiting a stream responder', async () => {
+    const controller = new AbortController();
+    let markStarted!: () => void;
+    let release!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const model = new ScriptedModel([
+      modelStreamResponder(async () => {
+        markStarted();
+        await gate;
+        return [];
+      }),
+    ]);
+    const pending = collectEvents(
+      model.getStreamedResponse(makeRequest('hello', controller.signal)),
+    );
+
+    await started;
+    controller.abort();
+    release();
+
+    await expect(pending).rejects.toBeInstanceOf(
+      ScriptedModelRequestAbortedError,
+    );
+  });
+});
+
+function makeRequest(
+  input: string,
+  signal?: AbortSignal,
+  modelSettings: ModelRequest['modelSettings'] = {},
+): ModelRequest {
+  return {
+    input,
+    modelSettings,
+    tools: [],
+    outputType: 'text',
+    handoffs: [],
+    tracing: false,
+    signal,
+  };
+}
+
+function getCompletedResponse(events: StreamEvent[]) {
+  const completed = events.find((event) => event.type === 'response_done');
+  if (!completed || completed.type !== 'response_done') {
+    throw new Error('Expected a completed response event.');
+  }
+  return completed.response;
+}
+
+async function collectEvents(
+  events: AsyncIterable<StreamEvent>,
+): Promise<StreamEvent[]> {
+  const collected: StreamEvent[] = [];
+  for await (const event of events) {
+    collected.push(event);
+  }
+  return collected;
+}
+
+function getStreamText(events: StreamEvent[]): string {
+  return events
+    .filter((event) => event.type === 'output_text_delta')
+    .map((event) => event.delta)
+    .join('');
+}

--- a/packages/agents-core/test/testing/scriptedSandboxSession.test.ts
+++ b/packages/agents-core/test/testing/scriptedSandboxSession.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { run } from '../../src';
+import type { SandboxSession } from '../../src/sandbox';
+import { SandboxAgent, shell } from '../../src/sandbox';
+import { registerSandboxPreStopHook } from '../../src/sandbox/runtime/sessionLifecycle';
+import {
+  InvalidScriptedSandboxStepError,
+  SandboxCallMatcherError,
+  ScriptedModel,
+  UnexpectedSandboxCallError,
+  UnconsumedSandboxStepsError,
+  assistantMessage,
+  functionCall,
+  scriptedSandboxSession,
+  type ScriptedSandboxCallFor,
+} from '../../src/testing';
+
+describe('scriptedSandboxSession', () => {
+  it('returns a session with only configured optional methods', async () => {
+    const session = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        match: ({ cmd }) => cmd === 'pwd',
+        result: '/workspace\n',
+      },
+    ]);
+
+    expectTypeOf(session).toMatchTypeOf<SandboxSession>();
+    expectTypeOf(session.execCommand).toEqualTypeOf<
+      NonNullable<SandboxSession['execCommand']>
+    >();
+    expect('execCommand' in session).toBe(true);
+    expect('writeStdin' in session).toBe(false);
+
+    await expect(session.execCommand({ cmd: 'pwd' })).resolves.toBe(
+      '/workspace\n',
+    );
+    expect(session.calls).toEqual([
+      {
+        index: 0,
+        method: 'execCommand',
+        args: [{ cmd: 'pwd' }],
+      },
+    ]);
+    expect(session.remainingSteps).toBe(0);
+    expect(() => session.assertComplete()).not.toThrow();
+  });
+
+  it('drives a SandboxAgent shell workflow with ScriptedModel', async () => {
+    const session = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        match: ({ cmd }) => cmd === 'pwd',
+        result: '/workspace\n',
+      },
+    ]);
+    const model = new ScriptedModel([
+      [functionCall('exec_command', { cmd: 'pwd' }, { callId: 'call_1' })],
+      [assistantMessage('The workspace is /workspace.')],
+    ]);
+    const agent = new SandboxAgent({
+      name: 'Test agent',
+      model,
+      capabilities: [shell()],
+    });
+
+    const result = await run(agent, 'Where am I?', {
+      sandbox: { session },
+    });
+
+    expect(result.finalOutput).toBe('The workspace is /workspace.');
+    expect(session.calls).toHaveLength(1);
+    expect(model.calls).toHaveLength(2);
+    session.assertComplete();
+    model.assertComplete();
+  });
+
+  it('supports typed responders and synchronous session methods', async () => {
+    const session = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        respond: (call) => `call ${call.index}: ${call.args[0].cmd as string}`,
+      },
+      {
+        method: 'supportsPty',
+        result: true,
+      },
+    ]);
+
+    await expect(session.execCommand({ cmd: 'echo hello' })).resolves.toBe(
+      'call 0: echo hello',
+    );
+    expect(session.supportsPty()).toBe(true);
+    expect(session.calls.map((call) => call.method)).toEqual([
+      'execCommand',
+      'supportsPty',
+    ]);
+  });
+
+  it('allows SDK-managed lifecycle hooks to wrap scripted methods', async () => {
+    const calls: string[] = [];
+    const session = scriptedSandboxSession([
+      {
+        method: 'stop',
+        respond: () => {
+          calls.push('stop');
+        },
+      },
+    ]);
+
+    registerSandboxPreStopHook(session, () => {
+      calls.push('hook');
+    });
+    await session.stop();
+
+    expect(calls).toEqual(['hook', 'stop']);
+    session.assertComplete();
+  });
+
+  it('records detached invocation-time argument snapshots', async () => {
+    const session = scriptedSandboxSession([
+      {
+        method: 'hydrateWorkspace',
+        result: undefined,
+      },
+    ]);
+    const archive = new Uint8Array([1, 2, 3]);
+
+    const hydration = session.hydrateWorkspace(archive);
+    archive[0] = 9;
+    await hydration;
+
+    const firstSnapshot = session.calls[0].args[0] as Uint8Array;
+    expect([...firstSnapshot]).toEqual([1, 2, 3]);
+    firstSnapshot[0] = 8;
+    expect([...(session.calls[0].args[0] as Uint8Array)]).toEqual([1, 2, 3]);
+  });
+
+  it('snapshots mutable static results when they are queued', async () => {
+    const archive = new Uint8Array([1, 2, 3]);
+    const session = scriptedSandboxSession([
+      {
+        method: 'persistWorkspace',
+        result: archive,
+      },
+    ]);
+
+    archive[0] = 9;
+
+    await expect(session.persistWorkspace()).resolves.toEqual(
+      new Uint8Array([1, 2, 3]),
+    );
+  });
+
+  it('preserves runtime identities in call snapshots', () => {
+    const hook = () => {};
+    const session = scriptedSandboxSession([
+      {
+        method: 'registerPreStopHook',
+        result: undefined,
+      },
+    ]);
+
+    session.registerPreStopHook(hook);
+
+    expect(session.calls[0].args[0]).toBe(hook);
+  });
+
+  it('reports mismatched, rejected, and extra calls without payloads', async () => {
+    const mismatch = scriptedSandboxSession([
+      { method: 'execCommand', result: 'ok' },
+      { method: 'readFile', result: 'contents' },
+    ]);
+
+    const mismatchError = await mismatch
+      .readFile({ path: '/secret/payload.txt' })
+      .catch((error: unknown) => error);
+    expect(mismatchError).toBeInstanceOf(UnexpectedSandboxCallError);
+    expect(mismatchError).toMatchObject({
+      callIndex: 0,
+      actualMethod: 'readFile',
+      expectedMethod: 'execCommand',
+      remainingSteps: 1,
+    });
+    expect(String(mismatchError)).not.toContain('/secret/payload.txt');
+
+    const rejected = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        match: () => false,
+        result: 'unused',
+      },
+    ]);
+    await expect(
+      rejected.execCommand({ cmd: 'secret command' }),
+    ).rejects.toBeInstanceOf(SandboxCallMatcherError);
+
+    const extra = scriptedSandboxSession([
+      { method: 'execCommand', result: 'first' },
+    ]);
+    await extra.execCommand({ cmd: 'first' });
+    await expect(extra.execCommand({ cmd: 'second' })).rejects.toMatchObject({
+      callIndex: 1,
+      actualMethod: 'execCommand',
+      expectedMethod: undefined,
+      remainingSteps: 0,
+    });
+  });
+
+  it('preserves matcher and injected errors', async () => {
+    const matcherError = new Error('matcher failed');
+    const matcherSession = scriptedSandboxSession([
+      {
+        method: 'execCommand',
+        match: () => {
+          throw matcherError;
+        },
+        result: 'unused',
+      },
+    ]);
+    await expect(matcherSession.execCommand({ cmd: 'pwd' })).rejects.toBe(
+      matcherError,
+    );
+
+    const injectedError = new Error('sandbox unavailable');
+    const errorSession = scriptedSandboxSession([
+      { method: 'execCommand', error: injectedError },
+    ]);
+    await expect(errorSession.execCommand({ cmd: 'pwd' })).rejects.toBe(
+      injectedError,
+    );
+  });
+
+  it('reports unconsumed steps with their method order', () => {
+    const session = scriptedSandboxSession([
+      { method: 'execCommand', result: 'first' },
+      { method: 'readFile', result: 'second' },
+    ]);
+
+    expect(() => session.assertComplete()).toThrowError(
+      UnconsumedSandboxStepsError,
+    );
+    try {
+      session.assertComplete();
+    } catch (error) {
+      expect(error).toMatchObject({
+        remainingSteps: 2,
+        pendingMethods: ['execCommand', 'readFile'],
+      });
+    }
+  });
+
+  it('validates scripted step envelopes before session use', () => {
+    expect(() =>
+      scriptedSandboxSession([{ method: 'unknown', result: 'nope' }] as any),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'InvalidScriptedSandboxStepError',
+        reason: 'unknown_method',
+        inputIndex: 0,
+        method: 'unknown',
+      }),
+    );
+    expect(() =>
+      scriptedSandboxSession([{ method: 'execCommand' }] as any),
+    ).toThrowError(
+      expect.objectContaining({
+        name: 'InvalidScriptedSandboxStepError',
+        reason: 'invalid_outcome',
+        inputIndex: 0,
+        method: 'execCommand',
+      }),
+    );
+    expect(() =>
+      scriptedSandboxSession([
+        { method: 'execCommand', result: 'ok', respond: 'not a function' },
+      ] as any),
+    ).toThrowError(InvalidScriptedSandboxStepError);
+  });
+
+  it('exposes method-specific call types', () => {
+    type ExecCall = ScriptedSandboxCallFor<'execCommand'>;
+    expectTypeOf<ExecCall['args'][0]>().toEqualTypeOf<
+      Parameters<NonNullable<SandboxSession['execCommand']>>[0]
+    >();
+  });
+});

--- a/packages/agents-core/test/toolCustomData.test.ts
+++ b/packages/agents-core/test/toolCustomData.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { Agent } from '../src/agent';
 import { RunToolCallOutputItem } from '../src/items';
-import type { ModelRequest, ModelResponse } from '../src/model';
+import type { ModelRequest } from '../src/model';
 import type { MCPServer, MCPTool } from '../src/mcp';
 import { mcpToFunctionTool } from '../src/mcp';
 import { run, Runner } from '../src/run';
@@ -17,14 +17,12 @@ import {
 import * as protocol from '../src/types/protocol';
 import { ToolCallError, UserError } from '../src/errors';
 import { Usage } from '../src/usage';
-import { FakeComputer, FakeEditor, FakeModel, fakeModelMessage } from './stubs';
+import { FakeComputer, FakeEditor, fakeModelMessage } from './stubs';
+import { ScriptedModel, modelResponse } from '../src/testing';
 
-class RecordingModel extends FakeModel {
-  readonly requests: ModelRequest[] = [];
-
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    this.requests.push(request);
-    return super.getResponse(request);
+class RecordingModel extends ScriptedModel {
+  get requests(): readonly Readonly<ModelRequest>[] {
+    return this.calls.map((call) => call.request);
   }
 }
 
@@ -39,7 +37,7 @@ function toolOutputItem(items: unknown[]): RunToolCallOutputItem {
 describe('tool output customData', () => {
   it('attaches function tool customData without replaying it to the model', async () => {
     const model = new RecordingModel([
-      {
+      modelResponse({
         output: [
           {
             type: 'function_call',
@@ -50,11 +48,11 @@ describe('tool output customData', () => {
           },
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const getData = tool({
       name: 'get_data',
@@ -97,7 +95,7 @@ describe('tool output customData', () => {
 
   it('rejects non-JSON-compatible customData', async () => {
     const model = new RecordingModel([
-      {
+      modelResponse({
         output: [
           {
             type: 'function_call',
@@ -108,7 +106,7 @@ describe('tool output customData', () => {
           },
         ],
         usage: new Usage(),
-      },
+      }),
     ]);
     const badData = tool({
       name: 'bad_data',
@@ -144,7 +142,7 @@ describe('tool output customData', () => {
     const rawServerName = `streamable-http: ${endpoint.toString()}`;
     let capturedServerName: string | undefined;
     const model = new RecordingModel([
-      {
+      modelResponse({
         output: [
           {
             type: 'function_call',
@@ -155,11 +153,11 @@ describe('tool output customData', () => {
           },
         ],
         usage: new Usage(),
-      },
-      {
+      }),
+      modelResponse({
         output: [fakeModelMessage('done')],
         usage: new Usage(),
-      },
+      }),
     ]);
     const server: MCPServer = {
       name: rawServerName,

--- a/packages/agents-core/test/toolInvocationReplay.test.ts
+++ b/packages/agents-core/test/toolInvocationReplay.test.ts
@@ -26,13 +26,8 @@ import {
 import { getFunctionToolStateKey } from '../src/toolIdentity';
 import type * as protocol from '../src/types/protocol';
 import { Usage } from '../src/usage';
-import {
-  FakeComputer,
-  FakeEditor,
-  FakeModel,
-  FakeShell,
-  fakeModelMessage,
-} from './stubs';
+import { FakeComputer, FakeEditor, FakeShell, fakeModelMessage } from './stubs';
+import { ScriptedModel, modelResponse } from '../src/testing';
 
 function response(output: protocol.ModelItem[]): ModelResponse {
   return { output, usage: new Usage() };
@@ -447,14 +442,16 @@ describe('tool invocation replay binding', () => {
         ...functionCall('numeric-execution-call', localTool.name, {}),
         arguments: `{"n":${first}}`,
       };
-      const model = new FakeModel([
-        response([firstCall]),
-        response([
-          {
-            ...firstCall,
-            arguments: `{"n":${changed}}`,
-          },
-        ]),
+      const model = new ScriptedModel([
+        modelResponse(response([firstCall])),
+        modelResponse(
+          response([
+            {
+              ...firstCall,
+              arguments: `{"n":${changed}}`,
+            },
+          ]),
+        ),
       ]);
       const agent = new Agent({
         name: 'NumericExecutionAgent',
@@ -482,18 +479,20 @@ describe('tool invocation replay binding', () => {
       ...functionCall('program-owned-call', localTool.name, { value: 'safe' }),
       caller: { type: 'program', callerId: 'program-call-a' },
     };
-    const model = new FakeModel([
-      response([firstCall]),
-      response([firstCall]),
-      response([
-        {
-          ...firstCall,
-          caller: {
-            type: 'program' as const,
-            callerId: 'program-call-b',
+    const model = new ScriptedModel([
+      modelResponse(response([firstCall])),
+      modelResponse(response([firstCall])),
+      modelResponse(
+        response([
+          {
+            ...firstCall,
+            caller: {
+              type: 'program' as const,
+              callerId: 'program-call-b',
+            },
           },
-        },
-      ]),
+        ]),
+      ),
     ]);
     const agent = new Agent({
       name: 'ProgramOwnedExecutionAgent',
@@ -515,11 +514,13 @@ describe('tool invocation replay binding', () => {
       parameters: z.object({ value: z.string() }),
       execute,
     });
-    const model = new FakeModel([
-      response([
-        functionCall('', localTool.name, { value: 'first' }),
-        functionCall('', localTool.name, { value: 'changed' }),
-      ]),
+    const model = new ScriptedModel([
+      modelResponse(
+        response([
+          functionCall('', localTool.name, { value: 'first' }),
+          functionCall('', localTool.name, { value: 'changed' }),
+        ]),
+      ),
     ]);
     const agent = new Agent({
       name: 'EmptyCallIdAgent',
@@ -582,12 +583,16 @@ describe('tool invocation replay binding', () => {
       execute: siblingExecute,
     });
     const callId = 'reused-arguments';
-    const model = new FakeModel([
-      response([functionCall(callId, approvedTool.name, { value: 'safe' })]),
-      response([
-        functionCall(callId, approvedTool.name, { value: 'changed' }),
-        functionCall('sibling-call', siblingTool.name, {}),
-      ]),
+    const model = new ScriptedModel([
+      modelResponse(
+        response([functionCall(callId, approvedTool.name, { value: 'safe' })]),
+      ),
+      modelResponse(
+        response([
+          functionCall(callId, approvedTool.name, { value: 'changed' }),
+          functionCall('sibling-call', siblingTool.name, {}),
+        ]),
+      ),
     ]);
     const agent = new Agent({
       name: 'ChangedArgumentsAgent',
@@ -634,20 +639,24 @@ describe('tool invocation replay binding', () => {
       toolSearchExecute,
     );
     const callId = 'tool-search-preflight-call';
-    const model = new FakeModel([
-      response([
-        functionCall(callId, approvedTool.name, { value: 'approved' }),
-      ]),
-      response([
-        functionCall(callId, approvedTool.name, { value: 'changed' }),
-        {
-          type: 'tool_search_call',
-          id: 'tool-search-preflight-item',
-          status: 'completed',
-          arguments: {},
-          providerData: { call_id: 'tool-search-preflight-search' },
-        } as protocol.ToolSearchCallItem,
-      ]),
+    const model = new ScriptedModel([
+      modelResponse(
+        response([
+          functionCall(callId, approvedTool.name, { value: 'approved' }),
+        ]),
+      ),
+      modelResponse(
+        response([
+          functionCall(callId, approvedTool.name, { value: 'changed' }),
+          {
+            type: 'tool_search_call',
+            id: 'tool-search-preflight-item',
+            status: 'completed',
+            arguments: {},
+            providerData: { call_id: 'tool-search-preflight-search' },
+          } as protocol.ToolSearchCallItem,
+        ]),
+      ),
     ]);
     const agent = new Agent({
       name: 'ToolSearchPreflightAgent',
@@ -682,9 +691,9 @@ describe('tool invocation replay binding', () => {
       execute: secondExecute,
     });
     const callId = 'reused-tool';
-    const model = new FakeModel([
-      response([functionCall(callId, firstTool.name, {})]),
-      response([functionCall(callId, secondTool.name, {})]),
+    const model = new ScriptedModel([
+      modelResponse(response([functionCall(callId, firstTool.name, {})])),
+      modelResponse(response([functionCall(callId, secondTool.name, {})])),
     ]);
     const agent = new Agent({
       name: 'ChangedToolAgent',
@@ -713,11 +722,17 @@ describe('tool invocation replay binding', () => {
       execute,
     });
     const callId = 'reused-rejection';
-    const model = new FakeModel([
-      response([
-        functionCall(callId, rejectedTool.name, { value: 'rejected' }),
-      ]),
-      response([functionCall(callId, rejectedTool.name, { value: 'changed' })]),
+    const model = new ScriptedModel([
+      modelResponse(
+        response([
+          functionCall(callId, rejectedTool.name, { value: 'rejected' }),
+        ]),
+      ),
+      modelResponse(
+        response([
+          functionCall(callId, rejectedTool.name, { value: 'changed' }),
+        ]),
+      ),
     ]);
     const agent = new Agent({
       name: 'ChangedRejectionAgent',
@@ -745,14 +760,18 @@ describe('tool invocation replay binding', () => {
       execute,
     });
     const callId = 'exact-replay';
-    const model = new FakeModel([
-      response([
-        functionCall(callId, approvalTool.name, { first: 1, second: 2 }),
-      ]),
-      response([
-        functionCall(callId, approvalTool.name, { second: 2, first: 1 }),
-      ]),
-      response([fakeModelMessage('done')]),
+    const model = new ScriptedModel([
+      modelResponse(
+        response([
+          functionCall(callId, approvalTool.name, { first: 1, second: 2 }),
+        ]),
+      ),
+      modelResponse(
+        response([
+          functionCall(callId, approvalTool.name, { second: 2, first: 1 }),
+        ]),
+      ),
+      modelResponse(response([fakeModelMessage('done')])),
     ]);
     const agent = new Agent({
       name: 'ExactReplayAgent',
@@ -785,17 +804,23 @@ describe('tool invocation replay binding', () => {
       });
       const firstCallId = 'serialized-first';
       const secondCallId = 'serialized-second';
-      const model = new FakeModel([
-        response([
-          functionCall(firstCallId, approvalTool.name, { value: 'first' }),
-        ]),
-        response([
-          functionCall(secondCallId, approvalTool.name, { value: 'second' }),
-        ]),
-        response([
-          functionCall(firstCallId, approvalTool.name, { value: 'first' }),
-        ]),
-        response([fakeModelMessage('done')]),
+      const model = new ScriptedModel([
+        modelResponse(
+          response([
+            functionCall(firstCallId, approvalTool.name, { value: 'first' }),
+          ]),
+        ),
+        modelResponse(
+          response([
+            functionCall(secondCallId, approvalTool.name, { value: 'second' }),
+          ]),
+        ),
+        modelResponse(
+          response([
+            functionCall(firstCallId, approvalTool.name, { value: 'first' }),
+          ]),
+        ),
+        modelResponse(response([fakeModelMessage('done')])),
       ]);
       const agent = new Agent({
         name: 'SerializedReplayAgent',
@@ -859,11 +884,15 @@ describe('tool invocation replay binding', () => {
       execute: async () => 'unused',
     });
     const completedCallId = 'tampered-completed-call';
-    const model = new FakeModel([
-      response([
-        functionCall(completedCallId, executedTool.name, { value: 'once' }),
-      ]),
-      response([functionCall('tampered-pause', pauseTool.name, {})]),
+    const model = new ScriptedModel([
+      modelResponse(
+        response([
+          functionCall(completedCallId, executedTool.name, { value: 'once' }),
+        ]),
+      ),
+      modelResponse(
+        response([functionCall('tampered-pause', pauseTool.name, {})]),
+      ),
     ]);
     const agent = new Agent({
       name: 'TamperedCompletionAgent',
@@ -1212,10 +1241,12 @@ describe('tool invocation replay binding', () => {
     });
     const targetAgent = new Agent({
       name: 'FilteredCompletionTarget',
-      model: new FakeModel([
-        response([
-          functionCall('filtered-completion-pause', pauseTool.name, {}),
-        ]),
+      model: new ScriptedModel([
+        modelResponse(
+          response([
+            functionCall('filtered-completion-pause', pauseTool.name, {}),
+          ]),
+        ),
       ]),
       tools: [pauseTool],
     });
@@ -1227,11 +1258,13 @@ describe('tool invocation replay binding', () => {
     });
     const sourceAgent = new Agent({
       name: 'FilteredCompletionSource',
-      model: new FakeModel([
-        response([
-          completedCall,
-          functionCall('filtered-completion-handoff', transfer.toolName, {}),
-        ]),
+      model: new ScriptedModel([
+        modelResponse(
+          response([
+            completedCall,
+            functionCall('filtered-completion-handoff', transfer.toolName, {}),
+          ]),
+        ),
       ]),
       tools: [executedTool],
       handoffs: [transfer],
@@ -1274,9 +1307,9 @@ describe('tool invocation replay binding', () => {
     const shell = new FakeShell();
     const localShell = shellTool({ shell, needsApproval: true });
     const callId = 'reused-shell';
-    const model = new FakeModel([
-      response([shellCall(callId, ['echo safe'])]),
-      response([shellCall(callId, ['echo changed'])]),
+    const model = new ScriptedModel([
+      modelResponse(response([shellCall(callId, ['echo safe'])])),
+      modelResponse(response([shellCall(callId, ['echo changed'])])),
     ]);
     const agent = new Agent({
       name: 'ChangedShellAgent',
@@ -1305,11 +1338,11 @@ describe('tool invocation replay binding', () => {
       execute: async () => 'approved',
     });
     const shellCallId = 'legacy-shell';
-    const model = new FakeModel([
-      response([shellCall(shellCallId, ['echo once'])]),
-      response([functionCall('pause-call', pauseTool.name, {})]),
-      response([shellCall(shellCallId, ['echo once'])]),
-      response([fakeModelMessage('done')]),
+    const model = new ScriptedModel([
+      modelResponse(response([shellCall(shellCallId, ['echo once'])])),
+      modelResponse(response([functionCall('pause-call', pauseTool.name, {})])),
+      modelResponse(response([shellCall(shellCallId, ['echo once'])])),
+      modelResponse(response([fakeModelMessage('done')])),
     ]);
     const agent = new Agent({
       name: 'LegacyShellReplayAgent',
@@ -1413,11 +1446,13 @@ describe('tool invocation replay binding', () => {
       execute: async () => 'approved',
     });
     const callId = 'legacy-computer';
-    const model = new FakeModel([
-      response([computerCall(callId)]),
-      response([functionCall('pause-computer', pauseTool.name, {})]),
-      response([computerCall(callId)]),
-      response([fakeModelMessage('done')]),
+    const model = new ScriptedModel([
+      modelResponse(response([computerCall(callId)])),
+      modelResponse(
+        response([functionCall('pause-computer', pauseTool.name, {})]),
+      ),
+      modelResponse(response([computerCall(callId)])),
+      modelResponse(response([fakeModelMessage('done')])),
     ]);
     const agent = new Agent({
       name: 'LegacyComputerReplayAgent',
@@ -1455,11 +1490,13 @@ describe('tool invocation replay binding', () => {
       execute: async () => 'approved',
     });
     const callId = 'legacy-apply-patch';
-    const model = new FakeModel([
-      response([applyPatchCall(callId)]),
-      response([functionCall('pause-patch', pauseTool.name, {})]),
-      response([applyPatchCall(callId)]),
-      response([fakeModelMessage('done')]),
+    const model = new ScriptedModel([
+      modelResponse(response([applyPatchCall(callId)])),
+      modelResponse(
+        response([functionCall('pause-patch', pauseTool.name, {})]),
+      ),
+      modelResponse(response([applyPatchCall(callId)])),
+      modelResponse(response([fakeModelMessage('done')])),
     ]);
     const agent = new Agent({
       name: 'LegacyApplyPatchReplayAgent',

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -73,12 +73,13 @@ import { Agent } from '../src/agent';
 import { StreamedRunResult } from '../src/result';
 import { RunContext } from '../src/runContext';
 import { RunState } from '../src/runState';
-import { FakeModel, fakeModelMessage, FakeModelProvider } from './stubs';
+import { fakeModelMessage, ScriptedModelProvider } from './stubs';
 import { Usage } from '../src/usage';
-import * as protocol from '../src/types/protocol';
 import { setDefaultModelProvider } from '../src/providers';
 import { AsyncLocalStorage as BrowserAsyncLocalStorage } from '../src/shims/shims-browser';
 import { supportsProcessLifecycleEvents as workerdSupportsProcessLifecycleEvents } from '../src/shims/shims-workerd';
+import { ScriptedModel, modelResponse, modelStream } from '../src/testing';
+import type { StreamEvent } from '../src/types/protocol';
 
 const ALS_SYMBOL = Symbol.for('openai.agents.core.asyncLocalStorage');
 const originalProcessMaxListeners = process.getMaxListeners();
@@ -647,7 +648,7 @@ describe('Span creation inherits tracing fields from parents', () => {
 
 describe('Runner tracing configuration', () => {
   beforeEach(() => {
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
     setTracingDisabled(false);
   });
 
@@ -662,11 +663,11 @@ describe('Runner tracing configuration', () => {
 
     const agent = new Agent({
       name: 'TestAgent',
-      model: new FakeModel([
-        {
+      model: new ScriptedModel([
+        modelResponse({
           output: [fakeModelMessage('hi')],
           usage: new Usage(),
-        },
+        }),
       ]),
     });
 
@@ -1537,7 +1538,7 @@ describe('withTrace & span helpers (integration)', () => {
 
   it('streaming run waits for stream loop to complete before calling onTraceEnd', async () => {
     // Set up model provider
-    setDefaultModelProvider(new FakeModelProvider());
+    setDefaultModelProvider(new ScriptedModelProvider());
 
     const traceStartTimes: number[] = [];
     const traceEndTimes: number[] = [];
@@ -1567,35 +1568,24 @@ describe('withTrace & span helpers (integration)', () => {
     const orderProcessor = new OrderTrackingProcessor();
     setTraceProcessors([orderProcessor]);
 
-    // Create a fake model that supports streaming
-    class StreamingFakeModel extends FakeModel {
-      async *getStreamedResponse(
-        _request: any,
-      ): AsyncIterable<protocol.StreamEvent> {
-        const response = await this.getResponse(_request);
-        yield {
-          type: 'response_done',
-          response: {
-            id: 'resp-1',
-            usage: {
-              requests: 1,
-              inputTokens: 0,
-              outputTokens: 0,
-              totalTokens: 0,
-            },
-            output: response.output,
-          },
-        } as any;
-      }
-    }
-
     const agent = new Agent({
       name: 'TestAgent',
-      model: new StreamingFakeModel([
-        {
-          output: [fakeModelMessage('Final output')],
-          usage: new Usage(),
-        },
+      model: new ScriptedModel([
+        modelStream([
+          {
+            type: 'response_done',
+            response: {
+              id: 'resp-1',
+              usage: {
+                requests: 1,
+                inputTokens: 0,
+                outputTokens: 0,
+                totalTokens: 0,
+              },
+              output: [fakeModelMessage('Final output')],
+            },
+          } as StreamEvent,
+        ]),
       ]),
     });
 

--- a/packages/agents-extensions/test/sandbox/vercel.test.ts
+++ b/packages/agents-extensions/test/sandbox/vercel.test.ts
@@ -1,10 +1,5 @@
-import {
-  Runner,
-  tool,
-  Usage,
-  type Model,
-  type ModelResponse,
-} from '@openai/agents-core';
+import { Runner, tool, Usage, type ModelResponse } from '@openai/agents-core';
+import { ScriptedModel, modelResponse } from '@openai/agents-core/testing';
 import {
   Manifest,
   SandboxArchiveError,
@@ -51,20 +46,9 @@ const domainMock = vi.fn();
 const remoteFilePaths = new Set<string>();
 const mountedPaths = new Set<string>();
 
-class SequenceModel implements Model {
-  constructor(private readonly responses: ModelResponse[]) {}
-
-  async getResponse(): Promise<ModelResponse> {
-    const response = this.responses.shift();
-    if (!response) {
-      throw new Error('No model response remains.');
-    }
-    return response;
-  }
-
-  // eslint-disable-next-line require-yield
-  async *getStreamedResponse(): AsyncIterable<never> {
-    throw new Error('Streaming is not used by this test.');
+class SequenceModel extends ScriptedModel {
+  constructor(responses: ModelResponse[]) {
+    super(responses.map(modelResponse));
   }
 }
 

--- a/packages/agents-openai/test/hitlOpenAIConversationsSession.test.ts
+++ b/packages/agents-openai/test/hitlOpenAIConversationsSession.test.ts
@@ -3,17 +3,15 @@ import { z } from 'zod';
 
 import {
   Agent,
-  type Model,
   type ModelRequest,
-  type ModelResponse,
   type ModelProvider,
-  type ResponseStreamEvent,
   Usage,
   protocol,
   run,
   setDefaultModelProvider,
   tool,
 } from '@openai/agents-core';
+import { ScriptedModel, modelResponder } from '@openai/agents-core/testing';
 
 import { OpenAIConversationsSession } from '../src';
 
@@ -60,45 +58,38 @@ type ScenarioStep = {
   expectedOutput: string;
 };
 
-class ScenarioModel implements Model {
-  #counter = 0;
+function createScenarioModel(): ScriptedModel {
+  return new ScriptedModel(
+    USER_MESSAGES.map(() =>
+      modelResponder((call) => {
+        const request = call.request;
+        const toolName =
+          typeof request.modelSettings.toolChoice === 'string'
+            ? request.modelSettings.toolChoice
+            : TOOL_ECHO;
+        const callId = `call_${call.index}`;
+        const query = extractUserMessage(request.input);
+        const toolCall: protocol.FunctionCallItem = {
+          id: `fc_${callId}`,
+          type: 'function_call',
+          name: toolName,
+          callId,
+          status: 'completed',
+          arguments: JSON.stringify({ query }),
+          providerData: {},
+        };
 
-  async getResponse(request: ModelRequest): Promise<ModelResponse> {
-    const toolName =
-      typeof request.modelSettings.toolChoice === 'string'
-        ? request.modelSettings.toolChoice
-        : TOOL_ECHO;
-    const callId = `call_${(this.#counter += 1)}`;
-    const query = extractUserMessage(request.input);
-    const toolCall: protocol.FunctionCallItem = {
-      id: `fc_${callId}`,
-      type: 'function_call',
-      name: toolName,
-      callId,
-      status: 'completed',
-      arguments: JSON.stringify({ query }),
-      providerData: {},
-    };
-
-    return {
-      usage: new Usage(),
-      output: [toolCall],
-    };
-  }
-
-  // eslint-disable-next-line require-yield -- this scenario does not stream.
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<ResponseStreamEvent> {
-    throw new Error('Streaming is not supported in this scenario.');
-  }
+        return { usage: new Usage(), output: [toolCall] };
+      }),
+    ),
+  );
 }
 
 describe('OpenAIConversationsSession HITL scenario', () => {
   beforeAll(() => {
     const provider: ModelProvider = {
       getModel() {
-        return new ScenarioModel();
+        return createScenarioModel();
       },
     };
     setDefaultModelProvider(provider);
@@ -139,7 +130,7 @@ describe('OpenAIConversationsSession HITL scenario', () => {
       client,
     });
 
-    const model = new ScenarioModel();
+    const model = createScenarioModel();
     const steps: ScenarioStep[] = [
       {
         label: 'turn 1',
@@ -186,7 +177,7 @@ describe('OpenAIConversationsSession HITL scenario', () => {
 
 async function runScenarioStep(
   session: OpenAIConversationsSession,
-  model: ScenarioModel,
+  model: ScriptedModel,
   step: ScenarioStep,
 ): Promise<{ approvalItem: protocol.FunctionCallItem }> {
   const agent = new Agent({

--- a/packages/agents-realtime/package.json
+++ b/packages/agents-realtime/package.json
@@ -24,6 +24,21 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
+    "./testing": {
+      "react-native": {
+        "types": "./dist/testing/index.d.ts",
+        "require": "./dist/testing/index.js",
+        "import": "./dist/testing/index.mjs"
+      },
+      "browser": {
+        "types": "./dist/testing/index.d.ts",
+        "require": "./dist/testing/index.js",
+        "import": "./dist/testing/index.mjs"
+      },
+      "types": "./dist/testing/index.d.ts",
+      "require": "./dist/testing/index.js",
+      "import": "./dist/testing/index.mjs"
+    },
     "./_shims": {
       "react-native": {
         "types": "./dist/shims/shims-react-native.d.ts",
@@ -52,6 +67,9 @@
   },
   "typesVersions": {
     "*": {
+      "testing": [
+        "dist/testing/index.d.ts"
+      ],
       "_shims": [
         "dist/shims/shims-node.d.ts"
       ]

--- a/packages/agents-realtime/src/testing/index.ts
+++ b/packages/agents-realtime/src/testing/index.ts
@@ -1,0 +1,20 @@
+export {
+  ScriptedRealtimeTransport,
+  UnexpectedRealtimeCallError,
+  RealtimeCallMatcherError,
+  IncompleteRealtimeScenarioError,
+  RealtimeTransportNotClosedError,
+  ScriptedRealtimeConnectionSupersededError,
+  ScriptedRealtimeScenarioCancelledError,
+} from './scriptedRealtimeTransport';
+
+export type {
+  PendingRealtimeExpectation,
+  PendingRealtimeFailure,
+  RecordedRealtimeTransportCall,
+  RealtimeCallMatcher,
+  RealtimeTransportCallFor,
+  RealtimeTransportMethod,
+  ScriptedRealtimeScenarioContext,
+  ScriptedRealtimeScenarioOptions,
+} from './scriptedRealtimeTransport';

--- a/packages/agents-realtime/src/testing/scriptedRealtimeTransport.ts
+++ b/packages/agents-realtime/src/testing/scriptedRealtimeTransport.ts
@@ -1,0 +1,940 @@
+import type {
+  RealtimeClientMessage,
+  RealtimeSessionConfig,
+  RealtimeUserInput,
+} from '../clientMessages';
+import type {
+  RealtimeItem,
+  RealtimeMcpCallApprovalRequestItem,
+} from '../items';
+import type {
+  RealtimeTransportLayer,
+  RealtimeTransportLayerConnectOptions,
+} from '../transportLayer';
+import type {
+  RealtimeTransportEventTypes,
+  TransportError,
+  TransportToolCallEvent,
+} from '../transportLayerEvents';
+import { snapshotTestingValue } from '@openai/agents-core/utils/internal';
+
+type FunctionKeys<T> = {
+  [TKey in keyof T]-?: NonNullable<T[TKey]> extends (...args: any[]) => any
+    ? TKey
+    : never;
+}[keyof T];
+
+export type RealtimeTransportMethod = Exclude<
+  FunctionKeys<RealtimeTransportLayer>,
+  'emit' | 'off' | 'on' | 'once'
+>;
+
+type DeclaredRealtimeTransportCallData = {
+  connect: {
+    options: Omit<RealtimeTransportLayerConnectOptions, 'apiKey'> & {
+      apiKeyProvided: boolean;
+    };
+  };
+  sendEvent: { event: RealtimeClientMessage };
+  requestResponse: { response?: Record<string, any> };
+  sendMessage: {
+    message: RealtimeUserInput;
+    otherEventData: Record<string, any>;
+    options?: { triggerResponse?: boolean };
+  };
+  addImage: {
+    image: string;
+    options?: { triggerResponse?: boolean };
+  };
+  sendAudio: {
+    audio: ArrayBuffer;
+    options: { commit?: boolean };
+  };
+  updateSessionConfig: { config: Partial<RealtimeSessionConfig> };
+  close: Record<never, never>;
+  mute: { muted: boolean };
+  sendFunctionCallOutput: {
+    toolCall: TransportToolCallEvent;
+    output: string;
+    startResponse: boolean;
+  };
+  interrupt: Record<never, never>;
+  resetHistory: {
+    oldHistory: RealtimeItem[];
+    newHistory: RealtimeItem[];
+  };
+  sendMcpResponse: {
+    approvalRequest: RealtimeMcpCallApprovalRequestItem;
+    approved: boolean;
+    reason?: string;
+  };
+};
+
+type ExactCallDataMap<TData> =
+  TData extends Record<RealtimeTransportMethod, object>
+    ? Exclude<keyof TData, RealtimeTransportMethod> extends never
+      ? TData
+      : never
+    : never;
+
+type RealtimeTransportCallData =
+  ExactCallDataMap<DeclaredRealtimeTransportCallData>;
+
+type RealtimeTransportCall = {
+  [TMethod in RealtimeTransportMethod]: Readonly<
+    { method: TMethod } & RealtimeTransportCallData[TMethod]
+  >;
+}[RealtimeTransportMethod];
+
+type KnownRecordedRealtimeTransportCall = {
+  [TMethod in RealtimeTransportMethod]: Readonly<
+    { index: number; method: TMethod } & RealtimeTransportCallData[TMethod]
+  >;
+}[RealtimeTransportMethod];
+
+/** A forward-compatible summary of an outbound transport call. */
+export type RecordedRealtimeTransportCall = Readonly<{
+  /** The zero-based position of this call in `calls`. */
+  index: number;
+  /** The invoked method. New SDK versions may add method names. */
+  method: string;
+}>;
+
+export type RealtimeTransportCallFor<TMethod extends RealtimeTransportMethod> =
+  Readonly<
+    { index: number; method: TMethod } & RealtimeTransportCallData[TMethod]
+  >;
+
+export type RealtimeCallMatcher<TMethod extends RealtimeTransportMethod> = (
+  call: RealtimeTransportCallFor<TMethod>,
+) => boolean | void;
+
+export type ScriptedRealtimeScenarioContext = {
+  expectCall: <TMethod extends RealtimeTransportMethod>(
+    method: TMethod,
+    matcher?: RealtimeCallMatcher<TMethod>,
+  ) => Promise<RealtimeTransportCallFor<TMethod>>;
+  emit: <TEvent extends keyof RealtimeTransportEventTypes>(
+    event: TEvent,
+    ...args: RealtimeTransportEventTypes[TEvent]
+  ) => boolean;
+};
+
+/** The callbacks and cancellation signal owned by `runScenario()`. */
+export type ScriptedRealtimeScenarioOptions<TResult = void> = {
+  scenario: (context: ScriptedRealtimeScenarioContext) => void | Promise<void>;
+  exercise: () => TResult | Promise<TResult>;
+  signal?: AbortSignal;
+};
+
+export type PendingRealtimeExpectation = Readonly<{
+  order: number;
+  method: RealtimeTransportMethod;
+}>;
+
+export type PendingRealtimeFailure = Readonly<{
+  method: RealtimeTransportMethod;
+  count: number;
+}>;
+
+type PendingExpectation = {
+  order: number;
+  method: RealtimeTransportMethod;
+  matcher?: (call: KnownRecordedRealtimeTransportCall) => boolean | void;
+  resolve: (call: KnownRecordedRealtimeTransportCall) => void;
+  reject: (error: unknown) => void;
+};
+
+type CapturedFailure = { present: false } | { present: true; error: unknown };
+
+type RealtimeTransportListener = (...args: any[]) => void;
+
+type RealtimeTransportListenerRegistration = {
+  listener: RealtimeTransportListener;
+  once: boolean;
+};
+
+export class UnexpectedRealtimeCallError extends Error {
+  /** The zero-based position of the call in `ScriptedRealtimeTransport.calls`. */
+  readonly callIndex: number;
+  readonly expectedMethod: RealtimeTransportMethod;
+  readonly actualMethod: string;
+
+  constructor(
+    expectedMethod: RealtimeTransportMethod,
+    actualCall: RecordedRealtimeTransportCall,
+  ) {
+    super(
+      `ScriptedRealtimeTransport expected ${expectedMethod} but received ${actualCall.method} call #${displayIndex(actualCall.index)}.`,
+    );
+    this.name = 'UnexpectedRealtimeCallError';
+    this.callIndex = actualCall.index;
+    this.expectedMethod = expectedMethod;
+    this.actualMethod = actualCall.method;
+  }
+}
+
+export class RealtimeCallMatcherError extends Error {
+  /** The zero-based position of the call in `ScriptedRealtimeTransport.calls`. */
+  readonly callIndex: number;
+  readonly actualMethod: string;
+
+  constructor(call: RecordedRealtimeTransportCall) {
+    super(
+      `ScriptedRealtimeTransport matcher rejected ${call.method} call #${displayIndex(call.index)}.`,
+    );
+    this.name = 'RealtimeCallMatcherError';
+    this.callIndex = call.index;
+    this.actualMethod = call.method;
+  }
+}
+
+export class IncompleteRealtimeScenarioError extends Error {
+  readonly unconsumedCalls: readonly RecordedRealtimeTransportCall[];
+  readonly pendingExpectations: readonly PendingRealtimeExpectation[];
+  readonly pendingFailures: readonly PendingRealtimeFailure[];
+
+  constructor(
+    unconsumedCalls: readonly RecordedRealtimeTransportCall[],
+    pendingExpectations: readonly PendingRealtimeExpectation[],
+    pendingFailures: readonly PendingRealtimeFailure[],
+  ) {
+    const pendingOrder = pendingExpectations
+      .map((expectation) => `#${expectation.order} ${expectation.method}`)
+      .join(', ');
+    const pendingFailureCount = pendingFailures.reduce(
+      (total, failure) => total + failure.count,
+      0,
+    );
+    super(
+      `ScriptedRealtimeTransport scenario is incomplete: ${unconsumedCalls.length} unconsumed call${unconsumedCalls.length === 1 ? '' : 's'}, ${pendingExpectations.length} pending expectation${pendingExpectations.length === 1 ? '' : 's'}${pendingOrder ? ` (${pendingOrder})` : ''}, and ${pendingFailureCount} pending failure${pendingFailureCount === 1 ? '' : 's'}.`,
+    );
+    this.name = 'IncompleteRealtimeScenarioError';
+    this.unconsumedCalls = Object.freeze([...unconsumedCalls]);
+    this.pendingExpectations = Object.freeze([...pendingExpectations]);
+    this.pendingFailures = Object.freeze([...pendingFailures]);
+  }
+}
+
+export class ScriptedRealtimeScenarioCancelledError extends Error {
+  readonly pendingExpectations: readonly PendingRealtimeExpectation[];
+
+  constructor(pendingExpectations: readonly PendingRealtimeExpectation[]) {
+    const pendingOrder = pendingExpectations
+      .map((expectation) => `#${expectation.order} ${expectation.method}`)
+      .join(', ');
+    super(
+      `ScriptedRealtimeTransport scenario was cancelled${pendingOrder ? ` with pending expectations: ${pendingOrder}` : ''}.`,
+    );
+    this.name = 'AbortError';
+    this.pendingExpectations = Object.freeze([...pendingExpectations]);
+  }
+}
+
+export class RealtimeTransportNotClosedError extends Error {
+  readonly status: ScriptedRealtimeTransport['status'];
+
+  constructor(status: ScriptedRealtimeTransport['status']) {
+    super(
+      `ScriptedRealtimeTransport is not closed; current status is ${status}.`,
+    );
+    this.name = 'RealtimeTransportNotClosedError';
+    this.status = status;
+  }
+}
+
+export class ScriptedRealtimeConnectionSupersededError extends Error {
+  readonly operation = 'connect' as const;
+
+  constructor() {
+    super(
+      'ScriptedRealtimeTransport connection attempt was superseded by another lifecycle operation.',
+    );
+    this.name = 'ScriptedRealtimeConnectionSupersededError';
+  }
+}
+
+/**
+ * An in-memory Realtime transport for deterministic session tests.
+ */
+export class ScriptedRealtimeTransport implements RealtimeTransportLayer {
+  status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting' =
+    'disconnected';
+  muted: boolean | null = false;
+
+  readonly #calls: KnownRecordedRealtimeTransportCall[] = [];
+  readonly #unconsumedCalls: KnownRecordedRealtimeTransportCall[] = [];
+  readonly #expectations: PendingExpectation[] = [];
+  readonly #failures = new Map<RealtimeTransportMethod, unknown[]>();
+  readonly #listeners = new Map<
+    keyof RealtimeTransportEventTypes,
+    RealtimeTransportListenerRegistration[]
+  >();
+  #lifecycleGeneration = 0;
+  #provisionalConnectedGeneration: number | undefined;
+  #nextExpectationOrder = 1;
+
+  /** Registers a synchronous transport event listener. */
+  on<TEvent extends keyof RealtimeTransportEventTypes>(
+    event: TEvent,
+    listener: (...args: RealtimeTransportEventTypes[TEvent]) => void,
+  ): this {
+    this.#addListener(event, listener, false);
+    return this;
+  }
+
+  /** Removes the most recently registered matching listener. */
+  off<TEvent extends keyof RealtimeTransportEventTypes>(
+    event: TEvent,
+    listener: (...args: RealtimeTransportEventTypes[TEvent]) => void,
+  ): this {
+    const registrations = this.#listeners.get(event);
+    if (!registrations) {
+      return this;
+    }
+    for (let index = registrations.length - 1; index >= 0; index -= 1) {
+      if (registrations[index].listener === listener) {
+        registrations.splice(index, 1);
+        break;
+      }
+    }
+    if (registrations.length === 0) {
+      this.#listeners.delete(event);
+    }
+    return this;
+  }
+
+  /** Emits an event synchronously and propagates listener failures. */
+  emit<TEvent extends keyof RealtimeTransportEventTypes>(
+    event: TEvent,
+    ...args: RealtimeTransportEventTypes[TEvent]
+  ): boolean {
+    const registrations = this.#listeners.get(event);
+    if (!registrations || registrations.length === 0) {
+      return false;
+    }
+    for (const registration of [...registrations]) {
+      if (registration.once) {
+        this.#removeListenerRegistration(event, registration);
+      }
+      registration.listener(...args);
+    }
+    return true;
+  }
+
+  /** Registers a synchronous one-time transport event listener. */
+  once<TEvent extends keyof RealtimeTransportEventTypes>(
+    event: TEvent,
+    listener: (...args: RealtimeTransportEventTypes[TEvent]) => void,
+  ): this {
+    this.#addListener(event, listener, true);
+    return this;
+  }
+
+  /** All outbound calls recorded in invocation order. */
+  get calls(): readonly RecordedRealtimeTransportCall[] {
+    return Object.freeze(this.#calls.map(snapshotRecordedRealtimeCall));
+  }
+
+  /** Registers an ordered expectation for the next outbound call. */
+  expectCall<TMethod extends RealtimeTransportMethod>(
+    method: TMethod,
+    matcher?: RealtimeCallMatcher<TMethod>,
+  ): Promise<RealtimeTransportCallFor<TMethod>> {
+    const order = this.#nextExpectationOrder++;
+    const existingCall = this.#unconsumedCalls.shift();
+    if (existingCall) {
+      try {
+        this.#validateExpectation(
+          method,
+          matcher as PendingExpectation['matcher'],
+          snapshotRecordedRealtimeCall(existingCall),
+        );
+        return Promise.resolve(
+          snapshotRecordedRealtimeCall(
+            existingCall,
+          ) as RealtimeTransportCallFor<TMethod>,
+        );
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+
+    return new Promise<RealtimeTransportCallFor<TMethod>>((resolve, reject) => {
+      this.#expectations.push({
+        order,
+        method,
+        matcher: matcher as PendingExpectation['matcher'],
+        resolve: (call) => resolve(call as RealtimeTransportCallFor<TMethod>),
+        reject,
+      });
+    });
+  }
+
+  /** Runs an exercised scenario without relying on a wall-clock timeout. */
+  async runScenario<TResult>(
+    options: ScriptedRealtimeScenarioOptions<TResult>,
+  ): Promise<TResult> {
+    let terminalError: unknown;
+    let active = true;
+    let exerciseCompleted = false;
+    let resolveExpectationFailure!: (outcome: {
+      source: 'expectation';
+      error: unknown;
+    }) => void;
+    const expectationFailureOutcome = new Promise<{
+      source: 'expectation';
+      error: unknown;
+    }>((resolve) => {
+      resolveExpectationFailure = resolve;
+    });
+    const abortError = () =>
+      new ScriptedRealtimeScenarioCancelledError(
+        this.#pendingExpectationDetails(),
+      );
+    if (options.signal?.aborted) {
+      throw abortError();
+    }
+
+    let removeAbortListener = () => {};
+    const abortOutcome = new Promise<{
+      source: 'abort';
+      error: ScriptedRealtimeScenarioCancelledError;
+    }>((resolve) => {
+      if (!options.signal) {
+        return;
+      }
+      const listener = () => resolve({ source: 'abort', error: abortError() });
+      options.signal.addEventListener('abort', listener, { once: true });
+      removeAbortListener = () =>
+        options.signal?.removeEventListener('abort', listener);
+    });
+    const settleOwnedExpectationFailure = (error: unknown) => {
+      if (!active) {
+        return;
+      }
+      terminalError = error;
+      active = false;
+      this.#rejectPendingExpectations(error);
+      resolveExpectationFailure({ source: 'expectation', error });
+    };
+
+    const context: ScriptedRealtimeScenarioContext = {
+      expectCall: (method, matcher) => {
+        if (!active) {
+          return Promise.reject(terminalError);
+        }
+        const expectation = this.expectCall(method, matcher);
+        void expectation.catch(settleOwnedExpectationFailure);
+        if (exerciseCompleted && this.#expectations.length > 0) {
+          settleOwnedExpectationFailure(this.#createIncompleteError());
+        }
+        return expectation;
+      },
+      emit: this.emit.bind(this),
+    };
+    const assertCompleteOrTerminate = () => {
+      if (!active) {
+        throw terminalError;
+      }
+      try {
+        this.assertComplete();
+      } catch (error) {
+        terminalError = error;
+        active = false;
+        this.#rejectPendingExpectations(error);
+        throw error;
+      }
+    };
+
+    const scenarioOutcome = Promise.resolve()
+      .then(() => options.scenario(context))
+      .then(
+        () => ({ source: 'scenario' as const, status: 'fulfilled' as const }),
+        (error: unknown) => ({
+          source: 'scenario' as const,
+          status: 'rejected' as const,
+          error,
+        }),
+      );
+    const exerciseOutcome = Promise.resolve()
+      .then(() => options.exercise())
+      .then(
+        (value) => {
+          exerciseCompleted = true;
+          return {
+            source: 'exercise' as const,
+            status: 'fulfilled' as const,
+            value,
+          };
+        },
+        (error: unknown) => ({
+          source: 'exercise' as const,
+          status: 'rejected' as const,
+          error,
+        }),
+      );
+
+    try {
+      const first = await Promise.race([
+        scenarioOutcome,
+        exerciseOutcome,
+        abortOutcome,
+        expectationFailureOutcome,
+      ]);
+      if (first.source === 'abort') {
+        terminalError = first.error;
+        active = false;
+        this.#rejectPendingExpectations(first.error);
+        throw first.error;
+      }
+      if (first.source === 'expectation') {
+        throw first.error;
+      }
+      if (first.status === 'rejected') {
+        terminalError = first.error;
+        active = false;
+        this.#rejectPendingExpectations(first.error);
+        throw first.error;
+      }
+
+      if (first.source === 'exercise') {
+        const immediateScenarioResult = await Promise.race([
+          scenarioOutcome,
+          Promise.resolve({ source: 'pending' as const }),
+        ]);
+        if (immediateScenarioResult.source === 'scenario') {
+          if (immediateScenarioResult.status === 'rejected') {
+            terminalError = immediateScenarioResult.error;
+            active = false;
+            this.#rejectPendingExpectations(immediateScenarioResult.error);
+            throw immediateScenarioResult.error;
+          }
+          assertCompleteOrTerminate();
+          return first.value;
+        }
+        if (this.#expectations.length > 0) {
+          const error = this.#createIncompleteError();
+          terminalError = error;
+          active = false;
+          this.#rejectPendingExpectations(error);
+          throw error;
+        }
+        const scenarioResult = await Promise.race([
+          scenarioOutcome,
+          abortOutcome,
+          expectationFailureOutcome,
+        ]);
+        if (scenarioResult.source === 'abort') {
+          terminalError = scenarioResult.error;
+          active = false;
+          this.#rejectPendingExpectations(scenarioResult.error);
+          throw scenarioResult.error;
+        }
+        if (scenarioResult.source === 'expectation') {
+          throw scenarioResult.error;
+        }
+        if (scenarioResult.status === 'rejected') {
+          terminalError = scenarioResult.error;
+          active = false;
+          this.#rejectPendingExpectations(scenarioResult.error);
+          throw scenarioResult.error;
+        }
+        assertCompleteOrTerminate();
+        return first.value;
+      }
+
+      const exerciseResult = await Promise.race([
+        exerciseOutcome,
+        abortOutcome,
+        expectationFailureOutcome,
+      ]);
+      if (exerciseResult.source === 'abort') {
+        terminalError = exerciseResult.error;
+        active = false;
+        this.#rejectPendingExpectations(exerciseResult.error);
+        throw exerciseResult.error;
+      }
+      if (exerciseResult.source === 'expectation') {
+        throw exerciseResult.error;
+      }
+      if (exerciseResult.status === 'rejected') {
+        terminalError = exerciseResult.error;
+        active = false;
+        this.#rejectPendingExpectations(exerciseResult.error);
+        throw exerciseResult.error;
+      }
+      assertCompleteOrTerminate();
+      return exerciseResult.value;
+    } finally {
+      active = false;
+      removeAbortListener();
+    }
+  }
+
+  /** Makes the next call to a transport method throw the supplied error. */
+  failNextCall(method: RealtimeTransportMethod, error: unknown): void {
+    const failures = this.#failures.get(method) ?? [];
+    failures.push(error);
+    this.#failures.set(method, failures);
+  }
+
+  /** Emits a controlled terminal disconnect and optional transport error. */
+  disconnect(error?: unknown): void {
+    this.#lifecycleGeneration += 1;
+    let notificationFailure: CapturedFailure = { present: false };
+    if (this.status !== 'disconnected') {
+      this.status = 'disconnected';
+      try {
+        this.emit('connection_change', 'disconnected');
+      } catch (caughtError) {
+        notificationFailure = { present: true, error: caughtError };
+      }
+    }
+    if (typeof error !== 'undefined') {
+      const transportError: TransportError = { type: 'error', error };
+      try {
+        this.emit('error', transportError);
+      } catch (caughtError) {
+        if (!notificationFailure.present) {
+          notificationFailure = { present: true, error: caughtError };
+        }
+      }
+    }
+    if (notificationFailure.present) {
+      throw notificationFailure.error;
+    }
+  }
+
+  /** Throws when calls or expectations remain unmatched. */
+  assertComplete(): void {
+    if (
+      this.#unconsumedCalls.length > 0 ||
+      this.#expectations.length > 0 ||
+      this.#failures.size > 0
+    ) {
+      throw this.#createIncompleteError();
+    }
+  }
+
+  /** Throws unless the transport is disconnected. */
+  assertClosed(): void {
+    if (this.status !== 'disconnected') {
+      throw new RealtimeTransportNotClosedError(this.status);
+    }
+  }
+
+  async connect(options: RealtimeTransportLayerConnectOptions): Promise<void> {
+    const generation = ++this.#lifecycleGeneration;
+    try {
+      this.status = 'connecting';
+      this.#recordAndThrowNextFailure({
+        method: 'connect',
+        options: {
+          model: options.model,
+          url: options.url,
+          callId: options.callId,
+          initialSessionConfig: options.initialSessionConfig,
+          apiKeyProvided: typeof options.apiKey !== 'undefined',
+        },
+      });
+      this.#assertCurrentConnectionAttempt(generation, 'connecting');
+      const connectingNotificationFailure =
+        this.#emitConnectionChange('connecting');
+      if (connectingNotificationFailure.present) {
+        throw connectingNotificationFailure.error;
+      }
+      this.#assertCurrentConnectionAttempt(generation, 'connecting');
+      this.status = 'connected';
+      this.#provisionalConnectedGeneration = generation;
+      const connectedNotificationFailure =
+        this.#emitConnectionChange('connected');
+      if (connectedNotificationFailure.present) {
+        throw connectedNotificationFailure.error;
+      }
+      this.#assertCurrentConnectionAttempt(generation, 'connected');
+      this.#provisionalConnectedGeneration = undefined;
+    } catch (error) {
+      if (this.#lifecycleGeneration === generation) {
+        this.#lifecycleGeneration += 1;
+        this.status = 'disconnected';
+        try {
+          this.emit('connection_change', 'disconnected');
+        } catch {
+          // Preserve the primary connection failure.
+        }
+      }
+      throw error;
+    } finally {
+      if (this.#provisionalConnectedGeneration === generation) {
+        this.#provisionalConnectedGeneration = undefined;
+      }
+    }
+  }
+
+  sendEvent(event: RealtimeClientMessage): void {
+    this.#recordAndThrowNextFailure({ method: 'sendEvent', event });
+  }
+
+  requestResponse(response?: Record<string, any>): void {
+    this.#recordAndThrowNextFailure({ method: 'requestResponse', response });
+  }
+
+  sendMessage(
+    message: RealtimeUserInput,
+    otherEventData: Record<string, any>,
+    options?: { triggerResponse?: boolean },
+  ): void {
+    this.#recordAndThrowNextFailure({
+      method: 'sendMessage',
+      message,
+      otherEventData,
+      options,
+    });
+  }
+
+  addImage(image: string, options?: { triggerResponse?: boolean }): void {
+    this.#recordAndThrowNextFailure({ method: 'addImage', image, options });
+  }
+
+  sendAudio(audio: ArrayBuffer, options: { commit?: boolean }): void {
+    this.#recordAndThrowNextFailure({ method: 'sendAudio', audio, options });
+  }
+
+  updateSessionConfig(config: Partial<RealtimeSessionConfig>): void {
+    this.#recordAndThrowNextFailure({ method: 'updateSessionConfig', config });
+  }
+
+  close(): void {
+    if (this.status === 'disconnected') {
+      return;
+    }
+
+    const generation = ++this.#lifecycleGeneration;
+    const previousStatus = this.status;
+    const previousConnectionWasEstablished =
+      previousStatus === 'connected' &&
+      typeof this.#provisionalConnectedGeneration === 'undefined';
+    this.status = 'disconnecting';
+    try {
+      this.#recordAndThrowNextFailure({ method: 'close' });
+      if (
+        this.#lifecycleGeneration !== generation ||
+        this.status !== 'disconnecting'
+      ) {
+        return;
+      }
+      this.status = 'disconnected';
+      this.emit('connection_change', 'disconnected');
+    } catch (error) {
+      if (
+        this.#lifecycleGeneration === generation &&
+        this.status === 'disconnecting'
+      ) {
+        this.status = previousConnectionWasEstablished
+          ? 'connected'
+          : 'disconnected';
+        if (this.status === 'disconnected') {
+          try {
+            this.emit('connection_change', 'disconnected');
+          } catch {
+            // Preserve the primary close failure.
+          }
+        }
+      }
+      throw error;
+    }
+  }
+
+  mute(muted: boolean): void {
+    this.#recordAndThrowNextFailure({ method: 'mute', muted });
+    this.muted = muted;
+  }
+
+  sendFunctionCallOutput(
+    toolCall: TransportToolCallEvent,
+    output: string,
+    startResponse: boolean,
+  ): void {
+    this.#recordAndThrowNextFailure({
+      method: 'sendFunctionCallOutput',
+      toolCall,
+      output,
+      startResponse,
+    });
+  }
+
+  interrupt(): void {
+    this.#recordAndThrowNextFailure({ method: 'interrupt' });
+  }
+
+  resetHistory(oldHistory: RealtimeItem[], newHistory: RealtimeItem[]): void {
+    this.#recordAndThrowNextFailure({
+      method: 'resetHistory',
+      oldHistory,
+      newHistory,
+    });
+  }
+
+  sendMcpResponse(
+    approvalRequest: RealtimeMcpCallApprovalRequestItem,
+    approved: boolean,
+    reason?: string,
+  ): void {
+    this.#recordAndThrowNextFailure({
+      method: 'sendMcpResponse',
+      approvalRequest,
+      approved,
+      reason,
+    });
+  }
+
+  #record(call: RealtimeTransportCall): void {
+    const callSnapshot = snapshotTestingValue(call);
+    const recordedCall = Object.freeze({
+      ...callSnapshot,
+      index: this.#calls.length,
+    }) as KnownRecordedRealtimeTransportCall;
+    this.#calls.push(recordedCall);
+
+    const expectation = this.#expectations.shift();
+    if (!expectation) {
+      this.#unconsumedCalls.push(recordedCall);
+      return;
+    }
+
+    try {
+      this.#validateExpectation(
+        expectation.method,
+        expectation.matcher,
+        snapshotRecordedRealtimeCall(recordedCall),
+      );
+      expectation.resolve(snapshotRecordedRealtimeCall(recordedCall));
+    } catch (error) {
+      expectation.reject(error);
+      throw error;
+    }
+  }
+
+  #addListener<TEvent extends keyof RealtimeTransportEventTypes>(
+    event: TEvent,
+    listener: (...args: RealtimeTransportEventTypes[TEvent]) => void,
+    once: boolean,
+  ): void {
+    const registrations = this.#listeners.get(event) ?? [];
+    registrations.push({
+      listener: listener as RealtimeTransportListener,
+      once,
+    });
+    this.#listeners.set(event, registrations);
+  }
+
+  #removeListenerRegistration(
+    event: keyof RealtimeTransportEventTypes,
+    registration: RealtimeTransportListenerRegistration,
+  ): void {
+    const registrations = this.#listeners.get(event);
+    if (!registrations) {
+      return;
+    }
+    const index = registrations.indexOf(registration);
+    if (index !== -1) {
+      registrations.splice(index, 1);
+    }
+    if (registrations.length === 0) {
+      this.#listeners.delete(event);
+    }
+  }
+
+  #validateExpectation(
+    method: RealtimeTransportMethod,
+    matcher: PendingExpectation['matcher'],
+    call: KnownRecordedRealtimeTransportCall,
+  ): void {
+    if (call.method !== method) {
+      throw new UnexpectedRealtimeCallError(method, call);
+    }
+    if (matcher && matcher(call) === false) {
+      throw new RealtimeCallMatcherError(call);
+    }
+  }
+
+  #recordAndThrowNextFailure(call: RealtimeTransportCall): void {
+    const failure = this.#takeNextFailure(call.method);
+    this.#record(call);
+    if (failure.present) {
+      throw failure.error;
+    }
+  }
+
+  #takeNextFailure(method: RealtimeTransportMethod): CapturedFailure {
+    const failures = this.#failures.get(method);
+    if (!failures || failures.length === 0) {
+      return { present: false };
+    }
+    const error = failures.shift();
+    if (failures.length === 0) {
+      this.#failures.delete(method);
+    }
+    return { present: true, error };
+  }
+
+  #emitConnectionChange(status: 'connected' | 'connecting'): CapturedFailure {
+    try {
+      this.emit('connection_change', status);
+      return { present: false };
+    } catch (error) {
+      return { present: true, error };
+    }
+  }
+
+  #assertCurrentConnectionAttempt(
+    generation: number,
+    expectedStatus: 'connecting' | 'connected',
+  ): void {
+    if (
+      this.#lifecycleGeneration !== generation ||
+      this.status !== expectedStatus
+    ) {
+      throw new ScriptedRealtimeConnectionSupersededError();
+    }
+  }
+
+  #pendingExpectationDetails(): PendingRealtimeExpectation[] {
+    return this.#expectations.map(({ order, method }) => ({ order, method }));
+  }
+
+  #pendingFailureDetails(): PendingRealtimeFailure[] {
+    return Array.from(this.#failures, ([method, failures]) => ({
+      method,
+      count: failures.length,
+    }));
+  }
+
+  #createIncompleteError(): IncompleteRealtimeScenarioError {
+    return new IncompleteRealtimeScenarioError(
+      this.#unconsumedCalls.map(({ index, method }) => ({ index, method })),
+      this.#pendingExpectationDetails(),
+      this.#pendingFailureDetails(),
+    );
+  }
+
+  #rejectPendingExpectations(error: unknown): void {
+    const expectations = this.#expectations.splice(0);
+    for (const expectation of expectations) {
+      expectation.reject(error);
+    }
+  }
+}
+
+function snapshotRecordedRealtimeCall(
+  call: KnownRecordedRealtimeTransportCall,
+): KnownRecordedRealtimeTransportCall {
+  return Object.freeze(
+    snapshotTestingValue(call),
+  ) as KnownRecordedRealtimeTransportCall;
+}
+
+function displayIndex(index: number): number {
+  return index + 1;
+}

--- a/packages/agents-realtime/test/stubs.ts
+++ b/packages/agents-realtime/test/stubs.ts
@@ -1,14 +1,6 @@
-import {
-  Agent,
-  Model,
-  ModelProvider,
-  ModelRequest,
-  ModelResponse,
-  protocol,
-  tool,
-  Usage,
-} from '@openai/agents-core';
+import { protocol, tool } from '@openai/agents-core';
 import { RuntimeEventEmitter } from '@openai/agents-core/_shims';
+import { assistantMessage } from '@openai/agents-core/testing';
 import { EventEmitterDelegate } from '@openai/agents-core/utils';
 import { z } from 'zod';
 import type {
@@ -24,67 +16,14 @@ import type {
 import type { TransportToolCallEvent } from '../src/transportLayerEvents';
 import { RealtimeTransportEventTypes } from '../src/transportLayerEvents';
 
-export const TEST_MODEL_MESSAGE: protocol.AssistantMessageItem = {
-  id: '123',
-  status: 'completed' as const,
-  type: 'message' as const,
-  role: 'assistant' as const,
-  content: [
-    {
-      type: 'output_text' as const,
-      text: 'Hello World',
-      providerData: {
-        annotations: [],
-      },
-    },
-  ],
-};
+const TEST_MODEL_MESSAGE: protocol.AssistantMessageItem = assistantMessage(
+  'Hello World',
+  { id: '123' },
+);
 
 export function fakeModelMessage(text: string): protocol.AssistantMessageItem {
-  return {
-    ...TEST_MODEL_MESSAGE,
-    content: [
-      {
-        type: 'output_text' as const,
-        text,
-        providerData: {
-          annotations: [],
-        },
-      },
-    ],
-  };
+  return assistantMessage(text, { id: TEST_MODEL_MESSAGE.id });
 }
-
-export const TEST_MODEL_FUNCTION_CALL: protocol.FunctionCallItem = {
-  id: '123',
-  type: 'function_call' as const,
-  name: 'test',
-  callId: '123',
-  status: 'completed',
-  arguments: '{"test": "test"}',
-};
-
-export const TEST_MODEL_RESPONSE_WITH_FUNCTION: ModelResponse = {
-  output: [{ ...TEST_MODEL_FUNCTION_CALL }, { ...TEST_MODEL_MESSAGE }],
-  usage: new Usage(),
-};
-
-export const TEST_MODEL_RESPONSE_BASIC: ModelResponse = {
-  output: [{ ...TEST_MODEL_MESSAGE }],
-  usage: new Usage(),
-};
-
-export const TEST_AGENT = new Agent({
-  name: 'TestAgent',
-  instructions: 'Test instructions',
-  handoffDescription: 'Test handoff description',
-  handoffs: [],
-  model: 'gpt-4o',
-  modelSettings: {
-    temperature: 0.5,
-    maxTokens: 100,
-  },
-});
 
 export const TEST_TOOL = tool({
   name: 'test',
@@ -96,31 +35,6 @@ export const TEST_TOOL = tool({
     return 'Hello World';
   },
 });
-
-export class FakeModel implements Model {
-  constructor(private _responses: ModelResponse[] = []) {}
-
-  async getResponse(_request: ModelRequest): Promise<ModelResponse> {
-    const response = this._responses.shift();
-    if (!response) {
-      throw new Error('No response found');
-    }
-    return response;
-  }
-
-  /* eslint-disable require-yield */
-  async *getStreamedResponse(
-    _request: ModelRequest,
-  ): AsyncIterable<protocol.StreamEvent> {
-    throw new Error('Not implemented');
-  }
-}
-
-export class FakeModelProvider implements ModelProvider {
-  async getModel(_name: string): Promise<Model> {
-    return new FakeModel([TEST_MODEL_RESPONSE_BASIC]);
-  }
-}
 
 export class FakeTransport
   extends EventEmitterDelegate<RealtimeTransportEventTypes>

--- a/packages/agents-realtime/test/testing/scriptedRealtimeTransport.test.ts
+++ b/packages/agents-realtime/test/testing/scriptedRealtimeTransport.test.ts
@@ -1,0 +1,1113 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RealtimeAgent } from '../../src/realtimeAgent';
+import { RealtimeSession } from '../../src/realtimeSession';
+import {
+  IncompleteRealtimeScenarioError,
+  RealtimeCallMatcherError,
+  RealtimeTransportNotClosedError,
+  ScriptedRealtimeScenarioCancelledError,
+  ScriptedRealtimeTransport,
+  UnexpectedRealtimeCallError,
+  type RealtimeTransportCallFor,
+  type ScriptedRealtimeScenarioContext,
+} from '../../src/testing';
+
+describe('ScriptedRealtimeTransport', () => {
+  it('drives a session with ordered calls and typed events', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const outputDeltas: string[] = [];
+    transport.on('output_text_delta', (event) => {
+      outputDeltas.push(event.delta);
+    });
+    const session = new RealtimeSession(
+      new RealtimeAgent({ name: 'Assistant' }),
+      { transport },
+    );
+
+    await transport.runScenario({
+      scenario: async ({ expectCall, emit }) => {
+        await expectCall('connect', (call) => {
+          expect(call.options.apiKeyProvided).toBe(true);
+          expect(call.options).not.toHaveProperty('apiKey');
+          expect(call.options.initialSessionConfig).toBeDefined();
+        });
+        await expectCall('sendMessage', (call) => {
+          expect(call.message).toBe('Hello');
+          expect(call.otherEventData).toEqual({ source: 'test' });
+        });
+        emit('turn_started', {
+          type: 'response_started',
+          providerData: { response: { id: 'response_1' } },
+        });
+        emit('output_text_delta', {
+          type: 'output_text_delta',
+          responseId: 'response_1',
+          itemId: 'item_1',
+          delta: 'Hi',
+        });
+        await expectCall('close');
+      },
+      exercise: async () => {
+        await session.connect({ apiKey: 'test' });
+        session.sendMessage('Hello', { source: 'test' });
+        session.close();
+      },
+    });
+
+    expect(outputDeltas).toEqual(['Hi']);
+    expect(transport.calls.map((call) => call.method)).toEqual([
+      'connect',
+      'sendMessage',
+      'close',
+    ]);
+    expect(() => transport.assertComplete()).not.toThrow();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('matches calls that occurred before the expectation was registered', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    transport.sendEvent({ type: 'session.update', session: {} });
+
+    const call = await transport.expectCall('sendEvent');
+
+    expect(call).toMatchObject({
+      index: 0,
+      event: { type: 'session.update' },
+    });
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('rejects an unexpected call without a time-based wait', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await expect(
+      transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          await expectCall('sendMessage');
+        },
+        exercise: () => {
+          expect(() =>
+            transport.sendAudio(new ArrayBuffer(1), { commit: true }),
+          ).toThrow(UnexpectedRealtimeCallError);
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: 'UnexpectedRealtimeCallError',
+      callIndex: 0,
+      expectedMethod: 'sendMessage',
+      actualMethod: 'sendAudio',
+    });
+  });
+
+  it('fails when a call matcher returns false', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await expect(
+      transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          await expectCall('mute', () => false);
+        },
+        exercise: () => {
+          expect(() => transport.mute(true)).toThrow(RealtimeCallMatcherError);
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: 'RealtimeCallMatcherError',
+      callIndex: 0,
+      actualMethod: 'mute',
+    });
+  });
+
+  it('finishes with pending expectation details when the exercise completes', async () => {
+    const transport = new ScriptedRealtimeTransport();
+
+    await expect(
+      transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          await expectCall('sendMessage');
+        },
+        exercise: () => {},
+      }),
+    ).rejects.toMatchObject({
+      name: 'IncompleteRealtimeScenarioError',
+      pendingExpectations: [{ order: 1, method: 'sendMessage' }],
+    });
+
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('settles an unawaited expectation when completion is incomplete', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    let expectationFailure: Promise<unknown> | undefined;
+    let runFailure: unknown;
+
+    try {
+      await transport.runScenario({
+        scenario: ({ expectCall }) => {
+          expectationFailure = expectCall('mute').catch((error) => error);
+        },
+        exercise: () => {},
+      });
+    } catch (error) {
+      runFailure = error;
+    }
+
+    expect(runFailure).toBeInstanceOf(IncompleteRealtimeScenarioError);
+    await expect(expectationFailure).resolves.toBe(runFailure);
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it.each(['awaited', 'unawaited'] as const)(
+    'rejects an %s expectation registered after exercise completion',
+    async (handling) => {
+      const transport = new ScriptedRealtimeTransport();
+      let markScenarioWaiting!: () => void;
+      let markExerciseCalled!: () => void;
+      let releaseScenario!: () => void;
+      const scenarioWaiting = new Promise<void>((resolve) => {
+        markScenarioWaiting = resolve;
+      });
+      const exerciseCalled = new Promise<void>((resolve) => {
+        markExerciseCalled = resolve;
+      });
+      const scenarioGate = new Promise<void>((resolve) => {
+        releaseScenario = resolve;
+      });
+      const run = transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          markScenarioWaiting();
+          await scenarioGate;
+          const expectation = expectCall('mute');
+          if (handling === 'awaited') {
+            await expectation;
+          } else {
+            void expectation.catch(() => {});
+          }
+        },
+        exercise: () => {
+          markExerciseCalled();
+        },
+      });
+
+      await Promise.all([scenarioWaiting, exerciseCalled]);
+      await Promise.resolve();
+      releaseScenario();
+
+      await expect(run).rejects.toMatchObject({
+        name: 'IncompleteRealtimeScenarioError',
+        pendingExpectations: [{ order: 1, method: 'mute' }],
+      });
+      expect(() => transport.assertComplete()).not.toThrow();
+    },
+  );
+
+  it('rejects when a scenario catches a late expectation and stays pending', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    let markScenarioWaiting!: () => void;
+    let markExerciseCalled!: () => void;
+    let releaseScenario!: () => void;
+    let expectationFailure: unknown;
+    const scenarioWaiting = new Promise<void>((resolve) => {
+      markScenarioWaiting = resolve;
+    });
+    const exerciseCalled = new Promise<void>((resolve) => {
+      markExerciseCalled = resolve;
+    });
+    const scenarioGate = new Promise<void>((resolve) => {
+      releaseScenario = resolve;
+    });
+    const neverSettles = new Promise<void>(() => {});
+    const run = transport.runScenario({
+      scenario: async ({ expectCall }) => {
+        markScenarioWaiting();
+        await scenarioGate;
+        await expectCall('mute').catch((error) => {
+          expectationFailure = error;
+        });
+        await neverSettles;
+      },
+      exercise: () => {
+        markExerciseCalled();
+      },
+    });
+
+    await Promise.all([scenarioWaiting, exerciseCalled]);
+    await Promise.resolve();
+    releaseScenario();
+
+    let runFailure: unknown;
+    try {
+      await run;
+    } catch (error) {
+      runFailure = error;
+    }
+    expect(runFailure).toBeInstanceOf(IncompleteRealtimeScenarioError);
+    expect(expectationFailure).toBe(runFailure);
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('lets a late expectation consume a call recorded by the exercise', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    let markScenarioWaiting!: () => void;
+    let releaseScenario!: () => void;
+    const scenarioWaiting = new Promise<void>((resolve) => {
+      markScenarioWaiting = resolve;
+    });
+    const scenarioGate = new Promise<void>((resolve) => {
+      releaseScenario = resolve;
+    });
+    const run = transport.runScenario({
+      scenario: async ({ expectCall }) => {
+        markScenarioWaiting();
+        await scenarioGate;
+        await expectCall('mute', (call) => {
+          expect(call.muted).toBe(true);
+        });
+      },
+      exercise: () => {
+        transport.mute(true);
+      },
+    });
+
+    await scenarioWaiting;
+    await Promise.resolve();
+    releaseScenario();
+
+    await expect(run).resolves.toBeUndefined();
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it.each([
+    {
+      name: 'wrong method',
+      expectLateCall: (
+        expectCall: ScriptedRealtimeScenarioContext['expectCall'],
+      ) => expectCall('sendMessage'),
+      errorName: 'UnexpectedRealtimeCallError',
+    },
+    {
+      name: 'failing matcher',
+      expectLateCall: (
+        expectCall: ScriptedRealtimeScenarioContext['expectCall'],
+      ) => expectCall('mute', () => false),
+      errorName: 'RealtimeCallMatcherError',
+    },
+  ])(
+    'rejects an unawaited late $name expectation after exercise completion',
+    async ({ expectLateCall, errorName }) => {
+      const transport = new ScriptedRealtimeTransport();
+      let markScenarioWaiting!: () => void;
+      let releaseScenario!: () => void;
+      const scenarioWaiting = new Promise<void>((resolve) => {
+        markScenarioWaiting = resolve;
+      });
+      const scenarioGate = new Promise<void>((resolve) => {
+        releaseScenario = resolve;
+      });
+      const run = transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          markScenarioWaiting();
+          await scenarioGate;
+          void expectLateCall(expectCall).catch(() => {});
+        },
+        exercise: () => {
+          transport.mute(true);
+        },
+      });
+
+      await scenarioWaiting;
+      await Promise.resolve();
+      releaseScenario();
+
+      await expect(run).rejects.toMatchObject({ name: errorName });
+      expect(() => transport.assertComplete()).not.toThrow();
+    },
+  );
+
+  it('settles pending expectations with the original exercise failure', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const exerciseFailure = new Error('exercise failed');
+
+    await expect(
+      transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          await expectCall('sendMessage');
+        },
+        exercise: () => {
+          throw exerciseFailure;
+        },
+      }),
+    ).rejects.toBe(exerciseFailure);
+
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('settles pending expectations with the original scenario failure', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const scenarioFailure = new Error('scenario failed');
+
+    await expect(
+      transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          void expectCall('sendMessage').catch(() => {});
+          throw scenarioFailure;
+        },
+        exercise: () => {},
+      }),
+    ).rejects.toBe(scenarioFailure);
+
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('cancels a scenario explicitly without a default timer', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const controller = new AbortController();
+
+    await expect(
+      transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          await expectCall('sendMessage');
+        },
+        exercise: () => controller.abort(),
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({
+      name: 'AbortError',
+      pendingExpectations: [{ order: 1, method: 'sendMessage' }],
+    });
+
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('does not start callbacks for a pre-cancelled scenario', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const controller = new AbortController();
+    const scenario = vi.fn();
+    const exercise = vi.fn();
+    controller.abort();
+
+    await expect(
+      transport.runScenario({ scenario, exercise, signal: controller.signal }),
+    ).rejects.toBeInstanceOf(ScriptedRealtimeScenarioCancelledError);
+    expect(scenario).not.toHaveBeenCalled();
+    expect(exercise).not.toHaveBeenCalled();
+  });
+
+  it('preserves a matcher-thrown value unchanged', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const assertionFailure = new Error('assertion failed');
+
+    await expect(
+      transport.runScenario({
+        scenario: async ({ expectCall }) => {
+          await expectCall('mute', () => {
+            throw assertionFailure;
+          });
+        },
+        exercise: () => {
+          try {
+            transport.mute(true);
+          } catch (error) {
+            expect(error).toBe(assertionFailure);
+          }
+        },
+      }),
+    ).rejects.toBe(assertionFailure);
+  });
+
+  it('consumes an injected failure when matcher validation fails', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const injectedFailure = new Error('injected failure');
+    const matcherFailure = new Error('matcher failure');
+    transport.failNextCall('mute', injectedFailure);
+    const firstCall = transport.expectCall('mute', () => {
+      throw matcherFailure;
+    });
+
+    expect(() => transport.mute(true)).toThrow(matcherFailure);
+    await expect(firstCall).rejects.toBe(matcherFailure);
+    expect(() => transport.assertComplete()).not.toThrow();
+
+    const secondCall = transport.expectCall('mute');
+    expect(() => transport.mute(false)).not.toThrow();
+    await expect(secondCall).resolves.toMatchObject({ muted: false });
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it.each(['pending', 'already recorded'] as const)(
+    'isolates canonical history from %s expectation consumers',
+    async (registration) => {
+      const transport = new ScriptedRealtimeTransport();
+      const response = { nested: { value: 1 } };
+      const matcher = (call: RealtimeTransportCallFor<'requestResponse'>) => {
+        (call.response as typeof response).nested.value = 9;
+      };
+      let expectedCall: Promise<RealtimeTransportCallFor<'requestResponse'>>;
+
+      if (registration === 'pending') {
+        expectedCall = transport.expectCall('requestResponse', matcher);
+        transport.requestResponse(response);
+      } else {
+        transport.requestResponse(response);
+        expectedCall = transport.expectCall('requestResponse', matcher);
+      }
+
+      const exposedCall = await expectedCall;
+      expect(exposedCall.response?.nested.value).toBe(1);
+      exposedCall.response!.nested.value = 8;
+      expect(
+        (
+          transport
+            .calls[0] as unknown as RealtimeTransportCallFor<'requestResponse'>
+        ).response?.nested.value,
+      ).toBe(1);
+      expect(() => transport.assertComplete()).not.toThrow();
+    },
+  );
+
+  it('records invocation-time containers and immutable history indexes', async () => {
+    class RuntimeToken {}
+    const transport = new ScriptedRealtimeTransport();
+    const runtimeToken = new RuntimeToken();
+    const cycle: { value: number; self?: unknown } = { value: 1 };
+    cycle.self = cycle;
+    const ownProto = JSON.parse('{"__proto__":{"value":"snapshot"}}') as Record<
+      string,
+      unknown
+    >;
+    const response = { cycle, aliases: [cycle], runtimeToken, ownProto };
+    const audio = new Uint8Array([1, 2, 3]).buffer;
+    const responseCall = transport.expectCall('requestResponse');
+    transport.requestResponse(response);
+    const audioCall = transport.expectCall('sendAudio');
+    transport.sendAudio(audio, { commit: true });
+
+    cycle.value = 9;
+    new Uint8Array(audio)[0] = 9;
+    const recordedResponse = await responseCall;
+    const recordedAudio = await audioCall;
+    const recordedCycle = recordedResponse.response?.cycle as typeof cycle;
+
+    expect(recordedCycle.value).toBe(1);
+    expect(recordedCycle.self).toBe(recordedCycle);
+    expect(recordedResponse.response?.aliases[0]).toBe(recordedCycle);
+    expect(recordedResponse.response?.runtimeToken).toBe(runtimeToken);
+    expect(Object.getPrototypeOf(recordedResponse.response?.ownProto)).toBe(
+      Object.prototype,
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        recordedResponse.response?.ownProto,
+        '__proto__',
+      ),
+    ).toBe(true);
+    expect(recordedResponse.response?.ownProto.__proto__).toEqual({
+      value: 'snapshot',
+    });
+    expect(new Uint8Array(recordedAudio.audio)[0]).toBe(1);
+    expect(() =>
+      (transport.calls as Array<{ index: number; method: string }>).pop(),
+    ).toThrow(TypeError);
+
+    const nextCall = transport.expectCall('mute');
+    transport.mute(true);
+    await expect(nextCall).resolves.toMatchObject({ index: 2 });
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('injects a connect failure and restores disconnected state', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const error = new Error('connect failed');
+    transport.failNextCall('connect', error);
+    const expectedCall = transport.expectCall('connect');
+
+    await expect(transport.connect({ apiKey: 'test' })).rejects.toBe(error);
+    await expect(expectedCall).resolves.toMatchObject({ method: 'connect' });
+    expect(transport.status).toBe('disconnected');
+    expect(() => transport.assertComplete()).not.toThrow();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('reserves a connect failure before a reentrant matcher call', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const injectedFailure = new Error('outer connect failed');
+    let nestedConnect: Promise<void> | undefined;
+    transport.failNextCall('connect', injectedFailure);
+    const outerCall = transport.expectCall('connect', () => {
+      nestedConnect = transport.connect({ apiKey: 'nested' });
+    });
+
+    await expect(transport.connect({ apiKey: 'outer' })).rejects.toBe(
+      injectedFailure,
+    );
+    await outerCall;
+    await expect(nestedConnect).resolves.toBeUndefined();
+    await expect(transport.expectCall('connect')).resolves.toMatchObject({
+      index: 1,
+      method: 'connect',
+    });
+    expect(transport.status).toBe('connected');
+    transport.disconnect();
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('reserves a close failure before a reentrant matcher call', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.connect({ apiKey: 'test' });
+    await transport.expectCall('connect');
+    const injectedFailure = new Error('outer close failed');
+    transport.failNextCall('close', injectedFailure);
+    const outerCall = transport.expectCall('close', () => {
+      transport.close();
+    });
+
+    expect(() => transport.close()).toThrow(injectedFailure);
+    await outerCall;
+    await expect(transport.expectCall('close')).resolves.toMatchObject({
+      index: 2,
+      method: 'close',
+    });
+    expect(transport.status).toBe('disconnected');
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it.each(['connect matcher', 'connecting notification'] as const)(
+    'restores disconnected state when a failed close supersedes an in-flight connection from the %s',
+    async (trigger) => {
+      const transport = new ScriptedRealtimeTransport();
+      const injectedFailure = new Error('close failed');
+      const statuses: string[] = [];
+      let closeFailure: unknown;
+      transport.failNextCall('close', injectedFailure);
+      transport.on('connection_change', (status) => {
+        statuses.push(status);
+        if (trigger === 'connecting notification' && status === 'connecting') {
+          try {
+            transport.close();
+          } catch (error) {
+            closeFailure = error;
+          }
+        }
+      });
+      const connectCall = transport.expectCall('connect', () => {
+        if (trigger === 'connect matcher') {
+          try {
+            transport.close();
+          } catch (error) {
+            closeFailure = error;
+          }
+        }
+      });
+
+      await expect(transport.connect({ apiKey: 'test' })).rejects.toMatchObject(
+        {
+          name: 'ScriptedRealtimeConnectionSupersededError',
+        },
+      );
+      await connectCall;
+      await expect(transport.expectCall('close')).resolves.toMatchObject({
+        method: 'close',
+      });
+
+      expect(closeFailure).toBe(injectedFailure);
+      expect(transport.status).toBe('disconnected');
+      expect(statuses.at(-1)).toBe('disconnected');
+      expect(() => transport.assertComplete()).not.toThrow();
+      expect(() => transport.assertClosed()).not.toThrow();
+    },
+  );
+
+  it('restores disconnected state when a failed close supersedes the connected notification', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const session = new RealtimeSession(
+      new RealtimeAgent({ name: 'Assistant' }),
+      { transport },
+    );
+    const injectedFailure = new Error('close failed');
+    const statuses: string[] = [];
+    let closeFailure: unknown;
+    transport.failNextCall('close', injectedFailure);
+    transport.on('connection_change', (status) => {
+      statuses.push(status);
+      if (status === 'connected') {
+        try {
+          transport.close();
+        } catch (error) {
+          closeFailure = error;
+        }
+      }
+    });
+
+    await expect(session.connect({ apiKey: 'test' })).rejects.toMatchObject({
+      name: 'ScriptedRealtimeConnectionSupersededError',
+    });
+    await expect(transport.expectCall('connect')).resolves.toMatchObject({
+      method: 'connect',
+    });
+    await expect(transport.expectCall('close')).resolves.toMatchObject({
+      method: 'close',
+    });
+
+    expect(closeFailure).toBe(injectedFailure);
+    expect(transport.status).toBe('disconnected');
+    expect(statuses).toEqual(['connecting', 'connected', 'disconnected']);
+    expect(() => transport.assertComplete()).not.toThrow();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it.each(['connecting', 'connected'] as const)(
+    'preserves an uncaught close failure from the %s notification',
+    async (trigger) => {
+      const transport = new ScriptedRealtimeTransport();
+      const injectedFailure = new Error('close failed');
+      transport.failNextCall('close', injectedFailure);
+      transport.on('connection_change', (status) => {
+        if (status === trigger) {
+          transport.close();
+        }
+      });
+
+      await expect(transport.connect({ apiKey: 'test' })).rejects.toBe(
+        injectedFailure,
+      );
+      await expect(transport.expectCall('connect')).resolves.toMatchObject({
+        method: 'connect',
+      });
+      await expect(transport.expectCall('close')).resolves.toMatchObject({
+        method: 'close',
+      });
+
+      expect(transport.status).toBe('disconnected');
+      expect(() => transport.assertComplete()).not.toThrow();
+      expect(() => transport.assertClosed()).not.toThrow();
+    },
+  );
+
+  it('restores disconnected state when a nested failed close supersedes an outer close', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.connect({ apiKey: 'test' });
+    await transport.expectCall('connect');
+    const injectedFailure = new Error('nested close failed');
+    let closeFailure: unknown;
+    const outerCloseCall = transport.expectCall('close', () => {
+      transport.failNextCall('close', injectedFailure);
+      try {
+        transport.close();
+      } catch (error) {
+        closeFailure = error;
+      }
+    });
+
+    transport.close();
+    await outerCloseCall;
+    await expect(transport.expectCall('close')).resolves.toMatchObject({
+      index: 2,
+      method: 'close',
+    });
+
+    expect(closeFailure).toBe(injectedFailure);
+    expect(transport.status).toBe('disconnected');
+    expect(() => transport.assertComplete()).not.toThrow();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('restores an established connection when close fails', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.connect({ apiKey: 'test' });
+    await transport.expectCall('connect');
+    const injectedFailure = new Error('close failed');
+    transport.failNextCall('close', injectedFailure);
+
+    expect(() => transport.close()).toThrow(injectedFailure);
+    await expect(transport.expectCall('close')).resolves.toMatchObject({
+      method: 'close',
+    });
+
+    expect(transport.status).toBe('connected');
+    expect(() => transport.assertComplete()).not.toThrow();
+    transport.disconnect();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('reserves a synchronous failure before a reentrant matcher call', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const injectedFailure = new Error('outer mute failed');
+    transport.failNextCall('mute', injectedFailure);
+    const outerCall = transport.expectCall('mute', () => {
+      transport.mute(false);
+    });
+
+    expect(() => transport.mute(true)).toThrow(injectedFailure);
+    await outerCall;
+    await expect(transport.expectCall('mute')).resolves.toMatchObject({
+      index: 1,
+      method: 'mute',
+      muted: false,
+    });
+    expect(transport.muted).toBe(false);
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('preserves connect failures while completing state cleanup', async () => {
+    const observerFailure = new Error('connecting observer failed');
+    const observerTransport = new ScriptedRealtimeTransport();
+    observerTransport.on('connection_change', (status) => {
+      if (status === 'connecting') {
+        throw observerFailure;
+      }
+    });
+
+    await expect(observerTransport.connect({ apiKey: 'test' })).rejects.toBe(
+      observerFailure,
+    );
+    expect(observerTransport.status).toBe('disconnected');
+
+    const injectedFailure = new Error('injected connect failure');
+    const cleanupFailure = new Error('cleanup observer failed');
+    const injectedTransport = new ScriptedRealtimeTransport();
+    injectedTransport.failNextCall('connect', injectedFailure);
+    const connectCall = injectedTransport.expectCall('connect');
+    injectedTransport.on('connection_change', (status) => {
+      if (status === 'disconnected') {
+        throw cleanupFailure;
+      }
+    });
+
+    await expect(injectedTransport.connect({ apiKey: 'test' })).rejects.toBe(
+      injectedFailure,
+    );
+    await connectCall;
+    expect(injectedTransport.status).toBe('disconnected');
+    expect(() => injectedTransport.assertComplete()).not.toThrow();
+  });
+
+  it('propagates observer failures without invoking later listeners', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const observerFailure = new Error('connecting observer failed');
+    const laterObserver = vi.fn();
+    transport.on('connection_change', (status) => {
+      if (status === 'connecting') {
+        throw observerFailure;
+      }
+    });
+    transport.on('connection_change', laterObserver);
+
+    await expect(transport.connect({ apiKey: 'test' })).rejects.toBe(
+      observerFailure,
+    );
+
+    expect(laterObserver).toHaveBeenCalledOnce();
+    expect(laterObserver).toHaveBeenCalledWith('disconnected');
+    expect(transport.status).toBe('disconnected');
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('removes one-time observers before invoking them', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const observerFailure = new Error('connecting observer failed');
+    const observer = vi.fn((status: string) => {
+      if (status === 'connecting') {
+        throw observerFailure;
+      }
+    });
+    transport.once('connection_change', observer);
+
+    await expect(transport.connect({ apiKey: 'test' })).rejects.toBe(
+      observerFailure,
+    );
+    await expect(
+      transport.connect({ apiKey: 'test' }),
+    ).resolves.toBeUndefined();
+
+    expect(observer).toHaveBeenCalledOnce();
+    expect(transport.status).toBe('connected');
+    transport.disconnect();
+  });
+
+  it('settles connect expectations before observer failures', async () => {
+    const observerFailure = new Error('connecting observer failed');
+    const injectedFailure = new Error('injected failure');
+    const transport = new ScriptedRealtimeTransport();
+    const connectCall = transport.expectCall('connect');
+    transport.failNextCall('connect', injectedFailure);
+    transport.on('connection_change', (status) => {
+      if (status === 'connecting') {
+        throw observerFailure;
+      }
+    });
+
+    await expect(transport.connect({ apiKey: 'test' })).rejects.toBe(
+      injectedFailure,
+    );
+    await expect(connectCall).resolves.toMatchObject({ method: 'connect' });
+    expect(transport.status).toBe('disconnected');
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it.each(['close', 'disconnect'] as const)(
+    'preserves a reentrant %s during the connecting notification',
+    async (operation) => {
+      const transport = new ScriptedRealtimeTransport();
+      transport.on('connection_change', (status) => {
+        if (status !== 'connecting') {
+          return;
+        }
+        if (operation === 'close') {
+          transport.close();
+        } else {
+          transport.disconnect();
+        }
+      });
+
+      await expect(
+        transport.runScenario({
+          scenario: async ({ expectCall }) => {
+            await expectCall('connect');
+            if (operation === 'close') {
+              await expectCall('close');
+            }
+          },
+          exercise: () => transport.connect({ apiKey: 'test' }),
+        }),
+      ).rejects.toMatchObject({
+        name: 'ScriptedRealtimeConnectionSupersededError',
+      });
+      expect(transport.status).toBe('disconnected');
+      expect(transport.calls.map((call) => call.method)).toEqual(
+        operation === 'close' ? ['connect', 'close'] : ['connect'],
+      );
+      expect(() => transport.assertComplete()).not.toThrow();
+      expect(() => transport.assertClosed()).not.toThrow();
+    },
+  );
+
+  it.each(['close', 'disconnect'] as const)(
+    'preserves a reentrant %s from a connect matcher',
+    async (operation) => {
+      const transport = new ScriptedRealtimeTransport();
+      const connectCall = transport.expectCall('connect', () => {
+        if (operation === 'close') {
+          transport.close();
+        } else {
+          transport.disconnect();
+        }
+      });
+
+      await expect(transport.connect({ apiKey: 'test' })).rejects.toMatchObject(
+        { name: 'ScriptedRealtimeConnectionSupersededError' },
+      );
+      await connectCall;
+      if (operation === 'close') {
+        await expect(transport.expectCall('close')).resolves.toMatchObject({
+          method: 'close',
+        });
+      }
+      expect(transport.status).toBe('disconnected');
+      expect(transport.calls.map((call) => call.method)).toEqual(
+        operation === 'close' ? ['connect', 'close'] : ['connect'],
+      );
+      expect(() => transport.assertComplete()).not.toThrow();
+      expect(() => transport.assertClosed()).not.toThrow();
+    },
+  );
+
+  it('emits a controlled disconnect and transport error', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const statuses: string[] = [];
+    const errors: unknown[] = [];
+    transport.on('connection_change', (status) => statuses.push(status));
+    transport.on('error', (event) => errors.push(event.error));
+    const connectCall = transport.expectCall('connect');
+    await transport.connect({ apiKey: 'test' });
+    await connectCall;
+
+    const error = new Error('disconnected');
+    transport.disconnect(error);
+
+    expect(statuses).toEqual(['connecting', 'connected', 'disconnected']);
+    expect(errors).toEqual([error]);
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('closes idempotently and records only the effective close', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.runScenario({
+      scenario: async ({ expectCall }) => {
+        await expectCall('connect');
+        await expectCall('close');
+      },
+      exercise: async () => {
+        await transport.connect({ apiKey: 'test' });
+        transport.close();
+        transport.close();
+      },
+    });
+
+    expect(
+      transport.calls.filter((call) => call.method === 'close'),
+    ).toHaveLength(1);
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('keeps terminal state when close observers throw', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const connectCall = transport.expectCall('connect');
+    await transport.connect({ apiKey: 'test' });
+    await connectCall;
+    const closeCall = transport.expectCall('close');
+    const observerFailure = new Error('close observer failed');
+    transport.on('connection_change', (status) => {
+      if (status === 'disconnected') {
+        throw observerFailure;
+      }
+    });
+
+    expect(() => transport.close()).toThrow(observerFailure);
+    await closeCall;
+    expect(transport.status).toBe('disconnected');
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('preserves a reconnect started by a close matcher', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.connect({ apiKey: 'test' });
+    await transport.expectCall('connect');
+    let reconnect: Promise<void> | undefined;
+    const closeCall = transport.expectCall('close', () => {
+      reconnect = transport.connect({ apiKey: 'test' });
+    });
+    const reconnectCall = transport.expectCall('connect');
+
+    transport.close();
+    await closeCall;
+    await reconnectCall;
+    await reconnect;
+
+    expect(transport.status).toBe('connected');
+    expect(transport.calls.map((call) => call.method)).toEqual([
+      'connect',
+      'close',
+      'connect',
+    ]);
+    expect(() => transport.assertComplete()).not.toThrow();
+  });
+
+  it('preserves a matcher disconnect when close fails', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.connect({ apiKey: 'test' });
+    await transport.expectCall('connect');
+    const injectedFailure = new Error('close failed');
+    transport.failNextCall('close', injectedFailure);
+    const closeCall = transport.expectCall('close', () => {
+      transport.disconnect();
+    });
+
+    expect(() => transport.close()).toThrow(injectedFailure);
+    await closeCall;
+
+    expect(transport.status).toBe('disconnected');
+    expect(() => transport.assertComplete()).not.toThrow();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('attempts error notification after a disconnect observer throws', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const observerFailure = new Error('disconnect observer failed');
+    const transportFailure = new Error('transport failed');
+    const errors: unknown[] = [];
+    const connectCall = transport.expectCall('connect');
+    await transport.connect({ apiKey: 'test' });
+    await connectCall;
+    transport.on('connection_change', (status) => {
+      if (status === 'disconnected') {
+        throw observerFailure;
+      }
+    });
+    transport.on('error', (event) => errors.push(event.error));
+
+    expect(() => transport.disconnect(transportFailure)).toThrow(
+      observerFailure,
+    );
+    expect(errors).toEqual([transportFailure]);
+    expect(transport.status).toBe('disconnected');
+  });
+
+  it('propagates an undefined disconnect observer failure', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.connect({ apiKey: 'test' });
+    await transport.expectCall('connect');
+    transport.on('connection_change', (status) => {
+      if (status === 'disconnected') {
+        throw undefined;
+      }
+    });
+    let returned = true;
+    let caught: unknown = Symbol('unset');
+
+    try {
+      transport.disconnect();
+    } catch (error) {
+      returned = false;
+      caught = error;
+    }
+
+    expect(returned).toBe(false);
+    expect(caught).toBeUndefined();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('preserves a null disconnect observer failure over a later error observer failure', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    await transport.connect({ apiKey: 'test' });
+    await transport.expectCall('connect');
+    const laterFailure = new Error('error observer failed');
+    const errorObserver = vi.fn(() => {
+      throw laterFailure;
+    });
+    transport.on('connection_change', (status) => {
+      if (status === 'disconnected') {
+        throw null;
+      }
+    });
+    transport.on('error', errorObserver);
+    let caught: unknown;
+
+    try {
+      transport.disconnect(new Error('transport failed'));
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeNull();
+    expect(errorObserver).toHaveBeenCalledOnce();
+    expect(() => transport.assertClosed()).not.toThrow();
+  });
+
+  it('reports incomplete scenarios and open transports', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    transport.sendEvent({ type: 'session.update' });
+
+    expect(() => transport.assertComplete()).toThrow(
+      IncompleteRealtimeScenarioError,
+    );
+
+    const connected = new ScriptedRealtimeTransport();
+    const connectCall = connected.expectCall('connect');
+    await connected.connect({ apiKey: 'test' });
+    await connectCall;
+    expect(() => connected.assertClosed()).toThrow(
+      RealtimeTransportNotClosedError,
+    );
+  });
+
+  it('supports assertions in matchers', async () => {
+    const transport = new ScriptedRealtimeTransport();
+    const matcher = vi.fn((call: { muted: boolean }) => {
+      expect(call.muted).toBe(true);
+    });
+    const expectedCall = transport.expectCall('mute', matcher);
+
+    transport.mute(true);
+    await expectedCall;
+
+    expect(matcher).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -13,6 +13,11 @@
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "require": "./dist/testing/index.js",
+      "import": "./dist/testing/index.mjs"
+    },
     "./sandbox": {
       "types": "./dist/sandbox/index.d.ts",
       "require": "./dist/sandbox/index.js",
@@ -27,6 +32,21 @@
       "types": "./dist/realtime/index.d.ts",
       "require": "./dist/realtime/index.js",
       "import": "./dist/realtime/index.mjs"
+    },
+    "./realtime/testing": {
+      "react-native": {
+        "types": "./dist/realtime/testing/index.d.ts",
+        "require": "./dist/realtime/testing/index.js",
+        "import": "./dist/realtime/testing/index.mjs"
+      },
+      "browser": {
+        "types": "./dist/realtime/testing/index.d.ts",
+        "require": "./dist/realtime/testing/index.js",
+        "import": "./dist/realtime/testing/index.mjs"
+      },
+      "types": "./dist/realtime/testing/index.d.ts",
+      "require": "./dist/realtime/testing/index.js",
+      "import": "./dist/realtime/testing/index.mjs"
     },
     "./utils": {
       "types": "./dist/utils/index.d.ts",
@@ -66,6 +86,9 @@
   ],
   "typesVersions": {
     "*": {
+      "testing": [
+        "dist/testing/index.d.ts"
+      ],
       "sandbox": [
         "dist/sandbox/index.d.ts"
       ],
@@ -74,6 +97,9 @@
       ],
       "realtime": [
         "dist/realtime/index.d.ts"
+      ],
+      "realtime/testing": [
+        "dist/realtime/testing/index.d.ts"
       ],
       "utils": [
         "dist/utils/index.d.ts"

--- a/packages/agents/src/realtime/testing/index.ts
+++ b/packages/agents/src/realtime/testing/index.ts
@@ -1,0 +1,1 @@
+export * from '@openai/agents-realtime/testing';

--- a/packages/agents/src/testing/index.ts
+++ b/packages/agents/src/testing/index.ts
@@ -1,0 +1,1 @@
+export * from '@openai/agents-core/testing';

--- a/packages/agents/test/testing.test.ts
+++ b/packages/agents/test/testing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import * as CoreTesting from '../src/testing';
+import * as RealtimeTesting from '../src/realtime/testing';
+import {
+  ScriptedModel as CanonicalScriptedModel,
+  scriptedSandboxSession as canonicalScriptedSandboxSession,
+} from '@openai/agents-core/testing';
+import { ScriptedRealtimeTransport as CanonicalScriptedRealtimeTransport } from '@openai/agents-realtime/testing';
+import type { Model } from '@openai/agents-core';
+import type { RealtimeTransportLayer } from '@openai/agents-realtime';
+
+describe('testing convenience subpaths', () => {
+  it('re-exports Core testing without mixing in Realtime', () => {
+    expect(CoreTesting.ScriptedModel).toBe(CanonicalScriptedModel);
+    expect(CoreTesting.scriptedSandboxSession).toBe(
+      canonicalScriptedSandboxSession,
+    );
+    expect('ScriptedRealtimeTransport' in CoreTesting).toBe(false);
+    expectTypeOf(new CoreTesting.ScriptedModel()).toMatchTypeOf<Model>();
+    expectTypeOf(CoreTesting.scriptedSandboxSession([])).toMatchTypeOf<
+      import('@openai/agents-core/sandbox').SandboxSession
+    >();
+  });
+
+  it('re-exports Realtime testing from the nested subpath', () => {
+    expect(RealtimeTesting.ScriptedRealtimeTransport).toBe(
+      CanonicalScriptedRealtimeTransport,
+    );
+    expectTypeOf(
+      new RealtimeTesting.ScriptedRealtimeTransport(),
+    ).toMatchTypeOf<RealtimeTransportLayer>();
+  });
+});


### PR DESCRIPTION
This pull request adds provider-neutral testing utilities for deterministic agent workflow, Sandbox Agent, and Realtime session tests:

- `@openai/agents-core/testing` provides `ScriptedModel` and `scriptedSandboxSession()`.
- `@openai/agents-realtime/testing` provides `ScriptedRealtimeTransport`.
- `@openai/agents/testing` re-exports the Core testing utilities.
- `@openai/agents/realtime/testing` re-exports the Realtime testing utilities.
- Existing reusable model and Sandbox session fakes are migrated to these public utilities.
- Specialized doubles remain only where tests require provider-wire behavior, malformed streams, suspension, races, abort delivery, stateful filesystems, provider lifecycle, manifest or credential authority, or real process behavior.

### Script a model workflow

Ordinary normalized output can be passed directly without wrapping every response in `modelResponse(...)`:

```ts
import { Agent, run } from '@openai/agents';
import {
  ScriptedModel,
  assistantMessage,
} from '@openai/agents/testing';

const model = new ScriptedModel([
  [assistantMessage('Hello from the scripted model.')],
]);

const agent = new Agent({
  name: 'Test assistant',
  model,
});

const result = await run(agent, 'Hello');

expect(result.finalOutput).toBe('Hello from the scripted model.');
expect(model.firstCall?.request.input).toBe('Hello');
model.assertComplete();
```

Complete `ModelResponse` objects and explicit wrappers remain supported:

```ts
import { Usage } from '@openai/agents-core';
import { modelResponse } from '@openai/agents/testing';

const response = {
  output: [assistantMessage('Done')],
  usage: new Usage({ requests: 1 }),
  responseId: 'response_1',
};

const model = new ScriptedModel([
  response,
  modelResponse(response),
]);
```

Output-only shorthand defaults to one request. Explicit usage, including `requests: 0`, is preserved.

### Derive responses from recorded calls

```ts
import { modelResponder } from '@openai/agents/testing';

const model = new ScriptedModel([
  modelResponder((call) => [
    assistantMessage(`Received: ${String(call.request.input)}`),
  ]),
]);
```

Recorded calls preserve request values from invocation time. Mutable arrays, plain objects, `ArrayBuffer` values, and typed-array views are detached, including ordinary objects originating in another JavaScript realm. Runtime values such as callbacks, `AbortSignal`, and class instances retain identity.

### Script failures and exact streams

```ts
import {
  modelError,
  modelStream,
} from '@openai/agents/testing';

const model = new ScriptedModel([
  modelError(new Error('temporary failure'), {
    suggested: true,
    retryAfterMs: 100,
  }),
  modelStream([
    { type: 'response_started' },
    // Add exact normalized stream events here.
  ]),
]);
```

Automatic streaming generates a deterministic `scripted-response-N` ID when a complete response omits one because the released JavaScript terminal stream protocol requires an ID. `modelStream(...)` and `modelStreamResponder(...)` remain available when tests need exact normalized event control.

Raw provider usage is exposed only when `preserveRawUsage` was enabled at call time. Valid values are detached, while invalid, cyclic, or throwing values are omitted.

### Script a Sandbox Agent session

The factory returns the `SandboxSession` itself. There is no additional `.session` wrapper:

```ts
import { run } from '@openai/agents';
import { SandboxAgent, shell } from '@openai/agents-core';
import {
  ScriptedModel,
  assistantMessage,
  functionCall,
  scriptedSandboxSession,
} from '@openai/agents/testing';

const session = scriptedSandboxSession([
  {
    method: 'execCommand',
    match: ({ cmd }) => cmd === 'pwd',
    result: '/workspace\n',
  },
]);

const model = new ScriptedModel([
  [
    functionCall(
      'exec_command',
      { cmd: 'pwd' },
      { callId: 'call_1' },
    ),
  ],
  [assistantMessage('The workspace is /workspace.')],
]);

const agent = new SandboxAgent({
  name: 'Test assistant',
  model,
  capabilities: [shell()],
});

const result = await run(agent, 'Where am I?', {
  sandbox: { session },
});

expect(result.finalOutput).toBe('The workspace is /workspace.');
expect(session.calls[0]?.method).toBe('execCommand');

session.assertComplete();
model.assertComplete();
```

Only methods named by the initial script are installed, preserving the existing optional-method capability detection used by Sandbox capabilities. Steps support fixed results, responders, matchers, and injected errors.

Generated failures expose structured fields such as call index, expected method, actual method, remaining steps, and pending method order without including command payloads or secrets.

Repository adoption covers deterministic Sandbox fixtures for capabilities, memory access, lifecycle cleanup, skill materialization, shell tools, filesystem tools, and agent preparation.

Stateful in-memory filesystems, Sandbox client create/resume/serialization behavior, manifest and credential authority, mount handling, provider cleanup, and concrete Docker or Unix process behavior remain specialized doubles because those state machines or adapter boundaries are the behavior under test.

### Test Realtime sessions without a network connection

```ts
import {
  RealtimeAgent,
  RealtimeSession,
} from '@openai/agents-realtime';
import {
  ScriptedRealtimeTransport,
} from '@openai/agents/realtime/testing';

const transport = new ScriptedRealtimeTransport();
const session = new RealtimeSession(
  new RealtimeAgent({ name: 'Assistant' }),
  { transport },
);

await transport.runScenario({
  scenario: async ({ expectCall, emit }) => {
    await expectCall('connect');

    await expectCall('sendMessage', (call) => {
      expect(call.message).toBe('Hello');
    });

    emit('output_text_delta', {
      type: 'output_text_delta',
      responseId: 'response_1',
      itemId: 'item_1',
      delta: 'Hi',
    });

    await expectCall('close');
  },

  exercise: async () => {
    await session.connect({ apiKey: 'test' });
    session.sendMessage('Hello');
    session.close();
  },
});

transport.assertComplete();
transport.assertClosed();
```

`runScenario()` owns both the expected scenario and the exercised workflow. If either side fails, or the exercise finishes while an expected call can no longer arrive, pending expectations settle with an actionable structured error instead of waiting for the test-runner timeout. Explicit cancellation is supported through `AbortSignal`; no environment-dependent default timeout is introduced.

The transport records ordered calls without retaining API keys, supports typed matchers and inbound events, injects deterministic failures, and preserves synchronous observer-failure semantics across Node, browser, and React Native package conditions.

The concepts align with `openai/openai-agents-python#4362`: deterministic scripts, call recording, call-time settings snapshots, explicit raw-usage preservation, and provider-neutral workflow boundaries. The required streaming response ID remains a JavaScript protocol-specific constraint.

TypeDoc publication for these unreleased testing subpaths is intentionally deferred to a separate docs-only change coordinated with the package release.
