### PR TITLE
fix(openai): keep Chat Completions reasoning on its assistant message

### DIFF
--- a/.changeset/chat-completions-reasoning-message.md
+++ b/.changeset/chat-completions-reasoning-message.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: keep Chat Completions reasoning on the assistant message it belongs to

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -533,6 +533,10 @@ export function itemsToMessages(
         ]),
       });
     } else if (item.type === 'unknown') {
+      // An unknown provider item ends the current assistant turn. Flushing here
+      // keeps it in history order and stops reasoning from carrying across it
+      // to an assistant message it does not belong to.
+      flushAssistantMessage();
       result.push({
         ...item.providerData,
       } as any);

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -305,9 +305,28 @@ export function itemsToMessages(
     }
     return currentAssistantMsg;
   };
+  // A reasoning item is emitted right before the assistant message it belongs
+  // to, so hand its reasoning back to that message instead of flushing an
+  // assistant turn that carries no content and no tool calls.
+  const takeReasoningOnlyAssistantMessage = () => {
+    const pending: ChatCompletionAssistantMessageWithReasoning | null =
+      currentAssistantMsg;
+    if (
+      !pending ||
+      pending.content !== null ||
+      (pending.tool_calls && pending.tool_calls.length > 0) ||
+      !('reasoning' in pending)
+    ) {
+      return undefined;
+    }
+    currentAssistantMsg = null;
+    return pending;
+  };
   for (const item of items) {
     if (isMessageItem(item)) {
       const { content, role, providerData } = item;
+      const pendingReasoningMsg =
+        role === 'assistant' ? takeReasoningOnlyAssistantMessage() : undefined;
       flushAssistantMessage();
       if (role === 'assistant') {
         const phase = item.phase ?? providerData?.phase;
@@ -325,9 +344,12 @@ export function itemsToMessages(
           }
           logger.warn(`${message} The phase will be dropped.`);
         }
-        const assistant: ChatCompletionAssistantMessageParam = {
+        const assistant: ChatCompletionAssistantMessageWithReasoning = {
           role: 'assistant',
           content: extractAllAssistantContent(content),
+          ...(typeof pendingReasoningMsg?.reasoning === 'string'
+            ? { reasoning: pendingReasoningMsg.reasoning }
+            : {}),
           ...getProviderDataWithoutReservedKeys(providerData, [
             'role',
             'content',

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -957,6 +957,141 @@ describe('itemsToMessages', () => {
     ]);
   });
 
+  test('keeps reasoning on the assistant message it belongs to', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'reasoning',
+        content: [],
+        rawContent: [{ type: 'reasoning_text', text: 'why' }],
+      } as protocol.ReasoningItem,
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'hello' }],
+      } as protocol.AssistantMessageItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hello' }],
+        reasoning: 'why',
+      },
+    ]);
+  });
+
+  test('drops an empty reasoning item instead of emitting an empty assistant turn', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'reasoning',
+        content: [],
+        rawContent: [],
+      } as protocol.ReasoningItem,
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'hello' }],
+      } as protocol.AssistantMessageItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    ]);
+  });
+
+  test('keeps reasoning with the tool call message when a tool call follows', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'reasoning',
+        content: [],
+        rawContent: [{ type: 'reasoning_text', text: 'why' }],
+      } as protocol.ReasoningItem,
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'f',
+        arguments: '{}',
+        status: 'completed',
+      } as protocol.FunctionCallItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        reasoning: 'why',
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: { name: 'f', arguments: '{}' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('does not attach reasoning to a following user message', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'reasoning',
+        content: [],
+        rawContent: [{ type: 'reasoning_text', text: 'why' }],
+      } as protocol.ReasoningItem,
+      {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: 'hi' }],
+      } as protocol.UserMessageItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs).toEqual([
+      { role: 'assistant', content: null, reasoning: 'why' },
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    ]);
+  });
+
+  test('does not steal reasoning from a previous assistant message', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'reasoning',
+        content: [],
+        rawContent: [{ type: 'reasoning_text', text: 'first' }],
+      } as protocol.ReasoningItem,
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'one' }],
+      } as protocol.AssistantMessageItem,
+      {
+        id: 'msg_2',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'two' }],
+      } as protocol.AssistantMessageItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'one' }],
+        reasoning: 'first',
+      },
+      { role: 'assistant', content: [{ type: 'text', text: 'two' }] },
+    ]);
+  });
+
   test('propagates providerData from function_call to assistant message', () => {
     const items: protocol.ModelItem[] = [
       {

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -1092,6 +1092,55 @@ describe('itemsToMessages', () => {
     ]);
   });
 
+  test('does not carry reasoning across an unknown provider item', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'reasoning',
+        content: [],
+        rawContent: [{ type: 'reasoning_text', text: 'why' }],
+      } as protocol.ReasoningItem,
+      {
+        type: 'unknown',
+        providerData: { role: 'assistant', content: 'provider specific' },
+      } as unknown as protocol.ModelItem,
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'hello' }],
+      } as protocol.AssistantMessageItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs).toEqual([
+      { role: 'assistant', content: null, reasoning: 'why' },
+      { role: 'assistant', content: 'provider specific' },
+      { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    ]);
+  });
+
+  test('keeps an unknown provider item in history order', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'f',
+        arguments: '{}',
+        status: 'completed',
+      } as protocol.FunctionCallItem,
+      {
+        type: 'unknown',
+        providerData: { role: 'assistant', content: 'provider specific' },
+      } as unknown as protocol.ModelItem,
+    ];
+    const msgs = itemsToMessages(items);
+    expect(msgs.map((m) => (m as any).content)).toEqual([
+      null,
+      'provider specific',
+    ]);
+  });
+
   test('does not accumulate contentless assistant messages across turns', () => {
     // Replayed history from a provider that returns reasoning on the assistant
     // message grows by one reasoning item per turn. Each one used to add its own

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -1092,6 +1092,49 @@ describe('itemsToMessages', () => {
     ]);
   });
 
