### PR TITLE
fix: reject partially matched stacked diff anchors

### DIFF
--- a/.changeset/quiet-anchors-fail.md
+++ b/.changeset/quiet-anchors-fail.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reject partially matched stacked apply-diff anchors

--- a/packages/agents-core/src/utils/applyDiff.ts
+++ b/packages/agents-core/src/utils/applyDiff.ts
@@ -99,18 +99,20 @@ function parseUpdateDiff(
   let cursor = 0;
 
   while (!isDone(parser, END_SECTION_MARKERS)) {
-    const { anchors, hasAnchor } = readAnchors(parser);
+    const { anchors, anchorCount } = readAnchors(parser);
 
-    if (!(hasAnchor || cursor === 0)) {
+    if (!(anchorCount > 0 || cursor === 0)) {
       throw new Error(`Invalid Line:\n${parser.lines[parser.index]}`);
     }
 
+    const requireAnchorMatch = anchorCount > 1;
     for (const [index, anchor] of anchors.entries()) {
       cursor = advanceCursorToAnchor(
         anchor,
         inputLines,
         cursor,
         parser,
+        requireAnchorMatch,
         index > 0,
       );
     }
@@ -148,29 +150,27 @@ function parseUpdateDiff(
 
 function readAnchors(parser: ParserState): {
   anchors: string[];
-  hasAnchor: boolean;
+  anchorCount: number;
 } {
   const anchors: string[] = [];
-  let hasAnchor = false;
+  let anchorCount = 0;
 
   while (true) {
     const startIndex = parser.index;
     const anchor = readStr(parser, '@@ ');
     let consumed = parser.index !== startIndex;
-    let bare = false;
 
     if (!consumed && parser.lines[parser.index] === '@@') {
       parser.index += 1;
       consumed = true;
-      bare = true;
     }
 
     if (!consumed) break;
-    if (anchor || bare) hasAnchor = true;
+    anchorCount += 1;
     if (anchor.trim()) anchors.push(anchor);
   }
 
-  return { anchors, hasAnchor };
+  return { anchors, anchorCount };
 }
 
 function advanceCursorToAnchor(
@@ -178,14 +178,17 @@ function advanceCursorToAnchor(
   inputLines: string[],
   cursor: number,
   parser: ParserState,
+  requireMatch = false,
   forceForwardSearch = false,
 ): number {
   let found = false;
+  const hasExactMatchBeforeCursor =
+    !forceForwardSearch &&
+    inputLines.slice(0, cursor).some((line) => line === anchor);
 
-  if (
-    forceForwardSearch ||
-    !inputLines.slice(0, cursor).some((s) => s === anchor)
-  ) {
+  if (hasExactMatchBeforeCursor) {
+    found = true;
+  } else {
     for (let i = cursor; i < inputLines.length; i += 1) {
       if (inputLines[i] === anchor) {
         cursor = i + 1;
@@ -195,19 +198,27 @@ function advanceCursorToAnchor(
     }
   }
 
-  if (
-    !found &&
-    (forceForwardSearch ||
-      !inputLines.slice(0, cursor).some((s) => s.trim() === anchor.trim()))
-  ) {
-    for (let i = cursor; i < inputLines.length; i += 1) {
-      if (inputLines[i].trim() === anchor.trim()) {
-        cursor = i + 1;
-        parser.fuzz += 1;
-        found = true;
-        break;
+  if (!found) {
+    const hasTrimmedMatchBeforeCursor =
+      !forceForwardSearch &&
+      inputLines.slice(0, cursor).some((line) => line.trim() === anchor.trim());
+
+    if (hasTrimmedMatchBeforeCursor) {
+      found = true;
+    } else {
+      for (let i = cursor; i < inputLines.length; i += 1) {
+        if (inputLines[i].trim() === anchor.trim()) {
+          cursor = i + 1;
+          parser.fuzz += 1;
+          found = true;
+          break;
+        }
       }
     }
+  }
+
+  if (requireMatch && !found) {
+    throw new Error(`Invalid Anchor ${cursor}:\n${anchor}`);
   }
 
   return cursor;

--- a/packages/agents-core/test/utils/applyDiff.test.ts
+++ b/packages/agents-core/test/utils/applyDiff.test.ts
@@ -125,6 +125,39 @@ describe('applyDiff', () => {
     );
   });
 
+  it('reuses a prior parent anchor across stacked hunks', () => {
+    const input =
+      [
+        'class Target',
+        '    def first():',
+        '        pass',
+        '',
+        '    def second():',
+        '        pass',
+      ].join('\n') + '\n';
+    const diff = [
+      '@@ class Target',
+      '@@     def first():',
+      '-        pass',
+      '+        return 1',
+      '@@ class Target',
+      '@@     def second():',
+      '-        pass',
+      '+        return 2',
+    ].join('\n');
+
+    expect(applyDiff(input, diff)).toBe(
+      [
+        'class Target',
+        '    def first():',
+        '        return 1',
+        '',
+        '    def second():',
+        '        return 2',
+      ].join('\n') + '\n',
+    );
+  });
+
   it('uses each stacked anchor to narrow the target', () => {
     const input =
       [
@@ -162,11 +195,44 @@ describe('applyDiff', () => {
     );
   });
 
-  it('keeps unmatched stacked anchors advisory', () => {
-    const input = 'a\nb\n';
-    const diff = ['@@ nope', '@@ also-nope', '-b', '+B'].join('\n');
+  it('rejects partially matched stacked anchors', () => {
+    const input =
+      [
+        'class Target',
+        '    def helper():',
+        '        pass',
+        '',
+        '    def desired():',
+        '        return 1',
+      ].join('\n') + '\n';
+    const diff = [
+      '@@ class Target',
+      '@@     def missing():',
+      '-        pass',
+      '+        return 99',
+    ].join('\n');
 
-    expect(applyDiff(input, diff)).toBe('a\nB\n');
+    expect(() => applyDiff(input, diff)).toThrow('Invalid Anchor');
+  });
+
+  it('rejects a stacked diff when its first anchor is missing', () => {
+    const input =
+      ['class Wrong', '    def desired():', '        pass'].join('\n') + '\n';
+    const diff = [
+      '@@ class Target',
+      '@@     def desired():',
+      '-        pass',
+      '+        return 99',
+    ].join('\n');
+
+    expect(() => applyDiff(input, diff)).toThrow('Invalid Anchor');
+  });
+
+  it('rejects a missing anchor followed by a bare marker', () => {
+    const input = 'a\nb\n';
+    const diff = ['@@ missing', '@@', '-b', '+B'].join('\n');
+
+    expect(() => applyDiff(input, diff)).toThrow('Invalid Anchor');
   });
 
   it('accepts a trailing bare anchor in a stack', () => {


### PR DESCRIPTION
This pull request fixes stacked `@@` anchors in `applyDiff` so every non-empty anchor in a stack must match in sequence. Previously, when an earlier anchor matched but a later one did not, the parser could continue from the partial match and apply the hunk body to unrelated nearby content.

Single anchors and bare anchors keep their existing behavior, while incomplete stacks now fail before edited content is returned.
