### PR TITLE
docs: add deterministic agent testing guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -269,6 +269,15 @@ const sidebar = [
         },
       },
       {
+        label: 'Testing',
+        link: '/guides/testing',
+        translations: {
+          ja: 'テスト',
+          zh: '测试',
+          ko: '테스트',
+        },
+      },
+      {
         label: 'Streaming',
         link: '/guides/streaming',
         translations: {

--- a/docs/src/content/docs/guides/testing.mdx
+++ b/docs/src/content/docs/guides/testing.mdx
@@ -1,0 +1,61 @@
+---
+title: Testing agents
+description: Test agent workflows deterministically without model API calls
+---
+
+import { Code } from '@astrojs/starlight/components';
+import scriptedModelExample from '../../../../../examples/docs/testing/scriptedModel.ts?raw';
+
+Agent tests should be repeatable, fast, and independent of model availability. `ScriptedModel` is a provider-neutral test model that returns normalized responses in a fixed order and records every model request. Use it to test agent orchestration, tool calls, handoffs, guardrails, and session behavior without a model API key or model network request.
+
+Import `ScriptedModel` and its response builders from `@openai/agents/testing`. Keep the agent, runner, and tool imports in `@openai/agents`.
+
+## Test a tool workflow
+
+The following example scripts two model turns. The first turn requests the `get_weather` tool, and the second turn returns the final assistant message.
+
+<Code
+  lang="typescript"
+  code={scriptedModelExample}
+  title="Deterministic tool workflow"
+/>
+
+Each top-level script step passed to `ScriptedModel` represents one model request. An array of normalized output items is the shortest response form:
+
+- `functionCall()` creates a normalized function-tool call.
+- `assistantMessage()` creates a normalized assistant text message.
+- `modelResponse()` can wrap output items explicitly or provide a complete model response with custom usage and response metadata.
+
+The runner executes the real `get_weather` function between the two scripted model turns. The test therefore validates the agent and tool workflow while replacing only the model boundary.
+
+The example uses a dedicated `Runner` with tracing disabled for a fully offline test. If a test suite already configures tracing globally, use the suite's existing tracing setup instead.
+
+## Assert model requests
+
+`ScriptedModel` records frozen request snapshots in call order. The model detaches mutable input collections and model settings when it records a request:
+
+- `calls` contains every recorded model call.
+- `firstCall` and `lastCall` provide convenient access to the first and most recent calls.
+- Each call exposes `index`, `streamed`, and `request`.
+
+Assert on the request details that matter to the behavior under test. For example, a multi-turn tool test can check that the second request contains a `function_call_result`. Avoid snapshotting an entire request when a focused assertion would express the expected behavior more clearly.
+
+Call `assertComplete()` at the end of a test. It throws when the script contains unused steps, which catches workflows that finish earlier than expected. `ScriptedModel` also throws an `UnexpectedModelCallError` if the workflow makes more model calls than the script provides.
+
+## Derive responses from requests
+
+Use `modelResponder()` when a scripted response depends on the recorded request. The responder receives the same recorded call shape exposed through `calls`, and it returns either normalized output items or a complete model response.
+
+Use fixed response steps when the request does not affect the response. Fixed steps keep the test's expected sequence visible and make unexpected workflow changes easier to diagnose.
+
+## Test failures and streaming
+
+Use `modelError()` to make a model call fail. A scripted error can also provide retry advice when the test covers model retry behavior.
+
+For ordinary streaming tests, pass the same output items used by a non-streaming test. `ScriptedModel` converts a complete response into normalized stream events when the runner requests a stream. Use `modelStream()` or `modelStreamResponder()` only when the test must control the exact normalized event sequence.
+
+## Choose the right boundary
+
+`ScriptedModel` validates provider-neutral agent workflow behavior. It does not validate a provider's HTTP payloads, authentication, rate limits, or model quality. Keep a specialized model double when a test specifically covers provider-wire conversion, malformed streams, controlled concurrency, or exact abort delivery.
+
+For more workflow concepts, see [Running agents](/openai-agents-js/guides/running-agents) and [Tools](/openai-agents-js/guides/tools).

--- a/examples/docs/testing/scriptedModel.ts
+++ b/examples/docs/testing/scriptedModel.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { Agent, Runner, tool } from '@openai/agents';
+import {
+  ScriptedModel,
+  assistantMessage,
+  functionCall,
+} from '@openai/agents/testing';
+import { z } from 'zod';
+
+const getWeather = tool({
+  name: 'get_weather',
+  description: 'Gets the weather for a city.',
+  parameters: z.object({ city: z.string() }),
+  execute: async ({ city }) => `${city}: sunny`,
+});
+
+const model = new ScriptedModel([
+  [functionCall('get_weather', { city: 'Tokyo' }, { callId: 'weather_call' })],
+  [assistantMessage('It is sunny in Tokyo.')],
+]);
+
+const agent = new Agent({
+  name: 'Weather assistant',
+  instructions: 'Answer weather questions.',
+  model,
+  tools: [getWeather],
+});
+
+const runner = new Runner({ tracingDisabled: true });
+const result = await runner.run(agent, 'What is the weather in Tokyo?');
+
+assert.equal(result.finalOutput, 'It is sunny in Tokyo.');
+assert.equal(model.calls.length, 2);
+
+const secondRequest = model.lastCall?.request.input;
+assert.ok(Array.isArray(secondRequest));
+assert.ok(secondRequest.some((item) => item.type === 'function_call_result'));
+
+model.assertComplete();


### PR DESCRIPTION
### Summary

This pull request adds a guide for testing agent workflows deterministically with the provider-neutral `ScriptedModel` API introduced in #1640. It documents ordered response steps, focused request assertions, completion checks, request-aware responders, errors, streaming, and the boundary between workflow tests and provider-specific tests.

It also adds a compiled, executable tool-workflow example that uses a dedicated tracing-disabled `Runner`, plus localized sidebar labels for the new guide. Because `@openai/agents/testing` is present on `main` but not in v0.15.0, merge timing should be coordinated with the package release described in #1640.

### Test plan

- Ran `.agents/skills/code-change-verification/scripts/run.sh` successfully.
- Ran `pnpm docs:build` and confirmed `/guides/testing` and the `llms.txt` guide entry are generated.
- Ran `node --experimental-strip-types examples/docs/testing/scriptedModel.ts` successfully without an API key or model request.
- Completed two independent clean final-review passes against the contribution diff.

### Issue number

Follow-up to #1640.

### Checks

- [x] I've added new tests (not applicable; this is documentation plus a compiled example)
- [x] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've added a changeset using `pnpm changeset` (not applicable; no package files changed)
