### PR TITLE
fix: preserve complete session transcripts across inline compaction

### DIFF
--- a/.changeset/preserve-inline-compaction-session-transcript.md
+++ b/.changeset/preserve-inline-compaction-session-transcript.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve complete session transcripts across inline compaction

--- a/.changeset/preserve-inline-compaction-session-transcript.md
+++ b/.changeset/preserve-inline-compaction-session-transcript.md
@@ -1,5 +1,6 @@
 ---
 '@openai/agents-core': patch
+'@openai/agents-openai': patch
 ---
 
 fix: preserve complete session transcripts across inline compaction

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -444,6 +444,36 @@ function buildRunItemPersistencePlan(
   });
 }
 
+function validateSessionItemsBeforeSessionPreparation(options: {
+  session: Session | undefined;
+  state: RunState<any, any>;
+  runItems: RunItem[];
+  sessionInputItems: AgentInputItem[] | undefined;
+  outputBlocked: boolean;
+}): void {
+  const { session, state, runItems, sessionInputItems, outputBlocked } =
+    options;
+  const persistencePlan = buildRunItemPersistencePlan(
+    state,
+    runItems,
+    outputBlocked,
+    isSessionHistoryTransactionAwareSession(session),
+  );
+  const itemsToValidate =
+    outputBlocked && !persistencePlan.useHistoryTransaction
+      ? (sessionInputItems ?? [])
+      : [
+          ...(sessionInputItems ?? []),
+          ...extractOutputItemsFromRunItems(
+            persistencePlan.runItemsToPersist,
+            state._reasoningItemIdPolicy ?? 'preserve',
+          ),
+        ];
+  assertPersistableCompactionBoundary(
+    normalizeItemsForSessionPersistence(itemsToValidate),
+  );
+}
+
 class SessionReconciliationRecoveryError extends Error {
   readonly errors: readonly [unknown, unknown];
   readonly cause: unknown;
@@ -507,6 +537,7 @@ export function createSessionPersistenceTracker(options: {
     private readonly hasCallModelInputFilter: boolean;
     private readonly persistInput?: typeof saveStreamInputToSession;
     private originalSnapshot: AgentInputItem[] | undefined;
+    private replayTrimmedInputPrefix: AgentInputItem[] = [];
     private filteredSnapshot: AgentInputItem[] | undefined;
     private preparedSources: PreparedOwnedSource[] | undefined;
     private initialPreparedItems: AgentInputItem[] | undefined;
@@ -542,6 +573,13 @@ export function createSessionPersistenceTracker(options: {
           : []);
       this.originalSnapshot = cloneItems(
         deduplicateAgentInputItemsPreferringLatest(sessionItems),
+      );
+      const replaySnapshot = trimToLatestCompaction(this.originalSnapshot);
+      this.replayTrimmedInputPrefix = cloneItems(
+        this.originalSnapshot.slice(
+          0,
+          this.originalSnapshot.length - replaySnapshot.length,
+        ),
       );
       if (Array.isArray(preparedInput)) {
         this.preparedSources = undefined;
@@ -624,7 +662,7 @@ export function createSessionPersistenceTracker(options: {
 
     getItemsForPersistence = () => {
       if (this.filteredSnapshot !== undefined) {
-        return this.filteredSnapshot;
+        return [...this.replayTrimmedInputPrefix, ...this.filteredSnapshot];
       }
       if (this.hasCallModelInputFilter) {
         return undefined;
@@ -1060,6 +1098,13 @@ export async function saveToSession(
   options: SessionPersistenceOptions = {},
 ): Promise<void> {
   const state = result.state;
+  validateSessionItemsBeforeSessionPreparation({
+    session,
+    state,
+    runItems: result.newItems,
+    sessionInputItems,
+    outputBlocked: options.outputBlocked === true,
+  });
   await prepareSessionHistoryTransactionsForRun(session, state, {
     serverManagesConversation: false,
   });
@@ -1118,18 +1163,7 @@ export async function saveStreamInputToSession(
     return;
   }
   const sanitizedInput = normalizeItemsForSessionPersistence(sessionInputItems);
-  const compactedInput = trimToLatestCompaction(sanitizedInput);
-  assertPersistableCompactionBoundary(compactedInput);
-  if (compactedInput[0]?.type === 'compaction') {
-    const previousItems = await getSessionItems(session, runContext);
-    await replaceSessionItemsWithRecovery(
-      session,
-      previousItems,
-      compactedInput,
-      runContext,
-    );
-    return;
-  }
+  assertPersistableCompactionBoundary(sanitizedInput);
   await addSessionItems(session, sanitizedInput, runContext);
 }
 
@@ -1140,6 +1174,13 @@ export async function saveStreamResultToSession(
   sessionInputItems?: AgentInputItem[],
 ): Promise<void> {
   const state = result.state;
+  validateSessionItemsBeforeSessionPreparation({
+    session,
+    state,
+    runItems: result.newItems,
+    sessionInputItems,
+    outputBlocked: options.outputBlocked === true,
+  });
   await prepareSessionHistoryTransactionsForRun(session, state, {
     serverManagesConversation: false,
   });
@@ -1611,8 +1652,6 @@ async function persistRunItemsToSession(options: {
     return;
   }
 
-  await reconcileLegacyCompactionSessionBeforeResume(session, state);
-
   const effectiveReasoningItemIdPolicy =
     getEffectiveSessionReasoningItemIdPolicy(session, state);
   const frozenReasoningItemIdPolicy = useHistoryTransaction
@@ -1633,6 +1672,11 @@ async function persistRunItemsToSession(options: {
     ...extraInputItems,
     ...extractOutputItemsFromRunItems(newRunItems, frozenReasoningItemIdPolicy),
   ];
+  const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
+  assertPersistableCompactionBoundary(sanitizedItems);
+
+  await reconcileLegacyCompactionSessionBeforeResume(session, state);
+
   const commitPersistenceState = () => {
     state._currentTurnPersistedItemCount =
       alreadyPersistedCount + processedRunItemCount;
@@ -1662,7 +1706,6 @@ async function persistRunItemsToSession(options: {
     return;
   }
 
-  const sanitizedItems = normalizeItemsForSessionPersistence(itemsToSave);
   if (useHistoryTransaction) {
     if (
       !isSessionHistoryTransactionAwareSession(session) ||
@@ -1724,19 +1767,7 @@ async function persistRunItemsToSession(options: {
     }
     return;
   }
-  const compactedItems = trimToLatestCompaction(sanitizedItems);
-  assertPersistableCompactionBoundary(compactedItems);
-  if (compactedItems[0]?.type === 'compaction') {
-    const previousItems = await getSessionItems(session, state._context);
-    await replaceSessionItemsWithRecovery(
-      session,
-      previousItems,
-      compactedItems,
-      state._context,
-    );
-  } else {
-    await addSessionItems(session, sanitizedItems, state._context);
-  }
+  await addSessionItems(session, sanitizedItems, state._context);
   commitPersistenceState();
   if (runCompaction) {
     await runCompactionOnSession(

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -3,6 +3,7 @@ export { recordToolUsage } from '../runner/usageTracking';
 export {
   assertValidCompactionItems,
   CompactionItemValidationError,
+  trimToLatestCompaction,
 } from '../runner/items';
 export { normalizeToolAllowedCallers } from './toolCallers';
 export { snapshotRawUsage } from './rawUsage';

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -3733,9 +3733,9 @@ describe('Runner.run (streaming)', () => {
     });
   });
 
-  it('replaces session history from explicit compaction input when streaming fails', async () => {
+  it('preserves complete explicit compaction input when streaming fails', async () => {
     const previousSessionItem = user('previous session');
-    const discardedInput = user('discarded input');
+    const prefixInput = user('prefix input');
     const retainedInput = user('retained input');
     const compaction: protocol.CompactionItem = {
       type: 'compaction',
@@ -3759,7 +3759,7 @@ describe('Runner.run (streaming)', () => {
     const agent = new Agent({ name: 'StreamCompactedInputFailure', model });
     const result = await new Runner().run(
       agent,
-      [discardedInput, compaction, retainedInput],
+      [prefixInput, compaction, retainedInput],
       { stream: true, session },
     );
 
@@ -3768,7 +3768,12 @@ describe('Runner.run (streaming)', () => {
     );
 
     expect(model.firstCall?.request.input).toEqual([compaction, retainedInput]);
-    expect(sessionItems).toEqual([compaction, retainedInput]);
+    expect(sessionItems).toEqual([
+      previousSessionItem,
+      prefixInput,
+      compaction,
+      retainedInput,
+    ]);
   });
 
   it('does not retry streamed input after combined persistence reaches compaction', async () => {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -9500,7 +9500,7 @@ describe('Runner.run', () => {
       expect(result.history[0]).toEqual(COMPACTION_ITEM);
     });
 
-    it('rewrites ordinary session history from the latest compaction marker', async () => {
+    it('preserves the full session transcript while replaying from compaction', async () => {
       const session = new CoreMemorySession({
         initialItems: [user('earlier stored input')],
       });
@@ -9522,20 +9522,67 @@ describe('Runner.run', () => {
 
       await run(agent, 'new user input', { session });
 
-      expect(clearSession).toHaveBeenCalledOnce();
+      expect(clearSession).not.toHaveBeenCalled();
       const stored = await session.getItems();
-      expect(stored[0]).toEqual(COMPACTION_ITEM);
-      expect(stored).toHaveLength(2);
+      expect(stored).toEqual([
+        user('earlier stored input'),
+        {
+          type: 'message',
+          role: 'user',
+          content: 'new user input',
+        },
+        COMPACTION_ITEM,
+        fakeModelMessage('first turn done'),
+      ]);
 
       await run(agent, 'later user input', { session });
       const laterInput = getRequestInputItems(model.requests[1]);
       expect(laterInput[0]).toEqual(COMPACTION_ITEM);
+      expect(laterInput).toContainEqual(fakeModelMessage('first turn done'));
       expect(laterInput).not.toContainEqual(
         expect.objectContaining({ content: 'earlier stored input' }),
+      );
+      expect(laterInput).not.toContainEqual(
+        expect.objectContaining({ content: 'new user input' }),
       );
       expect(getFirstTextContent(laterInput[laterInput.length - 1])).toBe(
         'later user input',
       );
+    });
+
+    it('preserves explicit input before compaction while replaying only its suffix', async () => {
+      const previousSessionItem = user('previous session');
+      const prefixInput = user('prefix input');
+      const retainedInput = user('retained input');
+      const session = new CoreMemorySession({
+        initialItems: [previousSessionItem],
+      });
+      const model = new RecordingModel([
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'ExplicitInputCompactionAgent',
+        model,
+      });
+
+      await run(agent, [prefixInput, COMPACTION_ITEM, retainedInput], {
+        session,
+      });
+
+      expect(getRequestInputItems(model.requests[0])).toEqual([
+        COMPACTION_ITEM,
+        retainedInput,
+      ]);
+      expect(await session.getItems()).toEqual([
+        previousSessionItem,
+        prefixInput,
+        COMPACTION_ITEM,
+        retainedInput,
+        fakeModelMessage('done'),
+      ]);
     });
   });
 

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -3859,6 +3859,7 @@ export function registerRunStateCompactionTests(): void {
           runCompaction: false,
         });
         expect((await session.getItems()).map((item) => item.type)).toEqual([
+          'function_call',
           'compaction',
         ]);
       });
@@ -4030,6 +4031,7 @@ export function registerRunStateCompactionTests(): void {
           runCompaction: false,
         });
         expect((await session.getItems()).map((item) => item.type)).toEqual([
+          'hosted_tool_call',
           'compaction',
         ]);
       });

--- a/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.extended.test.ts
@@ -138,7 +138,7 @@ describe('sessionPersistence tracker (extended)', () => {
     expect(tracker.getItemsForPersistence()).toEqual([current]);
   });
 
-  it('remaps owned input after turn preparation trims a compaction prefix', () => {
+  it('preserves owned input after turn preparation trims a compaction prefix', () => {
     const session = makeSession();
     const tracker = createSessionPersistenceTracker({
       session,
@@ -171,7 +171,11 @@ describe('sessionPersistence tracker (extended)', () => {
     tracker.setPreparedTurnItems(preparedTurnInput, preparedTurnInput);
     tracker.recordTurnItems(preparedTurnInput, preparedTurnInput);
 
-    expect(tracker.getItemsForPersistence()).toEqual([compacted, current]);
+    expect(tracker.getItemsForPersistence()).toEqual([
+      discarded,
+      compacted,
+      current,
+    ]);
   });
 
   it('keeps current input ownership when context processing clones items', () => {

--- a/packages/agents-core/test/runner/sessionPersistence.test.ts
+++ b/packages/agents-core/test/runner/sessionPersistence.test.ts
@@ -3612,8 +3612,11 @@ describe('saveToSession', () => {
       return 'session';
     }
 
-    async getItems(): Promise<AgentInputItem[]> {
-      return [...this.items];
+    async getItems(limit?: number): Promise<AgentInputItem[]> {
+      if (limit === undefined) {
+        return [...this.items];
+      }
+      return this.items.slice(Math.max(this.items.length - limit, 0));
     }
 
     async addItems(items: AgentInputItem[]): Promise<void> {
@@ -3629,33 +3632,62 @@ describe('saveToSession', () => {
     }
   }
 
-  it('uses a session compaction replacement capability without clearing identity', async () => {
+  class RecordingSession extends MemorySession {
+    getItemsLimits: Array<number | undefined> = [];
+    addedBatches: AgentInputItem[][] = [];
+    replacementBatches: AgentInputItem[][] = [];
+    clearCount = 0;
+
+    override async getItems(limit?: number): Promise<AgentInputItem[]> {
+      this.getItemsLimits.push(limit);
+      return super.getItems(limit);
+    }
+
+    override async addItems(items: AgentInputItem[]): Promise<void> {
+      this.addedBatches.push(structuredClone(items));
+      await super.addItems(items);
+    }
+
+    async replaceHistoryWithCompaction(items: AgentInputItem[]): Promise<void> {
+      this.replacementBatches.push(structuredClone(items));
+    }
+
+    override async clearSession(): Promise<void> {
+      this.clearCount += 1;
+      await super.clearSession();
+    }
+  }
+
+  class TransactionRecordingSession extends RecordingSession {
+    sessionIdCalls = 0;
+    transactionCalls = 0;
+
+    override async getSessionId(): Promise<string> {
+      this.sessionIdCalls += 1;
+      return super.getSessionId();
+    }
+
+    async applyHistoryTransaction(
+      _args: SessionHistoryTransactionArgs,
+    ): Promise<void> {
+      this.transactionCalls += 1;
+    }
+  }
+
+  it('appends the complete ordinary batch without replacing session history', async () => {
     const previousItem = fakeModelMessage('previous history');
+    const earlierGeneratedItem = fakeModelMessage('earlier generated history');
     const compaction: protocol.CompactionItem = {
       type: 'compaction',
       id: 'cmp_identity_preserving_session',
       encrypted_content: 'ciphertext',
     };
     const retainedItem = fakeModelMessage('retained history');
-    class IdentityPreservingSession extends MemorySession {
-      clearCount = 0;
-      replacementItems: AgentInputItem[] | undefined;
-
-      async replaceHistoryWithCompaction(
-        items: AgentInputItem[],
-      ): Promise<void> {
-        this.replacementItems = structuredClone(items);
-      }
-
-      async clearSession(): Promise<void> {
-        this.clearCount += 1;
-        await super.clearSession();
-      }
-    }
-    const session = new IdentityPreservingSession();
+    const session = new RecordingSession();
     session.items = [previousItem];
     const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
     state._generatedItems = [
+      new MessageOutputItem(earlierGeneratedItem, TEST_AGENT),
       new CompactionItem(compaction, TEST_AGENT),
       new MessageOutputItem(retainedItem, TEST_AGENT),
     ];
@@ -3664,27 +3696,95 @@ describe('saveToSession', () => {
       runCompaction: false,
     });
 
-    expect(session.replacementItems).toEqual([compaction, retainedItem]);
+    expect(session.getItemsLimits).toEqual([]);
+    expect(session.addedBatches).toEqual([
+      [earlierGeneratedItem, compaction, retainedItem],
+    ]);
+    expect(session.replacementBatches).toEqual([]);
     expect(session.clearCount).toBe(0);
-    expect(session.items).toEqual([previousItem]);
+    expect(session.items).toEqual([
+      previousItem,
+      earlierGeneratedItem,
+      compaction,
+      retainedItem,
+    ]);
   });
 
   it('rejects malformed streaming compaction before mutating session history', async () => {
     const previousItem = fakeModelMessage('previous history');
-    const session = new MemorySession();
+    const session = new RecordingSession();
     session.items = [previousItem];
     const malformedCompaction = {
       type: 'compaction',
       id: 'cmp_missing_ciphertext',
     } as AgentInputItem;
+    const validCompaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_valid_after_malformed',
+      encrypted_content: 'ciphertext',
+    };
 
     await expect(
       saveStreamInputToSession(session, [
         malformedCompaction,
+        validCompaction,
         fakeModelMessage('new history'),
       ]),
     ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(session.getItemsLimits).toEqual([]);
+    expect(session.addedBatches).toEqual([]);
+    expect(session.clearCount).toBe(0);
+    expect(session.replacementBatches).toEqual([]);
     expect(session.items).toEqual([previousItem]);
+  });
+
+  it('appends the complete streaming input batch around a compaction marker', async () => {
+    const previousItem = fakeModelMessage('previous history');
+    const beforeCompaction = fakeModelMessage('before compaction');
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_stream_input_batch',
+      encrypted_content: 'ciphertext',
+    };
+    const afterCompaction = fakeModelMessage('after compaction');
+    const session = new RecordingSession();
+    session.items = [previousItem];
+
+    await saveStreamInputToSession(session, [
+      beforeCompaction,
+      compaction,
+      afterCompaction,
+    ]);
+
+    expect(session.addedBatches).toEqual([
+      [beforeCompaction, compaction, afterCompaction],
+    ]);
+    expect(session.replacementBatches).toEqual([]);
+    expect(session.clearCount).toBe(0);
+    expect(session.items).toEqual([
+      previousItem,
+      beforeCompaction,
+      compaction,
+      afterCompaction,
+    ]);
+  });
+
+  it('appends distinct identical streaming compaction batches', async () => {
+    const compaction: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_repeated_stream_input',
+      encrypted_content: 'ciphertext',
+    };
+    const retainedItem = fakeModelMessage('repeated retained history');
+    const batch = [compaction, retainedItem];
+    const session = new RecordingSession();
+
+    await saveStreamInputToSession(session, batch);
+    await saveStreamInputToSession(session, batch);
+
+    expect(session.getItemsLimits).toEqual([]);
+    expect(session.addedBatches).toEqual([batch, batch]);
+    expect(session.items).toEqual([...batch, ...batch]);
   });
 
   it('rejects malformed result compaction before mutating session history', async () => {
@@ -3708,46 +3808,77 @@ describe('saveToSession', () => {
     expect(session.items).toEqual([previousItem]);
   });
 
-  it('does not reappend an accepted compaction replacement on retry', async () => {
-    const compaction: protocol.CompactionItem = {
+  it('validates current result compaction before legacy session reconciliation', async () => {
+    const call = functionCall('call_legacy_validation_order');
+    const legacyCompaction: protocol.CompactionItem = {
       type: 'compaction',
-      id: 'cmp_accepted_then_throw',
+      id: 'cmp_legacy_validation_order',
       encrypted_content: 'ciphertext',
     };
-    const retainedItem = fakeModelMessage('retained history');
-    class AcceptedThenThrowSession extends MemorySession {
-      replacementCount = 0;
-
-      async replaceHistoryWithCompaction(
-        items: AgentInputItem[],
-      ): Promise<void> {
-        this.replacementCount += 1;
-        this.items.push(...structuredClone(items));
-        throw new Error('write outcome unknown');
-      }
-    }
-    const session = new AcceptedThenThrowSession();
-    session.items = [fakeModelMessage('old history')];
+    const malformedCurrentCompaction = {
+      type: 'compaction',
+      id: 'cmp_malformed_current_validation_order',
+    } as protocol.CompactionItem;
     const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
     state._generatedItems = [
-      new CompactionItem(compaction, TEST_AGENT),
-      new MessageOutputItem(retainedItem, TEST_AGENT),
+      new CompactionItem(legacyCompaction, TEST_AGENT),
+      new ToolCallItem(call, TEST_AGENT),
+      new CompactionItem(malformedCurrentCompaction, TEST_AGENT),
     ];
-    const result = new RunResult(state as any);
+    state._pendingLegacyCompactionSessionItems = [legacyCompaction, call];
+    state._currentTurnPersistedItemCount = 2;
+    const session = new RecordingSession();
+    session.items = [call];
 
     await expect(
-      saveToSession(session, [], result, { runCompaction: false }),
-    ).rejects.toThrow('write outcome unknown');
-    await expect(
-      saveToSession(session, [], result, { runCompaction: false }),
-    ).resolves.toBeUndefined();
-
-    expect(session.replacementCount).toBe(1);
-    expect(session.items.filter((item) => item.type === 'compaction')).toEqual([
-      compaction,
+      saveToSession(session, [], new RunResult(state as any), {
+        runCompaction: false,
+      }),
+    ).rejects.toThrow('Compaction item missing encrypted_content');
+    expect(session.getItemsLimits).toEqual([]);
+    expect(session.addedBatches).toEqual([]);
+    expect(session.replacementBatches).toEqual([]);
+    expect(session.clearCount).toBe(0);
+    expect(session.items).toEqual([call]);
+    expect(state._pendingLegacyCompactionSessionItems).toEqual([
+      legacyCompaction,
+      call,
     ]);
-    expect(state._currentTurnPersistedItemCount).toBe(2);
   });
+
+  it.each(['completed', 'streamed'] as const)(
+    'rejects malformed %s result before transaction-aware session access',
+    async (resultKind) => {
+      const malformedCompaction = {
+        type: 'compaction',
+        id: `cmp_malformed_${resultKind}_transaction`,
+      } as protocol.CompactionItem;
+      const state = new RunState(new RunContext(), 'input', TEST_AGENT, 1);
+      state._generatedItems = [
+        new CompactionItem(malformedCompaction, TEST_AGENT),
+      ];
+      const session = new TransactionRecordingSession();
+
+      const save =
+        resultKind === 'completed'
+          ? saveToSession(session, [], new RunResult(state as any), {
+              runCompaction: false,
+            })
+          : saveStreamResultToSession(
+              session,
+              new StreamedRunResult({ state: state as any }),
+              { runCompaction: false },
+            );
+
+      await expect(save).rejects.toThrow(
+        'Compaction item missing encrypted_content',
+      );
+      expect(session.sessionIdCalls).toBe(0);
+      expect(session.getItemsLimits).toEqual([]);
+      expect(session.transactionCalls).toBe(0);
+      expect(session.addedBatches).toEqual([]);
+    },
+  );
 
   it('retries a blocked-output transaction without duplicating committed tool effects', async () => {
     class AcceptedBlockedThenThrowSession extends TransactionMemorySession {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -1924,7 +1924,7 @@ describe('sandbox runner integration', () => {
   );
 
   it.each([false, true])(
-    'replaces current session input when a later sandbox turn compacts it away (stream=%s)',
+    'preserves current session input when a later sandbox turn compacts it (stream=%s)',
     async (stream) => {
       const client = new FakeSandboxClient();
       const continueTool = tool({
@@ -1982,23 +1982,18 @@ describe('sandbox runner integration', () => {
       }
 
       const persisted = await session.getItems();
-      expect(persisted[0]).toMatchObject({
+      expect(persisted).toContainEqual(current);
+      expect(persisted).toContainEqual({
         type: 'compaction',
         encrypted_content: 'later compacted history',
       });
-      expect(
-        persisted.filter(
-          (item) =>
-            item.type === 'message' &&
-            item.role === 'user' &&
-            Array.isArray(item.content) &&
-            item.content.some(
-              (content) =>
-                content.type === 'input_text' &&
-                content.text === 'current input',
-            ),
-        ),
-      ).toHaveLength(0);
+      expect(model.requests).toHaveLength(2);
+      const secondInput = model.requests[1]?.input as AgentInputItem[];
+      expect(secondInput[0]).toMatchObject({
+        type: 'compaction',
+        encrypted_content: 'later compacted history',
+      });
+      expect(secondInput).not.toContainEqual(current);
     },
   );
 

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -12,7 +12,10 @@ import type {
   Session,
 } from '@openai/agents-core';
 import type { OpenAIResponsesCompactionResult } from '@openai/agents-core';
-import { logModelAndToolActionWarning } from '@openai/agents-core/utils/internal';
+import {
+  logModelAndToolActionWarning,
+  trimToLatestCompaction,
+} from '@openai/agents-core/utils/internal';
 import { DEFAULT_OPENAI_MODEL, getDefaultOpenAIClient } from '../defaults';
 import { getInputItems } from '../openaiResponsesModel';
 import {
@@ -205,7 +208,9 @@ export class OpenAIResponsesCompactionSession
     if (resolvedMode === 'previous_response_id') {
       compactRequest.previous_response_id = this.responseId!;
     } else {
-      compactRequest.input = getInputItems(sessionItems);
+      compactRequest.input = getInputItems(
+        trimToLatestCompaction(sessionItems),
+      );
     }
 
     const compacted = await this.client.responses.compact(compactRequest);

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -297,6 +297,69 @@ describe('OpenAIResponsesCompactionSession', () => {
     });
   });
 
+  it('uses the latest logical compaction window in input mode', async () => {
+    const latestCompaction = {
+      type: 'compaction',
+      id: 'cmp_latest',
+      encrypted_content: 'encrypted-latest',
+    } as AgentInputItem;
+    const retainedItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'retained' }],
+    } as AgentInputItem;
+    const completeHistory = [
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'prefix' }],
+      },
+      {
+        type: 'compaction',
+        id: 'cmp_earlier',
+        encrypted_content: 'encrypted-earlier',
+      },
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'stale' }],
+      },
+      latestCompaction,
+      retainedItem,
+    ] as AgentInputItem[];
+    const compact = vi.fn().mockResolvedValue({
+      output: [],
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        total_tokens: 0,
+      },
+    });
+    let decisionSessionItems: AgentInputItem[] | undefined;
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession: new MemorySession({ initialItems: completeHistory }),
+      compactionMode: 'input',
+      shouldTriggerCompaction: ({ sessionItems }) => {
+        decisionSessionItems = sessionItems;
+        return true;
+      },
+    });
+
+    await expect(session.getItems()).resolves.toEqual(completeHistory);
+    await session.runCompaction();
+
+    expect(decisionSessionItems).toEqual(completeHistory);
+    expect(compact).toHaveBeenCalledTimes(1);
+    const [request] = compact.mock.calls[0] ?? [];
+    expect(request.previous_response_id).toBeUndefined();
+    expect(request.input).toHaveLength(2);
+    expect(request.input).toMatchObject([latestCompaction, retainedItem]);
+  });
+
   it('defaults to auto compaction and uses input without a response id', async () => {
     const compact = vi.fn().mockResolvedValue({
       output: [],


### PR DESCRIPTION
### Summary

This pull request fixes incomplete session persistence when a run produces inline compaction. Ordinary sessions now receive the complete validated batch through `addItems()`, while model replay continues from the latest valid compaction marker.

The built-in `OpenAIResponsesCompactionSession` also trims input-mode compaction requests to the latest logical window, without trimming stored history or the history exposed to its decision hook. Legacy `RunState` recovery and the public `replaceHistoryWithCompaction()` capability remain supported.

This lets session implementations retain complete transcripts, expose a trimmed `getItems()` view, or explicitly replace physical history. Complete retention can increase storage costs, and `addItems()` retains its existing at-least-once retry semantics.

### Test plan

- Added streaming and non-streaming persistence coverage.
- Added coverage for filtered input, malformed and multiple compaction markers, legacy `RunState` recovery, and built-in Responses compaction input.
- Ran the complete repository verification stack: 5,614 tests passed.

### Issue number

N/A