+  test('does not accumulate contentless assistant messages across turns', () => {
+    // Replayed history from a provider that returns reasoning on the assistant
+    // message grows by one reasoning item per turn. Each one used to add its own
+    // assistant message with no content and no tool calls.
+    const items: protocol.ModelItem[] = [];
+    for (const turn of [1, 2, 3, 4, 5]) {
+      items.push({
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: `question ${turn}` }],
+      } as protocol.UserMessageItem);
+      items.push({
+        type: 'reasoning',
+        content: [],
+        rawContent: [{ type: 'reasoning_text', text: `reasoning ${turn}` }],
+      } as protocol.ReasoningItem);
+      items.push({
+        id: `msg_${turn}`,
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: `answer ${turn}` }],
+      } as protocol.AssistantMessageItem);
+    }
+
+    const msgs = itemsToMessages(items);
+    const assistantMessages = msgs.filter((m) => m.role === 'assistant');
+
+    expect(assistantMessages).toHaveLength(5);
+    expect(
+      assistantMessages.filter(
+        (m) => m.content === null && !(m as any).tool_calls,
+      ),
+    ).toHaveLength(0);
+    expect(assistantMessages.map((m) => (m as any).reasoning)).toEqual([
+      'reasoning 1',
+      'reasoning 2',
+      'reasoning 3',
+      'reasoning 4',
+      'reasoning 5',
+    ]);
+  });
+
   test('propagates providerData from function_call to assistant message', () => {
     const items: protocol.ModelItem[] = [
       {


### PR DESCRIPTION
### Summary

Chat Completions responses that carry reasoning do not round trip. Providers that return `reasoning` on the assistant message get it recorded as a standalone `reasoning` item placed before the assistant `message` item, and on replay the converter turns that one provider message back into two assistant messages, with the reasoning on the one that has no content.

Captured live against OpenRouter and `deepseek/deepseek-r1` on `@openai/agents-openai@0.15.0`. Provider response, `choices[0].message`:

```json
{
  "role": "assistant",
  "content": "The capital of France is **Paris**.",
  "refusal": null,
  "reasoning": "Okay, the user asked a straightforward question: [truncated]",
  "reasoning_details": [ { "type": "reasoning.text", "text": "[truncated]", "format": "unknown", "index": 0 } ]
}
```

Second turn request from the same run:

```json
[
  { "role": "user", "content": "What is the capital of France?" },
  { "role": "assistant", "content": null, "reasoning": "[truncated]" },
  { "role": "assistant", "content": [ { "type": "text", "text": "The capital of France is **Paris**." } ] },
  { "role": "user", "content": "And Germany?" }
]
```

It compounds, because a reasoning item is added per turn. Assistant messages in each outgoing request over five turns:

```
turn | assistant msgs | contentless (content: null, no tool_calls)
  1  |       0        |      0
  2  |       2        |      1
  3  |       4        |      2
  4  |       6        |      3
  5  |       8        |      4
```

So a reasoning model on the Chat Completions path currently replays twice the assistant messages it needs, growing with conversation length, and the caller pays input tokens for the empty ones. The same applies to the streaming path, which produces the same history items.

OpenRouter documents passing reasoning back on the assistant message, via `message.reasoning` or `message.reasoning_details`, to preserve reasoning continuity across calls: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens

This is not an OpenAI Chat Completions field, and the SDK already targets it deliberately on both sides. `hasReasoningContent()` in `openaiChatCompletionsModel.ts` reads `message.reasoning`, the streaming converter accumulates `delta.reasoning`, and `ChatCompletionAssistantMessageWithReasoning` exists in the converter so it can be written back out. The read path and the write path just do not line up.

### Fix

When the pending assistant message was created only by a reasoning item, hand its reasoning to the assistant message that immediately follows instead of flushing it as a separate turn:

```json
[
  { "role": "user", "content": "What is the capital of France?" },
  {
    "role": "assistant",
    "content": [ { "type": "text", "text": "The capital of France is **Paris**." } ],
    "reasoning": "[truncated]"
  },
  { "role": "user", "content": "And Germany?" }
]
```

19 lines in one function. No public API change.

Behavior that is deliberately unchanged, and now covered by tests:

- Reasoning followed by a tool call still shares a single assistant message, which is how tool call turns already replayed.
- A trailing reasoning item with no following assistant message is still emitted on its own.
- Reasoning is never merged into a following user or system message.
- `providerData.reasoning` on the assistant message still wins, since provider data is spread last.
- Only the reasoning item directly before an assistant message is merged into it, so a later assistant message is unaffected.

A reasoning item with empty `rawContent` no longer produces an assistant message with neither content nor reasoning.

Out of scope here, happy to follow up if wanted: `reasoning_details` is not carried onto the assistant message at all, and the nested copy of `reasoning` inside the text content part comes from the existing `providerData` passthrough in `extractAllAssistantContent`.

### Test plan

Six cases in `packages/agents-openai/test/openaiChatCompletionsConverter.test.ts`. Four fail on `main` and pass with the change; two are guards that pass in both states so the unchanged paths stay pinned:

- `keeps reasoning on the assistant message it belongs to`
- `drops an empty reasoning item instead of emitting an empty assistant turn`
- `does not steal reasoning from a previous assistant message`
- `does not accumulate contentless assistant messages across turns`
- `keeps reasoning with the tool call message when a tool call follows` (guard)
- `does not attach reasoning to a following user message` (guard)

Commands run locally on Windows:

- `pnpm build` (0 errors)
- `pnpm test` for `packages/agents-openai`: 21 files, 665 tests passing
- full `pnpm test`: the only failures are pre-existing on this platform and unrelated to this change (the sandbox suites that require POSIX path separators, and the RunState fixture hash check that trips on CRLF checkouts)
- `pnpm lint`
- `pnpm -r build-check`

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
