### PR TITLE
feat(core): support read-only model input filters

### DIFF
--- a/.agents/references/conversation-state-ownership.md
+++ b/.agents/references/conversation-state-ownership.md
@@ -23,7 +23,7 @@ Do not create two authoritative histories accidentally. When server-managed cont
 
 ## Filters, Sessions, and Resume
 
-- `callModelInputFilter` receives a deep-cloned prepared payload and must return an input array. Persist filtered clones so session history reflects redaction or truncation rather than the unfiltered source.
+- `callModelInputFilter` receives a deep-cloned prepared payload by default and must return an input array. A filter that sets `readonlyInput` receives a shallow-copied array whose item identities are preserved; that filter and its helpers must treat the items as immutable. Model and persisted session inputs remain isolated clones after filtering so session history reflects redaction or truncation rather than the unfiltered source.
 - Track filtered items back to their originals so delta bookkeeping marks the items the model actually received. Rewind or preserve that mapping according to whether a failed attempt may have advanced server state.
 - `RunState` persists conversation identifiers and primes tracker state from prior model responses. Resume must not resend acknowledged input, lose unsent outputs, or increment the turn count without a model call.
 - Conversation continuation carries context into a new turn. RunState resume continues a paused turn. Do not substitute one for the other.

--- a/.changeset/quiet-filters-share.md
+++ b/.changeset/quiet-filters-share.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+---
+
+feat: allow read-only model-input filters to preserve item identity

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -35,9 +35,17 @@ export type CallModelInputFilterArgs<TContext = unknown> = {
   context: TContext | undefined;
 };
 
