### PR TITLE
fix(sandbox): describe granted view_image paths

### DIFF
--- a/.changeset/view-image-extra-path-grants.md
+++ b/.changeset/view-image-extra-path-grants.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: describe and test granted view_image paths

--- a/packages/agents-core/src/sandbox/capabilities/filesystem.ts
+++ b/packages/agents-core/src/sandbox/capabilities/filesystem.ts
@@ -568,9 +568,13 @@ class FilesystemCapability extends Capability {
         tool({
           name: 'view_image',
           description:
-            'Returns an image output from a local path in the sandbox workspace.',
+            'Returns an image output from a path in the sandbox workspace or an explicitly granted sandbox path.',
           parameters: z.object({
-            path: z.string().describe('Local filesystem path to an image file'),
+            path: z
+              .string()
+              .describe(
+                'Path to an image file in the sandbox workspace or an explicitly granted sandbox path',
+              ),
           }),
           execute: async (
             { path }: { path: string },
@@ -584,9 +588,13 @@ class FilesystemCapability extends Capability {
         tool({
           name: 'view_image',
           description:
-            'Returns an image from a local path in the sandbox workspace as a data URL or reference string.',
+            'Returns an image from a path in the sandbox workspace or an explicitly granted sandbox path as a data URL or reference string.',
           parameters: z.object({
-            path: z.string().describe('Local filesystem path to an image file'),
+            path: z
+              .string()
+              .describe(
+                'Path to an image file in the sandbox workspace or an explicitly granted sandbox path',
+              ),
           }),
           execute: async (
             { path }: { path: string },

--- a/packages/agents-core/test/sandboxTools.test.ts
+++ b/packages/agents-core/test/sandboxTools.test.ts
@@ -237,6 +237,12 @@ describe('sandbox filesystem tools', () => {
       'view_image',
       'apply_patch',
     ]);
+    expect((tools[0] as any).description).toBe(
+      'Returns an image output from a path in the sandbox workspace or an explicitly granted sandbox path.',
+    );
+    expect((tools[0] as any).parameters.properties.path.description).toBe(
+      'Path to an image file in the sandbox workspace or an explicitly granted sandbox path',
+    );
     expect(session.calls[0]).toMatchObject({
       method: 'createEditor',
       args: ['sandbox-user'],
@@ -457,6 +463,12 @@ describe('sandbox filesystem tools', () => {
       'apply_patch',
     ]);
     expect(tools.map((tool) => tool.type)).toEqual(['function', 'function']);
+    expect((tools[0] as any).description).toBe(
+      'Returns an image from a path in the sandbox workspace or an explicitly granted sandbox path as a data URL or reference string.',
+    );
+    expect((tools[0] as any).parameters.properties.path.description).toBe(
+      'Path to an image file in the sandbox workspace or an explicitly granted sandbox path',
+    );
 
     const imageResult = await (tools[0] as any).invoke(
       new RunContext(),

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -913,6 +913,40 @@ describe('UnixLocalSandboxClient', () => {
     );
   });
 
+  it('allows view_image only for explicitly granted absolute paths', async () => {
+    const grantedDir = join(rootDir, 'granted-images');
+    await mkdir(grantedDir);
+    const grantedImagePath = join(grantedDir, 'granted.png');
+    const ungrantedImagePath = join(
+      rootDir,
+      'ungranted-images',
+      'ungranted.png',
+    );
+    await writeFile(grantedImagePath, ONE_BY_ONE_PNG);
+
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(
+      new Manifest({
+        extraPathGrants: [{ path: grantedDir, readOnly: true }],
+      }),
+    );
+
+    await expect(
+      session.viewImage({ path: grantedImagePath }),
+    ).resolves.toMatchObject({
+      type: 'image',
+      image: {
+        data: expect.any(Uint8Array),
+        mediaType: 'image/png',
+      },
+    });
+    await expect(
+      session.viewImage({ path: ungrantedImagePath }),
+    ).rejects.toThrow(/escapes the workspace root/);
+  });
+
   it('rejects symlink escapes in filesystem helpers', async () => {
     const outsideDir = join(rootDir, 'outside');
     await mkdir(outsideDir);


### PR DESCRIPTION
This pull request fixes the model-visible `view_image` contract for sandbox paths. The tool and parameter descriptions now clarify that images may come from the sandbox workspace or an explicitly granted sandbox path.

It also adds focused UnixLocal coverage that verifies an explicitly granted absolute image path succeeds while an ungranted absolute path is rejected before image I/O. The existing manifest grant semantics and provider capability boundaries remain unchanged.