### PR TITLE
fix(extensions): forward strict settings through the AI SDK

### DIFF
--- a/.changeset/forward-ai-sdk-function-tool-strict.md
+++ b/.changeset/forward-ai-sdk-function-tool-strict.md
@@ -2,4 +2,4 @@
 '@openai/agents-extensions': patch
 ---
 
-Forward function-tool strict settings through the AI SDK adapter.
+fix: Forward function-tool strict settings through the AI SDK adapter.

--- a/.changeset/forward-ai-sdk-function-tool-strict.md
+++ b/.changeset/forward-ai-sdk-function-tool-strict.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+Forward function-tool strict settings through the AI SDK adapter.

--- a/packages/agents-extensions/src/ai-sdk/index.ts
+++ b/packages/agents-extensions/src/ai-sdk/index.ts
@@ -82,6 +82,10 @@ type LanguageModelV2ProviderTool = {
 type LanguageModelV2ProviderToolCompat =
   LanguageModelV2ProviderDefinedTool | LanguageModelV2ProviderTool;
 
+type LanguageModelV2FunctionToolCompat = LanguageModelV2FunctionTool & {
+  strict: boolean;
+};
+
 /**
  * Provider tool definition returned by an AI SDK provider tool factory.
  */
@@ -1903,7 +1907,7 @@ function getHostedToolArgs(providerData: unknown): Record<string, any> {
 export function toolToLanguageV2Tool(
   model: LanguageModelCompatible,
   tool: SerializedTool,
-): LanguageModelV2FunctionTool | LanguageModelV2ProviderToolCompat {
+): LanguageModelV2FunctionToolCompat | LanguageModelV2ProviderToolCompat {
   if (
     (tool.type === 'function' ||
       tool.type === 'shell' ||
@@ -1931,6 +1935,7 @@ export function toolToLanguageV2Tool(
       name: getSerializedFunctionToolName(tool),
       description: tool.description,
       inputSchema: tool.parameters as JSONSchema7,
+      strict: tool.strict,
       ...(Object.keys(providerOptions).length > 0 ? { providerOptions } : {}),
     };
   }

--- a/packages/agents-extensions/test/ai-sdk/index.test.ts
+++ b/packages/agents-extensions/test/ai-sdk/index.test.ts
@@ -2470,18 +2470,20 @@ describe('itemsToLanguageV2Messages', () => {
 
 describe('toolToLanguageV2Tool', () => {
   const model = stubModel({});
-  test('maps function tools', () => {
+  test.each([true, false])('maps function tools with strict: %s', (strict) => {
     const tool = {
       type: 'function',
       name: 'foo',
       description: 'd',
       parameters: {} as any,
+      strict,
     } as any;
     expect(toolToLanguageV2Tool(model, tool)).toEqual({
       type: 'function',
       name: 'foo',
       description: 'd',
       inputSchema: {},
+      strict,
     });
   });
 


### PR DESCRIPTION
`SerializedFunctionTool.strict` is currently discarded when converting Agents SDK tools to AI SDK function tools, so providers supporting strict tool schemas receive a non-strict definition and may produce schema-invalid arguments.

This change forwards the existing provider-neutral boolean unchanged for both `true` and `false`, without changing defaults or provider behavior; downstream AI SDK providers continue to own capability detection.

Parameterized tests cover both boolean values, and a patch changeset records the `@openai/agents-extensions` release note.

Handoff `strictJsonSchema`, schema rewriting, and Anthropic JSON Schema compatibility remain unchanged.

Validation passed across the focused adapter tests, extensions build/type check, changeset validation, independent review, and the repository verification stack (188 test files and 5,509 tests); broad checks were run locally and all passed.
