### PR TITLE
fix: finalize max-turn handler session output

### DIFF
--- a/.changeset/calm-max-turns.md
+++ b/.changeset/calm-max-turns.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: finalize max-turn handler items after guardrails and persistence

--- a/packages/agents-core/src/result.ts
+++ b/packages/agents-core/src/result.ts
@@ -360,11 +360,20 @@ export class StreamedRunResult<
   public maxTurns: number | null | undefined;
 
   #error: unknown = null;
+  #hasError = false;
   #combinedSignal?: AbortSignal;
   #abortSignalSnapshot?: AbortSignal;
   #abortController: AbortController;
   #readableController: ReadableStreamController<RunStreamEvent> | undefined;
   #readableStream: _ReadableStream<RunStreamEvent>;
+  #queuedStreamEvents: RunStreamEvent[] = [];
+  #queuedStreamEventIndex = 0;
+  #streamReadPending = false;
+  #streamTerminal:
+    | { type: 'done' }
+    | { type: 'error'; error: unknown; preserveQueuedItems: boolean }
+    | undefined;
+  #preserveQueuedItemsOnError = false;
   #completedPromise: Promise<void>;
   #completedPromiseResolve: (() => void) | undefined;
   #completedPromiseReject: ((err: unknown) => void) | undefined;
@@ -407,16 +416,26 @@ export class StreamedRunResult<
     this.#combinedSignalCleanup = cleanupCombinedSignal;
     this.#abortSignalSnapshot = combinedSignal;
 
-    this.#readableStream = new _ReadableStream<RunStreamEvent>({
-      start: (controller) => {
-        this.#readableController = controller;
+    this.#readableStream = new _ReadableStream<RunStreamEvent>(
+      {
+        start: (controller) => {
+          this.#readableController = controller;
+        },
+        pull: () => {
+          this.#streamReadPending = true;
+          this.#drainStreamQueue();
+        },
+        cancel: () => {
+          if (!this.#abortController.signal.aborted) {
+            this.#abortController.abort();
+          }
+          this.#cancelStream();
+        },
       },
-      cancel: () => {
-        if (!this.#abortController.signal.aborted) {
-          this.#abortController.abort();
-        }
+      {
+        highWaterMark: 0,
       },
-    });
+    );
 
     this.#completedPromise = new Promise((resolve, reject) => {
       this.#completedPromiseResolve = resolve;
@@ -447,9 +466,18 @@ export class StreamedRunResult<
    * Adds an item to the stream of output items
    */
   _addItem(item: RunStreamEvent) {
-    if (!this.cancelled) {
-      this.#readableController?.enqueue(item);
+    if (!this.cancelled && !this.#streamTerminal) {
+      this.#queuedStreamEvents.push(item);
+      this.#drainStreamQueue();
     }
+  }
+
+  /**
+   * @internal
+   * Keeps already queued events available if later cleanup fails.
+   */
+  _preserveQueuedItemsOnError() {
+    this.#preserveQueuedItemsOnError = true;
   }
 
   /**
@@ -457,9 +485,11 @@ export class StreamedRunResult<
    * Indicates that the stream has been completed
    */
   _done() {
-    if (!this.cancelled && this.#readableController) {
-      this.#readableController.close();
-      this.#readableController = undefined;
+    if (!this.cancelled) {
+      if (!this.#streamTerminal) {
+        this.#streamTerminal = { type: 'done' };
+      }
+      this.#drainStreamQueue();
     }
     this.#completedPromiseResolve?.();
     this.#detachAbortHandler();
@@ -469,16 +499,45 @@ export class StreamedRunResult<
    * @internal
    * Handles an error in the stream loop.
    */
-  _raiseError(err: unknown) {
-    if (!this.cancelled && this.#readableController) {
-      this.#readableController.error(err);
-      this.#readableController = undefined;
+  _raiseError(
+    err: unknown,
+    options?: {
+      preserveQueuedItems?: boolean;
+    },
+  ) {
+    if (!this.cancelled) {
+      const existingPreservedError =
+        this.#streamTerminal?.type === 'error' &&
+        this.#streamTerminal.preserveQueuedItems
+          ? this.#streamTerminal
+          : undefined;
+      const preserveQueuedItems =
+        options?.preserveQueuedItems === true ||
+        Boolean(existingPreservedError) ||
+        this.#preserveQueuedItemsOnError;
+      this.#streamTerminal = {
+        type: 'error',
+        error: existingPreservedError ? existingPreservedError.error : err,
+        preserveQueuedItems,
+      };
+      if (!preserveQueuedItems) {
+        this.#clearStreamQueue();
+        if (this.#readableController) {
+          this.#readableController.error(err);
+          this.#readableController = undefined;
+        }
+      } else {
+        this.#drainStreamQueue();
+      }
     }
-    this.#error = err;
-    this.#completedPromiseReject?.(err);
-    this.#completedPromise.catch((e) => {
-      logModelAndToolActionDebug(logger, 'Resulted in an error:', e);
-    });
+    if (!this.#hasError) {
+      this.#hasError = true;
+      this.#error = err;
+      this.#completedPromiseReject?.(err);
+      this.#completedPromise.catch((e) => {
+        logModelAndToolActionDebug(logger, 'Resulted in an error:', e);
+      });
+    }
     this.#detachAbortHandler();
   }
 
