### PR TITLE
fix(core): isolate interruption result arrays

### DIFF
--- a/.changeset/calm-arrays-copy.md
+++ b/.changeset/calm-arrays-copy.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: isolate interruption result arrays from pending approvals

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -256,11 +256,7 @@ class RunResultBase<
    * Any interruptions that occurred during the agent run for example for tool approvals.
    */
   get interruptions(): RunToolApprovalItem[] {
-    if (this.state._currentStep?.type === 'next_step_interruption') {
-      return this.state._currentStep.data.interruptions;
-    }
-
-    return [];
+    return this.state.getInterruptions();
   }
 
   /**

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -2424,7 +2424,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
     }
     const interruptions = this._currentStep.data.interruptions;
     return Array.isArray(interruptions)
-      ? (interruptions as RunToolApprovalItem[])
+      ? [...(interruptions as RunToolApprovalItem[])]
       : [];
   }
 

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -320,6 +320,51 @@ describe('Runner.run', () => {
       expect(result.finalOutput).toBe('done');
     });
 
+    it('isolates interruption arrays from pending approvals', async () => {
+      const approvalTool = tool({
+        name: 'snapshot_approval',
+        description: 'Requires approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            {
+              ...TEST_MODEL_FUNCTION_CALL,
+              name: approvalTool.name,
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [fakeModelMessage('done')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'SnapshotApprovalAgent',
+        model,
+        tools: [approvalTool],
+      });
+
+      const interrupted = await run(agent, 'start');
+      const [approval] = interrupted.interruptions;
+
+      interrupted.state.getInterruptions().splice(0);
+      interrupted.interruptions.splice(0);
+
+      expect(interrupted.state.getInterruptions()).toEqual([approval]);
+      expect(interrupted.interruptions).toEqual([approval]);
+
+      interrupted.state.approve(approval);
+      const result = await run(agent, interrupted.state);
+
+      expect(result.finalOutput).toBe('done');
+    });
+
     it('returns a redacted invalid-argument output to the model', async () => {
       const secret = 'SECRET_NON_STREAMING_MODEL_OUTPUT_123';
       const flagSpy = vi


### PR DESCRIPTION
This pull request fixes interruption result ownership so callers cannot accidentally remove pending approvals by mutating arrays returned from `RunState.getInterruptions()` or `RunResult.interruptions`.

`RunState.getInterruptions()` now returns a shallow snapshot of the pending interruption array, while preserving each approval item's identity so existing `state.approve(item)` and `state.reject(item)` flows continue to work. `RunResult.interruptions` delegates to the same source of truth so result and state accessors share the same ownership behavior.