### PR TITLE
feat(examples): add MCP agent discovery example

### DIFF
--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -30,3 +30,9 @@ pnpm -F mcp start:get-all-tools
 ```bash
 pnpm -F mcp start:mcp-servers
 ```
+
+`agent-discovery-example.ts` connects to a remote registry of third-party agents and discovers, at runtime, which of them can do a task the user needs done. Since the candidates it turns up are agents the user has never worked with, it then checks the trust data the registry returns for each one before recommending any. The registry also exposes tools that mutate its state, so the example uses `createMCPToolStaticFilter` to allow only the read-only lookups:
+
+```bash
+pnpm -F mcp start:agent-discovery
+```

--- a/examples/mcp/agent-discovery-example.ts
+++ b/examples/mcp/agent-discovery-example.ts
@@ -1,0 +1,69 @@
+import {
+  Agent,
+  run,
+  MCPServerStreamableHttp,
+  createMCPToolStaticFilter,
+  withTrace,
+} from '@openai/agents';
+
+// The registry exposes read-only lookups alongside tools that mutate registry state, such as
+// registering an agent or proxying a paid call. Discovery needs only the read-only subset, so the
+// filter keeps the agent from reaching the mutating tools at all.
+const READ_ONLY_TOOLS = [
+  // Discovery: find candidates by capability, or page through the whole registry.
+  'match_agents',
+  'list_registry',
+  // Due diligence on a candidate that discovery surfaced.
+  'verify_agent',
+  'get_agent',
+  'protocol_reference',
+];
+
+async function main() {
+  const mcpServer = new MCPServerStreamableHttp({
+    url: 'https://api.aidress.ai/mcp-http/mcp',
+    name: 'Aidress Agent Registry MCP Server',
+    clientSessionTimeoutSeconds: 15,
+    timeout: 15000,
+    toolFilter: createMCPToolStaticFilter({ allowed: READ_ONLY_TOOLS }),
+    reconnectionOptions: {
+      maxRetries: 2,
+      initialReconnectionDelay: 2000,
+      reconnectionDelayGrowFactor: 2,
+      maxReconnectionDelay: 30000,
+    },
+  });
+
+  const agent = new Agent({
+    name: 'Agent Discovery Assistant',
+    instructions: [
+      'You find third-party agents that can do a task the user needs done.',
+      'Start by searching the registry for agents offering the required capability, and report',
+      'what you found: how many candidates there are and what each one does.',
+      'Then, because the user has not worked with any of them before, check each candidate',
+      'trust score, whether it is verified, how many transactions it has completed, and any flags.',
+      'Close with the candidate you would pick and the evidence behind the choice.',
+      'Report only the values the tools return; never invent an agent or a score.',
+    ].join(' '),
+    mcpServers: [mcpServer],
+  });
+
+  try {
+    await withTrace('Aidress Agent Discovery Example', async () => {
+      await mcpServer.connect();
+      const result = await run(
+        agent,
+        "I need a web research task done, but I don't know which agents offer that. " +
+          'Find the ones that do, then tell me which of them I can trust with the job.',
+      );
+      console.log(result.finalOutput);
+    });
+  } finally {
+    await mcpServer.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/mcp/package.json
+++ b/examples/mcp/package.json
@@ -16,6 +16,7 @@
     "start:tool-filter": "tsx tool-filter-example.ts",
     "start:sse": "tsx sse-example.ts",
     "start:get-all-tools": "tsx get-all-mcp-tools-example.ts",
-    "start:mcp-servers": "tsx mcp-servers-example.ts"
+    "start:mcp-servers": "tsx mcp-servers-example.ts",
+    "start:agent-discovery": "tsx agent-discovery-example.ts"
   }
 }


### PR DESCRIPTION
### Summary

Adds `examples/mcp/agent-discovery-example.ts`, showing an agent **discovering other agents at runtime** — connecting to a remote registry over Streamable HTTP and searching it by capability to find third-party agents it had no prior knowledge of, then vetting the ones it finds.

The gap it fills: the current MCP examples all connect to a server whose tools the author already knew about — the filesystem server, DeepWiki, a local SSE server. This one covers the case where the candidate set is not known until the agent asks. Because the agents discovery returns are ones the user has never worked with, the example then checks the trust data the registry returns for each candidate (trust score, verified status, completed transaction count, flags) before recommending one.

Nothing is hard-coded: the registry holds real third-party agents, so the candidates and their numbers change between runs.

Two things worth flagging for review:

- **The tool filter is doing real work, not decoration.** The registry exposes 16 tools; the 5 discovery and lookup tools are read-only and the rest mutate registry state (registering an agent, rotating keys, proxying a paid call to another agent). `createMCPToolStaticFilter({ allowed: READ_ONLY_TOOLS })` means the example cannot write to a live registry. It also makes this the first example here to combine a remote server with tool filtering — `tool-filter-example.ts` demonstrates filtering against a local stdio server today.
- **No credentials beyond `OPENAI_API_KEY`.** The five read-only tools are public; the tools this example filters out are the ones that require a key. So it runs with no additional setup, same as `streamable-http-example.ts`.

This mirrors the Python example in openai/openai-agents-python#4418, so the two SDKs stay in step.

Disclosure: I'm one of the authors of the registry this example connects to. I've kept the example about the SDK pattern rather than the service, and it uses only public, unauthenticated endpoints. If you'd rather this live elsewhere, or not land at all, that's entirely your call.

### Test plan

Ran the full sequence from `CONTRIBUTING.md`:

```
pnpm build            ✓ all packages built
pnpm -r build-check   ✓ all packages Done (includes examples/mcp)
pnpm test             (see below)
pnpm lint             ✓ clean
```

No changeset: the change is confined to `examples/`, and nothing under `packages/` was touched.

The live path was verified against the deployed endpoint with the example's exact URL and filter, using the SDK's own client:

```
registry exposes 16 tools
after filter: 5 -> ['get_agent', 'list_registry', 'match_agents', 'protocol_reference', 'verify_agent']

match_agents returned 8 candidates (first 5 shown):
  agent_exa_ai              trust=76  verified=True  tx=14
  agent_parallel_ai         trust=72  verified=True  tx=16
  agent_ydc_index_io        trust=75  verified=True  tx=1
  agent_trytako_com         trust=72  verified=True  tx=1
  agent_google_serper_dev   trust=75  verified=True  tx=0
```

I also confirmed each option used on `MCPServerStreamableHttp` (`toolFilter`, `timeout`, `clientSessionTimeoutSeconds`, `reconnectionOptions`) against `MCPServerStreamableHttpOptions` in `packages/agents-core/src/mcp.ts` rather than porting them from the Python SDK on the assumption they matched.

Running the example connects the server, applies the filter, and reaches the model call as expected. I'll add the full end-to-end run output in a comment shortly.

### Issue number

N/A

### Checks

- [ ] I've added new tests, if relevant — no unit tests, consistent with the sibling examples
- [x] I've run `pnpm build && pnpm -r build-check && pnpm test && pnpm lint`
- [x] I've confirmed all verification steps pass
