### PR TITLE
fix(realtime): reject unsupported audio history replay

### DIFF
--- a/.changeset/calm-audio-history.md
+++ b/.changeset/calm-audio-history.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-realtime": patch
+---
+
+fix: reject unsupported assistant audio history replay before remote history mutation

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -5,7 +5,7 @@ import {
 } from './items';
 import type { InputAudioTranscriptionCompletedEvent } from './transportLayerEvents';
 import METADATA from './metadata';
-import { RunToolApprovalItem } from '@openai/agents-core';
+import { RunToolApprovalItem, UserError } from '@openai/agents-core';
 import { RealtimeAgent } from './realtimeAgent';
 
 /**
@@ -94,6 +94,14 @@ export type RealtimeHistoryDiff = {
   updates: RealtimeItem[];
 };
 
+function hasAssistantOutputAudio(item: RealtimeItem): boolean {
+  return (
+    item.type === 'message' &&
+    item.role === 'assistant' &&
+    item.content.some((entry) => entry.type === 'output_audio')
+  );
+}
+
 /**
  * Compare two conversation histories to determine the removals, additions, and updates.
  * @param oldHistory - The old history.
@@ -117,6 +125,14 @@ export function diffRealtimeHistory(
         JSON.stringify(oldItem) !== JSON.stringify(item),
     ),
   );
+  const unsupportedReplay = [...additions, ...updates].find(
+    hasAssistantOutputAudio,
+  );
+  if (unsupportedReplay) {
+    throw new UserError(
+      `Assistant output_audio history item ${unsupportedReplay.itemId} cannot be replayed through OpenAI Realtime. Convert its transcript to output_text content or remove the item before calling updateHistory().`,
+    );
+  }
   return {
     removals,
     additions,

--- a/packages/agents-realtime/test/historyReplay.test.ts
+++ b/packages/agents-realtime/test/historyReplay.test.ts
@@ -1,0 +1,93 @@
+import { UserError } from '@openai/agents-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RealtimeClientMessage } from '../src/clientMessages';
+import type { RealtimeMessageItem } from '../src/items';
+import { OpenAIRealtimeBase } from '../src/openaiRealtimeBase';
+
+class TestBase extends OpenAIRealtimeBase {
+  status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting' =
+    'connected';
+  events: RealtimeClientMessage[] = [];
+  connect = vi.fn(async () => {});
+  sendEvent(event: RealtimeClientMessage) {
+    this.events.push(event);
+  }
+  mute = vi.fn();
+  close = vi.fn();
+  interrupt = vi.fn();
+  get muted() {
+    return false;
+  }
+}
+
+function assistantAudio(
+  itemId: string,
+  transcript: string,
+): RealtimeMessageItem {
+  return {
+    itemId,
+    type: 'message',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ type: 'output_audio', transcript, audio: null }],
+  };
+}
+
+function userText(itemId: string, text: string): RealtimeMessageItem {
+  return {
+    itemId,
+    type: 'message',
+    role: 'user',
+    status: 'completed',
+    content: [{ type: 'input_text', text }],
+  };
+}
+
+describe('OpenAI realtime history replay', () => {
+  it('rejects assistant audio additions before sending history mutations', () => {
+    const base = new TestBase();
+    const oldHistory = [userText('old', 'hello')];
+    const newHistory = [assistantAudio('audio', 'response')];
+    let thrown: unknown;
+
+    try {
+      base.resetHistory(oldHistory, newHistory);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect((thrown as Error).message).toContain(
+      'Convert its transcript to output_text content or remove the item before calling updateHistory()',
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('rejects assistant audio updates before sending history mutations', () => {
+    const base = new TestBase();
+    const oldHistory = [assistantAudio('audio', 'before')];
+    const newHistory = [assistantAudio('audio', 'after')];
+
+    expect(() => base.resetHistory(oldHistory, newHistory)).toThrowError(
+      UserError,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('allows unchanged assistant audio while applying other supported changes', () => {
+    const base = new TestBase();
+    const audio = assistantAudio('audio', 'response');
+    const oldHistory = [audio, userText('remove-me', 'old')];
+    const newHistory = [audio];
+
+    base.resetHistory(oldHistory, newHistory);
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        item_id: 'remove-me',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
### Summary

`RealtimeSession.history` can contain assistant `output_audio` messages, but OpenAI Realtime cannot recreate those messages through `conversation.item.create`. The existing history reset path can therefore surface a lower-level server error after history mutations have already started.

This change detects assistant `output_audio` items only when they would need to be added or recreated, and raises an actionable `UserError` before any delete/create event is sent. Unchanged assistant audio items remain valid in local history while other supported changes are applied.

The error directs callers to convert the audio transcript to `output_text` content or remove the unsupported item before calling `updateHistory()`.

### Test plan

Added focused regression coverage for:

- rejecting new assistant audio items before any transport history mutation
- rejecting modified assistant audio items before any transport history mutation
- allowing unchanged assistant audio history while applying an independent supported removal

The repository verification stack could not be run locally because this environment has GitHub connector access but no materialized repository checkout or dependencies. CI is left to perform repository-level verification.

### Issue number

Refs #963

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
