### PR TITLE
fix: snapshot sandbox HTTP event sink headers

### DIFF
--- a/.changeset/snapshot-sandbox-http-headers.md
+++ b/.changeset/snapshot-sandbox-http-headers.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: snapshot sandbox HTTP event sink headers

--- a/packages/agents-core/src/sandbox/events.ts
+++ b/packages/agents-core/src/sandbox/events.ts
@@ -89,6 +89,8 @@ export function createSandboxJsonlEventSink(
 export function createSandboxHttpEventSink(
   options: SandboxHttpEventSinkOptions,
 ): SandboxEventSink {
+  const headers = { ...options.headers };
+
   return async (event) => {
     const fetch = options.fetch ?? readGlobalFetch();
     if (!fetch) {
@@ -101,7 +103,7 @@ export function createSandboxHttpEventSink(
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        ...options.headers,
+        ...headers,
       },
       body: JSON.stringify(event),
     });

--- a/packages/agents-core/test/sandboxEvents.test.ts
+++ b/packages/agents-core/test/sandboxEvents.test.ts
@@ -270,6 +270,42 @@ describe('sandbox events', () => {
     });
   });
 
+  it('snapshots HTTP sink headers when the sink is created', async () => {
+    const headers = {
+      authorization: 'Bearer original',
+      'content-type': 'application/custom+json',
+    };
+    const requests: Array<Record<string, string>> = [];
+    const sink = createSandboxHttpEventSink({
+      endpoint: 'https://example.test/sandbox-events',
+      headers,
+      fetch: async (_endpoint, request) => {
+        requests.push(request.headers);
+        return {
+          ok: true,
+          status: 204,
+        };
+      },
+    });
+
+    headers.authorization = 'Bearer mutated';
+    headers['content-type'] = 'text/plain';
+
+    await sink({
+      type: 'sandbox_operation',
+      name: 'sandbox.read_file',
+      phase: 'start',
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(requests).toEqual([
+      {
+        'content-type': 'application/custom+json',
+        authorization: 'Bearer original',
+      },
+    ]);
+  });
+
   it('isolates JSONL and HTTP sink failures from the operation', async () => {
     const events: SandboxEvent[] = [];
     addSandboxEventSink((event) => {


### PR DESCRIPTION
This pull request fixes sandbox HTTP event sinks so caller-provided headers are captured when the sink is created.

Previously, mutating the original headers object after creating a sink could change later event requests, including authorization headers. The sink now uses a shallow snapshot of the provided headers while preserving the existing default content type, caller override precedence, endpoint resolution, fetch behavior, and error handling.