### PR TITLE
fix(realtime): restore function calls in updateHistory

### DIFF
--- a/.changeset/green-function-history.md
+++ b/.changeset/green-function-history.md
@@ -1,0 +1,5 @@
+---
+"@openai/agents-realtime": patch
+---
+
+fix: restore function call items when populating realtime conversation history

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -1,4 +1,4 @@
-import { RuntimeEventEmitter, Usage } from '@openai/agents-core';
+import { RuntimeEventEmitter, Usage, UserError } from '@openai/agents-core';
 import { normalizeHostedMcpRequireApproval } from '@openai/agents-core/utils';
 import {
   logModelActionError,
@@ -18,6 +18,7 @@ import {
 } from './clientMessages';
 import {
   RealtimeItem,
+  RealtimeToolCallItem,
   realtimeMcpCallApprovalRequestItem,
   RealtimeMcpCallApprovalRequestItem,
   realtimeMcpCallItem,
@@ -163,6 +164,21 @@ export abstract class OpenAIRealtimeBase
   #apiKey: ApiKey | undefined;
   #tracingConfig: RealtimeTracingConfig | null = null;
   #rawSessionConfig: Record<string, any> | null = null;
+  #replayedFunctionCalls = new Map<
+    string,
+    {
+      item: RealtimeToolCallItem;
+      expectsOutput: boolean;
+      outputItemId?: string;
+      outputDeleted?: boolean;
+      callCreateEventId?: string;
+      outputCreateEventId?: string;
+      deleteEventId?: string;
+      deletePhase?: 'output' | 'call';
+    }
+  >();
+  #connectionStatePrepared = false;
+  #replayEventSequence = 0;
 
   protected eventEmitter: RuntimeEventEmitter<OpenAIRealtimeEventTypes> =
     new RuntimeEventEmitter<OpenAIRealtimeEventTypes>();
@@ -171,6 +187,20 @@ export abstract class OpenAIRealtimeBase
     super();
     this.#model = options.model ?? DEFAULT_OPENAI_REALTIME_MODEL;
     this.#apiKey = options.apiKey;
+  }
+
+  emit<K extends keyof OpenAIRealtimeEventTypes>(
+    type: K,
+    ...args: OpenAIRealtimeEventTypes[K]
+  ): boolean {
+    if (
+      type === 'connection_change' &&
+      (args as OpenAIRealtimeEventTypes['connection_change'])[0] === 'connected'
+    ) {
+      this._resetConnectionScopedState();
+      this.#connectionStatePrepared = true;
+    }
+    return super.emit(type, ...args);
   }
 
   /**
@@ -213,6 +243,20 @@ export abstract class OpenAIRealtimeBase
     // Intentionally empty.
   }
 
+  /** Clear state that is valid only for a single transport connection. */
+  protected _resetConnectionScopedState(): void {
+    this.#replayedFunctionCalls.clear();
+  }
+
+  #nextReplayEventId(
+    callId: string,
+    operation:
+      'call-create' | 'output-create' | 'output-delete' | 'call-delete',
+  ): string {
+    this.#replayEventSequence += 1;
+    return `agents-realtime-history-${operation}-${callId}-${this.#replayEventSequence}`;
+  }
+
   protected get _rawSessionConfig(): Record<string, any> | null {
     return this.#rawSessionConfig ?? null;
   }
@@ -240,6 +284,36 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'error') {
+      const failedClientEventId =
+        parsed.error && typeof parsed.error === 'object'
+          ? (parsed.error as { event_id?: unknown }).event_id
+          : undefined;
+      if (typeof failedClientEventId === 'string') {
+        for (const [callId, tracked] of this.#replayedFunctionCalls) {
+          if (tracked.callCreateEventId === failedClientEventId) {
+            this.#replayedFunctionCalls.delete(callId);
+            break;
+          }
+          if (tracked.outputCreateEventId === failedClientEventId) {
+            tracked.outputCreateEventId = undefined;
+            tracked.expectsOutput = false;
+            tracked.outputItemId = undefined;
+            tracked.outputDeleted = false;
+            tracked.item = realtimeToolCallItem.parse({
+              ...tracked.item,
+              status: 'in_progress',
+              output: null,
+            });
+            this.emit('item_update', tracked.item);
+            break;
+          }
+          if (tracked.deleteEventId === failedClientEventId) {
+            tracked.deleteEventId = undefined;
+            tracked.deletePhase = undefined;
+            break;
+          }
+        }
+      }
       this.emit('error', { type: 'error', error: parsed });
     } else {
       this.emit(parsed.type, parsed);
@@ -308,9 +382,46 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'conversation.item.deleted') {
+      let completedOutputCallId: string | undefined;
+
+      for (const [callId, tracked] of this.#replayedFunctionCalls) {
+        if (
+          tracked.deletePhase === 'output' &&
+          tracked.outputItemId === parsed.item_id
+        ) {
+          tracked.outputDeleted = true;
+          tracked.outputItemId = undefined;
+          tracked.deleteEventId = undefined;
+          tracked.deletePhase = undefined;
+          completedOutputCallId = callId;
+          break;
+        }
+        if (tracked.deletePhase === 'call' && callId === parsed.item_id) {
+          this.#replayedFunctionCalls.delete(callId);
+          break;
+        }
+      }
+
       this.emit('item_deleted', {
         itemId: parsed.item_id,
       });
+
+      if (completedOutputCallId) {
+        const tracked = this.#replayedFunctionCalls.get(completedOutputCallId);
+        if (tracked && !tracked.deletePhase) {
+          const callDeleteEventId = this.#nextReplayEventId(
+            completedOutputCallId,
+            'call-delete',
+          );
+          this.sendEvent({
+            type: 'conversation.item.delete',
+            event_id: callDeleteEventId,
+            item_id: completedOutputCallId,
+          });
+          tracked.deletePhase = 'call';
+          tracked.deleteEventId = callDeleteEventId;
+        }
+      }
       return;
     }
 
