### PR TITLE
feat(core): preserve model input identity

### DIFF
--- a/.agents/references/conversation-state-ownership.md
+++ b/.agents/references/conversation-state-ownership.md
@@ -23,7 +23,7 @@ Do not create two authoritative histories accidentally. When server-managed cont
 
 ## Filters, Sessions, and Resume
 
-- `callModelInputFilter` receives a deep-cloned prepared payload and must return an input array. Persist filtered clones so session history reflects redaction or truncation rather than the unfiltered source.
+- `callModelInputFilter` receives a deep-cloned prepared payload by default and must return an input array. A filter that sets `preserveInputIdentity` receives a shallow-copied array whose item identities are preserved; the SDK does not freeze those items, so that filter and its helpers must treat them as immutable. Model and persisted session inputs remain isolated clones after filtering so session history reflects redaction or truncation rather than the unfiltered source.
 - Track filtered items back to their originals so delta bookkeeping marks the items the model actually received. Rewind or preserve that mapping according to whether a failed attempt may have advanced server state.
 - `RunState` persists conversation identifiers and primes tracker state from prior model responses. Resume must not resend acknowledged input, lose unsent outputs, or increment the turn count without a model call.
 - Conversation continuation carries context into a new turn. RunState resume continues a paused turn. Do not substitute one for the other.

--- a/.changeset/quiet-filters-share.md
+++ b/.changeset/quiet-filters-share.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents': patch
+'@openai/agents-core': patch
+---
+
+feat: allow model-input filters to preserve item identity

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -3102,6 +3102,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       persistedItems,
       sourceMatchKinds,
       filterApplied,
+      preserveInputIdentity,
     } = await applyCallModelInputFilter(
       state._currentAgent,
       options.callModelInputFilter,
@@ -3135,6 +3136,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       persistedItems,
       sourceMatchKinds,
       filterApplied,
+      preserveInputIdentity,
       turnInput,
     };
   }

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -35,9 +35,18 @@ export type CallModelInputFilterArgs<TContext = unknown> = {
   context: TContext | undefined;
 };
 
