### PR TITLE
fix(realtime): reject unsupported audio history replay

### DIFF
--- a/.changeset/calm-audio-history.md
+++ b/.changeset/calm-audio-history.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-realtime": patch
+---
+
+fix: reject unsupported assistant audio history replay before remote history mutation

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -5,7 +5,7 @@ import {
 } from './items';
 import type { InputAudioTranscriptionCompletedEvent } from './transportLayerEvents';
 import METADATA from './metadata';
-import { RunToolApprovalItem } from '@openai/agents-core';
+import { RunToolApprovalItem, UserError } from '@openai/agents-core';
 import { RealtimeAgent } from './realtimeAgent';
 
 /**
@@ -94,6 +94,14 @@ export type RealtimeHistoryDiff = {
   updates: RealtimeItem[];
 };
 
+function hasAssistantOutputAudio(item: RealtimeItem): boolean {
+  return (
+    item.type === 'message' &&
+    item.role === 'assistant' &&
+    item.content.some((entry) => entry.type === 'output_audio')
+  );
+}
+
 /**
  * Compare two conversation histories to determine the removals, additions, and updates.
  * @param oldHistory - The old history.
@@ -117,6 +125,14 @@ export function diffRealtimeHistory(
         JSON.stringify(oldItem) !== JSON.stringify(item),
     ),
   );
+  const unsupportedReplay = [...additions, ...updates].find(
+    hasAssistantOutputAudio,
+  );
+  if (unsupportedReplay) {
+    throw new UserError(
+      `Assistant output_audio history item ${unsupportedReplay.itemId} cannot be replayed through OpenAI Realtime. Convert its transcript to output_text content or remove the item before calling updateHistory().`,
+    );
+  }
   return {
     removals,
     additions,

--- a/packages/agents-realtime/test/historyReplay.test.ts
+++ b/packages/agents-realtime/test/historyReplay.test.ts
@@ -1,0 +1,93 @@
+import { UserError } from '@openai/agents-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RealtimeClientMessage } from '../src/clientMessages';
+import type { RealtimeMessageItem } from '../src/items';
+import { OpenAIRealtimeBase } from '../src/openaiRealtimeBase';
+
+class TestBase extends OpenAIRealtimeBase {
+  status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting' =
+    'connected';
+  events: RealtimeClientMessage[] = [];
+  connect = vi.fn(async () => {});
+  sendEvent(event: RealtimeClientMessage) {
+    this.events.push(event);
+  }
+  mute = vi.fn();
+  close = vi.fn();
+  interrupt = vi.fn();
+  get muted() {
+    return false;
+  }
+}
+
+function assistantAudio(
+  itemId: string,
+  transcript: string,
+): RealtimeMessageItem {
+  return {
+    itemId,
+    type: 'message',
+    role: 'assistant',
+    status: 'completed',
+    content: [{ type: 'output_audio', transcript, audio: null }],
+  };
+}
+
+function userText(itemId: string, text: string): RealtimeMessageItem {
+  return {
+    itemId,
+    type: 'message',
+    role: 'user',
+    status: 'completed',
+    content: [{ type: 'input_text', text }],
+  };
+}
+
+describe('OpenAI realtime history replay', () => {
+  it('rejects assistant audio additions before sending history mutations', () => {
+    const base = new TestBase();
+    const oldHistory = [userText('old', 'hello')];
+    const newHistory = [assistantAudio('audio', 'response')];
+    let thrown: unknown;
+
+    try {
+      base.resetHistory(oldHistory, newHistory);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(UserError);
+    expect((thrown as Error).message).toContain(
+      'Convert its transcript to output_text content or remove the item before calling updateHistory()',
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('rejects assistant audio updates before sending history mutations', () => {
+    const base = new TestBase();
+    const oldHistory = [assistantAudio('audio', 'before')];
+    const newHistory = [assistantAudio('audio', 'after')];
+
+    expect(() => base.resetHistory(oldHistory, newHistory)).toThrowError(
+      UserError,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('allows unchanged assistant audio while applying other supported changes', () => {
+    const base = new TestBase();
+    const audio = assistantAudio('audio', 'response');
+    const oldHistory = [audio, userText('remove-me', 'old')];
+    const newHistory = [audio];
+
+    base.resetHistory(oldHistory, newHistory);
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        item_id: 'remove-me',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #963.

Assistant `output_audio` items cannot currently be recreated through Realtime history mutation. Detect additions and updates containing assistant audio before emitting any remote history events and raise a `UserError` with a supported transcript-based workaround instead of allowing the server request to fail after history mutation has started.

Unchanged assistant audio already present in history remains valid, so unrelated supported mutations can still proceed. Adds regression coverage for additions, updates, and unchanged audio.