@@ -380,6 +491,61 @@ export abstract class OpenAIRealtimeBase
         // We do not add this item to history; it's a transport-level side-channel.
         return;
       }
+      if (parsed.item.type === 'function_call') {
+        const callId = parsed.item.call_id;
+        const tracked = callId
+          ? this.#replayedFunctionCalls.get(callId)
+          : undefined;
+        if (tracked) {
+          tracked.callCreateEventId = undefined;
+          const previousItemId =
+            parsed.type === 'conversation.item.added' ||
+            parsed.type === 'conversation.item.done'
+              ? parsed.previous_item_id
+              : tracked.item.previousItemId;
+          const hasCompletedOutput =
+            tracked.outputItemId !== undefined &&
+            tracked.item.status === 'completed' &&
+            tracked.item.output !== null;
+          const item = realtimeToolCallItem.parse({
+            ...tracked.item,
+            previousItemId,
+            status: hasCompletedOutput
+              ? 'completed'
+              : tracked.expectsOutput
+                ? 'in_progress'
+                : tracked.item.status,
+            output: hasCompletedOutput ? tracked.item.output : null,
+          });
+          tracked.item = item;
+          this.emit('item_update', item);
+          return;
+        }
+      }
+
+      if (parsed.item.type === 'function_call_output') {
+        const callId = parsed.item.call_id;
+        const tracked = callId
+          ? this.#replayedFunctionCalls.get(callId)
+          : undefined;
+        if (tracked) {
+          tracked.expectsOutput = true;
+          tracked.outputDeleted = false;
+          tracked.outputCreateEventId = undefined;
+          if (parsed.item.id) {
+            tracked.outputItemId = parsed.item.id;
+          }
+          const item = realtimeToolCallItem.parse({
+            ...tracked.item,
+            status: 'completed',
+            output: parsed.item.output ?? null,
+          });
+          tracked.item = item;
+          this.emit('item_update', item);
+          return;
+        }
+      }
+
       if (parsed.item.type === 'message') {
         const previousItemId =
           parsed.type === 'conversation.item.added' ||
@@ -537,10 +703,20 @@ export abstract class OpenAIRealtimeBase
   }
 
   protected _onOpen() {
+    // Most transports announce connection_change before invoking this hook.
+    // In that case replay state was already reset before listeners ran, and
+    // history restored by those listeners must survive this hook. Custom
+    // transports that call only _onOpen still get the same reset guarantee.
+    if (!this.#connectionStatePrepared) {
+      this._resetConnectionScopedState();
+    }
+    this.#connectionStatePrepared = false;
     this.emit('connected');
   }
 
   protected _onClose() {
+    this.#connectionStatePrepared = false;
+    this._resetConnectionScopedState();
     this.emit('disconnected');
   }
 
@@ -882,7 +1058,7 @@ export abstract class OpenAIRealtimeBase
 
   /**
    * Updates the session config. This will merge it with the current session config with the default
-   * values and send it to the Realtime API.
+   * values and send it to the Realtime API to update the history.
    *
    * @param config - The session config to update.
    */
