### PR TITLE
fix: detach Manifest snapshots in scripted sandbox calls

### DIFF
--- a/.changeset/fix-scripted-sandbox-manifest-snapshots.md
+++ b/.changeset/fix-scripted-sandbox-manifest-snapshots.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: detach Manifest arguments in scripted sandbox call snapshots

--- a/packages/agents-core/src/testing/scriptedSandboxSession.ts
+++ b/packages/agents-core/src/testing/scriptedSandboxSession.ts
@@ -1,4 +1,4 @@
-import { Manifest } from '../sandbox/manifest';
+import { cloneManifest, Manifest } from '../sandbox/manifest';
 import type { SandboxSession, SandboxSessionState } from '../sandbox/session';
 import { snapshotTestingValue } from '../utils/testingSnapshot';
 
@@ -255,7 +255,7 @@ export function scriptedSandboxSession(
     const call: InternalRecordedSandboxCall = Object.freeze({
       index: calls.length,
       method,
-      args: Object.freeze(snapshotTestingValue(args)),
+      args: Object.freeze(snapshotSandboxCallArgs(method, args)),
     });
     calls.push(call);
 
@@ -270,7 +270,7 @@ export function scriptedSandboxSession(
     }
 
     if (step.match) {
-      const matchArgs = snapshotTestingValue(call.args) as unknown[];
+      const matchArgs = snapshotSandboxCallArgs(method, call.args);
       if (step.match(...matchArgs) === false) {
         throw new SandboxCallMatcherError(call);
       }
@@ -419,8 +419,19 @@ function snapshotRecordedCall(
   return Object.freeze({
     index: call.index,
     method: call.method,
-    args: Object.freeze(snapshotTestingValue(call.args)),
+    args: Object.freeze(snapshotSandboxCallArgs(call.method, call.args)),
   });
+}
+
+function snapshotSandboxCallArgs(
+  method: ScriptedSandboxMethod,
+  args: readonly unknown[],
+): unknown[] {
+  const snapshot = snapshotTestingValue([...args]);
+  if (method === 'applyManifest' && snapshot[0] instanceof Manifest) {
+    snapshot[0] = cloneManifest(snapshot[0]);
+  }
+  return snapshot;
 }
 
 function isRecord(value: unknown): value is Record<PropertyKey, unknown> {

--- a/packages/agents-core/test/testing/scriptedSandboxSession.test.ts
+++ b/packages/agents-core/test/testing/scriptedSandboxSession.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import { run } from '../../src';
 import type { SandboxSession } from '../../src/sandbox';
-import { SandboxAgent, shell } from '../../src/sandbox';
+import { Manifest, SandboxAgent, shell } from '../../src/sandbox';
+import { manifestAcknowledgesInContainerMountCredentialExposure } from '../../src/sandbox/manifest';
 import { registerSandboxPreStopHook } from '../../src/sandbox/runtime/sessionLifecycle';
 import {
   InvalidScriptedSandboxStepError,
@@ -134,6 +135,63 @@ describe('scriptedSandboxSession', () => {
     expect([...firstSnapshot]).toEqual([1, 2, 3]);
     firstSnapshot[0] = 8;
     expect([...(session.calls[0].args[0] as Uint8Array)]).toEqual([1, 2, 3]);
+  });
+
+  it('isolates applyManifest matcher snapshots from the caller and call history', async () => {
+    const manifest = createMutableManifest();
+    const session = scriptedSandboxSession([
+      {
+        method: 'applyManifest',
+        match: (snapshot) => {
+          expectManifestValues(snapshot, 'initial');
+          mutateManifest(snapshot, 'matcher');
+          return true;
+        },
+        result: undefined,
+      },
+    ]);
+
+    await session.applyManifest(manifest);
+
+    expectManifestValues(manifest, 'initial');
+    expectManifestValues(session.calls[0].args[0] as Manifest, 'initial');
+  });
+
+  it('isolates applyManifest responder snapshots from call history', async () => {
+    const manifest = createMutableManifest();
+    const session = scriptedSandboxSession([
+      {
+        method: 'applyManifest',
+        respond: (call) => {
+          const snapshot = call.args[0];
+          expectManifestValues(snapshot, 'initial');
+          mutateManifest(snapshot, 'responder');
+        },
+      },
+    ]);
+
+    await session.applyManifest(manifest);
+
+    expectManifestValues(manifest, 'initial');
+    expectManifestValues(session.calls[0].args[0] as Manifest, 'initial');
+  });
+
+  it('keeps applyManifest call snapshots stable after later mutations', async () => {
+    const manifest = createMutableManifest();
+    const session = scriptedSandboxSession([
+      {
+        method: 'applyManifest',
+        result: undefined,
+      },
+    ]);
+
+    await session.applyManifest(manifest);
+    mutateManifest(manifest, 'caller');
+
+    const firstRead = session.calls[0].args[0] as Manifest;
+    expectManifestValues(firstRead, 'initial');
+    mutateManifest(firstRead, 'observer');
+    expectManifestValues(session.calls[0].args[0] as Manifest, 'initial');
   });
 
   it('snapshots mutable static results when they are queued', async () => {
@@ -285,3 +343,67 @@ describe('scriptedSandboxSession', () => {
     >();
   });
 });
+
+function createMutableManifest(): Manifest {
+  return new Manifest({
+    root: '/workspace',
+    entries: {
+      'config.json': {
+        type: 'file',
+        content: 'initial',
+      },
+    },
+    environment: {
+      TEST_VALUE: 'initial',
+    },
+    users: ['initial'],
+    groups: [{ name: 'initial', users: ['initial'] }],
+    extraPathGrants: [
+      {
+        path: '/initial',
+        hostPath: '/host/initial',
+        description: 'initial',
+      },
+    ],
+    remoteMountCommandAllowlist: ['initial'],
+  }).withInContainerMountCredentialExposureAcknowledged('/workspace/mount');
+}
+
+function expectManifestValues(manifest: Manifest, value: string): void {
+  expect(manifest.root).toBe(value === 'initial' ? '/workspace' : `/${value}`);
+  expect(manifest.entries['config.json']).toMatchObject({ content: value });
+  expect(manifest.environment.TEST_VALUE.value).toBe(value);
+  expect(manifest.users[0]?.name).toBe(value);
+  expect(manifest.groups[0]).toMatchObject({
+    name: value,
+    users: [{ name: value }],
+  });
+  expect(manifest.extraPathGrants[0]).toMatchObject({
+    path: `/${value}`,
+    hostPath: `/host/${value}`,
+    description: value,
+  });
+  expect(manifest.remoteMountCommandAllowlist).toEqual([value]);
+  if (value === 'initial') {
+    expect(
+      manifestAcknowledgesInContainerMountCredentialExposure(
+        manifest,
+        '/workspace/mount',
+        'mount_scoped',
+      ),
+    ).toBe(true);
+  }
+}
+
+function mutateManifest(manifest: Manifest, value: string): void {
+  (manifest as { root: string }).root = `/${value}`;
+  (manifest.entries['config.json'] as { content: string }).content = value;
+  (manifest.environment.TEST_VALUE as { value: string }).value = value;
+  manifest.users[0]!.name = value;
+  manifest.groups[0]!.name = value;
+  manifest.groups[0]!.users![0]!.name = value;
+  manifest.extraPathGrants[0]!.path = `/${value}`;
+  manifest.extraPathGrants[0]!.hostPath = `/host/${value}`;
+  manifest.extraPathGrants[0]!.description = value;
+  manifest.remoteMountCommandAllowlist[0] = value;
+}


### PR DESCRIPTION
This pull request fixes `scriptedSandboxSession` call recording for `applyManifest`. The generic testing snapshot helper intentionally preserves class instances, so recorded manifest arguments could drift when a caller, matcher, responder, or call-history reader mutated a `Manifest` after invocation.

- Clone `applyManifest` arguments through the canonical `cloneManifest` pipeline at recording and observer boundaries.
- Preserve existing callback, signal, arbitrary-class, optional-method, and sync/async behavior outside this SDK-owned class boundary.
- Cover mutable manifest containers and trusted runtime-only manifest policy with focused mutation regressions.
