### PR TITLE
fix(realtime): seed user transcript into history when a tool call pre-empts item seeding

### DIFF
--- a/.changeset/agents-realtime-history-transcript.md
+++ b/.changeset/agents-realtime-history-transcript.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-realtime": patch
+---
+
+Seed the user audio transcript into realtime history when a tool call pre-empts item seeding, so `conversation.item.input_audio_transcription.completed` transcripts are retained and surfaced via `history_updated`.

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -239,6 +239,28 @@ export function updateRealtimeHistory(
 ): RealtimeItem[] {
   // Merge transcript into placeholder input_audio message
   if (event.type === 'conversation.item.input_audio_transcription.completed') {
+    const hasUserItem = history.some(
+      (item) =>
+        item.itemId === event.item_id &&
+        item.type === 'message' &&
+        'role' in item &&
+        item.role === 'user',
+    );
+
+    if (!hasUserItem) {
+      // The user item has not been committed to history yet (e.g. the utterance
+      // triggered a tool call before the transcript was emitted). Seed a
+      // placeholder user message so the transcript is not dropped.
+      const seededItem: RealtimeMessageItem = {
+        itemId: event.item_id,
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_audio', transcript: event.transcript }],
+      };
+      return [...history, seededItem];
+    }
+
     return history.map((item) => {
       if (
         item.itemId === event.item_id &&

--- a/packages/agents-realtime/test/utils.test.ts
+++ b/packages/agents-realtime/test/utils.test.ts
@@ -282,6 +282,51 @@ describe('realtime utils', () => {
     }
   });
 
+  it('seeds a placeholder user message when a tool call pre-empts item seeding', () => {
+    const history: RealtimeMessageItem[] = [];
+
+    const event: InputAudioTranscriptionCompletedEvent = {
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'u-tool-call',
+      transcript: 'book a flight to paris',
+    };
+
+    const updated = updateRealtimeHistory(history, event, true);
+    expect(updated).toHaveLength(1);
+    const seeded = updated[0] as RealtimeMessageItem;
+    expect(seeded.itemId).toBe('u-tool-call');
+    expect(seeded.role).toBe('user');
+    expect(seeded.status).toBe('completed');
+    expect((seeded.content[0] as any).type).toBe('input_audio');
+    expect((seeded.content[0] as any).transcript).toBe('book a flight to paris');
+  });
+
+  it('keeps the user transcript when the item is not yet in history', () => {
+    const history: RealtimeMessageItem[] = [
+      {
+        itemId: 'a1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'hi' }],
+      },
+    ];
+
+    const event: InputAudioTranscriptionCompletedEvent = {
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'u1',
+      transcript: 'call the tool',
+    };
+
+    const updated = updateRealtimeHistory(history, event, true);
+    expect(updated).toHaveLength(2);
+    const seeded = updated.find(
+      (item) => item.itemId === 'u1',
+    ) as RealtimeMessageItem;
+    expect(seeded.role).toBe('user');
+    expect((seeded.content[0] as any).transcript).toBe('call the tool');
+  });
+
   it('appends items when previousItemId is missing', () => {
     const history: RealtimeMessageItem[] = [
       {


### PR DESCRIPTION
## Problem

The Realtime SDK drops the user's transcript / history entry when an audio utterance triggers a tool call. `packages/agents-realtime/src/utils.ts`'s `updateRealtimeHistory()` only merges the `conversation.item.input_audio_transcription.completed` transcript into a user message item that is *already present* in the history. When the utterance triggers a tool call, the user item has not been committed to the local history yet by the time the transcript event arrives, so `history.map(...)` finds nothing to update and the transcript is silently discarded (no `history_updated` event is emitted with the user message).

## Root cause

The `conversation.item.input_audio_transcription.completed` branch of `updateRealtimeHistory()` maps over the existing history and only updates an item whose `itemId` matches `event.item_id`. If no matching user message item is present (the tool-call turn pre-empts the item from being seeded into history), the branch returns the history unchanged and the transcript is lost. The transport's fallback (`conversation.item.retrieve` -> `conversation.item.retrieved` -> `item_update`) does not fire in the tool-call case either, as noted in the maintainer's investigation on the issue, so the transcript never reaches history through any path.

## Fix

In `updateRealtimeHistory()`, before attempting to merge into an existing item, check whether a matching user message item is present in the history. If it is not, seed a placeholder user message item (`type: 'message'`, `role: 'user'`, `status: 'completed'`, `input_audio` content carrying the transcript) and append it to the history. The transcript is now retained and surfaced via `history_updated` even when the tool call pre-empted the item from being committed. The existing in-place merge behavior (item already present) is unchanged.

## Test

Two new unit tests in `packages/agents-realtime/test/utils.test.ts`:

- `seeds a placeholder user message when a tool call pre-empts item seeding`
- `keeps the user transcript when the item is not yet in history`

Both fail on `main` (transcript dropped) and pass with the fix. The existing `merges input audio transcripts into history items` test continues to pass, confirming the in-place merge path is unchanged.

Fixes #141