@@ -907,14 +1083,44 @@ export abstract class OpenAIRealtimeBase
     output: string,
     startResponse: boolean = true,
   ): void {
-    this.sendEvent({
-      type: 'conversation.item.create',
-      item: {
-        type: 'function_call_output',
-        output,
-        call_id: toolCall.callId,
-      },
-    });
+    const tracked = this.#replayedFunctionCalls.get(toolCall.callId);
+    if (tracked?.outputCreateEventId) {
+      throw new UserError(
+        `Function call ${toolCall.callId} already has an output awaiting Realtime API acknowledgement.`,
+      );
+    }
+    if (tracked?.outputItemId && !tracked.outputDeleted) {
+      throw new UserError(
+        `Function call ${toolCall.callId} already has an acknowledged output. Sending another output for the same replayed call is not supported.`,
+      );
+    }
+    const outputCreateEventId = tracked
+      ? this.#nextReplayEventId(toolCall.callId, 'output-create')
+      : undefined;
+    if (tracked) {
+      tracked.expectsOutput = true;
+      tracked.outputDeleted = false;
+      tracked.outputCreateEventId = outputCreateEventId;
+    }
+
+    try {
+      this.sendEvent({
+        type: 'conversation.item.create',
+        ...(outputCreateEventId ? { event_id: outputCreateEventId } : {}),
+        item: {
+          type: 'function_call_output',
+          output,
+          call_id: toolCall.callId,
+        },
+      });
+    } catch (error) {
+      if (tracked?.outputCreateEventId === outputCreateEventId) {
+        tracked.outputCreateEventId = undefined;
+        tracked.expectsOutput = false;
+        tracked.outputDeleted = false;
+      }
+      throw error;
+    }
 
     try {
       const item = realtimeToolCallItem.parse({
@@ -926,6 +1132,9 @@ export abstract class OpenAIRealtimeBase
         name: toolCall.name,
         output,
       });
+      if (tracked) {
+        tracked.item = item;
+      }
       this.emit('item_update', item);
     } catch (error) {
       logToolActionError(
@@ -978,23 +1187,157 @@ export abstract class OpenAIRealtimeBase
       newHistory,
     );
 
-    const removalIds = new Set(removals.map((item) => item.itemId));
-    // we don't have an update event for items so we will remove and re-add what's there
-    for (const update of updates) {
-      removalIds.add(update.itemId);
+    const oldItemsById = new Map(
+      oldHistory.map((item) => [item.itemId, item] as const),
+    );
+    const functionCallUpdates = updates.filter(
+      (item) =>
+        item.type === 'function_call' ||
+        oldItemsById.get(item.itemId)?.type === 'function_call',
+    );
+
+    // Function-call replay has asynchronous server ownership. Reject unsupported
+    // replacements before sending any mutation so local and server history stay
+    // on the same projection when the operation fails.
+    if (functionCallUpdates.length > 0) {
+      throw new UserError(
+        'Updating or replacing function call history items is not supported. Remove the item in one update and replay a new item only after the removal is acknowledged.',
+      );
     }
 
-    if (removalIds.size > 0) {
-      for (const itemId of removalIds) {
-        this.sendEvent({
-          type: 'conversation.item.delete',
-          item_id: itemId,
-        });
+    const updatedIds = new Set(updates.map((item) => item.itemId));
+    const retainedOldIds = new Set(
+      oldHistory
+        .filter(
+          (item) =>
+            !updatedIds.has(item.itemId) &&
+            newHistory.some((newItem) => newItem.itemId === item.itemId),
+        )
+        .map((item) => item.itemId),
+    );
+    let lastRetainedIndex = -1;
+    for (let index = 0; index < newHistory.length; index++) {
+      if (retainedOldIds.has(newHistory[index].itemId)) {
+        lastRetainedIndex = index;
       }
     }
 
-    const additionsAndUpdates = [...additions, ...updates];
+    const functionCallAdditions = additions.filter(
+      (item): item is RealtimeToolCallItem => item.type === 'function_call',
+    );
+    for (const addition of functionCallAdditions) {
+      const additionIndex = newHistory.findIndex(
+        (item) => item.itemId === addition.itemId,
+      );
+      const hasPrecedingUpdate = updates.some((update) => {
+        const updateIndex = newHistory.findIndex(
+          (item) => item.itemId === update.itemId,
+        );
+        return updateIndex >= 0 && updateIndex < additionIndex;
+      });
+      if (hasPrecedingUpdate) {
+        throw new UserError(
+          'Function call history replay cannot follow an updated history item in the same operation. Apply the update first, then replay the function call after the updated history is acknowledged.',
+        );
+      }
+      if (additionIndex < lastRetainedIndex) {
+        throw new UserError(
+          'Function call history items can only be replayed as appended history. Mid-history insertion is not supported.',
+        );
+      }
+      if (this.#replayedFunctionCalls.has(addition.itemId)) {
+        throw new UserError(
+          `Function call ${addition.itemId} is already owned by an acknowledgement-pending replay. Wait for the Realtime API acknowledgement before replaying it again.`,
+        );
+      }
+    }
 
+    for (const removal of removals) {
+      if (removal.type !== 'function_call') {
+        continue;
+      }
+      const tracked = this.#replayedFunctionCalls.get(removal.itemId);
+      if (tracked?.deletePhase) {
+        throw new UserError(
+          `Function call ${removal.itemId} already has a deletion awaiting Realtime API acknowledgement.`,
+        );
+      }
+      if (
+        tracked?.expectsOutput &&
+        !tracked.outputItemId &&
+        !tracked.outputDeleted
+      ) {
+        throw new UserError(
+          'Cannot remove a replayed completed function call before its output item is acknowledged by the Realtime API.',
+        );
+      }
+    }
+
+    const initialDeletes: Array<{
+      itemId: string;
+      trackedCallId?: string;
+      phase?: 'output' | 'call';
+    }> = [];
+
+    for (const removal of removals) {
+      if (removal.type === 'function_call') {
+        const tracked = this.#replayedFunctionCalls.get(removal.itemId);
+        if (
+          tracked?.expectsOutput &&
+          tracked.outputItemId &&
+          !tracked.outputDeleted
+        ) {
+          initialDeletes.push({
+            itemId: tracked.outputItemId,
+            trackedCallId: removal.itemId,
+            phase: 'output',
+          });
+          continue;
+        }
+        initialDeletes.push({
+          itemId: removal.itemId,
+          trackedCallId: tracked ? removal.itemId : undefined,
+          phase: tracked ? 'call' : undefined,
+        });
+        continue;
+      }
+      initialDeletes.push({ itemId: removal.itemId });
+    }
+
+    // Existing non-function-call updates retain their delete-and-recreate
+    // behavior. Function-call updates were rejected above before any mutation.
+    for (const update of updates) {
+      initialDeletes.push({ itemId: update.itemId });
+    }
+
+    for (const deletion of initialDeletes) {
+      const tracked = deletion.trackedCallId
+        ? this.#replayedFunctionCalls.get(deletion.trackedCallId)
+        : undefined;
+      const deleteEventId =
+        tracked && deletion.phase && deletion.trackedCallId
+          ? this.#nextReplayEventId(
+              deletion.trackedCallId,
+              deletion.phase === 'output' ? 'output-delete' : 'call-delete',
+            )
+          : undefined;
+      this.sendEvent({
+        type: 'conversation.item.delete',
+        ...(deleteEventId ? { event_id: deleteEventId } : {}),
+        item_id: deletion.itemId,
+      });
+      if (tracked && deletion.phase) {
+        tracked.deletePhase = deletion.phase;
+        tracked.deleteEventId = deleteEventId;
+      }
+    }
+
+    const recreatedIds = new Set(
+      [...additions, ...updates].map((item) => item.itemId),
+    );
+    const additionsAndUpdates = newHistory.filter((item) =>
+      recreatedIds.has(item.itemId),
+    );
     for (const addition of additionsAndUpdates) {
       if (addition.type === 'message') {
         const itemEntry: Record<string, any> = {
@@ -1011,9 +1354,63 @@ export abstract class OpenAIRealtimeBase
           item: itemEntry,
         });
       } else if (addition.type === 'function_call') {
-        logger.warn(
-          'Function calls cannot be manually added or updated at the moment. Ignoring.',
+        const callId = addition.itemId;
+        const callCreateEventId = this.#nextReplayEventId(
+          callId,
+          'call-create',
         );
+        const tracked = {
+          item: addition,
+          expectsOutput: addition.output !== null,
+          callCreateEventId,
+          outputCreateEventId: undefined as string | undefined,
+        };
+        this.#replayedFunctionCalls.set(callId, tracked);
+        let callCreateSent = false;
+        try {
+          this.sendEvent({
+            type: 'conversation.item.create',
+            event_id: callCreateEventId,
+            item: {
+              type: 'function_call',
+              id: addition.itemId,
+              call_id: callId,
+              name: addition.name,
+              arguments: addition.arguments,
+              status: addition.status,
+            },
+          });
+          callCreateSent = true;
+          if (addition.output !== null) {
+            const outputCreateEventId = this.#nextReplayEventId(
+              callId,
+              'output-create',
+            );
+            tracked.outputCreateEventId = outputCreateEventId;
+            this.sendEvent({
+              type: 'conversation.item.create',
+              event_id: outputCreateEventId,
+              item: {
+                type: 'function_call_output',
+                call_id: callId,
+                output: addition.output,
+              },
+            });
+          }
+        } catch (error) {
+          if (!callCreateSent) {
+            this.#replayedFunctionCalls.delete(callId);
+          } else if (tracked.outputCreateEventId) {
+            tracked.outputCreateEventId = undefined;
+            tracked.expectsOutput = false;
+            tracked.item = realtimeToolCallItem.parse({
+              ...tracked.item,
+              status: 'in_progress',
+              output: null,
+            });
+          }
+          throw error;
+        }
       }
     }
   }

--- a/packages/agents-realtime/test/functionCallHistoryReplay.test.ts
+++ b/packages/agents-realtime/test/functionCallHistoryReplay.test.ts
@@ -1,0 +1,660 @@
+import { UserError } from '@openai/agents-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RealtimeClientMessage } from '../src/clientMessages';
+import type { RealtimeItem, RealtimeToolCallItem } from '../src/items';
+import { OpenAIRealtimeBase } from '../src/openaiRealtimeBase';
+
+class TestBase extends OpenAIRealtimeBase {
+  status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting' =
+    'connected';
+  events: RealtimeClientMessage[] = [];
+  failNextSend = false;
+  failOnSendAttempt: number | null = null;
+  sendAttempts = 0;
+  connect = vi.fn(async () => {});
+  sendEvent(event: RealtimeClientMessage) {
+    this.sendAttempts += 1;
+    if (this.failNextSend || this.failOnSendAttempt === this.sendAttempts) {
+      this.failNextSend = false;
+      this.failOnSendAttempt = null;
+      throw new Error('synchronous send failure');
+    }
+    this.events.push(event);
+  }
+  mute = vi.fn();
+  close = vi.fn();
+  interrupt = vi.fn();
+  get muted() {
+    return false;
+  }
+
+  open() {
+    this._onOpen();
+  }
+
+  announceConnected() {
+    this.emit('connection_change', 'connected');
+    this._onOpen();
+  }
+
+  closeTransport() {
+    this._onClose();
+  }
+}
+
+function functionCall({
+  output = null,
+}: { output?: string | null } = {}): RealtimeToolCallItem {
+  return {
+    itemId: 'fc_1',
+    type: 'function_call',
+    status: output === null ? 'in_progress' : 'completed',
+    arguments: '{"city":"Paris"}',
+    name: 'get_weather',
+    output,
+  };
+}
+
+function message(itemId: string, text: string): RealtimeItem {
+  return {
+    itemId,
+    type: 'message',
+    role: 'user',
+    status: 'completed',
+    content: [{ type: 'input_text', text }],
+  };
+}
+
+function receive(base: TestBase, payload: Record<string, unknown>) {
+  (base as any)._onMessage({ data: JSON.stringify(payload) });
+}
+
+function echoFunctionCall(
+  base: TestBase,
+  type:
+    | 'conversation.item.added'
+    | 'conversation.item.done' = 'conversation.item.added',
+) {
+  receive(base, {
+    type,
+    event_id: 'evt_call',
+    previous_item_id: 'previous',
+    item: {
+      type: 'function_call',
+      id: 'fc_1',
+      call_id: 'fc_1',
+      name: 'get_weather',
+      arguments: '{"city":"Paris"}',
+      status: 'completed',
+    },
+  });
+}
+
+function echoFunctionCallOutput(base: TestBase) {
+  receive(base, {
+    type: 'conversation.item.done',
+    event_id: 'evt_output',
+    previous_item_id: 'previous',
+    item: {
+      type: 'function_call_output',
+      id: 'fco_1',
+      call_id: 'fc_1',
+      output: '{"temp":21}',
+      status: 'completed',
+    },
+  });
+}
+
+function echoDeleted(base: TestBase, itemId: string) {
+  receive(base, {
+    type: 'conversation.item.deleted',
+    event_id: `evt_delete_${itemId}`,
+    item_id: itemId,
+  });
+}
+
+function echoClientEventError(base: TestBase, clientEventId: string) {
+  base.on('error', () => {});
+  receive(base, {
+    type: 'error',
+    event_id: `server_error_${clientEventId}`,
+    error: {
+      type: 'invalid_request_error',
+      message: 'rejected client event',
+      event_id: clientEventId,
+    },
+  });
+}
+
+describe('Realtime function call history replay', () => {
+  it('adds a function call item to conversation history', () => {
+    const base = new TestBase();
+    base.resetHistory([], [functionCall()]);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.any(String),
+        item: {
+          type: 'function_call',
+          id: 'fc_1',
+          call_id: 'fc_1',
+          name: 'get_weather',
+          arguments: '{"city":"Paris"}',
+          status: 'in_progress',
+        },
+      },
+    ]);
+  });
+
+  it('restores the recorded output with the same synthetic call ID', () => {
+    const base = new TestBase();
+    base.resetHistory([], [functionCall({ output: '{"temp":21}' })]);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.any(String),
+        item: {
+          type: 'function_call',
+          id: 'fc_1',
+          call_id: 'fc_1',
+          name: 'get_weather',
+          arguments: '{"city":"Paris"}',
+          status: 'completed',
+        },
+      },
+      {
+        type: 'conversation.item.create',
+        event_id: expect.any(String),
+        item: {
+          type: 'function_call_output',
+          call_id: 'fc_1',
+          output: '{"temp":21}',
+        },
+      },
+    ]);
+  });
+
+  it('rejects an in-place function call edit before sending mutations', () => {
+    const base = new TestBase();
+    const oldCall = functionCall();
+    const editedCall = { ...oldCall, arguments: '{"city":"London"}' };
+    expect(() => base.resetHistory([oldCall], [editedCall])).toThrowError(
+      UserError,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('rejects a cross-type replacement before unrelated removals are sent', () => {
+    const base = new TestBase();
+    const oldMessage = message('msg_old', 'old');
+    const call = functionCall({ output: '{"temp":21}' });
+    const replacement = message('fc_1', 'replacement');
+    expect(() =>
+      base.resetHistory([oldMessage, call], [replacement]),
+    ).toThrowError(UserError);
+    expect(base.events).toEqual([]);
+  });
+
+  it('rejects mid-history function call insertion before sending mutations', () => {
+    const base = new TestBase();
+    const first = message('msg_1', 'first');
+    const second = message('msg_2', 'second');
+    expect(() =>
+      base.resetHistory([first, second], [first, functionCall(), second]),
+    ).toThrowError(/only be replayed as appended history/);
+    expect(base.events).toEqual([]);
+  });
+
+  it('rejects function call replay after an updated item before mutations', () => {
+    const base = new TestBase();
+    const oldMessage = message('msg_1', 'old');
+    const editedMessage = message('msg_1', 'edited');
+    expect(() =>
+      base.resetHistory([oldMessage], [editedMessage, functionCall()]),
+    ).toThrowError(/cannot follow an updated history item/);
+    expect(base.events).toEqual([]);
+  });
+
+  it('rejects repeated replay while acknowledgement is pending', () => {
+    const base = new TestBase();
+    const call = functionCall();
+    base.resetHistory([], [call]);
+    base.events = [];
+    expect(() => base.resetHistory([], [call])).toThrowError(
+      /acknowledgement-pending replay/,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('projects echoed replayed calls and outputs into item updates', () => {
+    const base = new TestBase();
+    const updates: RealtimeToolCallItem[] = [];
+    base.on('item_update', (item) => {
+      if (item.type === 'function_call') updates.push(item);
+    });
+    base.resetHistory([], [functionCall({ output: '{"temp":21}' })]);
+    echoFunctionCall(base);
+    echoFunctionCallOutput(base);
+    expect(updates).toEqual([
+      {
+        itemId: 'fc_1',
+        previousItemId: 'previous',
+        type: 'function_call',
+        status: 'in_progress',
+        arguments: '{"city":"Paris"}',
+        name: 'get_weather',
+        output: null,
+      },
+      {
+        itemId: 'fc_1',
+        previousItemId: 'previous',
+        type: 'function_call',
+        status: 'completed',
+        arguments: '{"city":"Paris"}',
+        name: 'get_weather',
+        output: '{"temp":21}',
+      },
+    ]);
+  });
+
+  it('clears replay ownership before exposing a new connection', () => {
+    const base = new TestBase();
+    const call = functionCall();
+    base.resetHistory([], [call]);
+    base.open();
+    base.events = [];
+    expect(() => base.resetHistory([], [call])).not.toThrow();
+    expect(base.events).toHaveLength(1);
+  });
+
+  it('clears replay ownership when the transport closes', () => {
+    const base = new TestBase();
+    const call = functionCall();
+    base.resetHistory([], [call]);
+    base.closeTransport();
+    base.events = [];
+    expect(() => base.resetHistory([], [call])).not.toThrow();
+    expect(base.events).toHaveLength(1);
+  });
+
+  it('cleans replay ownership after a synchronous send failure', () => {
+    const base = new TestBase();
+    const call = functionCall();
+    base.failNextSend = true;
+    expect(() => base.resetHistory([], [call])).toThrowError(
+      'synchronous send failure',
+    );
+    expect(base.events).toEqual([]);
+    expect(() => base.resetHistory([], [call])).not.toThrow();
+    expect(base.events).toHaveLength(1);
+  });
+
+  it('waits for output deletion acknowledgement before deleting its call', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [call]);
+    echoFunctionCall(base);
+    echoFunctionCallOutput(base);
+    base.events = [];
+
+    base.resetHistory([call], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fco_1',
+      },
+    ]);
+
+    echoDeleted(base, 'fco_1');
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fco_1',
+      },
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fc_1',
+      },
+    ]);
+    echoDeleted(base, 'fc_1');
+  });
+
+  it('advances deletion state before exposing deletion acknowledgements', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [call]);
+    echoFunctionCall(base);
+    echoFunctionCallOutput(base);
+    base.events = [];
+    base.resetHistory([call], []);
+
+    let retryError: unknown;
+    base.on('item_deleted', ({ itemId }) => {
+      if (itemId !== 'fco_1') return;
+      try {
+        base.resetHistory([call], []);
+      } catch (error) {
+        retryError = error;
+      }
+    });
+
+    echoDeleted(base, 'fco_1');
+    expect(retryError).toBeUndefined();
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fco_1',
+      },
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fc_1',
+      },
+    ]);
+
+    let replayError: unknown;
+    base.on('item_deleted', ({ itemId }) => {
+      if (itemId !== 'fc_1') return;
+      try {
+        base.resetHistory([], [functionCall()]);
+      } catch (error) {
+        replayError = error;
+      }
+    });
+
+    echoDeleted(base, 'fc_1');
+    expect(replayError).toBeUndefined();
+    expect(base.events.at(-1)).toEqual({
+      type: 'conversation.item.create',
+      event_id: expect.any(String),
+      item: {
+        type: 'function_call',
+        id: 'fc_1',
+        call_id: 'fc_1',
+        name: 'get_weather',
+        arguments: '{"city":"Paris"}',
+        status: 'in_progress',
+      },
+    });
+  });
+
+  it('rejects repeated removal while deletion is awaiting acknowledgement', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [call]);
+    echoFunctionCall(base);
+    echoFunctionCallOutput(base);
+    base.events = [];
+    base.resetHistory([call], []);
+    base.events = [];
+    expect(() => base.resetHistory([call], [])).toThrowError(
+      /deletion awaiting Realtime API acknowledgement/,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('rejects completed-call removal before output acknowledgement', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [call]);
+    echoFunctionCall(base);
+    base.events = [];
+    expect(() => base.resetHistory([call], [])).toThrowError(
+      /before its output item is acknowledged/,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('preserves history restored synchronously from the connected notification', () => {
+    const base = new TestBase();
+    const call = functionCall();
+    base.resetHistory([], [call]);
+    base.closeTransport();
+    base.events = [];
+
+    base.on('connection_change', (status) => {
+      if (status === 'connected') {
+        base.resetHistory([], [call]);
+      }
+    });
+    base.announceConnected();
+
+    expect(base.events).toHaveLength(1);
+    base.events = [];
+    expect(() => base.resetHistory([], [call])).toThrowError(
+      /acknowledgement-pending replay/,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('retains ownership when a completed replay partially sends', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.failOnSendAttempt = 2;
+
+    expect(() => base.resetHistory([], [call])).toThrowError(
+      'synchronous send failure',
+    );
+    expect(base.events).toEqual([
+      expect.objectContaining({
+        type: 'conversation.item.create',
+        item: expect.objectContaining({ type: 'function_call', id: 'fc_1' }),
+      }),
+    ]);
+
+    base.events = [];
+    expect(() => base.resetHistory([], [call])).toThrowError(
+      /acknowledgement-pending replay/,
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('retains in-progress replay correlation through a later public output', () => {
+    const base = new TestBase();
+    const pendingCall = functionCall();
+    const completedCall = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [pendingCall]);
+    echoFunctionCall(base, 'conversation.item.done');
+    base.events = [];
+
+    base.sendFunctionCallOutput(
+      {
+        id: 'fc_1',
+        type: 'function_call',
+        name: 'get_weather',
+        callId: 'fc_1',
+        arguments: '{"city":"Paris"}',
+        responseId: 'response_1',
+      },
+      '{"temp":21}',
+      false,
+    );
+    base.events = [];
+
+    expect(() => base.resetHistory([completedCall], [])).toThrowError(
+      /before its output item is acknowledged/,
+    );
+    echoFunctionCallOutput(base);
+    base.events = [];
+
+    base.resetHistory([completedCall], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fco_1',
+      },
+    ]);
+  });
+
+  it('correlates asynchronous rejection of a public replay output', () => {
+    const base = new TestBase();
+    const pendingCall = functionCall();
+    const completedCall = functionCall({ output: '{"temp":21}' });
+    const updates: RealtimeToolCallItem[] = [];
+    base.on('item_update', (item) => {
+      if (item.type === 'function_call') updates.push(item);
+    });
+    base.resetHistory([], [pendingCall]);
+    echoFunctionCall(base, 'conversation.item.done');
+    updates.length = 0;
+    base.events = [];
+
+    base.sendFunctionCallOutput(
+      {
+        id: 'fc_1',
+        type: 'function_call',
+        name: 'get_weather',
+        callId: 'fc_1',
+        arguments: '{"city":"Paris"}',
+        responseId: 'response_1',
+      },
+      '{"temp":21}',
+      false,
+    );
+    const outputEventId = base.events[0].event_id;
+    expect(outputEventId).toEqual(expect.any(String));
+    expect(updates.at(-1)).toMatchObject({
+      itemId: 'fc_1',
+      status: 'completed',
+      output: '{"temp":21}',
+    });
+
+    echoClientEventError(base, outputEventId);
+    expect(updates.at(-1)).toMatchObject({
+      itemId: 'fc_1',
+      status: 'in_progress',
+      output: null,
+    });
+    base.events = [];
+
+    expect(() => base.resetHistory([completedCall], [])).not.toThrow();
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fc_1',
+      },
+    ]);
+  });
+
+  it('retains deletion ownership across synchronous send failures', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [call]);
+    echoFunctionCall(base);
+    echoFunctionCallOutput(base);
+    base.events = [];
+
+    base.failNextSend = true;
+    expect(() => base.resetHistory([call], [])).toThrowError(
+      'synchronous send failure',
+    );
+    expect(base.events).toEqual([]);
+
+    base.resetHistory([call], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fco_1',
+      },
+    ]);
+
+    base.failNextSend = true;
+    expect(() => echoDeleted(base, 'fco_1')).toThrowError(
+      'synchronous send failure',
+    );
+    base.events = [];
+
+    base.resetHistory([call], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fc_1',
+      },
+    ]);
+  });
+
+  it('releases replay ownership after an asynchronous call-create rejection', () => {
+    const base = new TestBase();
+    const call = functionCall();
+    base.resetHistory([], [call]);
+    const failedEventId = base.events[0].event_id;
+    expect(failedEventId).toEqual(expect.any(String));
+
+    echoClientEventError(base, failedEventId);
+    base.events = [];
+
+    expect(() => base.resetHistory([], [call])).not.toThrow();
+    expect(base.events).toHaveLength(1);
+    expect(base.events[0].event_id).not.toBe(failedEventId);
+  });
+
+  it('transitions a rejected replay output so the acknowledged call can be removed', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [call]);
+    const outputEventId = base.events[1].event_id;
+    expect(outputEventId).toEqual(expect.any(String));
+
+    echoClientEventError(base, outputEventId);
+    echoFunctionCall(base);
+    base.events = [];
+
+    const projectedCall = functionCall();
+    base.resetHistory([projectedCall], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fc_1',
+      },
+    ]);
+  });
+
+  it('retries tracked deletions after asynchronous provider rejection', () => {
+    const base = new TestBase();
+    const call = functionCall({ output: '{"temp":21}' });
+    base.resetHistory([], [call]);
+    echoFunctionCall(base);
+    echoFunctionCallOutput(base);
+    base.events = [];
+
+    base.resetHistory([call], []);
+    const outputDeleteEventId = base.events[0].event_id;
+    expect(outputDeleteEventId).toEqual(expect.any(String));
+    echoClientEventError(base, outputDeleteEventId);
+    base.events = [];
+
+    base.resetHistory([call], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fco_1',
+      },
+    ]);
+
+    echoDeleted(base, 'fco_1');
+    const callDeleteEventId = base.events.at(-1)?.event_id;
+    expect(callDeleteEventId).toEqual(expect.any(String));
+    echoClientEventError(base, callDeleteEventId);
+    base.events = [];
+
+    base.resetHistory([call], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fc_1',
+      },
+    ]);
+  });
+});

