### PR TITLE
fix: apply stacked diff anchors sequentially

### DIFF
--- a/.changeset/stacked-diff-anchors.md
+++ b/.changeset/stacked-diff-anchors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: apply stacked diff anchors sequentially

--- a/packages/agents-core/src/utils/applyDiff.ts
+++ b/packages/agents-core/src/utils/applyDiff.ts
@@ -99,16 +99,20 @@ function parseUpdateDiff(
   let cursor = 0;
 
   while (!isDone(parser, END_SECTION_MARKERS)) {
-    const anchor = readStr(parser, '@@ ');
-    const hasBareAnchor = !anchor && parser.lines[parser.index] === '@@';
-    if (hasBareAnchor) parser.index += 1;
+    const { anchors, hasAnchor } = readAnchors(parser);
 
-    if (!(anchor || hasBareAnchor || cursor === 0)) {
+    if (!(hasAnchor || cursor === 0)) {
       throw new Error(`Invalid Line:\n${parser.lines[parser.index]}`);
     }
 
-    if (anchor.trim()) {
-      cursor = advanceCursorToAnchor(anchor, inputLines, cursor, parser);
+    for (const [index, anchor] of anchors.entries()) {
+      cursor = advanceCursorToAnchor(
+        anchor,
+        inputLines,
+        cursor,
+        parser,
+        index > 0,
+      );
     }
 
     const { nextContext, sectionChunks, endIndex, eof } = readSection(
@@ -142,15 +146,46 @@ function parseUpdateDiff(
   return { chunks, fuzz: parser.fuzz };
 }
 
+function readAnchors(parser: ParserState): {
+  anchors: string[];
+  hasAnchor: boolean;
+} {
+  const anchors: string[] = [];
+  let hasAnchor = false;
+
+  while (true) {
+    const startIndex = parser.index;
+    const anchor = readStr(parser, '@@ ');
+    let consumed = parser.index !== startIndex;
+    let bare = false;
+
+    if (!consumed && parser.lines[parser.index] === '@@') {
+      parser.index += 1;
+      consumed = true;
+      bare = true;
+    }
+
+    if (!consumed) break;
+    if (anchor || bare) hasAnchor = true;
+    if (anchor.trim()) anchors.push(anchor);
+  }
+
+  return { anchors, hasAnchor };
+}
+
 function advanceCursorToAnchor(
   anchor: string,
   inputLines: string[],
   cursor: number,
   parser: ParserState,
+  forceForwardSearch = false,
 ): number {
   let found = false;
 
-  if (!inputLines.slice(0, cursor).some((s) => s === anchor)) {
+  if (
+    forceForwardSearch ||
+    !inputLines.slice(0, cursor).some((s) => s === anchor)
+  ) {
     for (let i = cursor; i < inputLines.length; i += 1) {
       if (inputLines[i] === anchor) {
         cursor = i + 1;
@@ -162,7 +197,8 @@ function advanceCursorToAnchor(
 
   if (
     !found &&
-    !inputLines.slice(0, cursor).some((s) => s.trim() === anchor.trim())
+    (forceForwardSearch ||
+      !inputLines.slice(0, cursor).some((s) => s.trim() === anchor.trim()))
   ) {
     for (let i = cursor; i < inputLines.length; i += 1) {
       if (inputLines[i].trim() === anchor.trim()) {

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -1105,6 +1105,63 @@ describe('UnixLocalSandboxClient', () => {
     });
   });
 
+  it('applies stacked anchors through the sandbox editor', async () => {
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'stacked.py': {
+            type: 'file',
+            content: [
+              'class First',
+              '    def target():',
+              '        return 0',
+              '',
+              'class Second',
+              '    def helper():',
+              '        pass',
+              '',
+              '    def target():',
+              '        pass',
+              '',
+            ].join('\n'),
+          },
+        },
+      }),
+    );
+
+    await session.createEditor().updateFile({
+      type: 'update_file',
+      path: 'stacked.py',
+      diff: [
+        '@@ class Second',
+        '@@     def target():',
+        '-        pass',
+        '+        return 1',
+      ].join('\n'),
+    });
+
+    await expect(
+      readFile(join(session.state.workspaceRootPath, 'stacked.py'), 'utf8'),
+    ).resolves.toBe(
+      [
+        'class First',
+        '    def target():',
+        '        return 0',
+        '',
+        'class Second',
+        '    def helper():',
+        '        pass',
+        '',
+        '    def target():',
+        '        return 1',
+        '',
+      ].join('\n'),
+    );
+  });
+
   it('rejects hostPath before applying a manifest delta', async () => {
     const client = new UnixLocalSandboxClient({
       workspaceBaseDir: rootDir,

--- a/packages/agents-core/test/utils/applyDiff.test.ts
+++ b/packages/agents-core/test/utils/applyDiff.test.ts
@@ -90,6 +90,99 @@ describe('applyDiff', () => {
     );
   });
 
+  it('applies stacked anchors in sequence', () => {
+    const input =
+      [
+        'class BaseClass',
+        '    def search():',
+        '        pass',
+        '',
+        'class Subclass',
+        '    def search():',
+        '        pass',
+      ].join('\n') + '\n';
+    const diff = [
+      '@@ class BaseClass',
+      '@@     def search():',
+      '-        pass',
+      '+        raise NotImplementedError()',
+      '@@ class Subclass',
+      '@@     def search():',
+      '-        pass',
+      '+        raise NotImplementedError()',
+    ].join('\n');
+
+    expect(applyDiff(input, diff)).toBe(
+      [
+        'class BaseClass',
+        '    def search():',
+        '        raise NotImplementedError()',
+        '',
+        'class Subclass',
+        '    def search():',
+        '        raise NotImplementedError()',
+      ].join('\n') + '\n',
+    );
+  });
+
+  it('uses each stacked anchor to narrow the target', () => {
+    const input =
+      [
+        'class First',
+        '    def target():',
+        '        return 0',
+        '',
+        'class Second',
+        '    def helper():',
+        '        pass',
+        '',
+        '    def target():',
+        '        pass',
+      ].join('\n') + '\n';
+    const diff = [
+      '@@ class Second',
+      '@@     def target():',
+      '-        pass',
+      '+        return 1',
+    ].join('\n');
+
+    expect(applyDiff(input, diff)).toBe(
+      [
+        'class First',
+        '    def target():',
+        '        return 0',
+        '',
+        'class Second',
+        '    def helper():',
+        '        pass',
+        '',
+        '    def target():',
+        '        return 1',
+      ].join('\n') + '\n',
+    );
+  });
+
+  it('keeps unmatched stacked anchors advisory', () => {
+    const input = 'a\nb\n';
+    const diff = ['@@ nope', '@@ also-nope', '-b', '+B'].join('\n');
+
+    expect(applyDiff(input, diff)).toBe('a\nB\n');
+  });
+
+  it('accepts a trailing bare anchor in a stack', () => {
+    const input = 'class Only\n    def run():\n        pass\n';
+    const diff = [
+      '@@ class Only',
+      '@@',
+      '-        pass',
+      '+        return 1',
+    ].join('\n');
+
+    expect(applyDiff(input, diff)).toBe(
+      'class Only\n    def run():\n        return 1\n',
+    );
+  });
+
   it('treats line-number markers as context anchors', () => {
     const input = 'one\ntwo\n';
     const diff = ['@@ -1,2 +1,2 @@', ' one', '-two', '+2'].join('\n');


### PR DESCRIPTION
This pull request fixes V4A update diff parsing so consecutive `@@` anchors narrow a hunk in order. Previously, a second consecutive header was treated as an empty section; later anchors now search forward from the cursor selected by the preceding anchor while preserving single-anchor, unmatched-anchor, and bare-anchor behavior.

The shared `applyDiff()` path covers both Unix local and Docker sandbox editors. The change adds direct and sandbox regression coverage for sequential narrowing and wrong-target prevention, plus patch release metadata for `@openai/agents-core`.