@@ -579,12 +638,20 @@ export class StreamedRunResult<
   }
 
   #handleAbort() {
+    this.#cancelStream();
+  }
+
+  #cancelStream() {
     if (this.#cancelled) {
       this.#detachAbortHandler();
       return;
     }
 
     this.#cancelled = true;
+    this.#clearStreamQueue();
+    this.#preserveQueuedItemsOnError = false;
+    this.#streamTerminal = { type: 'done' };
+    this.#streamReadPending = false;
 
     const controller = this.#readableController;
     this.#readableController = undefined;
@@ -602,6 +669,53 @@ export class StreamedRunResult<
     }
 
     this.#detachAbortHandler();
+  }
+
+  #drainStreamQueue() {
+    const controller = this.#readableController;
+    if (!controller || !this.#streamReadPending) {
+      return;
+    }
+    if (this.#queuedStreamEventIndex < this.#queuedStreamEvents.length) {
+      const event = this.#queuedStreamEvents[this.#queuedStreamEventIndex];
+      this.#queuedStreamEventIndex += 1;
+      this.#compactStreamQueue();
+      this.#streamReadPending = false;
+      controller.enqueue(event);
+      return;
+    }
+    if (this.#streamTerminal?.type === 'done') {
+      this.#streamReadPending = false;
+      controller.close();
+      this.#readableController = undefined;
+      return;
+    }
+    if (this.#streamTerminal?.type === 'error') {
+      this.#streamReadPending = false;
+      controller.error(this.#streamTerminal.error);
+      this.#readableController = undefined;
+    }
+  }
+
+  #clearStreamQueue() {
+    this.#queuedStreamEvents = [];
+    this.#queuedStreamEventIndex = 0;
+  }
+
+  #compactStreamQueue() {
+    if (this.#queuedStreamEventIndex === this.#queuedStreamEvents.length) {
+      this.#clearStreamQueue();
+      return;
+    }
+    if (
+      this.#queuedStreamEventIndex >= 1024 &&
+      this.#queuedStreamEventIndex * 2 >= this.#queuedStreamEvents.length
+    ) {
+      this.#queuedStreamEvents = this.#queuedStreamEvents.slice(
+        this.#queuedStreamEventIndex,
+      );
+      this.#queuedStreamEventIndex = 0;
+    }
   }
 
   #detachAbortHandler() {

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -158,7 +158,10 @@ import {
   invalidateAcceptedResponseReplayEvidence,
   prepareRunErrorFinalOutput,
 } from './runner/errorHandlers';
-import type { RunErrorHandlers } from './runner/errorHandlers';
+import type {
+  PreparedRunErrorFinalOutput,
+  RunErrorHandlers,
+} from './runner/errorHandlers';
 import {
   finalizeSandboxRuntime,
   isSandboxRuntimeAgent,
@@ -196,6 +199,20 @@ function hasRetainableBlockedOutputEffect(state: RunState<any, any>): boolean {
     state._generatedItems,
     state._currentTurnPersistedItemCount,
   );
+}
+
+function commitDeferredRunErrorItemAfterPartialPersistence(
+  state: RunState<any, any>,
+  preparedErrorOutput?: PreparedRunErrorFinalOutput,
+): boolean {
+  if (
+    preparedErrorOutput?.deferredItem &&
+    state._currentTurnPersistedItemCount > state._generatedItems.length
+  ) {
+    state._generatedItems.push(preparedErrorOutput.deferredItem);
+    return true;
+  }
+  return false;
 }
 
 export type {
@@ -1241,12 +1258,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       };
       const persistNonStreamingResult = async (
         result: RunResult<TContext, TAgent>,
+        overrideOptions?: SessionPersistenceOptions,
       ) => {
         const hasUnpersistedItems =
-          result.newItems.length > state._currentTurnPersistedItemCount;
+          result.newItems.length > state._currentTurnPersistedItemCount ||
+          (overrideOptions?.additionalRunItems?.length ?? 0) > 0;
         const modelResponseAdvanced =
           result.rawResponses.length > approvedToolCheckpointModelResponseCount;
-        const persistenceOptions =
+        const compactionOptions =
           approvedToolCheckpointRequiresLocalInputCompaction
             ? approvedToolCheckpointCompacted &&
               !hasUnpersistedItems &&
@@ -1254,6 +1273,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ? { runCompaction: false }
               : { compactionMode: 'input' as const }
             : undefined;
+        const persistenceOptions = {
+          ...compactionOptions,
+          ...overrideOptions,
+        };
         await persistResult?.(result, persistenceOptions);
       };
       const recordNonStreamingError = (error: unknown) => {
@@ -1280,9 +1303,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         );
         runError = error;
       };