--- a/packages/agents-realtime/test/functionCallHistoryReplayFollowups.test.ts
+++ b/packages/agents-realtime/test/functionCallHistoryReplayFollowups.test.ts
@@ -1,0 +1,170 @@
+import { UserError } from '@openai/agents-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RealtimeClientMessage } from '../src/clientMessages';
+import type { RealtimeItem, RealtimeToolCallItem } from '../src/items';
+import { OpenAIRealtimeBase } from '../src/openaiRealtimeBase';
+
+class TestBase extends OpenAIRealtimeBase {
+  status: 'connected' | 'disconnected' | 'connecting' | 'disconnecting' =
+    'connected';
+  events: RealtimeClientMessage[] = [];
+  connect = vi.fn(async () => {});
+  sendEvent(event: RealtimeClientMessage) {
+    this.events.push(event);
+  }
+  mute = vi.fn();
+  close = vi.fn();
+  interrupt = vi.fn();
+  get muted() {
+    return false;
+  }
+}
+
+function functionCall({
+  output = null,
+}: { output?: string | null } = {}): RealtimeToolCallItem {
+  return {
+    itemId: 'fc_1',
+    type: 'function_call',
+    status: output === null ? 'in_progress' : 'completed',
+    arguments: '{"city":"Paris"}',
+    name: 'get_weather',
+    output,
+  };
+}
+
+function message(itemId: string, text: string): RealtimeItem {
+  return {
+    itemId,
+    type: 'message',
+    role: 'user',
+    status: 'completed',
+    content: [{ type: 'input_text', text }],
+  };
+}
+
+function receive(base: TestBase, payload: Record<string, unknown>) {
+  (base as any)._onMessage({ data: JSON.stringify(payload) });
+}
+
+function echoFunctionCall(base: TestBase) {
+  receive(base, {
+    type: 'conversation.item.done',
+    event_id: 'evt_call',
+    previous_item_id: 'previous',
+    item: {
+      type: 'function_call',
+      id: 'fc_1',
+      call_id: 'fc_1',
+      name: 'get_weather',
+      arguments: '{"city":"Paris"}',
+      status: 'completed',
+    },
+  });
+}
+
+function echoFunctionCallOutput(base: TestBase) {
+  receive(base, {
+    type: 'conversation.item.done',
+    event_id: 'evt_output',
+    previous_item_id: 'previous',
+    item: {
+      type: 'function_call_output',
+      id: 'fco_1',
+      call_id: 'fc_1',
+      output: '{"temp":21}',
+      status: 'completed',
+    },
+  });
+}
+
+const toolCall = {
+  id: 'fc_1',
+  type: 'function_call' as const,
+  name: 'get_weather',
+  callId: 'fc_1',
+  arguments: '{"city":"Paris"}',
+  responseId: 'response_1',
+};
+
+describe('Realtime function call history replay follow-up invariants', () => {
+  it('rejects another output after acknowledgement and preserves output deletion ownership', () => {
+    const base = new TestBase();
+    const pendingCall = functionCall();
+    const completedCall = functionCall({ output: '{"temp":21}' });
+
+    base.resetHistory([], [pendingCall]);
+    echoFunctionCall(base);
+    base.events = [];
+
+    base.sendFunctionCallOutput(toolCall, '{"temp":21}', false);
+    echoFunctionCallOutput(base);
+    base.events = [];
+
+    expect(() =>
+      base.sendFunctionCallOutput(toolCall, '{"temp":22}', false),
+    ).toThrowError(UserError);
+    expect(base.events).toEqual([]);
+
+    base.resetHistory([completedCall], []);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.any(String),
+        item_id: 'fco_1',
+      },
+    ]);
+  });
+
+  it('recreates mixed replay changes in target history order', () => {
+    const base = new TestBase();
+    const oldMessage = message('msg_1', 'old');
+    const editedMessage = message('msg_1', 'edited');
+    const newMessage = message('msg_2', 'new');
+
+    base.resetHistory(
+      [oldMessage],
+      [functionCall(), editedMessage, newMessage],
+    );
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        item_id: 'msg_1',
+      },
+      {
+        type: 'conversation.item.create',
+        event_id: expect.any(String),
+        item: {
+          type: 'function_call',
+          id: 'fc_1',
+          call_id: 'fc_1',
+          name: 'get_weather',
+          arguments: '{"city":"Paris"}',
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'conversation.item.create',
+        item: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'edited' }],
+          id: 'msg_1',
+          status: 'completed',
+        },
+      },
+      {
+        type: 'conversation.item.create',
+        item: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'new' }],
+          id: 'msg_2',
+          status: 'completed',
+        },
+      },
+    ]);
+  });
+});

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -565,25 +565,35 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
   });
 