-export type CallModelInputFilter<TContext = unknown> = (
+export type CallModelInputFilter<TContext = unknown> = ((
   args: CallModelInputFilterArgs<TContext>,
-) => ModelInputData | Promise<ModelInputData>;
+) => ModelInputData | Promise<ModelInputData>) & {
+  /**
+   * Opt into receiving the Runner's input item objects by reference inside a
+   * shallow-copied array. Set this only when the filter and every helper it
+   * calls treat each input item and its nested values as immutable. Model and
+   * session inputs remain isolated copies after the filter returns.
+   */
+  readonlyInput?: true;
+};
 
 /**
  * Result of applying a `callModelInputFilter`.
@@ -108,12 +116,22 @@ export async function applyCallModelInputFilter<TContext>(
       return cloned;
     });
 
-  // Record the relationship between the cloned array passed to filters and the original inputs.
+  // Record the relationship between the array passed to filters and the original inputs.
   const cloneMap = new WeakMap<object, AgentInputItem>();
 
-  // Always create a deep copy so downstream mutations inside filters cannot affect
-  // the cached turn state.
-  const clonedBaseInput = cloneInputItems(inputItems, cloneMap);
+  // Read-only filters may opt into stable item identities. Other filters still
+  // receive deep copies so their mutations cannot affect the cached turn state.
+  const readOnlyInput = callModelInputFilter?.readonlyInput === true;
+  const clonedBaseInput = readOnlyInput
+    ? [...inputItems]
+    : cloneInputItems(inputItems, cloneMap);
+  if (readOnlyInput) {
+    for (const item of inputItems) {
+      if (item && typeof item === 'object') {
+        cloneMap.set(item as object, item);
+      }
+    }
+  }
   const base = {
     input: clonedBaseInput,
     instructions: systemInstructions,
@@ -174,7 +192,16 @@ export async function applyCallModelInputFilter<TContext>(
     const normalizedInput = deduplicateAgentInputItemsPreferringLatest(
       result.input,
     );
-    const consumedExactClones = new WeakSet<object>();
+    const availableExactOccurrences = new WeakMap<object, number>();
+    for (const item of clonedBaseInput) {
+      if (item && typeof item === 'object') {
+        availableExactOccurrences.set(
+          item as object,
+          (availableExactOccurrences.get(item as object) ?? 0) + 1,
+        );
+      }
+    }
+    const consumedExactOccurrences = new WeakMap<object, number>();
     const injectedExactCloneIndexes = new Set<number>();
 
     // Preserve a pointer to the original object backing each filtered clone so downstream
@@ -188,11 +215,16 @@ export async function applyCallModelInputFilter<TContext>(
         if (!original) {
           return undefined;
         }
-        if (consumedExactClones.has(item as object)) {
+        const consumedOccurrences =
+          consumedExactOccurrences.get(item as object) ?? 0;
+        if (
+          consumedOccurrences >=
+          (availableExactOccurrences.get(item as object) ?? 0)
+        ) {
           injectedExactCloneIndexes.add(index);
           return undefined;
         }
-        consumedExactClones.add(item as object);
+        consumedExactOccurrences.set(item as object, consumedOccurrences + 1);
         removeFromFallback(original);
         removeAgentInputFromPool(originalPool, original);
         return original;

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -36,6 +36,7 @@ import {
   user,
   assistant,
   type ToolExecutionConfig,
+  type CallModelInputFilter,
   type ToolNameCollisionPolicy,
   type ToolNotFoundBehavior,
 } from '../src';
@@ -6382,6 +6383,70 @@ describe('Runner.run', () => {
         return this.lastCall?.request;
       }
     }
+
+    it('preserves read-only filter item identity across model calls', async () => {
+      class RawRequestTrackingModel extends ScriptedModel {
+        readonly rawRequestInputs: AgentInputItem[][] = [];
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.rawRequestInputs.push(getRequestInputItems(request));
+          return super.getResponse(request);
+        }
+      }
+
+      const executeTool = tool({
+        name: 'continue_read_only_filter',
+        description: 'Continues the scripted run.',
+        parameters: z.object({}),
+        execute: async () => 'done',
+      });
+      const model = new RawRequestTrackingModel([
+        modelResponse({
+          output: [
+            {
+              type: 'function_call',
+              callId: 'call_read_only_filter',
+              name: executeTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'ReadOnlyFilterAgent',
+        model,
+        tools: [executeTool],
+      });
+      const stableInput = user('Stable history');
+      const filterInputs: AgentInputItem[][] = [];
+      const filter: CallModelInputFilter = ({ modelData }) => {
+        filterInputs.push(modelData.input);
+        return modelData;
+      };
+      filter.readonlyInput = true;
+
+      await new Runner({ callModelInputFilter: filter }).run(agent, [
+        stableInput,
+      ]);
+
+      expect(filterInputs).toHaveLength(2);
+      expect(filterInputs[0]).not.toBe(filterInputs[1]);
+      const stablePreparedInput = filterInputs[0]?.[0];
+      expect(stablePreparedInput).toBeDefined();
+      expect(stablePreparedInput).not.toBe(stableInput);
+      expect(filterInputs[1]?.[0]).toBe(stablePreparedInput);
+      expect(model.calls).toHaveLength(2);
+      expect(model.rawRequestInputs).toHaveLength(2);
+      for (const rawRequestInput of model.rawRequestInputs) {
+        expect(rawRequestInput[0]).not.toBe(stablePreparedInput);
+        expect(rawRequestInput[0]).not.toBe(stableInput);
+      }
+    });
 
     it('modifies model input for non-streaming runs', async () => {
       const model = new FilterTrackingModel([

--- a/packages/agents-core/test/runner/conversation.test.ts
+++ b/packages/agents-core/test/runner/conversation.test.ts
@@ -3,7 +3,10 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { setDefaultModelProvider, setTracingDisabled } from '../../src';
 import { Agent, AgentOutputType } from '../../src/agent';
 import { RunContext } from '../../src/runContext';
-import { applyCallModelInputFilter } from '../../src/runner/conversation';
+import {
+  applyCallModelInputFilter,
+  type CallModelInputFilter,
+} from '../../src/runner/conversation';
 import type { AgentInputItem } from '../../src/types';
 import { UserError } from '../../src/errors';
 import { ScriptedModelProvider } from '../stubs';
@@ -83,6 +86,75 @@ describe('applyCallModelInputFilter', () => {
     expect(result.persistedItems[0]).not.toBe(result.modelInput.input[0]);
     expect(first.content).toBe('secret');
     expect(second.content).toBe('keep me');
+  });
+
+  it('preserves source identity only for filters that opt into read-only input', async () => {
+    const agent = makeAgent('ReadOnlyFilter');
+    const context = new RunContext();
+    const shared: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'shared',
+    };
+    const original = [shared, shared];
+    let receivedInput: AgentInputItem[] | undefined;
+    const filter: CallModelInputFilter = ({ modelData }) => {
+      receivedInput = modelData.input;
+      return {
+        ...modelData,
+        input: [...modelData.input, shared],
+      };
+    };
+    filter.readonlyInput = true;
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      filter,
+      context,
+      original,
+      undefined,
+    );
+
+    expect(receivedInput).not.toBe(original);
+    expect(receivedInput?.[0]).toBe(shared);
+    expect(receivedInput?.[1]).toBe(shared);
+    expect(result.sourceItems).toEqual([shared, shared, undefined]);
+    expect(result.sourceMatchKinds).toEqual([
+      'identity',
+      'identity',
+      'injected',
+    ]);
+    expect(result.modelInput.input[0]).not.toBe(shared);
+    expect(result.persistedItems[0]).not.toBe(shared);
+    expect(result.persistedItems[0]).not.toBe(result.modelInput.input[0]);
+  });
+
+  it('keeps default filter input isolated from source mutations', async () => {
+    const agent = makeAgent('MutableFilter');
+    const context = new RunContext();
+    const original: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'original',
+    };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      ({ modelData }) => {
+        const received = modelData.input[0];
+        if (received?.type === 'message') {
+          received.content = 'filtered';
+        }
+        return modelData;
+      },
+      context,
+      [original],
+      undefined,
+    );
+
+    expect(original.content).toBe('original');
+    expect(result.modelInput.input[0]).toMatchObject({ content: 'filtered' });
+    expect(result.persistedItems[0]).toMatchObject({ content: 'filtered' });
   });
 
   it('leaves sourceItems undefined for injected filter items', async () => {


### PR DESCRIPTION
### Summary

`callModelInputFilter` currently receives a deep copy of the full input on every model call. This is safe for filters that modify input, but expensive for filters that only read it.

We run long, tool-heavy agent turns inside Cloudflare Durable Objects, which have a fixed memory limit. As the history grows, repeatedly copying it increases peak memory use and can force us to compact earlier. It also creates new item objects on every call, so identity-based caches cannot be reused.

This PR lets a filter set `readonlyInput = true`. The filter still receives a new array, but the items inside it keep the same identity across model calls. This avoids one full-history copy and allows read-only caches to work across a Runner loop.

Safety stays the same for everyone else:

- Existing filters still receive a deep copy by default.
- Inputs sent to the model and saved to a session are still copied.
- A filter should opt in only if it and its helpers never modify input items.

This does not change the model's context window. It only reduces runtime memory overhead so constrained environments can use more of the available context before compacting.

### Test plan

- Added a real two-model-call Runner/tool-loop test covering stable prepared identity and raw model-request isolation.
- Added focused tests for default mutation isolation, repeated source references, injected occurrences, and independent model/session clones.
- Ran `pnpm exec vitest run packages/agents-core/test/run.test.ts packages/agents-core/test/runner/conversation.test.ts` (214 tests passed).
- Ran `.agents/skills/code-change-verification/scripts/run.sh`, including install, build, declaration/type checks, lint, all 5,634 tests, and changed-file formatting.
- Ran the staged-tree TruffleHog scan with zero findings.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes

### Performance

I ran a local benchmark through the real `Runner` boundary using 1,000 history items (~4.1 MB) and a 20-call tool loop. These are median results from 7 isolated runs per mode on an Apple M5 Pro with Node.js 25.9.

| Metric | Default | `readonlyInput` | Change |
| --- | ---: | ---: | ---: |
| `structuredClone` calls | 102,238 | 81,858 | -19.9% |
| No-op filter time | 930.5 ms | 923.8 ms | -0.7% |
| No-op maximum RSS | 441.7 MB | 410.2 MB | -31.5 MB (-7.1%) |
| Memoizing filter time | 1,121.6 ms | 1,027.2 ms | -8.4% |
| Identity-cache hit rate | 0% | 94.9% | +94.9 points |

For this input, the removed pre-filter clone avoids roughly 83 MB of repeated history copying across 20 calls. The no-op time changes very little because model and session copies still remain. The larger gain comes from preserving item identity, which lets read-only caches reuse work across calls.

This is a synthetic local benchmark, not a Cloudflare production measurement. Network time is excluded, and Node RSS should not be treated as Durable Object memory usage.