-      const finalizeCurrentOutput = async (): Promise<
-        RunResult<TContext, TAgent>
-      > => {
+      const finalizeCurrentOutput = async (
+        preparedErrorOutput?: PreparedRunErrorFinalOutput,
+      ): Promise<RunResult<TContext, TAgent>> => {
         const currentStep = state._currentStep;
         if (currentStep?.type !== 'next_step_final_output') {
           throw new ModelBehaviorError(
@@ -1344,7 +1367,23 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         setRunStateTurnSpanParent(state, undefined);
         currentTurnSpan = undefined;
         const result = new RunResult<TContext, TAgent>(state);
-        await persistNonStreamingResult(result);
+        try {
+          await persistNonStreamingResult(
+            result,
+            preparedErrorOutput?.deferredItem
+              ? { additionalRunItems: [preparedErrorOutput.deferredItem] }
+              : undefined,
+          );
+        } catch (error) {
+          commitDeferredRunErrorItemAfterPartialPersistence(
+            state,
+            preparedErrorOutput,
+          );
+          throw error;
+        }
+        if (preparedErrorOutput?.deferredItem) {
+          state._generatedItems.push(preparedErrorOutput.deferredItem);
+        }
         completedResultPersisted = true;
         state._currentTurnInProgress = false;
         this.emit(
@@ -1840,7 +1879,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         });
         if (errorHandled) {
           try {
-            return await finalizeCurrentOutput();
+            return await finalizeCurrentOutput(errorHandled);
           } catch (finalizationError) {
             recordNonStreamingError(finalizationError);
             throw finalizationError;
@@ -2020,18 +2059,22 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       overrideOptions?: SessionPersistenceOptions,
     ) => {
       const hasUnpersistedItems =
-        result.newItems.length > result.state._currentTurnPersistedItemCount;
+        result.newItems.length > result.state._currentTurnPersistedItemCount ||
+        (overrideOptions?.additionalRunItems?.length ?? 0) > 0;
       const modelResponseAdvanced =
         result.rawResponses.length > approvedToolCheckpointModelResponseCount;
-      const persistenceOptions =
-        overrideOptions ??
-        (approvedToolCheckpointRequiresLocalInputCompaction
+      const compactionOptions =
+        approvedToolCheckpointRequiresLocalInputCompaction
           ? approvedToolCheckpointCompacted &&
             !hasUnpersistedItems &&
             !modelResponseAdvanced
             ? { runCompaction: false }
             : { compactionMode: 'input' as const }
-          : undefined);
+          : undefined;
+      const persistenceOptions = {
+        ...compactionOptions,
+        ...overrideOptions,
+      };
       const sessionInputItems = streamInputPersisted
         ? undefined
         : getStreamInputForPersistence?.();
@@ -2069,7 +2112,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       );
       runError = error;
     };
-    const finalizeStreamOutput = async (): Promise<void> => {
+    const finalizeStreamOutput = async (
+      preparedErrorOutput?: PreparedRunErrorFinalOutput,
+    ): Promise<void> => {
       const currentStep = result.state._currentStep;
       if (currentStep?.type !== 'next_step_final_output') {
         throw new ModelBehaviorError(
@@ -2131,7 +2176,35 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       result.state._currentTurnInProgress = false;
       // Guardrails must succeed before persisting session memory to avoid storing blocked outputs.
       if (!serverManagesConversation) {
-        await saveStreamResultWithCompactionOwnership();
+        try {
+          await saveStreamResultWithCompactionOwnership(
+            preparedErrorOutput?.deferredItem
+              ? { additionalRunItems: [preparedErrorOutput.deferredItem] }
+              : undefined,
+          );
+        } catch (error) {
+          const itemCommitted =
+            commitDeferredRunErrorItemAfterPartialPersistence(
+              result.state,
+              preparedErrorOutput,
+            );
+          if (itemCommitted && preparedErrorOutput?.deferredItem) {
+            streamStepItemsToRunResult(result, [
+              preparedErrorOutput.deferredItem,
+            ]);
+            recordStreamingError(error);
+            result._raiseError(error, { preserveQueuedItems: true });
+            return;
+          }
+          throw error;
+        }
+      }
+      if (preparedErrorOutput?.deferredItem) {
+        result.state._generatedItems.push(preparedErrorOutput.deferredItem);
+      }
+      if (preparedErrorOutput?.deferredItem) {
+        streamStepItemsToRunResult(result, [preparedErrorOutput.deferredItem]);
+        result._preserveQueuedItemsOnError();
       }
       result._revealFinalOutput();
       this.emit(
@@ -2799,7 +2872,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       });
       if (errorHandled) {
         try {
-          await finalizeStreamOutput();
+          await finalizeStreamOutput(errorHandled);
           return;
         } catch (finalizationError) {
           recordStreamingError(finalizationError);

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -85,6 +85,10 @@ type TryHandleRunErrorArgs<TContext, TAgent extends Agent<any, any>> = {
   attemptedErrors?: WeakSet<object>;
 };
 
+export type PreparedRunErrorFinalOutput = {
+  deferredItem?: RunMessageOutputItem;
+};
+
 type ResolveRunErrorHandlerArgs<TContext, TAgent extends Agent<any, any>> = {
   error: unknown;
   errorKind?: RunErrorKind;
@@ -263,7 +267,9 @@ export const prepareRunErrorFinalOutput = async <
   streamResult,
   responseAccepted,
   attemptedErrors,
-}: TryHandleRunErrorArgs<TContext, TAgent>): Promise<boolean> => {
+}: TryHandleRunErrorArgs<TContext, TAgent>): Promise<
+  PreparedRunErrorFinalOutput | undefined
+> => {
   const handlerResult = await resolveRunErrorHandler({
     error,
     errorHandlers,
@@ -272,7 +278,7 @@ export const prepareRunErrorFinalOutput = async <
     attemptedErrors,
   });
   if (!handlerResult) {
-    return false;
+    return undefined;
   }
   const includeInHistory = handlerResult.includeInHistory !== false;
   const outputText = formatFinalOutput(
@@ -284,10 +290,18 @@ export const prepareRunErrorFinalOutput = async <
   state._lastTurnResponse = undefined;
   state._lastProcessedResponse = undefined;
   const item = createFinalOutputItem(state._currentAgent, outputText);
-  if (includeInHistory) {
+  const deferredItem =
+    error instanceof MaxTurnsExceededError && includeInHistory
+      ? item
+      : undefined;
+  if (includeInHistory && !deferredItem) {
     state._generatedItems.push(item);
   }
-  if (streamResult) {
+  if (
+    streamResult &&
+    !deferredItem &&
+    (includeInHistory || !(error instanceof MaxTurnsExceededError))
+  ) {
     streamStepItemsToRunResult(streamResult, [item]);
   }
   state._currentStep = {
@@ -296,5 +310,5 @@ export const prepareRunErrorFinalOutput = async <
     ...(responseAccepted ? { responseAccepted: true } : {}),
   };
   state._finalOutputSource = 'error_handler';
-  return true;
+  return { deferredItem };
 };

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -49,6 +49,7 @@ export type SessionPersistenceOptions = {
   runCompaction?: boolean;
   compactionMode?: OpenAIResponsesCompactionArgs['compactionMode'];
   outputBlocked?: boolean;
+  additionalRunItems?: RunItem[];
 };
 
 const SESSION_LIMIT_UNSET = Symbol('sessionLimitUnset');
@@ -1063,6 +1064,29 @@ export async function saveToSession(
   await prepareSessionHistoryTransactionsForRun(session, state, {
     serverManagesConversation: false,
   });
+  const additionalRunItems = options.additionalRunItems ?? [];
+  if (additionalRunItems.length > 0) {
+    const { additionalRunItems: _additionalRunItems, ...baseOptions } = options;
+    await saveToSession(session, sessionInputItems, result, {
+      ...baseOptions,
+      runCompaction: false,
+    });
+    await persistRunItemsToSession({
+      session,
+      state,
+      newRunItems: additionalRunItems,
+      runItemsToReplace: [],
+      processedRunItemCount: additionalRunItems.length,
+      deferredRunItemIndexes: [],
+      useHistoryTransaction: false,
+      extraInputItems: [],
+      lastResponseId: result.lastResponseId,
+      alreadyPersistedCount: state._currentTurnPersistedItemCount,
+      runCompaction: options.runCompaction ?? true,
+      compactionMode: options.compactionMode,
+    });
+    return;
+  }
   const persistencePlan = buildRunItemPersistencePlan(
     state,
     result.newItems,
@@ -1143,6 +1167,34 @@ export async function saveStreamResultToSession(
   await prepareSessionHistoryTransactionsForRun(session, state, {
     serverManagesConversation: false,
   });
+  const additionalRunItems = options.additionalRunItems ?? [];
+  if (additionalRunItems.length > 0) {
+    const { additionalRunItems: _additionalRunItems, ...baseOptions } = options;
+    await saveStreamResultToSession(
+      session,
+      result,
+      {
+        ...baseOptions,
+        runCompaction: false,
+      },
+      sessionInputItems,
+    );
+    await persistRunItemsToSession({
+      session,
+      state,
+      newRunItems: additionalRunItems,
+      runItemsToReplace: [],
+      processedRunItemCount: additionalRunItems.length,
+      deferredRunItemIndexes: [],
+      useHistoryTransaction: false,
+      extraInputItems: [],
+      lastResponseId: result.lastResponseId,
+      alreadyPersistedCount: state._currentTurnPersistedItemCount,
+      runCompaction: options.runCompaction ?? true,
+      compactionMode: options.compactionMode,
+    });
+    return;
+  }
   const persistencePlan = buildRunItemPersistencePlan(
     state,
     result.newItems,

--- a/packages/agents-core/test/result.test.ts
+++ b/packages/agents-core/test/result.test.ts
@@ -202,6 +202,136 @@ describe('StreamedRunResult', () => {
     expect(sr.error).toBe(err);
   });
 
+  it('drains preserved events before retaining the first stream error', async () => {
+    const state = createState();
+    const sr = new StreamedRunResult({ state });
+    const persistenceError = new Error('persistence failed');
+    const cleanupError = new Error('cleanup failed');
+    sr._addItem(
+      new RunRawModelStreamEvent({ type: 'output_text_delta', delta: 'x' }),
+    );
+
+    sr._raiseError(persistenceError, { preserveQueuedItems: true });
+    sr._raiseError(cleanupError);
+
+    await expect(sr.completed).rejects.toBe(persistenceError);
+    const events: RunRawModelStreamEvent[] = [];
+    await expect(
+      (async () => {
+        for await (const event of sr) {
+          events.push(event as RunRawModelStreamEvent);
+        }
+      })(),
+    ).rejects.toBe(persistenceError);
+    expect(events).toHaveLength(1);
+    expect(sr.error).toBe(persistenceError);
+  });
+
+  it('retains a null preserved error across secondary failures', async () => {
+    const state = createState();
+    const sr = new StreamedRunResult({ state });
+    const cleanupError = new Error('cleanup failed');
+    sr._addItem(
+      new RunRawModelStreamEvent({ type: 'output_text_delta', delta: 'x' }),
+    );
+
+    sr._raiseError(null, { preserveQueuedItems: true });
+    sr._raiseError(cleanupError);
+
+    await expect(sr.completed).rejects.toBeNull();
+    await expect(
+      (async () => {
+        for await (const _event of sr) {
+          // Drain the preserved event before observing the terminal error.
+        }
+      })(),
+    ).rejects.toBeNull();
+    expect(sr.error).toBeNull();
+  });
+
+  it('drains committed events before a later cleanup error', async () => {
+    const state = createState();
+    const sr = new StreamedRunResult({ state });
+    const cleanupError = new Error('cleanup failed');
+    sr._addItem(
+      new RunRawModelStreamEvent({ type: 'output_text_delta', delta: 'x' }),
+    );
+    sr._preserveQueuedItemsOnError();
+
+    sr._raiseError(cleanupError);
+
+    await expect(sr.completed).rejects.toBe(cleanupError);
+    const events: RunRawModelStreamEvent[] = [];
+    await expect(
+      (async () => {
+        for await (const event of sr) {
+          events.push(event as RunRawModelStreamEvent);
+        }
+      })(),
+    ).rejects.toBe(cleanupError);
+    expect(events).toHaveLength(1);
+  });
+
+  it('drains a large queued stream in order', async () => {
+    const state = createState();
+    const sr = new StreamedRunResult({ state });
+    const eventCount = 4096;
+    for (let index = 0; index < eventCount; index += 1) {
+      sr._addItem(
+        new RunRawModelStreamEvent({
+          type: 'output_text_delta',
+          delta: String(index),
+        }),
+      );
+    }
+    sr._done();
+
+    let receivedCount = 0;
+    for await (const _event of sr) {
+      receivedCount += 1;
+    }
+
+    expect(receivedCount).toBe(eventCount);
+  });
+
+  it('clears delayed terminal buffering when the consumer cancels', async () => {
+    const state = createState();
+    const sr = new StreamedRunResult({ state });
+    for (let index = 0; index < 4096; index += 1) {
+      sr._addItem(
+        new RunRawModelStreamEvent({
+          type: 'output_text_delta',
+          delta: String(index),
+        }),
+      );
+    }
+    sr._done();
+
+    const reader = (sr.toStream() as any).getReader();
+    await reader.cancel();
+
+    expect(sr.cancelled).toBe(true);
+  });
+
+  it('propagates consumer cancellation before fallback cleanup', async () => {
+    vi.spyOn(
+      AbortSignal as typeof AbortSignal & { any: typeof AbortSignal.any },
+      'any',
+    ).mockImplementation(() => {
+      throw new Error('AbortSignal.any failed');
+    });
+    const state = createState();
+    const sr = new StreamedRunResult({ state });
+    const signal = sr._getAbortSignal();
+    const reader = (sr.toStream() as any).getReader();
+
+    await reader.cancel();
+
+    expect(signal?.aborted).toBe(true);
+    expect(sr.cancelled).toBe(true);
+    vi.restoreAllMocks();
+  });
+
   it.each([
     [true, false],
     [false, true],

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -3151,9 +3151,14 @@ describe('approved tool output guardrail session persistence', () => {
     },
   );
 
-  it.each<RunMode>(['non_streamed', 'streamed'])(
-    'compacts an empty post-resume response when $mode handling omits history',
-    async (mode) => {
+  it.each([
+    ['non_streamed', false],
+    ['streamed', false],
+    ['non_streamed', true],
+    ['streamed', true],
+  ] as const)(
+    'compacts an empty post-resume response when $0 handling includes history: $1',
+    async (mode, includeInHistory) => {
       const approvalTool = tool({
         name: 'empty_response_approval_tool',
         description: 'Returns a result after approval.',
@@ -3200,7 +3205,7 @@ describe('approved tool output guardrail session persistence', () => {
           errorHandlers: {
             maxTurns: () => ({
               finalOutput: 'handled-empty-response',
-              includeInHistory: false,
+              includeInHistory,
             }),
           },
         } as const;
@@ -3229,8 +3234,9 @@ describe('approved tool output guardrail session persistence', () => {
         compactionMode: 'input',
         store: false,
       });
+      const persistedItems = await session.getItems();
       expect(
-        getPersistedToolItems(await session.getItems()).map((item) => [
+        getPersistedToolItems(persistedItems).map((item) => [
           item.type,
           item.callId,
         ]),
@@ -3238,8 +3244,336 @@ describe('approved tool output guardrail session persistence', () => {
         ['function_call', 'call-before-empty-response'],
         ['function_call_result', 'call-before-empty-response'],
       ]);
+      expect(
+        persistedItems.some(
+          (item) =>
+            item.type === 'message' &&
+            item.role === 'assistant' &&
+            item.content.some(
+              (content) =>
+                content.type === 'output_text' &&
+                content.text === 'handled-empty-response',
+            ),
+        ),
+      ).toBe(includeInHistory);
     },
   );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'publishes a $mode max-turn handler item only after finalization succeeds',
+    async (mode) => {
+      type Outcome =
+        'success' | 'guardrail_error' | 'tripwire' | 'session_failure';
+
+      for (const resumed of [false, true]) {
+        for (const outcome of [
+          'success',
+          'guardrail_error',
+          'tripwire',
+          'session_failure',
+        ] as const satisfies readonly Outcome[]) {
+          class FinalSaveSession extends MemorySession {
+            async addItems(items: AgentInputItem[]): Promise<void> {
+              if (
+                outcome === 'session_failure' &&
+                items.some(
+                  (item) =>
+                    item.type === 'message' &&
+                    item.role === 'assistant' &&
+                    item.content.some(
+                      (content) =>
+                        content.type === 'output_text' &&
+                        content.text === 'handled max turn',
+                    ),
+                )
+              ) {
+                throw new Error('session save failed');
+              }
+              await super.addItems(items);
+            }
+          }
+
+          const session = new FinalSaveSession();
+          const agent = new Agent({
+            name: 'Deferred max-turn output agent',
+            model: new ScriptedModel(),
+            outputGuardrails:
+              outcome === 'success' || outcome === 'session_failure'
+                ? []
+                : [
+                    {
+                      name: 'max-turn output guardrail',
+                      execute: async () => {
+                        if (outcome === 'guardrail_error') {
+                          throw new Error('guardrail failed');
+                        }
+                        return {
+                          outputInfo: null,
+                          tripwireTriggered: true,
+                        };
+                      },
+                    },
+                  ],
+          });
+          const resumedState = resumed
+            ? new RunState(new RunContext(), 'x', agent, 0)
+            : undefined;
+          const input = resumedState ?? 'x';
+          const options = {
+            session,
+            maxTurns: 0,
+            errorHandlers: {
+              maxTurns: () => ({ finalOutput: 'handled max turn' }),
+            },
+          } as const;
+          const streamedEvents: unknown[] = [];
+
+          if (mode === 'streamed') {
+            const result = await run(agent, input, {
+              ...options,
+              stream: true,
+            });
+            const completion = (async () => {
+              for await (const event of result.toStream()) {
+                streamedEvents.push(event);
+              }
+              await result.completed;
+            })();
+            if (outcome === 'success') {
+              await completion;
+              expect(result.finalOutput).toBe('handled max turn');
+              if (resumedState) {
+                expect(result.state).toBe(resumedState);
+              }
+            } else if (outcome === 'tripwire') {
+              await expect(completion).rejects.toBeInstanceOf(
+                OutputGuardrailTripwireTriggered,
+              );
+            } else {
+              await expect(completion).rejects.toThrow(
+                outcome === 'guardrail_error'
+                  ? 'guardrail failed'
+                  : 'session save failed',
+              );
+            }
+            expect(
+              streamedEvents.filter(
+                (event) =>
+                  typeof event === 'object' &&
+                  event !== null &&
+                  'type' in event &&
+                  event.type === 'run_item_stream_event',
+              ),
+            ).toHaveLength(outcome === 'success' ? 1 : 0);
+            expect(
+              result.newItems.filter(
+                (item) =>
+                  item.rawItem.type === 'message' &&
+                  item.rawItem.role === 'assistant',
+              ),
+            ).toHaveLength(outcome === 'success' ? 1 : 0);
+          } else if (outcome === 'success') {
+            const result = await run(agent, input, options);
+            expect(result.finalOutput).toBe('handled max turn');
+            if (resumedState) {
+              expect(result.state).toBe(resumedState);
+            }
+            expect(
+              result.newItems.filter(
+                (item) =>
+                  item.rawItem.type === 'message' &&
+                  item.rawItem.role === 'assistant',
+              ),
+            ).toHaveLength(1);
+          } else if (outcome === 'tripwire') {
+            await expect(run(agent, input, options)).rejects.toBeInstanceOf(
+              OutputGuardrailTripwireTriggered,
+            );
+          } else {
+            await expect(run(agent, input, options)).rejects.toThrow(
+              outcome === 'guardrail_error'
+                ? 'guardrail failed'
+                : 'session save failed',
+            );
+          }
+
+          if (outcome !== 'success') {
+            expect(
+              (resumedState?._generatedItems ?? []).filter(
+                (item) =>
+                  item.rawItem.type === 'message' &&
+                  item.rawItem.role === 'assistant',
+              ),
+            ).toHaveLength(0);
+            if (resumedState && outcome === 'guardrail_error') {
+              await expect(
+                RunState.fromString(agent, resumedState.toString()),
+              ).resolves.toBeInstanceOf(RunState);
+            }
+          }
+          expect(
+            (await session.getItems()).filter(
+              (item) => item.type === 'message' && item.role === 'assistant',
+            ),
+          ).toHaveLength(outcome === 'success' ? 1 : 0);
+        }
+      }
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'does not publish a $mode max-turn handler item when history is omitted',
+    async (mode) => {
+      const agent = new Agent({
+        name: 'Omitted max-turn output agent',
+        model: new ScriptedModel(),
+      });
+      const session = new MemorySession();
+      const options = {
+        session,
+        maxTurns: 0,
+        errorHandlers: {
+          maxTurns: () => ({
+            finalOutput: 'omitted max turn',
+            includeInHistory: false,
+          }),
+        },
+      } as const;
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'x', { ...options, stream: true });
+        const events = [];
+        for await (const event of result.toStream()) {
+          events.push(event);
+        }
+        await result.completed;
+        expect(result.finalOutput).toBe('omitted max turn');
+        expect(
+          events.filter((event) => event.type === 'run_item_stream_event'),
+        ).toHaveLength(0);
+        expect(result.newItems).toHaveLength(0);
+      } else {
+        const result = await run(agent, 'x', options);
+        expect(result.finalOutput).toBe('omitted max turn');
+        expect(result.newItems).toHaveLength(0);
+      }
+
+      expect(
+        (await session.getItems()).filter(
+          (item) => item.type === 'message' && item.role === 'assistant',
+        ),
+      ).toHaveLength(0);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'keeps a resumed $mode max-turn handler item hidden while persistence is pending',
+    async (mode) => {
+      let markSaveStarted: (() => void) | undefined;
+      let releaseSave: (() => void) | undefined;
+      const saveStarted = new Promise<void>((resolve) => {
+        markSaveStarted = resolve;
+      });
+      const saveCanFinish = new Promise<void>((resolve) => {
+        releaseSave = resolve;
+      });
+      class DeferredFinalSaveSession extends MemorySession {
+        async addItems(items: AgentInputItem[]): Promise<void> {
+          if (
+            items.some(
+              (item) => item.type === 'message' && item.role === 'assistant',
+            )
+          ) {
+            markSaveStarted?.();
+            await saveCanFinish;
+          }
+          await super.addItems(items);
+        }
+      }
+
+      const agent = new Agent({
+        name: 'Pending max-turn output agent',
+        model: new ScriptedModel(),
+      });
+      const state = new RunState(new RunContext(), 'x', agent, 0);
+      const session = new DeferredFinalSaveSession();
+      const options = {
+        session,
+        maxTurns: 0,
+        errorHandlers: {
+          maxTurns: () => ({ finalOutput: 'pending max turn' }),
+        },
+      } as const;
+
+      if (mode === 'streamed') {
+        const result = await run(agent, state, {
+          ...options,
+          stream: true,
+        });
+        await saveStarted;
+        expect(result.newItems).toHaveLength(0);
+        expect(state._generatedItems).toHaveLength(0);
+        releaseSave?.();
+        for await (const _event of result.toStream()) {
+          // Drain the completed stream.
+        }
+        await result.completed;
+        expect(result.newItems).toHaveLength(1);
+      } else {
+        const resultPromise = run(agent, state, options);
+        await saveStarted;
+        expect(state._generatedItems).toHaveLength(0);
+        releaseSave?.();
+        const result = await resultPromise;
+        expect(result.newItems).toHaveLength(1);
+      }
+    },
+  );
+
+  it('keeps a committed streamed max-turn event for delayed readers after compaction fails', async () => {
+    class FailingFinalCompactionSession extends CompactionTrackingSession {
+      async runCompaction(
+        args?: OpenAIResponsesCompactionArgs,
+      ): Promise<OpenAIResponsesCompactionResult | null> {
+        const result = await super.runCompaction(args);
+        if (
+          (await this.getItems()).some(
+            (item) => item.type === 'message' && item.role === 'assistant',
+          )
+        ) {
+          throw new Error('final compaction failed');
+        }
+        return result;
+      }
+    }
+
+    const agent = new Agent({
+      name: 'Compaction failure max-turn output agent',
+      model: new ScriptedModel(),
+    });
+    const result = await run(agent, 'x', {
+      stream: true,
+      session: new FailingFinalCompactionSession(),
+      maxTurns: 0,
+      errorHandlers: {
+        maxTurns: () => ({ finalOutput: 'partially persisted max turn' }),
+      },
+    });
+    const events: { type: string }[] = [];
+    await expect(result.completed).rejects.toThrow('final compaction failed');
+    await result._getStreamLoopPromise();
+    await expect(
+      (async () => {
+        for await (const event of result.toStream()) {
+          events.push(event);
+        }
+      })(),
+    ).rejects.toThrow('final compaction failed');
+    expect(result.newItems).toHaveLength(1);
+    expect(
+      events.filter((event) => event.type === 'run_item_stream_event'),
+    ).toHaveLength(1);
+  });
 
   it.each<RunMode>(['non_streamed', 'streamed'])(
     'rebinds $mode transaction authority before a post-approval final tool executes',


### PR DESCRIPTION
This pull request fixes max-turn error-handler finalization so synthesized handler items are not exposed before output guardrails and session persistence settle.

The runner now defers max-turn handler history items into the existing finalization pipeline, publishes streamed item events only after the corresponding state transition is owned, and keeps `includeInHistory: false` free of synthesized items and events. Session persistence can accept unpublished additional run items while preserving existing resume, checkpoint compaction, blocked-output, and transaction ownership behavior.

When a session append has already committed but post-append compaction fails, the runner reflects the durable item in state and emits the matching stream event before rethrowing so session history, resumed state, and streamed observations remain aligned.