-  it('resetHistory warns on function call additions', () => {
+  it('resetHistory replays function call additions', () => {
     const base = new TestBase();
     const newHist = [
       {
         itemId: 'f1',
-        type: 'function_call',
-        status: 'completed',
+        type: 'function_call' as const,
+        status: 'in_progress' as const,
         arguments: '{}',
-        name: 'calc',
+        name: 'tool',
         output: null,
       },
     ];
 
-    base.resetHistory([], newHist as any);
+    base.resetHistory([], newHist);
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Function calls cannot be manually added or updated at the moment. Ignoring.',
-    );
-    expect(base.events).toHaveLength(0);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.any(String),
+        item: {
+          type: 'function_call',
+          id: 'f1',
+          call_id: 'f1',
+          name: 'tool',
+          arguments: '{}',
+          status: 'in_progress',
+        },
+      },
+    ]);
   });
 
   it('sendMcpResponse emits approval response items', () => {


### PR DESCRIPTION
### Summary

Fixes #645 by restoring `function_call` items when Realtime conversation history is populated through `updateHistory`.

New function-call history items are replayed with a stable synthetic `call_id` derived from the SDK history item ID. Completed calls replay their matching `function_call_output`, and Realtime API acknowledgements are correlated back into the local history projection.

Replay ownership is connection-scoped and fails closed around asynchronous server state:

- unsupported in-place function-call edits and cross-type replacements are rejected before any server mutation;
- mid-history function-call insertion, replay after a preceding item update, and repeated acknowledgement-pending replay are rejected before mutation;
- completed call removal deletes the acknowledged output first and waits for `conversation.item.deleted` before deleting the call;
- replay deletion state is advanced before normalized deletion acknowledgements are exposed to consumers;
- asynchronous provider rejection of replay-owned public function outputs is correlated through client event IDs;
- duplicate public outputs are rejected while an output is pending or after one has been acknowledged, preserving the acknowledged output item for later deletion;
- mixed additions and non-function-call updates are recreated in target-history order;
- repeated deletion while acknowledgement is pending is rejected;
- replay ownership is cleared on synchronous send failure, transport close, and reconnect.

Existing non-function-call history behavior is preserved.

### Test plan

Focused regression coverage verifies:

- replay with and without function output;
- echoed call/output projection into local history;
- late/stale echo handling across reconnects;
- reconnect and close ownership cleanup;
- synchronous send-failure cleanup;
- rejection of in-place edits, cross-type replacements, mid-history insertion, replay after preceding item updates, repeated replay, and repeated removal without emitting partial server mutations;
- output deletion acknowledgement before function-call deletion;
- synchronous callbacks observe advanced deletion state;
- asynchronous rejection of a public replay output releases pending output state;
- an acknowledged replay output cannot be overwritten by a duplicate output attempt and remains deletable by its output item ID;
- mixed replay additions and recreated message updates are emitted in `newHistory` order.

The branch is based directly on current `main` and collapsed to one signed-off commit.

### Issue number

Fixes #645.