### PR TITLE
fix(core): detach scripted model stream snapshots

### DIFF
--- a/.changeset/quiet-streams-detach.md
+++ b/.changeset/quiet-streams-detach.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: detach automatically generated scripted model stream events

--- a/packages/agents-core/src/testing/scriptedModel.ts
+++ b/packages/agents-core/src/testing/scriptedModel.ts
@@ -733,20 +733,20 @@ async function* streamResponse(
     for (const part of item.content) {
       if (part.type === 'output_text') {
         throwIfAborted(signal, callIndex);
-        yield {
+        yield snapshotTestingValue<StreamEvent>({
           type: 'output_text_delta',
           itemId: item.id,
           delta: part.text,
           ...(typeof part.providerData === 'undefined'
             ? {}
             : { providerData: part.providerData }),
-        };
+        });
       }
     }
   }
 
   throwIfAborted(signal, callIndex);
-  yield {
+  yield snapshotTestingValue<StreamEvent>({
     type: 'response_done',
     response: {
       id: response.responseId!,
@@ -779,7 +779,7 @@ async function* streamResponse(
       providerData: response.providerData,
       output: response.output,
     },
-  } as StreamEvent;
+  } as StreamEvent);
 }
 
 function throwIfAborted(signal?: AbortSignal, callIndex?: number): void {

--- a/packages/agents-core/test/testing/scriptedModel.test.ts
+++ b/packages/agents-core/test/testing/scriptedModel.test.ts
@@ -552,6 +552,53 @@ describe('ScriptedModel', () => {
     expect(streamingModel.lastCall?.streamed).toBe(true);
   });
 
+  it('detaches automatic stream events from later events', async () => {
+    const model = new ScriptedModel([
+      modelResponse([
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [
+            {
+              type: 'output_text',
+              text: 'hello',
+              providerData: { nested: { value: 1 } },
+            },
+          ],
+        },
+      ]),
+    ]);
+    const iterator = model
+      .getStreamedResponse(makeRequest('hello'))
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    const delta = await iterator.next();
+    if (
+      delta.done ||
+      delta.value.type !== 'output_text_delta' ||
+      !delta.value.providerData
+    ) {
+      throw new Error('Expected an output text delta with provider data.');
+    }
+    (delta.value.providerData.nested as { value: number }).value = 99;
+
+    const completed = await iterator.next();
+    if (completed.done || completed.value.type !== 'response_done') {
+      throw new Error('Expected a completed response.');
+    }
+    const output = completed.value.response.output[0];
+    if (
+      output?.type !== 'message' ||
+      output.content[0]?.type !== 'output_text'
+    ) {
+      throw new Error('Expected an assistant output text item.');
+    }
+
+    expect(output.content[0].providerData).toEqual({ nested: { value: 1 } });
+  });
+
   it('checks abort signals before every automatic stream event', async () => {
     const controller = new AbortController();
     const model = new ScriptedModel([


### PR DESCRIPTION
This pull request fixes aliasing between automatically generated `ScriptedModel` stream events. Previously, mutating nested `providerData` on an earlier `output_text_delta` could mutate the later `response_done` response.

Each generated event is now copied through `snapshotTestingValue`, detaching supported mutable containers while preserving deterministic IDs, usage and provider data, identity-sensitive runtime values, abort checks, and the exact semantics of raw `modelStream()` and `modelStreamResponder()` steps.
