### PR TITLE
fix: avoid redundant Standard Schema validation

### DIFF
--- a/.changeset/standard-schema-single-validation.md
+++ b/.changeset/standard-schema-single-validation.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: avoid redundant Standard Schema validation without dynamic approval

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -582,6 +582,9 @@ function parseToolArguments<TContext>(
       approvalArgs = preparedInput?.result.success
         ? preparedInput.result.value
         : approvalArgs;
+      if (!hasDynamicFunctionToolApprovalPolicy(toolRun.tool)) {
+        return { success: true, approvalArgs, preparedInput };
+      }
       const executionPreparedInput = prepareFunctionToolInput(
         toolRun.tool,
         toolRun.toolCall.arguments,

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -38,6 +38,7 @@ import {
   type ToolExecutionConfig,
   type ToolNameCollisionPolicy,
   type ToolNotFoundBehavior,
+  type StandardSchemaWithJSON,
 } from '../src';
 import { RunStreamEvent } from '../src/events';
 import { InvalidToolInputError, ToolCallError } from '../src/errors';
@@ -180,6 +181,142 @@ describe('Runner.run', () => {
       });
 
       expect(runner.config.toolExecution).toBe(toolExecution);
+    });
+
+    it('validates Standard Schema input once without approval', async () => {
+      type Input = { value?: string | null };
+      type Output = { value: string };
+      const validate = vi.fn((input: unknown) => ({
+        value: {
+          value: (input as Input | undefined)?.value ?? 'default',
+        },
+      }));
+      const parameters: StandardSchemaWithJSON<Input, Output> = {
+        '~standard': {
+          version: 1,
+          vendor: 'test',
+          types: undefined as unknown as { input: Input; output: Output },
+          jsonSchema: {
+            input: () => ({
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              additionalProperties: false,
+            }),
+            output: () => ({ type: 'object' }),
+          },
+          validate,
+        },
+      };
+      const execute = vi.fn(async (input: Output) => input.value);
+      const standardSchemaTool = tool({
+        name: 'standard_schema_no_approval',
+        description: 'Validate Standard Schema input once.',
+        parameters,
+        execute,
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: standardSchemaTool.name,
+              arguments: JSON.stringify({ value: null }),
+            },
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'StandardSchemaNoApprovalAgent',
+        model,
+        tools: [standardSchemaTool],
+      });
+
+      const result = await run(agent, 'start');
+
+      expect(validate).toHaveBeenCalledTimes(1);
+      expect(execute).toHaveBeenCalledWith(
+        { value: 'default' },
+        expect.any(RunContext),
+        expect.anything(),
+      );
+      expect(result.finalOutput).toBe('done');
+    });
+
+    it('validates Standard Schema input once per static approval attempt', async () => {
+      type Input = { value?: string | null };
+      type Output = { value: string };
+      const validate = vi.fn((input: unknown) => ({
+        value: {
+          value: (input as Input | undefined)?.value ?? 'default',
+        },
+      }));
+      const parameters: StandardSchemaWithJSON<Input, Output> = {
+        '~standard': {
+          version: 1,
+          vendor: 'test',
+          types: undefined as unknown as { input: Input; output: Output },
+          jsonSchema: {
+            input: () => ({
+              type: 'object',
+              properties: { value: { type: 'string' } },
+              additionalProperties: false,
+            }),
+            output: () => ({ type: 'object' }),
+          },
+          validate,
+        },
+      };
+      const execute = vi.fn(async (input: Output) => input.value);
+      const standardSchemaTool = tool({
+        name: 'standard_schema_static_approval',
+        description: 'Validate Standard Schema input once per run attempt.',
+        parameters,
+        needsApproval: true,
+        execute,
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: standardSchemaTool.name,
+              arguments: JSON.stringify({ value: null }),
+            },
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'StandardSchemaStaticApprovalAgent',
+        model,
+        tools: [standardSchemaTool],
+      });
+
+      const interrupted = await run(agent, 'start');
+
+      expect(validate).toHaveBeenCalledTimes(1);
+      expect(execute).not.toHaveBeenCalled();
+      expect(interrupted.interruptions).toHaveLength(1);
+      interrupted.state.approve(interrupted.interruptions[0]);
+
+      const result = await run(agent, interrupted.state);
+
+      expect(validate).toHaveBeenCalledTimes(2);
+      expect(execute).toHaveBeenCalledWith(
+        { value: 'default' },
+        expect.any(RunContext),
+        expect.anything(),
+      );
+      expect(result.finalOutput).toBe('done');
     });
 
     it('returns a redacted invalid-argument output to the model', async () => {


### PR DESCRIPTION
This pull request fixes duplicate Standard Schema validation for function tools whose approval policy cannot observe or mutate parsed arguments. Ordinary tools and tools with static approval settings now reuse the existing prepared input, so each runner attempt validates once.

Dynamic `needsApproval` callbacks continue to receive an independently validated value, preserving isolation when approval code mutates transformed input before execution. The change adds public `run()` coverage for tools without approval and for static approval interruption and resume, while retaining the existing dynamic-isolation and asynchronous-validation behavior.
