### PR TITLE
fix(agents-core): redact invalid typed tool output diagnostics

### DIFF
--- a/.changeset/redact-invalid-tool-output.md
+++ b/.changeset/redact-invalid-tool-output.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: redact invalid structured tool output diagnostics

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -7,7 +7,6 @@ import {
 import { consumeAgentToolRunResult } from '../agentToolRunResults';
 import {
   clearToolErrorState,
-  InvalidToolOutputError,
   isToolTimeoutError,
   ToolCallError,
   UserError,
@@ -18,6 +17,13 @@ import {
   isRedactedInvalidToolInputError,
   refreshInvalidToolInputFailure,
 } from '../toolInputError';
+import {
+  createInvalidToolOutputError,
+  getInvalidToolOutputFailure,
+  type InvalidToolOutputFailure,
+  isRedactedInvalidToolOutputError,
+  refreshInvalidToolOutputFailure,
+} from '../toolOutputError';
 import { getTransferMessage, HandoffInputData } from '../handoff';
 import {
   RunHandoffCallItem,
@@ -40,6 +46,7 @@ import {
   FunctionToolResult,
   FunctionToolCustomDataContext,
   ToolCallDetails,
+  FUNCTION_TOOL_INVALID_OUTPUT_FAILURE_CALLBACK,
   FUNCTION_TOOL_PARSED_INPUT_CALLBACK,
   ApplyPatchToolCustomDataContext,
   invokeFunctionTool,
@@ -120,6 +127,7 @@ type FunctionToolCallDeps<TContext = UnknownContext> = {
   toolErrorFormatter?: ToolErrorFormatter;
   agentToolParentRunConfig?: Partial<RunConfig>;
   signal?: AbortSignal;
+  onInvalidOutputFailure?: (failure: InvalidToolOutputFailure) => void;
 };
 
 const REDACTED_TOOL_ERROR_MESSAGE =
@@ -268,9 +276,8 @@ export function getToolCallOutputItem(
       }
       textOutput = serializedOutput;
     } catch (error) {
-      throw new InvalidToolOutputError(
+      throw createInvalidToolOutputError(
         `Function tool '${toolCall.name}' outputSchema requires a JSON-serializable output.`,
-        undefined,
         error,
         { output },
       );
@@ -310,6 +317,19 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
   signal?: AbortSignal,
   onFatalFailure?: () => void,
 ): Promise<FunctionToolResult<TContext>[]> {
+  const startedInvalidInputFailures: InvalidToolInputFailure[] = [];
+  const startedInvalidOutputFailures: InvalidToolOutputFailure[] = [];
+  const trackInvalidOutputFailure = (failure: InvalidToolOutputFailure) => {
+    if (!startedInvalidOutputFailures.includes(failure)) {
+      startedInvalidOutputFailures.push(failure);
+    }
+  };
+  const trackInvalidOutputError = (error: unknown) => {
+    const failure = getInvalidToolOutputFailure(error);
+    if (failure) {
+      trackInvalidOutputFailure(failure);
+    }
+  };
   const deps: FunctionToolCallDeps<TContext> = {
     agent,
     runner,
@@ -317,9 +337,8 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     toolErrorFormatter,
     agentToolParentRunConfig,
     signal,
+    onInvalidOutputFailure: trackInvalidOutputFailure,
   };
-
-  const startedInvalidInputFailures: InvalidToolInputFailure[] = [];
 
   const executeToolRun = async (
     toolRun: ToolRunFunction<TContext>,
@@ -379,8 +398,10 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
             parseResult.approvalArgs,
             parseResult.preparedInput,
             failure,
+            trackInvalidOutputFailure,
           );
         } catch (error) {
+          trackInvalidOutputError(error);
           if (
             executionSignal?.aborted &&
             (error === executionSignal.reason || isAbortError(error))
@@ -431,8 +452,11 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
         toolRun,
         parseResult.approvalArgs,
         parseResult.preparedInput,
+        undefined,
+        trackInvalidOutputFailure,
       );
     } catch (error) {
+      trackInvalidOutputError(error);
       if (
         executionSignal?.aborted &&
         (error === executionSignal.reason || isAbortError(error))
@@ -458,11 +482,20 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
     const redactInvalidInputFailure = startedInvalidInputFailures.some(
       (failure) => refreshInvalidToolInputFailure(failure),
     );
-    if (redactInvalidInputFailure) {
+    const invalidOutputFailure = getInvalidToolOutputFailure(e);
+    const redactStartedInvalidOutputFailure = startedInvalidOutputFailures.some(
+      (failure) => refreshInvalidToolOutputFailure(failure),
+    );
+    const redactSurfacedInvalidOutputFailure = invalidOutputFailure
+      ? refreshInvalidToolOutputFailure(invalidOutputFailure)
+      : isRedactedInvalidToolOutputError(e);
+    const redactInvalidOutputFailure =
+      redactStartedInvalidOutputFailure || redactSurfacedInvalidOutputFailure;
+    if (redactInvalidInputFailure || redactInvalidOutputFailure) {
       clearToolErrorState(e, state);
     }
     if (isToolTimeoutError(e)) {
-      if (redactInvalidInputFailure) {
+      if (redactInvalidInputFailure || redactInvalidOutputFailure) {
         e.state = undefined;
       } else {
         e.state ??= state;
@@ -470,11 +503,13 @@ export async function executeFunctionToolCalls<TContext = UnknownContext>(
       throw e;
     }
 
-    const surfacedError = e as Error;
+    const surfacedError = (invalidOutputFailure?.error ?? e) as Error;
     throw new ToolCallError(
       `Failed to run function tools: ${surfacedError}`,
       surfacedError,
-      redactInvalidInputFailure || isRedactedInvalidToolInputError(e)
+      redactInvalidInputFailure ||
+        isRedactedInvalidToolInputError(e) ||
+        redactInvalidOutputFailure
         ? undefined
         : state,
     );
@@ -641,17 +676,23 @@ function buildFunctionFailureResult<TContext>(
   toolRun: ToolRunFunction<TContext>,
   output: unknown,
 ): FunctionToolResult<TContext> {
+  let rawItem: FunctionCallResultItem;
+  try {
+    rawItem = getToolCallOutputItem(toolRun.toolCall, output, {
+      outputSchema: toolRun.tool.outputSchema,
+    });
+  } catch (error) {
+    const invalidOutputFailure = getInvalidToolOutputFailure(error);
+    if (invalidOutputFailure) {
+      deps.onInvalidOutputFailure?.(invalidOutputFailure);
+    }
+    throw error;
+  }
   return {
     type: 'function_output' as const,
     tool: toolRun.tool,
     output,
-    runItem: new RunToolCallOutputItem(
-      getToolCallOutputItem(toolRun.toolCall, output, {
-        outputSchema: toolRun.tool.outputSchema,
-      }),
-      deps.agent,
-      output,
-    ),
+    runItem: new RunToolCallOutputItem(rawItem, deps.agent, output),
   };
 }
 
@@ -710,12 +751,21 @@ async function resolveFunctionFailureOutput<TContext>(
     ) {
       throw redactionBoundary.failure.error;
     }
-    const validatedOutput = validateFunctionToolOutput({
-      tool: toolRun.tool,
-      output,
-      runContext: deps.state._context,
-      details,
-    });
+    let validatedOutput: unknown;
+    try {
+      validatedOutput = validateFunctionToolOutput({
+        tool: toolRun.tool,
+        output,
+        runContext: deps.state._context,
+        details,
+      });
+    } catch (error) {
+      const invalidOutputFailure = getInvalidToolOutputFailure(error);
+      if (invalidOutputFailure) {
+        deps.onInvalidOutputFailure?.(invalidOutputFailure);
+      }
+      throw error;
+    }
     if (
       redactionBoundary &&
       !redactedBeforeCallback &&
@@ -1030,6 +1080,7 @@ async function runApprovedFunctionTool<TContext>(
   approvalArgs: unknown,
   preparedInput: FunctionToolPreparedInput | undefined,
   invalidInputFailure?: InvalidToolInputFailure,
+  onInvalidOutputFailure?: (failure: InvalidToolOutputFailure) => void,
 ): Promise<FunctionToolResult<TContext>> {
   const { agent, runner, state, agentToolParentRunConfig, signal } = deps;
   const toolName = getFunctionToolIdentity(toolRun);
@@ -1202,6 +1253,8 @@ async function runApprovedFunctionTool<TContext>(
           [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]: (input: unknown) => {
             executedInput = cloneForCustomDataContext(input);
           },
+          [FUNCTION_TOOL_INVALID_OUTPUT_FAILURE_CALLBACK]:
+            onInvalidOutputFailure,
         };
         if (preparedInput) {
           setFunctionToolPreparedInput(toolDetails, preparedInput);
@@ -1402,6 +1455,10 @@ async function runApprovedFunctionTool<TContext>(
 
       return functionResult;
     } catch (error) {
+      const invalidOutputFailure = getInvalidToolOutputFailure(error);
+      if (invalidOutputFailure) {
+        onInvalidOutputFailure?.(invalidOutputFailure);
+      }
       if (committedOutputOnFailure) {
         throw error;
       }

--- a/packages/agents-core/src/tool.ts
+++ b/packages/agents-core/src/tool.ts
@@ -19,7 +19,7 @@ import {
 import { RunContext } from './runContext';
 import type { RunConfig } from './run';
 import type { RunResult } from './result';
-import { InvalidToolOutputError, ToolTimeoutError, UserError } from './errors';
+import { ToolTimeoutError, UserError } from './errors';
 import {
   createInvalidToolInputDisposition,
   createInvalidToolInputFailure,
@@ -28,6 +28,13 @@ import {
   isRedactedInvalidToolInputError,
   refreshInvalidToolInputFailure,
 } from './toolInputError';
+import {
+  createInvalidToolOutputError,
+  getInvalidToolOutputFailure,
+  type InvalidToolOutputFailure,
+  isRedactedInvalidToolOutputError,
+  refreshInvalidToolOutputFailure,
+} from './toolOutputError';
 import logger, { logToolActionWarning } from './logger';
 import { getCurrentSpan } from './tracing';
 import { RunToolApprovalItem, RunToolCallOutputItem } from './items';
@@ -95,6 +102,9 @@ export type ToolApprovalFunction<TParameters extends ToolInputParameters> = (
 
 export const FUNCTION_TOOL_PARSED_INPUT_CALLBACK = Symbol(
   'openai.agents.functionToolParsedInputCallback',
+);
+export const FUNCTION_TOOL_INVALID_OUTPUT_FAILURE_CALLBACK = Symbol(
+  'openai.agents.functionToolInvalidOutputFailureCallback',
 );
 const FUNCTION_TOOL_OUTPUT_VALIDATOR = Symbol(
   'openai.agents.functionToolOutputValidator',
@@ -204,6 +214,9 @@ export type ToolCallDetails = {
   resumeState?: string;
   signal?: AbortSignal;
   [FUNCTION_TOOL_PARSED_INPUT_CALLBACK]?: (input: unknown) => void;
+  [FUNCTION_TOOL_INVALID_OUTPUT_FAILURE_CALLBACK]?: (
+    failure: InvalidToolOutputFailure,
+  ) => void;
   /**
    * Internal: parent runner config for nested agent-tool runs (Agent.asTool).
    */
@@ -2140,7 +2153,20 @@ async function invokeFunctionToolWithTimeout<
     }
 
     if (timeoutErrorFunction) {
-      return timeoutErrorFunction(runContext, timeoutError, details);
+      try {
+        return await timeoutErrorFunction(runContext, timeoutError, details);
+      } catch (error) {
+        const invalidOutputFailure = getInvalidToolOutputFailure(error);
+        if (invalidOutputFailure) {
+          details?.[FUNCTION_TOOL_INVALID_OUTPUT_FAILURE_CALLBACK]?.(
+            invalidOutputFailure,
+          );
+          if (refreshInvalidToolOutputFailure(invalidOutputFailure)) {
+            throw invalidOutputFailure.error;
+          }
+        }
+        throw error;
+      }
     }
 
     return defaultFunctionToolTimeoutErrorMessage({
@@ -2319,9 +2345,8 @@ export function tool<
         Result
       >;
     } catch (error) {
-      throw new InvalidToolOutputError(
+      throw createInvalidToolOutputError(
         `Invalid output for function tool '${name}'.`,
-        undefined,
         error,
         { runContext, output, details },
       );
@@ -2436,14 +2461,32 @@ export function tool<
     error: any,
     details?: ToolCallDetails,
   ): Promise<ToolExecuteResult<TOutputSchema, Result>> {
+    const invalidOutputFailure = getInvalidToolOutputFailure(error);
+    if (invalidOutputFailure) {
+      details?.[FUNCTION_TOOL_INVALID_OUTPUT_FAILURE_CALLBACK]?.(
+        invalidOutputFailure,
+      );
+    }
     if (!toolErrorFunction) {
+      if (
+        invalidOutputFailure &&
+        refreshInvalidToolOutputFailure(invalidOutputFailure)
+      ) {
+        throw invalidOutputFailure.error;
+      }
       throw error;
     }
     const invalidInputFailure = getInvalidToolInputFailure(error);
-    const redactedBeforeCallback = invalidInputFailure
+    const redactedInputBeforeCallback = invalidInputFailure
       ? refreshInvalidToolInputFailure(invalidInputFailure)
       : isRedactedInvalidToolInputError(error);
-    const callbackError = invalidInputFailure?.error ?? error;
+    const redactedOutputBeforeCallback = invalidOutputFailure
+      ? refreshInvalidToolOutputFailure(invalidOutputFailure)
+      : isRedactedInvalidToolOutputError(error);
+    const redactedBeforeCallback =
+      redactedInputBeforeCallback || redactedOutputBeforeCallback;
+    const callbackError =
+      invalidInputFailure?.error ?? invalidOutputFailure?.error ?? error;
     const errorDetails = redactedBeforeCallback ? undefined : details;
     const currentSpan = getCurrentSpan();
     currentSpan?.setError({
@@ -2461,18 +2504,32 @@ export function tool<
       );
       if (
         invalidInputFailure &&
-        !redactedBeforeCallback &&
+        !redactedInputBeforeCallback &&
         refreshInvalidToolInputFailure(invalidInputFailure)
       ) {
         throw invalidInputFailure.error;
       }
+      if (
+        invalidOutputFailure &&
+        !redactedOutputBeforeCallback &&
+        refreshInvalidToolOutputFailure(invalidOutputFailure)
+      ) {
+        throw invalidOutputFailure.error;
+      }
       const validatedOutput = validateOutput(output, runContext, errorDetails);
       if (
         invalidInputFailure &&
-        !redactedBeforeCallback &&
+        !redactedInputBeforeCallback &&
         refreshInvalidToolInputFailure(invalidInputFailure)
       ) {
         throw invalidInputFailure.error;
+      }
+      if (
+        invalidOutputFailure &&
+        !redactedOutputBeforeCallback &&
+        refreshInvalidToolOutputFailure(invalidOutputFailure)
+      ) {
+        throw invalidOutputFailure.error;
       }
       return validatedOutput;
     } catch (callbackFailure) {
@@ -2481,6 +2538,22 @@ export function tool<
         refreshInvalidToolInputFailure(invalidInputFailure)
       ) {
         throw invalidInputFailure.error;
+      }
+      if (
+        invalidOutputFailure &&
+        refreshInvalidToolOutputFailure(invalidOutputFailure)
+      ) {
+        throw invalidOutputFailure.error;
+      }
+      const callbackInvalidOutputFailure =
+        getInvalidToolOutputFailure(callbackFailure);
+      if (callbackInvalidOutputFailure) {
+        details?.[FUNCTION_TOOL_INVALID_OUTPUT_FAILURE_CALLBACK]?.(
+          callbackInvalidOutputFailure,
+        );
+        if (refreshInvalidToolOutputFailure(callbackInvalidOutputFailure)) {
+          throw callbackInvalidOutputFailure.error;
+        }
       }
       throw callbackFailure;
     }

--- a/packages/agents-core/src/toolOutputError.ts
+++ b/packages/agents-core/src/toolOutputError.ts
@@ -1,0 +1,85 @@
+import { InvalidToolOutputError, type ToolOutputErrorContext } from './errors';
+import logger from './logger';
+
+export type InvalidToolOutputFailure = {
+  error: InvalidToolOutputError;
+  redacted: boolean;
+  disposition: InvalidToolOutputDisposition;
+};
+
+export type InvalidToolOutputDisposition = {
+  redacted: boolean;
+};
+
+const redactedInvalidToolOutputErrors = new WeakSet<InvalidToolOutputError>();
+const invalidToolOutputFailures = new WeakMap<
+  InvalidToolOutputError,
+  InvalidToolOutputFailure
+>();
+const invalidToolOutputRedactedMessages = new WeakMap<
+  InvalidToolOutputFailure,
+  string
+>();
+
+const REDACTED_INVALID_TOOL_OUTPUT_MESSAGE = 'Invalid function tool output.';
+
+/**
+ * Constructs invalid tool output errors without retaining tool output or
+ * validator details when tool data is redacted.
+ *
+ * @internal
+ */
+export function createInvalidToolOutputError(
+  message: string,
+  originalError?: unknown,
+  toolOutput?: ToolOutputErrorContext,
+): InvalidToolOutputError {
+  const disposition = { redacted: logger.dontLogToolData };
+  const error = disposition.redacted
+    ? new InvalidToolOutputError(message)
+    : new InvalidToolOutputError(message, undefined, originalError, toolOutput);
+  if (disposition.redacted) {
+    redactedInvalidToolOutputErrors.add(error);
+  }
+  const failure = {
+    error,
+    redacted: disposition.redacted,
+    disposition,
+  };
+  invalidToolOutputFailures.set(error, failure);
+  invalidToolOutputRedactedMessages.set(failure, message);
+  return error;
+}
+
+/** @internal */
+export function refreshInvalidToolOutputFailure(
+  failure: InvalidToolOutputFailure,
+): boolean {
+  if (logger.dontLogToolData) {
+    failure.disposition.redacted = true;
+  }
+  if (failure.disposition.redacted) {
+    failure.error = new InvalidToolOutputError(
+      invalidToolOutputRedactedMessages.get(failure) ??
+        REDACTED_INVALID_TOOL_OUTPUT_MESSAGE,
+    );
+    redactedInvalidToolOutputErrors.add(failure.error);
+    invalidToolOutputFailures.set(failure.error, failure);
+  }
+  failure.redacted = failure.disposition.redacted;
+  return failure.redacted;
+}
+
+/** @internal */
+export function getInvalidToolOutputFailure(
+  error: unknown,
+): InvalidToolOutputFailure | undefined {
+  return invalidToolOutputFailures.get(error as InvalidToolOutputError);
+}
+
+/** @internal */
+export function isRedactedInvalidToolOutputError(
+  error: unknown,
+): error is InvalidToolOutputError {
+  return redactedInvalidToolOutputErrors.has(error as InvalidToolOutputError);
+}

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -383,6 +383,54 @@ describe('getToolCallOutputItem', () => {
     });
   });
 
+  it.each([
+    ['redacted', true],
+    ['diagnostic', false],
+  ] as const)(
+    '%s schema-backed serialization errors respect tool-data logging',
+    (_mode, dontLogToolData) => {
+      const secret = 'SECRET_STRUCTURED_SERIALIZATION_OUTPUT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(dontLogToolData);
+      const output: Record<string, unknown> = { secret };
+      output.self = output;
+
+      try {
+        let error: unknown;
+        try {
+          getToolCallOutputItem(TEST_MODEL_FUNCTION_CALL, output, {
+            outputSchema: {
+              type: 'object',
+              properties: { secret: { type: 'string' } },
+              required: ['secret'],
+              additionalProperties: true,
+            },
+          });
+        } catch (caught) {
+          error = caught;
+        }
+
+        expect(error).toBeInstanceOf(InvalidToolOutputError);
+        if (!(error instanceof InvalidToolOutputError)) {
+          throw new Error('Expected InvalidToolOutputError.');
+        }
+        expect(error.message).not.toContain(secret);
+        expect(error).not.toHaveProperty('cause');
+
+        if (dontLogToolData) {
+          expect(error.originalError).toBeUndefined();
+          expect(error.toolOutput).toBeUndefined();
+        } else {
+          expect(error.originalError).toBeDefined();
+          expect(error.toolOutput?.output).toBe(output);
+        }
+      } finally {
+        flagSpy.mockRestore();
+      }
+    },
+  );
+
   it('returns an empty array as plain text output', () => {
     const result = getToolCallOutputItem(TEST_MODEL_FUNCTION_CALL, []);
 
@@ -7172,6 +7220,99 @@ describe('executeShellActions', () => {
       );
     });
 
+    it('does not expose redacted invalid Zod output through the runner wrapper', async () => {
+      const secret = 'SECRET_RUNNER_INVALID_TOOL_OUTPUT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      const output = { value: secret };
+      (state._context.context as any).payload = output;
+      const t = tool({
+        name: 'redacted_structured_output_tool',
+        description: 'tool with structured output',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.number() }),
+        execute: vi.fn(async () => output as any),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall, tool: t }],
+            runner,
+            state,
+          ).catch((caught) => caught),
+        );
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect(error.message).not.toContain(secret);
+        expect(error.state).toBeUndefined();
+        expect(error).not.toHaveProperty('cause');
+        const outputError = (error as ToolCallError).error;
+        expect(outputError).toBeInstanceOf(InvalidToolOutputError);
+        expect(outputError.message).not.toContain(secret);
+        expect(outputError).toMatchObject({
+          originalError: undefined,
+          toolOutput: undefined,
+        });
+        expect(outputError).not.toHaveProperty('cause');
+      } finally {
+        delete (state._context.context as any).payload;
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('refreshes serialization redaction before runner wrapping', async () => {
+      const secret = 'SECRET_LATE_SERIALIZATION_OUTPUT_123';
+      let flagReads = 0;
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockImplementation(() => {
+          flagReads += 1;
+          return flagReads > 3;
+        });
+      const output: Record<string, unknown> = { secret };
+      output.self = output;
+      (state._context.context as any).payload = output;
+      const t = tool({
+        name: 'late_serialization_redaction_tool',
+        description: 'tool with structured output',
+        parameters: z.object({}),
+        outputSchema: {
+          type: 'object',
+          properties: { secret: { type: 'string' } },
+          required: ['secret'],
+          additionalProperties: true,
+        },
+        execute: vi.fn(async () => output),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await withTrace('test', () =>
+          executeFunctionToolCalls(
+            state._currentAgent,
+            [{ toolCall, tool: t }],
+            runner,
+            state,
+          ).catch((caught) => caught),
+        );
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect(error.state).toBeUndefined();
+        expect(error.message).not.toContain(secret);
+        const outputError = (error as ToolCallError).error;
+        expect(outputError).toBeInstanceOf(InvalidToolOutputError);
+        expect(outputError).toMatchObject({
+          originalError: undefined,
+          toolOutput: undefined,
+        });
+      } finally {
+        delete (state._context.context as any).payload;
+        flagSpy.mockRestore();
+      }
+    });
+
     it('does not validate Zod outputs twice in the runner', async () => {
       let validationCount = 0;
       const t = tool({
@@ -8788,6 +8929,325 @@ describe('executeShellActions', () => {
         expect((error as ToolCallError).state).toBeUndefined();
         expect(JSON.stringify(error)).not.toContain(secret);
       } finally {
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('omits state when a sibling failure wins a batch with redacted invalid output', async () => {
+      const secret = 'SECRET_MIXED_OUTPUT_FAILURE_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      let markOutputStarted: (() => void) | undefined;
+      const outputStarted = new Promise<void>((resolve) => {
+        markOutputStarted = resolve;
+      });
+      let releaseOutput: (() => void) | undefined;
+      const outputReleased = new Promise<void>((resolve) => {
+        releaseOutput = resolve;
+      });
+      const output = { value: secret };
+      (state._context.context as any).payload = output;
+      const invalidOutputTool = tool({
+        name: 'invalid_output',
+        description: 'Return invalid output after sibling failure.',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.number() }),
+        execute: vi.fn(async () => {
+          markOutputStarted?.();
+          await outputReleased;
+          return output as any;
+        }),
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'sibling_failure',
+        description: 'Fail independently.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          await outputStarted;
+          setTimeout(() => releaseOutput?.(), 0);
+          throw new Error('sibling failed');
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'invalid_output',
+                arguments: '{}',
+              },
+              tool: invalidOutputTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'sibling_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toMatchObject({
+          message: 'sibling failed',
+        });
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        delete (state._context.context as any).payload;
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('tracks redacted invalid output before a fallback loses sibling ownership', async () => {
+      const secret = 'SECRET_FALLBACK_OUTPUT_FAILURE_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      let markFallbackStarted: (() => void) | undefined;
+      const fallbackStarted = new Promise<void>((resolve) => {
+        markFallbackStarted = resolve;
+      });
+      let releaseFallback: (() => void) | undefined;
+      const fallbackReleased = new Promise<void>((resolve) => {
+        releaseFallback = resolve;
+      });
+      const output = { value: secret };
+      (state._context.context as any).payload = output;
+      const invalidOutputTool = tool({
+        name: 'fallback_invalid_output',
+        description: 'Recover after invalid output.',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.number() }),
+        execute: vi.fn(async () => output as any),
+        errorFunction: async () => {
+          markFallbackStarted?.();
+          await fallbackReleased;
+          return { value: 1 };
+        },
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'fallback_sibling_failure',
+        description: 'Fail while fallback is pending.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          await fallbackStarted;
+          setTimeout(() => releaseFallback?.(), 0);
+          throw new Error('sibling failed');
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'fallback_invalid_output',
+                arguments: '{}',
+              },
+              tool: invalidOutputTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'fallback_sibling_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toMatchObject({
+          message: 'sibling failed',
+        });
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        delete (state._context.context as any).payload;
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('tracks redacted guardrail fallback output before losing sibling ownership', async () => {
+      const secret = 'SECRET_GUARDRAIL_FALLBACK_OUTPUT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      let markFallbackStarted: (() => void) | undefined;
+      const fallbackStarted = new Promise<void>((resolve) => {
+        markFallbackStarted = resolve;
+      });
+      let releaseFallback: (() => void) | undefined;
+      const fallbackReleased = new Promise<void>((resolve) => {
+        releaseFallback = resolve;
+      });
+      const output = { value: secret };
+      (state._context.context as any).payload = output;
+      const rejectingGuardrail = defineToolInputGuardrail({
+        name: 'reject_for_invalid_fallback',
+        run: async () =>
+          ToolGuardrailFunctionOutputFactory.rejectContent('blocked'),
+      });
+      const invalidFallbackTool = tool({
+        name: 'guardrail_invalid_fallback',
+        description: 'Return invalid output from a guardrail fallback.',
+        parameters: z.object({}),
+        outputSchema: z.object({ value: z.number() }),
+        inputGuardrails: [rejectingGuardrail],
+        execute: vi.fn(async () => ({ value: 1 })),
+        errorFunction: async () => {
+          markFallbackStarted?.();
+          await fallbackReleased;
+          return output as any;
+        },
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'guardrail_fallback_sibling_failure',
+        description: 'Fail while a guardrail fallback is pending.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          await fallbackStarted;
+          setTimeout(() => releaseFallback?.(), 0);
+          throw new Error('sibling failed');
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'guardrail_invalid_fallback',
+                arguments: '{}',
+              },
+              tool: invalidFallbackTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'guardrail_fallback_sibling_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toMatchObject({
+          message: 'sibling failed',
+        });
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        delete (state._context.context as any).payload;
+        flagSpy.mockRestore();
+      }
+    });
+
+    it('tracks redacted fallback serialization before losing sibling ownership', async () => {
+      const secret = 'SECRET_GUARDRAIL_SERIALIZATION_OUTPUT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(true);
+      let markFallbackStarted: (() => void) | undefined;
+      const fallbackStarted = new Promise<void>((resolve) => {
+        markFallbackStarted = resolve;
+      });
+      let releaseFallback: (() => void) | undefined;
+      const fallbackReleased = new Promise<void>((resolve) => {
+        releaseFallback = resolve;
+      });
+      const output: Record<string, unknown> = { secret };
+      output.self = output;
+      (state._context.context as any).payload = output;
+      const invalidFallbackTool = tool({
+        name: 'parse_invalid_serialization',
+        description: 'Return unserializable output from a parse fallback.',
+        parameters: z.object({ value: z.number() }),
+        outputSchema: {
+          type: 'object',
+          properties: { secret: { type: 'string' } },
+          required: ['secret'],
+          additionalProperties: true,
+        },
+        execute: vi.fn(async () => ({ secret: 'unused' })),
+        errorFunction: async () => {
+          markFallbackStarted?.();
+          await fallbackReleased;
+          return output;
+        },
+      }) as unknown as FunctionTool;
+      const failingTool = tool({
+        name: 'serialization_fallback_sibling_failure',
+        description: 'Fail while fallback serialization is pending.',
+        parameters: z.object({}),
+        errorFunction: null,
+        execute: vi.fn(async () => {
+          await fallbackStarted;
+          setTimeout(() => releaseFallback?.(), 0);
+          throw new Error('sibling failed');
+        }),
+      }) as unknown as FunctionTool;
+
+      try {
+        const error = await executeFunctionToolCalls(
+          state._currentAgent,
+          [
+            {
+              toolCall: {
+                ...toolCall,
+                name: 'parse_invalid_serialization',
+                arguments: '{"value":',
+              },
+              tool: invalidFallbackTool,
+            },
+            {
+              toolCall: {
+                ...toolCall,
+                callId: 'c2',
+                name: 'serialization_fallback_sibling_failure',
+                arguments: '{}',
+              },
+              tool: failingTool,
+            },
+          ],
+          runner,
+          state,
+        ).catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(ToolCallError);
+        expect((error as ToolCallError).error).toMatchObject({
+          message: 'sibling failed',
+        });
+        expect((error as ToolCallError).state).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain(secret);
+      } finally {
+        delete (state._context.context as any).payload;
         flagSpy.mockRestore();
       }
     });

--- a/packages/agents-core/test/tool.test.ts
+++ b/packages/agents-core/test/tool.test.ts
@@ -1344,6 +1344,9 @@ describe('Tool', () => {
   });
 
   it('rejects invalid Zod output at runtime', async () => {
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(false);
     const t = tool({
       name: 'invalid_runtime_structured_zod_lookup',
       description: 'Return structured data.',
@@ -1352,10 +1355,181 @@ describe('Tool', () => {
       execute: async () => ({ value: 123 }) as any,
     });
 
-    await expect(t.invoke(new RunContext(), '{}')).rejects.toMatchObject({
-      name: 'InvalidToolOutputError',
-      toolOutput: { output: { value: 123 } },
+    try {
+      await expect(t.invoke(new RunContext(), '{}')).rejects.toMatchObject({
+        name: 'InvalidToolOutputError',
+        toolOutput: { output: { value: 123 } },
+      });
+    } finally {
+      flagSpy.mockRestore();
+    }
+  });
+
+  it.each([
+    ['redacted', true],
+    ['diagnostic', false],
+  ] as const)(
+    '%s invalid Zod output errors respect tool-data logging',
+    async (_mode, dontLogToolData) => {
+      const secret = 'SECRET_INVALID_TOOL_OUTPUT_123';
+      const flagSpy = vi
+        .spyOn(logger, 'dontLogToolData', 'get')
+        .mockReturnValue(dontLogToolData);
+      const output = { value: secret };
+      const outputSchema = z
+        .object({ value: z.string() })
+        .superRefine((value, context) => {
+          context.addIssue({
+            code: 'custom',
+            message: `Rejected tool output: ${value.value}`,
+          });
+        });
+      const t = tool({
+        name: 'invalid_runtime_structured_zod_redaction',
+        description: 'Return structured data.',
+        parameters: z.object({}),
+        outputSchema,
+        execute: async () => output,
+      });
+
+      try {
+        const error = await t
+          .invoke(new RunContext(), '{}')
+          .catch((caught) => caught);
+
+        expect(error).toBeInstanceOf(InvalidToolOutputError);
+        expect(error.message).toBe(
+          "Invalid output for function tool 'invalid_runtime_structured_zod_redaction'.",
+        );
+        expect(error).not.toHaveProperty('cause');
+
+        if (dontLogToolData) {
+          expect(error.originalError).toBeUndefined();
+          expect(error.toolOutput).toBeUndefined();
+          expect(
+            JSON.stringify({
+              message: error.message,
+              originalError: error.originalError,
+              toolOutput: error.toolOutput,
+              cause: error.cause,
+            }),
+          ).not.toContain(secret);
+        } else {
+          expect(error.originalError).toBeDefined();
+          expect(String(error.originalError)).toContain(secret);
+          expect(error.toolOutput).toMatchObject({ output });
+        }
+      } finally {
+        flagSpy.mockRestore();
+      }
+    },
+  );
+
+  it('promotes invalid Zod output redaction before direct rethrow', async () => {
+    const secret = 'SECRET_LATE_INVALID_TOOL_OUTPUT_123';
+    let flagReads = 0;
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockImplementation(() => {
+        flagReads += 1;
+        return flagReads > 2;
+      });
+    const t = tool({
+      name: 'late_invalid_runtime_structured_zod_redaction',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.number() }),
+      execute: async () => ({ value: secret }) as any,
     });
+
+    try {
+      const error = await t
+        .invoke(new RunContext(), '{}')
+        .catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(InvalidToolOutputError);
+      expect(error.originalError).toBeUndefined();
+      expect(error.toolOutput).toBeUndefined();
+      expect(error.message).not.toContain(secret);
+    } finally {
+      flagSpy.mockRestore();
+    }
+  });
+
+  it('uses the fixed message when late redaction replaces a mutated error', async () => {
+    const secret = 'SECRET_MUTATED_INVALID_OUTPUT_MESSAGE_123';
+    let redactToolData = false;
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockImplementation(() => redactToolData);
+    const t = tool({
+      name: 'fixed_invalid_output_redaction_message',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.number() }),
+      execute: async () => ({ value: secret }) as any,
+      errorFunction: (_context, error) => {
+        if (!(error instanceof Error)) {
+          throw new Error('Expected Error.');
+        }
+        error.message = secret;
+        redactToolData = true;
+        return { value: 1 };
+      },
+    });
+
+    try {
+      const error = await t
+        .invoke(new RunContext(), '{}')
+        .catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(InvalidToolOutputError);
+      expect(error.message).toBe(
+        "Invalid output for function tool 'fixed_invalid_output_redaction_message'.",
+      );
+      expect(error.originalError).toBeUndefined();
+      expect(error.toolOutput).toBeUndefined();
+      expect(JSON.stringify(error)).not.toContain(secret);
+    } finally {
+      flagSpy.mockRestore();
+    }
+  });
+
+  it('rebuilds an already-redacted error after callback mutation', async () => {
+    const secret = 'SECRET_EARLY_REDACTED_MUTATED_MESSAGE_123';
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockReturnValue(true);
+    const t = tool({
+      name: 'early_invalid_output_redaction_message',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.number() }),
+      execute: async () => ({ value: secret }) as any,
+      errorFunction: (_context, error) => {
+        if (!(error instanceof Error)) {
+          throw new Error('Expected Error.');
+        }
+        error.message = secret;
+        throw error;
+      },
+    });
+
+    try {
+      const error = await t
+        .invoke(new RunContext(), '{}')
+        .catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(InvalidToolOutputError);
+      expect(error.message).toBe(
+        "Invalid output for function tool 'early_invalid_output_redaction_message'.",
+      );
+      expect(error.originalError).toBeUndefined();
+      expect(error.toolOutput).toBeUndefined();
+      expect(JSON.stringify(error)).not.toContain(secret);
+    } finally {
+      flagSpy.mockRestore();
+    }
   });
 
   it('requires schema-compatible error fallbacks for Zod outputs', async () => {
@@ -1398,6 +1572,40 @@ describe('Tool', () => {
     await expect(noFallback.invoke(new RunContext(), '{}')).rejects.toThrow(
       'boom',
     );
+  });
+
+  it('promotes invalid fallback output redaction before direct rethrow', async () => {
+    const secret = 'SECRET_LATE_INVALID_FALLBACK_OUTPUT_123';
+    let flagReads = 0;
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockImplementation(() => {
+        flagReads += 1;
+        return flagReads > 1;
+      });
+    const t = tool({
+      name: 'late_invalid_fallback_output_redaction',
+      description: 'Return structured data.',
+      parameters: z.object({}),
+      outputSchema: z.object({ value: z.number() }),
+      execute: async () => {
+        throw new Error('boom');
+      },
+      errorFunction: () => ({ value: secret }) as any,
+    });
+
+    try {
+      const error = await t
+        .invoke(new RunContext(), '{}')
+        .catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(InvalidToolOutputError);
+      expect(error.originalError).toBeUndefined();
+      expect(error.toolOutput).toBeUndefined();
+      expect(error.message).not.toContain(secret);
+    } finally {
+      flagSpy.mockRestore();
+    }
   });
 
   it('rejects invalid allowedCallers values at tool construction', () => {
@@ -2681,6 +2889,69 @@ describe('tool.invoke', () => {
         },
       }),
     ).resolves.toEqual({ status: 'call-structured-timeout' });
+  });
+
+  it('refreshes late redaction for invalid structured timeout fallbacks', async () => {
+    const secret = 'SECRET_LATE_TIMEOUT_FALLBACK_OUTPUT_123';
+    let redactToolData = false;
+    const flagSpy = vi
+      .spyOn(logger, 'dontLogToolData', 'get')
+      .mockImplementation(() => redactToolData);
+    const outputSchema = z
+      .object({ status: z.string() })
+      .superRefine((_value, context) => {
+        queueMicrotask(() => {
+          redactToolData = true;
+        });
+        context.addIssue({
+          code: 'custom',
+          message: 'Reject timeout fallback.',
+        });
+      });
+    const t = tool({
+      name: 'late_timeout_fallback_redaction',
+      description: 'Slow structured tool.',
+      parameters: z.object({}),
+      outputSchema,
+      timeoutMs: 5,
+      timeoutBehavior: 'error_as_result',
+      timeoutErrorFunction: () => ({ status: secret }),
+      execute: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        return { status: 'done' };
+      },
+    });
+
+    try {
+      const error = await t
+        .invoke(new RunContext(), '{}')
+        .catch((caught) => caught);
+
+      expect(error).toBeInstanceOf(InvalidToolOutputError);
+      expect(error.message).toBe(
+        "Invalid output for function tool 'late_timeout_fallback_redaction'.",
+      );
+      expect(error.originalError).toBeUndefined();
+      expect(error.toolOutput).toBeUndefined();
+      expect(JSON.stringify(error)).not.toContain(secret);
+
+      redactToolData = false;
+      const helperError = await invokeFunctionTool({
+        tool: t,
+        runContext: new RunContext(),
+        input: '{}',
+      }).catch((caught) => caught);
+
+      expect(helperError).toBeInstanceOf(InvalidToolOutputError);
+      expect(helperError.message).toBe(
+        "Invalid output for function tool 'late_timeout_fallback_redaction'.",
+      );
+      expect(helperError.originalError).toBeUndefined();
+      expect(helperError.toolOutput).toBeUndefined();
+      expect(JSON.stringify(helperError)).not.toContain(secret);
+    } finally {
+      flagSpy.mockRestore();
+    }
   });
 
   it('requires timeout fallbacks for structured error results', () => {


### PR DESCRIPTION
This pull request fixes sensitive-data retention when a Zod-backed function tool returns output that fails runtime output validation.

When tool-data logging is disabled, `InvalidToolOutputError` now keeps its fixed message but omits the validator error and tool-output context that can retain the returned value. Explicit diagnostic mode preserves the existing `originalError` and `toolOutput` details.