-export type CallModelInputFilter<TContext = unknown> = (
+export type CallModelInputFilter<TContext = unknown> = ((
   args: CallModelInputFilterArgs<TContext>,
-) => ModelInputData | Promise<ModelInputData>;
+) => ModelInputData | Promise<ModelInputData>) & {
+  /**
+   * Preserve prepared input item identities by passing a shallow-copied array
+   * to the filter. The SDK does not freeze these items; enable this only when
+   * the filter and every helper it calls treat each input item and its nested
+   * values as immutable. Model and session inputs remain isolated copies after
+   * the filter returns.
+   */
+  preserveInputIdentity?: boolean;
+};
 
 /**
  * Result of applying a `callModelInputFilter`.
@@ -55,6 +64,7 @@ export type FilterApplicationResult = {
   persistedItems: AgentInputItem[];
   sourceMatchKinds: Array<'identity' | 'content' | 'fallback' | 'injected'>;
   filterApplied: boolean;
+  preserveInputIdentity: boolean;
 };
 
 export type ServerConversationOwner =
@@ -108,12 +118,23 @@ export async function applyCallModelInputFilter<TContext>(
       return cloned;
     });
 
-  // Record the relationship between the cloned array passed to filters and the original inputs.
+  // Record the relationship between the array passed to filters and the original inputs.
   const cloneMap = new WeakMap<object, AgentInputItem>();
 
-  // Always create a deep copy so downstream mutations inside filters cannot affect
-  // the cached turn state.
-  const clonedBaseInput = cloneInputItems(inputItems, cloneMap);
+  // Identity-preserving filters may opt into stable item identities. Other filters still
+  // receive deep copies so their mutations cannot affect the cached turn state.
+  const preserveInputIdentity =
+    callModelInputFilter?.preserveInputIdentity === true;
+  const clonedBaseInput = preserveInputIdentity
+    ? [...inputItems]
+    : cloneInputItems(inputItems, cloneMap);
+  if (preserveInputIdentity) {
+    for (const item of inputItems) {
+      if (item && typeof item === 'object') {
+        cloneMap.set(item as object, item);
+      }
+    }
+  }
   const base = {
     input: clonedBaseInput,
     instructions: systemInstructions,
@@ -129,6 +150,7 @@ export async function applyCallModelInputFilter<TContext>(
       persistedItems: cloneInputItems(normalizedInput),
       sourceMatchKinds: normalizedInput.map(() => 'identity'),
       filterApplied: false,
+      preserveInputIdentity,
     };
   }
 
@@ -174,7 +196,16 @@ export async function applyCallModelInputFilter<TContext>(
     const normalizedInput = deduplicateAgentInputItemsPreferringLatest(
       result.input,
     );
-    const consumedExactClones = new WeakSet<object>();
+    const availableExactOccurrences = new WeakMap<object, number>();
+    for (const item of clonedBaseInput) {
+      if (item && typeof item === 'object') {
+        availableExactOccurrences.set(
+          item as object,
+          (availableExactOccurrences.get(item as object) ?? 0) + 1,
+        );
+      }
+    }
+    const consumedExactOccurrences = new WeakMap<object, number>();
     const injectedExactCloneIndexes = new Set<number>();
 
     // Preserve a pointer to the original object backing each filtered clone so downstream
@@ -188,11 +219,16 @@ export async function applyCallModelInputFilter<TContext>(
         if (!original) {
           return undefined;
         }
-        if (consumedExactClones.has(item as object)) {
+        const consumedOccurrences =
+          consumedExactOccurrences.get(item as object) ?? 0;
+        if (
+          consumedOccurrences >=
+          (availableExactOccurrences.get(item as object) ?? 0)
+        ) {
           injectedExactCloneIndexes.add(index);
           return undefined;
         }
-        consumedExactClones.add(item as object);
+        consumedExactOccurrences.set(item as object, consumedOccurrences + 1);
         removeFromFallback(original);
         removeAgentInputFromPool(originalPool, original);
         return original;
@@ -257,6 +293,7 @@ export async function applyCallModelInputFilter<TContext>(
       persistedItems: clonedFilteredInput.map((item) => structuredClone(item)),
       sourceMatchKinds,
       filterApplied: true,
+      preserveInputIdentity,
     };
   } catch (error) {
     addErrorToCurrentSpan({
@@ -465,9 +502,11 @@ export class ServerConversationTracker {
     originalInput: string | AgentInputItem[],
     generatedItems: RunItem[],
     supplementalGeneratedItems: AgentInputItem[] = [],
+    pendingInputItems: RunInputItem[] = [],
   ): AgentInputItem[] {
     const inputItems: AgentInputItem[] = [];
     const generatedItemsForInput: RunItem[] = [];
+    const pendingInputItemSet = new Set<RunItem>(pendingInputItems);
 
     if (!this.sentInitialInput) {
       const initialItems = toAgentInputList(originalInput);
@@ -500,7 +539,10 @@ export class ServerConversationTracker {
       if (!rawItem || typeof rawItem !== 'object') {
         continue;
       }
-      if (this.sentItems.has(rawItem) || this.serverItems.has(rawItem)) {
+      if (
+        !pendingInputItemSet.has(item) &&
+        (this.sentItems.has(rawItem) || this.serverItems.has(rawItem))
+      ) {
         continue;
       }
       generatedItemsForInput.push(item);

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -216,6 +216,19 @@ export function agentInputSerializationReplacer(
 
 export type ReasoningItemIdPolicy = 'preserve' | 'omit';
 
+// Keep each model-input normalization stable for one generated item so identity-preserving
+// filters can reuse caches across turns without mutating the provider item.
+const normalizedOutputItemByRunItem = new WeakMap<
+  RunItem,
+  Partial<Record<'preserve' | 'omit', AgentInputItem>>
+>();
+
+export function invalidateOutputItemNormalization(items: RunItem[]): void {
+  for (const item of items) {
+    normalizedOutputItemByRunItem.delete(item);
+  }
+}
+
 function shouldOmitReasoningItemIds(
   reasoningItemIdPolicy?: ReasoningItemIdPolicy,
 ): boolean {
@@ -248,11 +261,30 @@ export function extractOutputItemsFromRunItems(
   return items
     .filter((item) => item.type !== 'tool_approval_item')
     .map((item) => {
-      const rawItem = withoutNullStatus(item.rawItem as AgentInputItem);
-      if (item.type !== 'reasoning_item') {
-        return rawItem;
+      const normalizationKey =
+        item.type === 'reasoning_item' &&
+        shouldOmitReasoningItemIds(reasoningItemIdPolicy)
+          ? 'omit'
+          : 'preserve';
+      const cached =
+        normalizedOutputItemByRunItem.get(item)?.[normalizationKey];
+      if (cached) {
+        return cached;
       }
-      return stripReasoningItemIdForPolicy(rawItem, reasoningItemIdPolicy);
+      const withoutNullStatusItem = withoutNullStatus(
+        item.rawItem as AgentInputItem,
+      );
+      const normalizedItem =
+        normalizationKey === 'omit'
+          ? stripReasoningItemIdForPolicy(
+              withoutNullStatusItem,
+              reasoningItemIdPolicy,
+            )
+          : withoutNullStatusItem;
+      const cachedByPolicy = normalizedOutputItemByRunItem.get(item) ?? {};
+      cachedByPolicy[normalizationKey] = normalizedItem;
+      normalizedOutputItemByRunItem.set(item, cachedByPolicy);
+      return normalizedItem;
     });
 }
 

--- a/packages/agents-core/src/runner/pendingInput.ts
+++ b/packages/agents-core/src/runner/pendingInput.ts
@@ -10,6 +10,7 @@ type PendingInputPreparation = {
   sourceItems: (AgentInputItem | undefined)[];
   persistedItems: AgentInputItem[];
   sourceMatchKinds: Array<'identity' | 'content' | 'fallback' | 'injected'>;
+  preserveInputIdentity: boolean;
 };
 
 /**
@@ -88,12 +89,19 @@ export function selectPendingInputForAdmission(
       continue;
     }
     acceptedIds.add(pendingItem.inputId);
+    const preservesPreparedItem =
+      preparation.preserveInputIdentity &&
+      preparation.sourceMatchKinds[index] === 'identity' &&
+      getAgentInputItemKey(pendingItem.rawItem) ===
+        getAgentInputItemKey(persistedItem);
     admitted.push(
-      new RunInputItem(
-        structuredClone(persistedItem),
-        pendingItem.agent,
-        pendingItem.inputId,
-      ),
+      preservesPreparedItem
+        ? pendingItem
+        : new RunInputItem(
+            structuredClone(persistedItem),
+            pendingItem.agent,
+            pendingItem.inputId,
+          ),
     );
   }
   return admitted;
@@ -145,7 +153,7 @@ export function commitPendingInput(
     ...(preparedQueueIsIntact
       ? preparedItems
           .filter((item) => !admittedIds.has(item.inputId))
-          .map((item) => structuredClone(item.rawItem))
+          .map((item) => item.rawItem)
       : []),
     ...structuredClone(newlyStagedItems),
   ];

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -111,6 +111,7 @@ import {
   COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
 } from './streamReconciliation';
 import { runWithSiblingCancellation } from './siblingCancellation';
+import { invalidateOutputItemNormalization } from './items';
 
 type FunctionToolCallDeps<TContext = UnknownContext> = {
   agent: Agent<TContext, any>;
@@ -2575,6 +2576,10 @@ export async function executeHandoffCalls<
         };
 
         const filtered = inputFilter(handoffInputData);
+        invalidateOutputItemNormalization([
+          ...handoffInputData.preHandoffItems,
+          ...handoffInputData.newItems,
+        ]);
 
         originalInput = filtered.inputHistory;
         preStepItems = filtered.preHandoffItems;

--- a/packages/agents-core/src/runner/turnPreparation.ts
+++ b/packages/agents-core/src/runner/turnPreparation.ts
@@ -31,6 +31,80 @@ type PreparedTurn = {
   pendingInputSourceItems: AgentInputItem[];
 };
 
+// Keep run-local input normalizations stable so identity-preserving filters can reuse them
+// across turns without changing the serialized RunState boundary.
+type PreparedInputIdentityCache = {
+  normalizedStringInput?: {
+    source: string;
+    items: AgentInputItem[];
+  };
+  pendingInputItems: WeakMap<object, RunInputItem[]>;
+};
+
+const preparedInputIdentityByRunState = new WeakMap<
+  RunState<any, any>,
+  PreparedInputIdentityCache
+>();
+
+function getPreparedInputIdentityCache<
+  TContext,
+  TAgent extends Agent<TContext, AgentOutputType>,
+>(state: RunState<TContext, TAgent>): PreparedInputIdentityCache {
+  const cached = preparedInputIdentityByRunState.get(state);
+  if (cached) {
+    return cached;
+  }
+  const created = { pendingInputItems: new WeakMap<object, RunInputItem[]>() };
+  preparedInputIdentityByRunState.set(state, created);
+  return created;
+}
+
+function getPreparedOriginalInput<
+  TContext,
+  TAgent extends Agent<TContext, AgentOutputType>,
+>(
+  state: RunState<TContext, TAgent>,
+  input: string | AgentInputItem[],
+): AgentInputItem[] {
+  if (typeof input !== 'string') {
+    return input;
+  }
+  const cache = getPreparedInputIdentityCache(state);
+  if (cache.normalizedStringInput?.source === input) {
+    return cache.normalizedStringInput.items;
+  }
+  const normalized = prepareModelInputItems(input, []);
+  cache.normalizedStringInput = { source: input, items: normalized };
+  return normalized;
+}
+
+function getPreparedPendingInputItem<
+  TContext,
+  TAgent extends Agent<TContext, AgentOutputType>,
+>(
+  state: RunState<TContext, TAgent>,
+  item: AgentInputItem,
+  occurrenceIndex: number,
+): RunInputItem {
+  if (!item || typeof item !== 'object') {
+    return new RunInputItem(structuredClone(item), state._currentAgent);
+  }
+  const cache = getPreparedInputIdentityCache(state);
+  const cached = cache.pendingInputItems.get(item as object)?.[occurrenceIndex];
+  if (cached) {
+    cached.agent = state._currentAgent;
+    return cached;
+  }
+  const prepared = new RunInputItem(structuredClone(item), state._currentAgent);
+  const preparedOccurrences = cache.pendingInputItems.get(item as object) ?? [];
+  preparedOccurrences[occurrenceIndex] = prepared;
+  cache.pendingInputItems.set(item as object, preparedOccurrences);
+  if (prepared.rawItem && typeof prepared.rawItem === 'object') {
+    cache.pendingInputItems.set(prepared.rawItem as object, [prepared]);
+  }
+  return prepared;
+}
+
 type PrepareTurnOptions<
   TContext,
   TAgent extends Agent<TContext, AgentOutputType>,
@@ -112,19 +186,29 @@ export async function prepareTurn<
     guardrailHandlers,
   );
 
-  const pendingInputItems = pendingInputSourceItems.map(
-    (item) => new RunInputItem(structuredClone(item), state._currentAgent),
-  );
+  const pendingInputOccurrences = new WeakMap<object, number>();
+  const pendingInputItems = pendingInputSourceItems.map((item) => {
+    const occurrenceIndex =
+      item && typeof item === 'object'
+        ? (pendingInputOccurrences.get(item as object) ?? 0)
+        : 0;
+    if (item && typeof item === 'object') {
+      pendingInputOccurrences.set(item as object, occurrenceIndex + 1);
+    }
+    return getPreparedPendingInputItem(state, item, occurrenceIndex);
+  });
   const generatedItemsForTurn = generatedItems.concat(pendingInputItems);
+  const preparedOriginalInput = getPreparedOriginalInput(state, input);
 
   const turnInput = serverConversationTracker
     ? serverConversationTracker.prepareInput(
-        input,
+        preparedOriginalInput,
         generatedItemsForTurn,
         getManagedConversationSupplementalItems(state),
+        pendingInputItems,
       )
     : prepareModelInputItems(
-        input,
+        preparedOriginalInput,
         generatedItemsForTurn,
         state._reasoningItemIdPolicy,
       );

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -125,6 +125,7 @@ export type PreparedModelCall<TContext = UnknownContext> =
     persistedItems: AgentInputItem[];
     sourceMatchKinds: Array<'identity' | 'content' | 'fallback' | 'injected'>;
     filterApplied: boolean;
+    preserveInputIdentity: boolean;
     turnInput: AgentInputItem[];
   };
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -36,6 +36,7 @@ import {
   user,
   assistant,
   type ToolExecutionConfig,
+  type CallModelInputFilterArgs,
   type ToolNameCollisionPolicy,
   type ToolNotFoundBehavior,
   type StandardSchemaWithJSON,
@@ -6519,6 +6520,430 @@ describe('Runner.run', () => {
         return this.lastCall?.request;
       }
     }
+
+    it('preserves filter item identity across model calls', async () => {
+      class RawRequestTrackingModel extends ScriptedModel {
+        readonly rawRequestInputs: AgentInputItem[][] = [];
+
+        async getResponse(request: ModelRequest): Promise<ModelResponse> {
+          this.rawRequestInputs.push(getRequestInputItems(request));
+          return super.getResponse(request);
+        }
+      }
+
+      const executeTool = tool({
+        name: 'continue_read_only_filter',
+        description: 'Continues the scripted run.',
+        parameters: z.object({}),
+        execute: async () => 'done',
+      });
+      const model = new RawRequestTrackingModel([
+        modelResponse({
+          output: [
+            {
+              type: 'function_call',
+              callId: 'call_read_only_filter',
+              name: executeTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'IdentityPreservingFilterAgent',
+        model,
+        tools: [executeTool],
+      });
+      const stableInput = user('Stable history');
+      const filterInputs: AgentInputItem[][] = [];
+      const filter = ({ modelData }: CallModelInputFilterArgs) => {
+        filterInputs.push(modelData.input);
+        return modelData;
+      };
+      filter.preserveInputIdentity = true;
+
+      await new Runner({ callModelInputFilter: filter }).run(agent, [
+        stableInput,
+      ]);
+
+      expect(filterInputs).toHaveLength(2);
+      expect(filterInputs[0]).not.toBe(filterInputs[1]);
+      const stablePreparedInput = filterInputs[0]?.[0];
+      expect(stablePreparedInput).toBeDefined();
+      expect(stablePreparedInput).not.toBe(stableInput);
+      expect(filterInputs[1]?.[0]).toBe(stablePreparedInput);
+      expect(model.calls).toHaveLength(2);
+      expect(model.rawRequestInputs).toHaveLength(2);
+      for (const rawRequestInput of model.rawRequestInputs) {
+        expect(rawRequestInput[0]).not.toBe(stablePreparedInput);
+        expect(rawRequestInput[0]).not.toBe(stableInput);
+      }
+    });
+
+    it('preserves string input identity across model calls', async () => {
+      const executeTool = tool({
+        name: 'continue_string_input_identity',
+        description: 'Continues the scripted run.',
+        parameters: z.object({}),
+        execute: async () => 'done',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_string_identity_1',
+              callId: 'call_string_identity_1',
+              name: executeTool.name,
+              status: 'completed',
+              arguments: '{}',
+            } satisfies protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_string_identity_2',
+              callId: 'call_string_identity_2',
+              name: executeTool.name,
+              status: 'completed',
+              arguments: '{}',
+            } satisfies protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'StringInputIdentityAgent',
+        model,
+        tools: [executeTool],
+      });
+      const userInputs: AgentInputItem[] = [];
+      const filter = ({ modelData }: CallModelInputFilterArgs) => {
+        const userInput = modelData.input.find(
+          (item) => item.type === 'message' && item.role === 'user',
+        );
+        if (userInput) {
+          userInputs.push(userInput);
+        }
+        return modelData;
+      };
+      filter.preserveInputIdentity = true;
+
+      await new Runner({ callModelInputFilter: filter }).run(agent, 'hello');
+
+      expect(model.calls).toHaveLength(3);
+      expect(userInputs).toHaveLength(3);
+      expect(userInputs[0]).toBe(userInputs[1]);
+      expect(userInputs[1]).toBe(userInputs[2]);
+    });
+
+    it('rebuilds cached string input after a handoff filter replaces it', async () => {
+      const agentBModel = new ScriptedModel([
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agentB = new Agent({
+        name: 'FilteredStringInputAgentB',
+        model: agentBModel,
+      });
+      const handoffToB = handoff(agentB, {
+        inputFilter: (input) => ({ ...input, inputHistory: 'after' }),
+      });
+      const agentA = new Agent({
+        name: 'FilteredStringInputAgentA',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              {
+                type: 'function_call',
+                id: 'fc_filtered_string_input',
+                callId: 'call_filtered_string_input',
+                name: handoffToB.toolName,
+                status: 'completed',
+                arguments: '{}',
+              } satisfies protocol.FunctionCallItem,
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        handoffs: [handoffToB],
+      });
+      const filter = ({ modelData }: CallModelInputFilterArgs) => modelData;
+      filter.preserveInputIdentity = true;
+
+      await new Runner({ callModelInputFilter: filter }).run(agentA, 'before');
+
+      expect(agentBModel.calls[0]?.request.input).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'message',
+            role: 'user',
+            content: 'after',
+          }),
+        ]),
+      );
+      expect(agentBModel.calls[0]?.request.input).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'message',
+            role: 'user',
+            content: 'before',
+          }),
+        ]),
+      );
+    });
+
+    it('rebuilds cached generated input after a handoff filter rewrites it', async () => {
+      const agentBModel = new ScriptedModel([
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agentB = new Agent({
+        name: 'FilteredGeneratedInputAgentB',
+        model: agentBModel,
+      });
+      const handoffToB = handoff(agentB, {
+        inputFilter: (input) => {
+          const messageItem = input.preHandoffItems.find(
+            (item) => item.type === 'message_output_item',
+          );
+          if (
+            messageItem?.rawItem.type === 'message' &&
+            messageItem.rawItem.role === 'assistant'
+          ) {
+            messageItem.rawItem.content = fakeModelMessage('redacted').content;
+          }
+          return input;
+        },
+      });
+      const executeTool = tool({
+        name: 'continue_before_filtered_handoff',
+        description: 'Continues the scripted run.',
+        parameters: z.object({}),
+        execute: async () => 'done',
+      });
+      const agentA = new Agent({
+        name: 'FilteredGeneratedInputAgentA',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              {
+                ...fakeModelMessage('secret'),
+                status: null,
+              } as unknown as protocol.AssistantMessageItem,
+              {
+                type: 'function_call',
+                id: 'fc_before_filtered_handoff',
+                callId: 'call_before_filtered_handoff',
+                name: executeTool.name,
+                status: 'completed',
+                arguments: '{}',
+              } satisfies protocol.FunctionCallItem,
+            ],
+            usage: new Usage(),
+          }),
+          modelResponse({
+            output: [
+              {
+                type: 'function_call',
+                id: 'fc_filtered_generated_input',
+                callId: 'call_filtered_generated_input',
+                name: handoffToB.toolName,
+                status: 'completed',
+                arguments: '{}',
+              } satisfies protocol.FunctionCallItem,
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        handoffs: [handoffToB],
+        tools: [executeTool],
+      });
+
+      await new Runner().run(agentA, 'hello');
+
+      expect(agentBModel.calls[0]?.request.input).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'message',
+            role: 'assistant',
+            content: expect.arrayContaining([
+              expect.objectContaining({ text: 'redacted' }),
+            ]),
+          }),
+        ]),
+      );
+      expect(agentBModel.calls[0]?.request.input).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'message',
+            role: 'assistant',
+            content: expect.arrayContaining([
+              expect.objectContaining({ text: 'secret' }),
+            ]),
+          }),
+        ]),
+      );
+    });
+
+    it('preserves omitted-ID reasoning identity across model calls', async () => {
+      const executeTool = tool({
+        name: 'continue_reasoning_identity',
+        description: 'Continues the scripted run.',
+        parameters: z.object({}),
+        execute: async () => 'done',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            {
+              type: 'reasoning',
+              id: 'rs_identity',
+              content: [{ type: 'input_text', text: 'thinking...' }],
+            } satisfies protocol.ReasoningItem,
+            {
+              type: 'function_call',
+              id: 'fc_identity_1',
+              callId: 'call_identity_1',
+              name: executeTool.name,
+              status: 'completed',
+              arguments: '{}',
+            } satisfies protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_identity_2',
+              callId: 'call_identity_2',
+              name: executeTool.name,
+              status: 'completed',
+              arguments: '{}',
+            } satisfies protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'OmittedReasoningIdentityAgent',
+        model,
+        tools: [executeTool],
+      });
+      const reasoningInputs: protocol.ReasoningItem[] = [];
+      const filter = ({ modelData }: CallModelInputFilterArgs) => {
+        const reasoning = modelData.input.find(
+          (item): item is protocol.ReasoningItem => item.type === 'reasoning',
+        );
+        if (reasoning) {
+          reasoningInputs.push(reasoning);
+        }
+        return modelData;
+      };
+      filter.preserveInputIdentity = true;
+
+      await new Runner({
+        reasoningItemIdPolicy: 'omit',
+        callModelInputFilter: filter,
+      }).run(agent, 'hello');
+
+      expect(model.calls).toHaveLength(3);
+      expect(reasoningInputs).toHaveLength(2);
+      expect(reasoningInputs[0]).toBe(reasoningInputs[1]);
+      expect(reasoningInputs[0]).not.toHaveProperty('id');
+    });
+
+    it('preserves null-status item identity across model calls', async () => {
+      const executeTool = tool({
+        name: 'continue_null_status_identity',
+        description: 'Continues the scripted run.',
+        parameters: z.object({}),
+        execute: async () => 'done',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            {
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'intermediate' }],
+              status: null,
+            } as unknown as protocol.AssistantMessageItem,
+            {
+              type: 'function_call',
+              id: 'fc_null_status_1',
+              callId: 'call_null_status_1',
+              name: executeTool.name,
+              status: 'completed',
+              arguments: '{}',
+            } satisfies protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_null_status_2',
+              callId: 'call_null_status_2',
+              name: executeTool.name,
+              status: 'completed',
+              arguments: '{}',
+            } satisfies protocol.FunctionCallItem,
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'NullStatusIdentityAgent',
+        model,
+        tools: [executeTool],
+      });
+      const assistantInputs: protocol.AssistantMessageItem[] = [];
+      const filter = ({ modelData }: CallModelInputFilterArgs) => {
+        const assistantInput = modelData.input.find(
+          (item): item is protocol.AssistantMessageItem =>
+            item.type === 'message' && item.role === 'assistant',
+        );
+        if (assistantInput) {
+          assistantInputs.push(assistantInput);
+        }
+        return modelData;
+      };
+      filter.preserveInputIdentity = true;
+
+      await new Runner({ callModelInputFilter: filter }).run(agent, 'hello');
+
+      expect(model.calls).toHaveLength(3);
+      expect(assistantInputs).toHaveLength(2);
+      expect(assistantInputs[0]).toBe(assistantInputs[1]);
+      expect(assistantInputs[0]).not.toHaveProperty('status');
+    });
 
     it('modifies model input for non-streaming runs', async () => {
       const model = new FilterTrackingModel([

--- a/packages/agents-core/test/runState.pendingInput.test.ts
+++ b/packages/agents-core/test/runState.pendingInput.test.ts
@@ -8,9 +8,11 @@ import {
   RunState,
   Runner,
   UserError,
+  handoff,
   run,
   tool,
   type AgentInputItem,
+  type CallModelInputFilterArgs,
 } from '../src';
 import type { ModelRequest, ModelResponse } from '../src/model';
 import { RunContext } from '../src/runContext';
@@ -1533,6 +1535,193 @@ describe('RunState pending input', () => {
     );
     expect(admitted?.rawItem).toEqual(message('rewritten input'));
     expect(rewrittenState.pendingInput).toEqual([]);
+  });
+
+  it('preserves omitted pending input identity across model calls', async () => {
+    const agentBModel = new RecordingModel([
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agentB = new Agent({
+      name: 'pending-identity-b',
+      model: agentBModel,
+    });
+    const handoffToB = handoff(agentB);
+    const agentAModel = new RecordingModel([
+      {
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_pending_identity',
+            callId: 'call_pending_identity',
+            name: handoffToB.toolName,
+            status: 'completed',
+            arguments: '{}',
+          } satisfies protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      },
+    ]);
+    const agentA = new Agent({
+      name: 'pending-identity-a',
+      model: agentAModel,
+      handoffs: [handoffToB],
+    });
+    const state = createResumableState(agentA);
+    state.addInput('keep pending');
+    const pendingInputs: AgentInputItem[] = [];
+    const filter = ({ modelData }: CallModelInputFilterArgs) => {
+      const pending = modelData.input.find(
+        (item) => item.type === 'message' && item.content === 'keep pending',
+      );
+      if (pending) {
+        pendingInputs.push(pending);
+      }
+      if (pendingInputs.length > 1) {
+        return modelData;
+      }
+      return {
+        ...modelData,
+        input: modelData.input.filter((item) => item !== pending),
+      };
+    };
+    filter.preserveInputIdentity = true;
+
+    await run(agentA, state, { callModelInputFilter: filter });
+
+    expect(agentAModel.requests).toHaveLength(1);
+    expect(agentBModel.requests).toHaveLength(1);
+    expect(pendingInputs).toHaveLength(2);
+    expect(pendingInputs[0]).toBe(pendingInputs[1]);
+    expect(state.pendingInput).toEqual([]);
+    expect(
+      state._generatedItems.find((item) => item instanceof RunInputItem)?.agent,
+    ).toBe(agentB);
+  });
+
+  it('preserves duplicate pending input occurrences', async () => {
+    const model = new RecordingModel([
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agent = new Agent({ name: 'pending-duplicates', model });
+    const state = createResumableState(agent);
+    const sharedInput = message('duplicate pending');
+    state.addInput([sharedInput, sharedInput]);
+    const filter = ({ modelData }: CallModelInputFilterArgs) => modelData;
+    filter.preserveInputIdentity = true;
+
+    await run(agent, state, { callModelInputFilter: filter });
+
+    expect(
+      state._generatedItems.filter((item) => item instanceof RunInputItem),
+    ).toHaveLength(2);
+  });
+
+  it('preserves admitted pending input identity on later model calls', async () => {
+    const executeTool = tool({
+      name: 'continue_admitted_pending_identity',
+      description: 'Continues the scripted run.',
+      parameters: z.object({}),
+      execute: async () => 'done',
+    });
+    const model = new RecordingModel([
+      {
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_admitted_pending_identity',
+            callId: 'call_admitted_pending_identity',
+            name: executeTool.name,
+            status: 'completed',
+            arguments: '{}',
+          } satisfies protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      },
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agent = new Agent({
+      name: 'admitted-pending-identity',
+      model,
+      tools: [executeTool],
+    });
+    const state = createResumableState(agent);
+    state.addInput('admit pending');
+    const pendingInputs: AgentInputItem[] = [];
+    const filter = ({ modelData }: CallModelInputFilterArgs) => {
+      const pending = modelData.input.find(
+        (item) => item.type === 'message' && item.content === 'admit pending',
+      );
+      if (pending) {
+        pendingInputs.push(pending);
+      }
+      return modelData;
+    };
+    filter.preserveInputIdentity = true;
+
+    await run(agent, state, { callModelInputFilter: filter });
+
+    expect(pendingInputs).toHaveLength(2);
+    expect(pendingInputs[0]).toBe(pendingInputs[1]);
+  });
+
+  it('replays omitted pending input in server-managed continuations', async () => {
+    const executeTool = tool({
+      name: 'continue_server_pending_identity',
+      description: 'Continues the scripted run.',
+      parameters: z.object({}),
+      execute: async () => 'done',
+    });
+    const model = new RecordingModel([
+      {
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_server_pending_identity',
+            callId: 'call_server_pending_identity',
+            name: executeTool.name,
+            status: 'completed',
+            arguments: '{}',
+          } satisfies protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      },
+      { output: [fakeModelMessage('done')], usage: new Usage() },
+    ]);
+    const agent = new Agent({
+      name: 'server-pending-identity',
+      model,
+      tools: [executeTool],
+    });
+    const state = createResumableState(agent);
+    state.setConversationContext('server-pending-identity');
+    state.addInput('replay pending');
+    const pendingInputs: AgentInputItem[] = [];
+    const filter = ({ modelData }: CallModelInputFilterArgs) => {
+      const pending = modelData.input.find(
+        (item) => item.type === 'message' && item.content === 'replay pending',
+      );
+      if (pending) {
+        pendingInputs.push(pending);
+      }
+      if (pendingInputs.length > 1) {
+        return modelData;
+      }
+      return {
+        ...modelData,
+        input: modelData.input.filter((item) => item !== pending),
+      };
+    };
+    filter.preserveInputIdentity = true;
+
+    await run(agent, state, {
+      conversationId: 'server-pending-identity',
+      callModelInputFilter: filter,
+    });
+
+    expect(model.requests).toHaveLength(2);
+    expect(pendingInputs).toHaveLength(2);
+    expect(pendingInputs[0]).toBe(pendingInputs[1]);
+    expect(state.pendingInput).toEqual([]);
   });
 
   it('rejects an ambiguous reconstructed filter item before model invocation', async () => {

--- a/packages/agents-core/test/runner/conversation.test.ts
+++ b/packages/agents-core/test/runner/conversation.test.ts
@@ -3,7 +3,10 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { setDefaultModelProvider, setTracingDisabled } from '../../src';
 import { Agent, AgentOutputType } from '../../src/agent';
 import { RunContext } from '../../src/runContext';
-import { applyCallModelInputFilter } from '../../src/runner/conversation';
+import {
+  applyCallModelInputFilter,
+  type CallModelInputFilterArgs,
+} from '../../src/runner/conversation';
 import type { AgentInputItem } from '../../src/types';
 import { UserError } from '../../src/errors';
 import { ScriptedModelProvider } from '../stubs';
@@ -83,6 +86,75 @@ describe('applyCallModelInputFilter', () => {
     expect(result.persistedItems[0]).not.toBe(result.modelInput.input[0]);
     expect(first.content).toBe('secret');
     expect(second.content).toBe('keep me');
+  });
+
+  it('preserves source identity only for filters that opt in', async () => {
+    const agent = makeAgent('IdentityPreservingFilter');
+    const context = new RunContext();
+    const shared: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'shared',
+    };
+    const original = [shared, shared];
+    let receivedInput: AgentInputItem[] | undefined;
+    const filter = ({ modelData }: CallModelInputFilterArgs) => {
+      receivedInput = modelData.input;
+      return {
+        ...modelData,
+        input: [...modelData.input, shared],
+      };
+    };
+    filter.preserveInputIdentity = true;
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      filter,
+      context,
+      original,
+      undefined,
+    );
+
+    expect(receivedInput).not.toBe(original);
+    expect(receivedInput?.[0]).toBe(shared);
+    expect(receivedInput?.[1]).toBe(shared);
+    expect(result.sourceItems).toEqual([shared, shared, undefined]);
+    expect(result.sourceMatchKinds).toEqual([
+      'identity',
+      'identity',
+      'injected',
+    ]);
+    expect(result.modelInput.input[0]).not.toBe(shared);
+    expect(result.persistedItems[0]).not.toBe(shared);
+    expect(result.persistedItems[0]).not.toBe(result.modelInput.input[0]);
+  });
+
+  it('keeps default filter input isolated from source mutations', async () => {
+    const agent = makeAgent('MutableFilter');
+    const context = new RunContext();
+    const original: AgentInputItem = {
+      type: 'message',
+      role: 'user',
+      content: 'original',
+    };
+
+    const result = await applyCallModelInputFilter(
+      agent,
+      ({ modelData }) => {
+        const received = modelData.input[0];
+        if (received?.type === 'message') {
+          received.content = 'filtered';
+        }
+        return modelData;
+      },
+      context,
+      [original],
+      undefined,
+    );
+
+    expect(original.content).toBe('original');
+    expect(result.modelInput.input[0]).toMatchObject({ content: 'filtered' });
+    expect(result.persistedItems[0]).toMatchObject({ content: 'filtered' });
   });
 
   it('leaves sourceItems undefined for injected filter items', async () => {


### PR DESCRIPTION
This pull request supersedes #1652 and adds an explicit `preserveInputIdentity` opt-in for `CallModelInputFilter` functions that need stable prepared item identities across model calls.

The original proposal called the flag `readonlyInput`. This replacement renames it because the SDK does not freeze or otherwise enforce read-only access. `preserveInputIdentity` describes the observable behavior instead: the filter receives a shallow-copied input array whose item objects retain their prepared identities.

By default, filters still receive deep-cloned input and cannot mutate runner-owned turn state. Filters that enable `preserveInputIdentity` must treat the items and nested values as immutable. Model requests and persisted session items remain isolated clones after filtering.

The change also preserves source tracking for repeated object occurrences, marks excess returned references as injected items, adds regression coverage for identity preservation and default mutation isolation, and records the updated conversation ownership boundary.

