### PR TITLE
feat(core): add model call timeouts

### DIFF
--- a/.changeset/steady-model-timeouts.md
+++ b/.changeset/steady-model-timeouts.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+feat: add provider-neutral model call timeouts (#894)

--- a/packages/agents-core/src/errors.ts
+++ b/packages/agents-core/src/errors.ts
@@ -58,6 +58,24 @@ export class ModelRefusalError extends AgentsError {
 export class ModelBehaviorError extends AgentsError {}
 
 /**
+ * Error thrown when a model call exceeds its configured timeout.
+ */
+export class ModelTimeoutError extends AgentsError {
+  readonly code = 'ETIMEDOUT' as const;
+  readonly timeoutMs: number;
+  /**
+   * The provider or transport error observed after the timeout signal was sent, if any.
+   */
+  readonly cause?: unknown;
+
+  constructor({ timeoutMs, cause }: { timeoutMs: number; cause?: unknown }) {
+    super(`Model call timed out after ${timeoutMs}ms.`);
+    this.timeoutMs = timeoutMs;
+    this.cause = cause;
+  }
+}
+
+/**
  * Context from tool invocation that failed validation.
  */
 export type ToolInvocationErrorContext = {

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -36,6 +36,7 @@ export {
   MaxTurnsExceededError,
   ModelBehaviorError,
   ModelRefusalError,
+  ModelTimeoutError,
   OutputGuardrailTripwireTriggered,
   ToolInputGuardrailTripwireTriggered,
   ToolOutputGuardrailTripwireTriggered,

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -131,9 +131,9 @@ export type RetryDecision =
 
       /**
        * Explicit application approval to repeat provider-side work that may
-       * already have happened. This only applies when the provider marks a
-       * non-streaming replay as unsafe; ordinary retry decisions never bypass
-       * replay protection.
+       * already have happened. This is required when replay safety is unknown
+       * or unsafe, including timed-out requests. Streamed requests remain
+       * non-retryable after any output event is emitted.
        */
       approveUnsafeReplay?: boolean;
     };
@@ -317,6 +317,14 @@ export type ModelRetrySettings = {
  * for the specific model and provider you are using.
  */
 export type ModelSettings = {
+  /**
+   * Cooperative timeout in milliseconds for each model call.
+   * The timeout aborts only the current model call; a run-level abort signal
+   * still cancels the entire run. Must be greater than 0 and less than or
+   * equal to 2147483647 when provided.
+   */
+  timeoutMs?: number;
+
   /**
    * The temperature to use when calling the model.
    */

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -3,6 +3,7 @@ import { RunAgentUpdatedStreamEvent, RunRawModelStreamEvent } from './events';
 import {
   AgentsError,
   ModelBehaviorError,
+  ModelTimeoutError,
   OutputGuardrailTripwireTriggered,
   UserError,
 } from './errors';
@@ -72,6 +73,7 @@ import {
 import {
   getResponseWithRetry,
   getStreamedResponseWithRetry,
+  validateModelTimeoutMs,
 } from './runner/modelRetry';
 import { processModelResponseAsync } from './runner/modelOutputs';
 import {
@@ -673,6 +675,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   ): Promise<
     RunResult<TContext, TAgent> | StreamedRunResult<TContext, TAgent>
   > {
+    this.#validateModelTimeoutForAgent(
+      input instanceof RunState ? input._currentAgent : agent,
+    );
     if (input instanceof RunState) {
       if (isNoopTrace(input._trace)) {
         input._trace = null;
@@ -1126,6 +1131,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ? DEFAULT_MAX_TURNS
               : options.maxTurns,
           );
+      this.#validateModelTimeoutForAgent(state._currentAgent);
       if (isResumedState) {
         state._agentToolInvocation = undefined;
         if (options.maxTurns !== undefined) {
@@ -1414,6 +1420,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolErrorFormatter,
               agentToolParentRunConfig,
               signal: options.signal,
+              validateHandoffAgent: (handoffAgent) =>
+                this.#validateModelTimeoutForAgent(handoffAgent),
             });
           }
 
@@ -1446,6 +1454,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               toolErrorFormatter,
               agentToolParentRunConfig,
               signal: options.signal,
+              validateHandoffAgent: (handoffAgent) =>
+                this.#validateModelTimeoutForAgent(handoffAgent),
             });
             if (interruptedOutcome.approvedToolResumed && persistResult) {
               const approvedToolResult = new RunResult<TContext, TAgent>(state);
@@ -1487,6 +1497,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           }
 
           if (state._currentStep.type === 'next_step_run_again') {
+            this.#validateModelTimeoutForAgent(state._currentAgent);
             if (
               approvedToolCheckpointCompacted &&
               state._currentTurnSessionHistoryTransactionSessionId === undefined
@@ -1680,6 +1691,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                     admittedPendingInput.map((item) => item.rawItem),
                   );
                 }
+              }
+              if (pendingInputItems.length > 0 || !responseAvailable) {
                 if (!responseAvailable) {
                   state._lastTurnResponse = undefined;
                 }
@@ -1694,7 +1707,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             const pendingModelResponse = getResponseWithRetry(
               preparedCall.model,
               modelRequest,
-              serverConversationTracker && pendingInputItems.length > 0
+              serverConversationTracker
                 ? {
                     onPossiblyAcceptedRequestFailure: () =>
                       markServerInputAccepted(false),
@@ -1789,8 +1802,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               options.signal,
               suppressedToolCalls,
               attemptedRunErrorHandlers,
+              (handoffAgent) =>
+                this.#validateModelTimeoutForAgent(handoffAgent),
             );
 
+            if (turnResult.nextStep.type === 'next_step_handoff') {
+              this.#validateModelTimeoutForAgent(turnResult.nextStep.newAgent);
+            }
             applyTurnResult({
               state,
               turnResult,
@@ -1827,6 +1845,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               options.signal?.throwIfAborted();
               return await finalizeCurrentOutput();
             case 'next_step_handoff':
+              this.#validateModelTimeoutForAgent(currentStep.newAgent);
               state.setCurrentAgent(currentStep.newAgent as TAgent);
               if (state._currentAgentSpan) {
                 state._currentAgentSpan.end();
@@ -2253,6 +2272,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             toolErrorFormatter,
             agentToolParentRunConfig,
             signal: options.signal,
+            validateHandoffAgent: (handoffAgent) =>
+              this.#validateModelTimeoutForAgent(handoffAgent),
             onStepItems: (turnResult) => {
               addStepToRunResult(result, turnResult);
             },
@@ -2289,6 +2310,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             toolErrorFormatter,
             agentToolParentRunConfig,
             signal: options.signal,
+            validateHandoffAgent: (handoffAgent) =>
+              this.#validateModelTimeoutForAgent(handoffAgent),
             onStepItems: (turnResult) => {
               addStepToRunResult(result, turnResult);
             },
@@ -2332,6 +2355,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         }
 
         if (result.state._currentStep.type === 'next_step_run_again') {
+          this.#validateModelTimeoutForAgent(result.state._currentAgent);
           commitDeferredLocalPendingInput = undefined;
           if (
             approvedToolCheckpointCompacted &&
@@ -2493,43 +2517,56 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           const abortReconciliationState =
             createStreamAbortReconciliationState();
           let inputMarked = false;
-          const markServerInputAccepted = () => {
-            if (inputMarked || !serverConversationTracker) {
+          let responseAcceptedCheckpointed = false;
+          let receivedStreamEvent = false;
+          let timedOutModelCallFailed = false;
+          const markServerInputAccepted = (responseAvailable = true) => {
+            if (!serverConversationTracker) {
               return;
             }
-            // Mark inputs after the first stream event, an explicit abort after
-            // request start, or provider advice that the failed request may have
-            // been accepted.
-            // Record the exact input that was sent so the server tracker can advance safely.
-            serverConversationTracker.markInputAsSent(
-              preparedCall.filterApplied
-                ? preparedCall.sourceItems
-                : preparedCall.turnInput,
-              {
-                filterApplied: preparedCall.filterApplied,
-                allTurnItems: preparedCall.turnInput,
-              },
-            );
-            commitPendingInput(
-              result.state,
-              pendingInputItems,
-              admittedPendingInput,
-              pendingInputSourceItems,
-            );
-            if (pendingInputItems.length > 0) {
-              if (admittedPendingInput.length > 0) {
-                serverConversationTracker.markInputAsSent(
-                  admittedPendingInput.map((item) => item.rawItem),
-                );
+            if (!inputMarked) {
+              // Mark inputs after the first stream event, an explicit abort after
+              // request start, or provider advice that the failed request may have
+              // been accepted.
+              // Record the exact input that was sent so the server tracker can advance safely.
+              serverConversationTracker.markInputAsSent(
+                preparedCall.filterApplied
+                  ? preparedCall.sourceItems
+                  : preparedCall.turnInput,
+                {
+                  filterApplied: preparedCall.filterApplied,
+                  allTurnItems: preparedCall.turnInput,
+                },
+              );
+              commitPendingInput(
+                result.state,
+                pendingInputItems,
+                admittedPendingInput,
+                pendingInputSourceItems,
+              );
+              if (pendingInputItems.length > 0) {
+                if (admittedPendingInput.length > 0) {
+                  serverConversationTracker.markInputAsSent(
+                    admittedPendingInput.map((item) => item.rawItem),
+                  );
+                }
               }
-              result.state._lastTurnResponse = undefined;
+              inputMarked = true;
+            }
+            if (
+              !responseAcceptedCheckpointed &&
+              (pendingInputItems.length > 0 || !responseAvailable)
+            ) {
+              if (!responseAvailable) {
+                result.state._lastTurnResponse = undefined;
+              }
               result.state._lastProcessedResponse = undefined;
               result.state._currentStep = {
                 type: 'next_step_interruption',
                 data: { interruptions: [], responseAccepted: true },
               };
+              responseAcceptedCheckpointed = true;
             }
-            inputMarked = true;
           };
           const reconcileStreamAbortIfNeeded = async () => {
             if (
@@ -2627,13 +2664,20 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             for await (const event of getStreamedResponseWithRetry(
               preparedCall.model,
               modelRequest,
-              serverConversationTracker && pendingInputItems.length > 0
-                ? {
-                    onPossiblyAcceptedRequestFailure: markServerInputAccepted,
-                  }
-                : undefined,
+              {
+                onModelTimeout: () => {
+                  timedOutModelCallFailed = true;
+                },
+                ...(serverConversationTracker
+                  ? {
+                      onPossiblyAcceptedRequestFailure: () =>
+                        markServerInputAccepted(false),
+                    }
+                  : {}),
+              },
             )) {
-              markServerInputAccepted();
+              receivedStreamEvent = true;
+              markServerInputAccepted(pendingInputItems.length === 0);
               await guardrailTracker.throwIfError();
               recordStreamEventForAbortReconciliation(
                 abortReconciliationState,
@@ -2695,6 +2739,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               await commitDeferredLocalPendingInput?.();
               await reconcileStreamAbortIfNeeded();
               return;
+            }
+            if (error instanceof ModelTimeoutError || timedOutModelCallFailed) {
+              if (receivedStreamEvent) {
+                markServerInputAccepted(false);
+              }
+              await awaitInputGuardrails();
+              await commitDeferredLocalPendingInput?.();
+              await reconcileStreamAbortIfNeeded();
             }
             throw error;
           }
@@ -2784,8 +2836,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             options.signal,
             suppressedToolCalls,
             attemptedRunErrorHandlers,
+            (handoffAgent) => this.#validateModelTimeoutForAgent(handoffAgent),
           );
 
+          if (turnResult.nextStep.type === 'next_step_handoff') {
+            this.#validateModelTimeoutForAgent(turnResult.nextStep.newAgent);
+          }
           applyTurnResult({
             state: result.state,
             turnResult,
@@ -2815,6 +2871,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             }
             return;
           case 'next_step_handoff':
+            this.#validateModelTimeoutForAgent(currentStep.newAgent);
             result.state.setCurrentAgent(currentStep.newAgent as TAgent);
             if (result.state._currentAgentSpan) {
               result.state._currentAgentSpan.end();
@@ -2978,6 +3035,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ? DEFAULT_MAX_TURNS
               : options.maxTurns,
           );
+      this.#validateModelTimeoutForAgent(state._currentAgent);
       if (isResumedState) {
         state._agentToolInvocation = undefined;
         if (options.maxTurns !== undefined) {
@@ -3096,6 +3154,22 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
   /**
    * @internal
+   * Validates timeout settings before turn preparation can run hooks, persist
+   * input, or initialize sandbox resources.
+   */
+  #validateModelTimeoutForAgent<TContext>(
+    executionAgent: Agent<TContext, AgentOutputType>,
+  ): void {
+    const agentModelSettings = executionAgent.hasExplicitModelSettings()
+      ? executionAgent.modelSettings
+      : undefined;
+    validateModelTimeoutMs(
+      mergeModelSettings(this.config.modelSettings, agentModelSettings),
+    );
+  }
+
+  /**
+   * @internal
    * Applies call-level filters and merges session updates so the model request mirrors exactly
    * what we persisted for history.
    */
@@ -3155,6 +3229,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       state._toolUseTracker,
       modelSettings,
     );
+    validateModelTimeoutMs(modelSettings);
     state._lastModelSettings = modelSettings;
 
     const systemInstructions = await executionAgent.getSystemPrompt(

--- a/packages/agents-core/src/runner/errorHandlers.ts
+++ b/packages/agents-core/src/runner/errorHandlers.ts
@@ -3,6 +3,7 @@ import {
   MaxTurnsExceededError,
   ModelBehaviorError,
   ModelRefusalError,
+  ModelTimeoutError,
   ToolCallError,
   ToolInputGuardrailTripwireTriggered,
   ToolOutputGuardrailTripwireTriggered,
@@ -115,12 +116,17 @@ export async function preserveInvalidFinalOutputRedaction<T>(
 }
 
 /**
- * Attaches the active run state to nested tool guardrail tripwire errors without replacing them.
+ * Attaches the active run state to errors that need resumable caller context.
  */
 export const attachRunStateToError = <TContext, TAgent extends Agent<any, any>>(
   error: unknown,
   state: RunState<TContext, TAgent>,
 ): void => {
+  if (error instanceof ModelTimeoutError) {
+    error.state ??= state;
+    return;
+  }
+
   if (!(error instanceof ToolCallError)) {
     return;
   }

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -6,10 +6,12 @@ import type {
   ModelRetryAdviceRequest,
   ModelRetryBackoffSettings,
   ModelRetryNormalizedError,
+  ModelSettings,
   RetryDecision,
   RetryPolicy,
   RetryPolicyContext,
 } from '../model';
+import { ModelTimeoutError, UserError } from '../errors';
 import type { StreamEvent } from '../types/protocol';
 import { RequestUsage, Usage } from '../usage';
 
@@ -19,6 +21,7 @@ const DEFAULT_BACKOFF_MULTIPLIER = 2;
 const DEFAULT_BACKOFF_JITTER = true;
 const RETRY_AFTER_MS_HEADER = 'retry-after-ms';
 const RETRY_AFTER_HEADER = 'retry-after';
+const MAX_MODEL_TIMEOUT_MS = 2_147_483_647;
 
 type ResolvedRetryDecision = {
   retry: boolean;
@@ -61,10 +64,20 @@ type EvaluateRetryParams = {
   emittedVisibleEvent: boolean;
   emittedRawModelEvent: boolean;
   providerAdvice?: ModelRetryAdvice;
+  allowUnsafeStreamReplayApproval?: boolean;
 };
 
 type ModelRetryHandlers = {
+  onModelTimeout?: () => void;
   onPossiblyAcceptedRequestFailure?: () => void;
+};
+
+type ModelAttemptScope = {
+  request: ModelRequest;
+  cleanup: () => void;
+  normalizeError: (error: unknown) => unknown;
+  timeoutError: () => ModelTimeoutError | undefined;
+  timedOut: () => boolean;
 };
 
 function addFailedRetryAttemptsToUsage(
@@ -129,6 +142,116 @@ function shouldDisableProviderManagedRetry(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+export function validateModelTimeoutMs(
+  modelSettings: ModelSettings,
+): number | undefined {
+  const timeoutMs = modelSettings.timeoutMs;
+  if (timeoutMs === undefined) {
+    return undefined;
+  }
+  if (
+    !Number.isFinite(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > MAX_MODEL_TIMEOUT_MS
+  ) {
+    throw new UserError(
+      `modelSettings.timeoutMs must be a positive finite number less than or equal to ${MAX_MODEL_TIMEOUT_MS} when provided.`,
+    );
+  }
+  return timeoutMs;
+}
+
+function createModelTimeoutError(
+  timeoutMs: number,
+  cause?: unknown,
+): ModelTimeoutError {
+  return new ModelTimeoutError({ timeoutMs, cause });
+}
+
+function createModelAttemptScope(
+  request: ModelRequest,
+  timeoutMs: number | undefined,
+): ModelAttemptScope {
+  if (timeoutMs === undefined) {
+    return {
+      request,
+      cleanup: () => {},
+      normalizeError: (error) => error,
+      timeoutError: () => undefined,
+      timedOut: () => false,
+    };
+  }
+
+  const controller = new AbortController();
+  const parentSignal = request.signal;
+  let didTimeOut = false;
+  let timeoutError: ModelTimeoutError | undefined;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const clearAttemptTimeout = () => {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+  };
+  const detachParentAbort = () => {
+    parentSignal?.removeEventListener('abort', onParentAbort);
+  };
+  const onParentAbort = () => {
+    clearAttemptTimeout();
+    detachParentAbort();
+    controller.abort(parentSignal?.reason);
+  };
+
+  if (parentSignal?.aborted) {
+    onParentAbort();
+  } else {
+    parentSignal?.addEventListener('abort', onParentAbort, { once: true });
+    timeout = setTimeout(() => {
+      didTimeOut = true;
+      timeoutError = createModelTimeoutError(timeoutMs);
+      timeout = undefined;
+      detachParentAbort();
+      controller.abort(timeoutError);
+    }, timeoutMs);
+  }
+
+  const cleanup = () => {
+    clearAttemptTimeout();
+    detachParentAbort();
+  };
+
+  return {
+    request: {
+      ...request,
+      signal: controller.signal,
+    },
+    cleanup,
+    normalizeError: (error) => {
+      if (parentSignal?.aborted) {
+        try {
+          throwAbortError(parentSignal);
+        } catch (parentError) {
+          return parentError;
+        }
+      }
+      if (!didTimeOut) {
+        return error;
+      }
+      if (error === timeoutError) {
+        return error;
+      }
+      return createModelTimeoutError(timeoutMs, error);
+    },
+    timeoutError: () => timeoutError,
+    timedOut: () => didTimeOut,
+  };
+}
+
+function isStatefulRequest(request: ModelRequest): boolean {
+  return Boolean(request.previousResponseId || request.conversationId);
 }
 
 function asError(value: unknown): Error | undefined {
@@ -340,13 +463,15 @@ function normalizeRetryError(
   signal: AbortSignal | undefined,
   providerAdvice?: ModelRetryAdvice,
 ): ModelRetryNormalizedError {
+  const isModelTimeout = error instanceof ModelTimeoutError;
   const headers = extractHeaders(error);
   const normalized: ModelRetryNormalizedError = {
     statusCode: getStatusCode(error),
     retryAfterMs: getRetryAfterMs(headers),
     errorCode: getErrorCode(error),
     isNetworkError: isNetworkLikeError(error),
-    isAbort: Boolean(signal?.aborted) || isAbortLikeError(error),
+    isAbort:
+      !isModelTimeout && (Boolean(signal?.aborted) || isAbortLikeError(error)),
   };
 
   if (providerAdvice?.retryAfterMs !== undefined) {
@@ -359,7 +484,9 @@ function normalizeRetryError(
     ...(providerNormalized ?? {}),
     // Provider normalization may add abort evidence but cannot clear evidence
     // inferred from the signal or raw exception.
-    isAbort: normalized.isAbort || providerNormalized?.isAbort === true,
+    isAbort:
+      !isModelTimeout &&
+      (normalized.isAbort || providerNormalized?.isAbort === true),
   };
 }
 
@@ -375,6 +502,19 @@ function createProviderRetryAuthority(
         : 'unknown',
     responseStarted: providerAdvice?.responseStarted,
   });
+}
+
+function withTimeoutReplayAuthority(
+  providerAdvice: ModelRetryAdvice | undefined,
+  timedOut: boolean,
+): ModelRetryAdvice | undefined {
+  if (!timedOut || providerAdvice?.replaySafety === 'safe') {
+    return providerAdvice;
+  }
+  return {
+    ...providerAdvice,
+    replaySafety: 'unsafe',
+  };
 }
 
 function requestMayHaveBeenAccepted(
@@ -570,6 +710,59 @@ function throwAbortError(signal: AbortSignal | undefined): never {
   throw error;
 }
 
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throwAbortError(signal);
+  }
+}
+
+function throwIfTimedModelCallParentAborted(
+  signal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): void {
+  if (timeoutMs !== undefined) {
+    throwIfAborted(signal);
+  }
+}
+
+async function awaitWithTimedModelCallParentAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal | undefined,
+  timeoutMs: number | undefined,
+): Promise<T> {
+  if (timeoutMs === undefined || !signal) {
+    return await promise;
+  }
+  if (signal.aborted) {
+    throwAbortError(signal);
+  }
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      try {
+        throwAbortError(signal);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort);
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
 async function waitForRetryDelay(
   signal: AbortSignal | undefined,
   delayMs: number,
@@ -633,6 +826,7 @@ async function evaluateRetry({
   emittedVisibleEvent,
   emittedRawModelEvent,
   providerAdvice,
+  allowUnsafeStreamReplayApproval,
 }: EvaluateRetryParams): Promise<ResolvedRetryDecision> {
   if (attempt > maxRetries) {
     return { retry: false };
@@ -660,7 +854,9 @@ async function evaluateRetry({
     normalized.isAbort ||
     emittedVisibleEvent ||
     emittedRawModelEvent ||
-    (stream && authority.replaySafety === 'unsafe')
+    (stream &&
+      authority.replaySafety === 'unsafe' &&
+      !allowUnsafeStreamReplayApproval)
   ) {
     return {
       retry: false,
@@ -870,6 +1066,7 @@ export async function getResponseWithRetry(
   const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
   const retryPolicy = request.modelSettings.retry?.policy;
   const retryBackoff = request.modelSettings.retry?.backoff;
+  const timeoutMs = validateModelTimeoutMs(request.modelSettings);
 
   let attempt = 1;
   while (true) {
@@ -879,8 +1076,15 @@ export async function getResponseWithRetry(
     )
       ? withRunnerManagedRetry(request)
       : request;
+    const attemptScope = createModelAttemptScope(requestForAttempt, timeoutMs);
     try {
-      const response = await model.getResponse(requestForAttempt);
+      const response = await model.getResponse(attemptScope.request);
+      throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+      if (attemptScope.timedOut()) {
+        throw (
+          attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
+        );
+      }
       if (attempt === 1) {
         return response;
       }
@@ -888,38 +1092,75 @@ export async function getResponseWithRetry(
         ...response,
         usage: addFailedRetryAttemptsToUsage(response.usage, attempt - 1),
       };
-    } catch (error) {
-      const providerAdvice = await getRetryAdvice(model, {
-        request,
-        error,
-        stream: false,
-        attempt,
-      });
+    } catch (caughtError) {
+      attemptScope.cleanup();
+      const error = attemptScope.normalizeError(caughtError);
+      let providerAdvice: ModelRetryAdvice | undefined;
+      try {
+        providerAdvice = await awaitWithTimedModelCallParentAbort(
+          getRetryAdvice(model, {
+            request,
+            error: caughtError,
+            stream: false,
+            attempt,
+          }),
+          request.signal,
+          timeoutMs,
+        );
+      } catch (retryAdviceError) {
+        if (attemptScope.timedOut() && isStatefulRequest(request)) {
+          handlers.onPossiblyAcceptedRequestFailure?.();
+        }
+        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+        throw retryAdviceError;
+      }
+      providerAdvice = withTimeoutReplayAuthority(
+        providerAdvice,
+        attemptScope.timedOut(),
+      );
       const authority = createProviderRetryAuthority(providerAdvice);
       const markPossiblyAcceptedFailure = () => {
-        if (requestMayHaveBeenAccepted(authority)) {
+        if (
+          requestMayHaveBeenAccepted(authority) ||
+          (attemptScope.timedOut() &&
+            isStatefulRequest(request) &&
+            authority.replaySafety !== 'safe')
+        ) {
           handlers.onPossiblyAcceptedRequestFailure?.();
         }
       };
+      const throwIfParentAbortedAfterTimedFailure = () => {
+        if (timeoutMs !== undefined && request.signal?.aborted) {
+          markPossiblyAcceptedFailure();
+          throwAbortError(request.signal);
+        }
+      };
+      throwIfParentAbortedAfterTimedFailure();
       let decision: ResolvedRetryDecision;
       try {
-        decision = await evaluateRetry({
-          error,
-          attempt,
-          maxRetries,
-          retryPolicy,
-          retryBackoff,
-          signal: request.signal,
-          stream: false,
-          request,
-          emittedVisibleEvent: false,
-          emittedRawModelEvent: false,
-          providerAdvice,
-        });
+        decision = await awaitWithTimedModelCallParentAbort(
+          evaluateRetry({
+            error,
+            attempt,
+            maxRetries,
+            retryPolicy,
+            retryBackoff,
+            signal: request.signal,
+            stream: false,
+            request,
+            emittedVisibleEvent: false,
+            emittedRawModelEvent: false,
+            providerAdvice,
+          }),
+          request.signal,
+          timeoutMs,
+        );
       } catch (retryError) {
         markPossiblyAcceptedFailure();
+        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
         throw retryError;
       }
+      throwIfParentAbortedAfterTimedFailure();
 
       if (!decision.retry) {
         markPossiblyAcceptedFailure();
@@ -933,6 +1174,8 @@ export async function getResponseWithRetry(
         throw retryDelayError;
       }
       attempt += 1;
+    } finally {
+      attemptScope.cleanup();
     }
   }
 }
@@ -945,6 +1188,7 @@ export async function* getStreamedResponseWithRetry(
   const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
   const retryPolicy = request.modelSettings.retry?.policy;
   const retryBackoff = request.modelSettings.retry?.backoff;
+  const timeoutMs = validateModelTimeoutMs(request.modelSettings);
 
   let attempt = 1;
   while (true) {
@@ -956,12 +1200,24 @@ export async function* getStreamedResponseWithRetry(
     )
       ? withRunnerManagedRetry(request)
       : request;
+    const attemptScope = createModelAttemptScope(requestForAttempt, timeoutMs);
     try {
-      for await (const event of model.getStreamedResponse(requestForAttempt)) {
+      for await (const event of model.getStreamedResponse(
+        attemptScope.request,
+      )) {
+        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+        if (attemptScope.timedOut()) {
+          throw (
+            attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
+          );
+        }
         if (event.type === 'model') {
           emittedRawModelEvent = true;
         }
         emittedVisibleEvent = true;
+        if (event.type === 'response_done') {
+          attemptScope.cleanup();
+        }
         if (event.type === 'response_done' && attempt > 1) {
           yield {
             ...event,
@@ -977,41 +1233,93 @@ export async function* getStreamedResponseWithRetry(
         }
         yield event;
       }
+      throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+      if (attemptScope.timedOut()) {
+        throw (
+          attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
+        );
+      }
       return;
-    } catch (error) {
-      const providerAdvice = await getRetryAdvice(model, {
-        request,
-        error,
-        stream: true,
-        attempt,
-      });
+    } catch (caughtError) {
+      attemptScope.cleanup();
+      const error = attemptScope.normalizeError(caughtError);
+      const markTimedOutFailure = () => {
+        if (attemptScope.timedOut()) {
+          handlers.onModelTimeout?.();
+        }
+      };
+      let providerAdvice: ModelRetryAdvice | undefined;
+      try {
+        providerAdvice = await awaitWithTimedModelCallParentAbort(
+          getRetryAdvice(model, {
+            request,
+            error: caughtError,
+            stream: true,
+            attempt,
+          }),
+          request.signal,
+          timeoutMs,
+        );
+      } catch (retryAdviceError) {
+        markTimedOutFailure();
+        if (attemptScope.timedOut() && isStatefulRequest(request)) {
+          handlers.onPossiblyAcceptedRequestFailure?.();
+        }
+        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+        throw retryAdviceError;
+      }
+      providerAdvice = withTimeoutReplayAuthority(
+        providerAdvice,
+        attemptScope.timedOut(),
+      );
       const authority = createProviderRetryAuthority(providerAdvice);
       const markPossiblyAcceptedFailure = () => {
-        if (requestMayHaveBeenAccepted(authority)) {
+        if (
+          requestMayHaveBeenAccepted(authority) ||
+          (attemptScope.timedOut() &&
+            isStatefulRequest(request) &&
+            authority.replaySafety !== 'safe')
+        ) {
           handlers.onPossiblyAcceptedRequestFailure?.();
         }
       };
+      const throwIfParentAbortedAfterTimedFailure = () => {
+        if (timeoutMs !== undefined && request.signal?.aborted) {
+          markPossiblyAcceptedFailure();
+          throwAbortError(request.signal);
+        }
+      };
+      throwIfParentAbortedAfterTimedFailure();
       let decision: ResolvedRetryDecision;
       try {
-        decision = await evaluateRetry({
-          error,
-          attempt,
-          maxRetries,
-          retryPolicy,
-          retryBackoff,
-          signal: request.signal,
-          stream: true,
-          request,
-          emittedVisibleEvent,
-          emittedRawModelEvent,
-          providerAdvice,
-        });
+        decision = await awaitWithTimedModelCallParentAbort(
+          evaluateRetry({
+            error,
+            attempt,
+            maxRetries,
+            retryPolicy,
+            retryBackoff,
+            signal: request.signal,
+            stream: true,
+            request,
+            emittedVisibleEvent,
+            emittedRawModelEvent,
+            providerAdvice,
+            allowUnsafeStreamReplayApproval: attemptScope.timedOut(),
+          }),
+          request.signal,
+          timeoutMs,
+        );
       } catch (retryError) {
+        markTimedOutFailure();
         markPossiblyAcceptedFailure();
+        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
         throw retryError;
       }
+      throwIfParentAbortedAfterTimedFailure();
 
       if (!decision.retry) {
+        markTimedOutFailure();
         markPossiblyAcceptedFailure();
         throw error;
       }
@@ -1019,10 +1327,13 @@ export async function* getStreamedResponseWithRetry(
       try {
         await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
       } catch (retryDelayError) {
+        markTimedOutFailure();
         markPossiblyAcceptedFailure();
         throw retryDelayError;
       }
       attempt += 1;
+    } finally {
+      attemptScope.cleanup();
     }
   }
 }

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -125,6 +125,7 @@ export async function resumeAcceptedModelResponse<
   agentToolParentRunConfig?: Partial<RunConfig>;
   signal?: AbortSignal;
   onStepItems?: (turnResult: SingleStepResult) => void;
+  validateHandoffAgent?: (agent: Agent<any, any>) => void;
 }): Promise<SingleStepResult> {
   const { state } = options;
   if (!state._lastTurnResponse || !state._lastProcessedResponse) {
@@ -166,6 +167,8 @@ export async function resumeAcceptedModelResponse<
     undefined,
     options.signal,
     suppressedToolCalls,
+    undefined,
+    options.validateHandoffAgent,
   );
   applyTurnResult({
     state,
@@ -245,6 +248,7 @@ export async function resumeInterruptedTurn<
   agentToolParentRunConfig?: Partial<RunConfig>;
   signal?: AbortSignal;
   onStepItems?: (turnResult: SingleStepResult) => void;
+  validateHandoffAgent?: (agent: Agent<any, any>) => void;
 }): Promise<InterruptedTurnOutcome> {
   const {
     state,
@@ -253,6 +257,7 @@ export async function resumeInterruptedTurn<
     agentToolParentRunConfig,
     signal,
     onStepItems,
+    validateHandoffAgent,
   } = options;
   const approvedToolWillResume = state.getInterruptions().some((item) => {
     const rawItem = item.rawItem;
@@ -291,6 +296,7 @@ export async function resumeInterruptedTurn<
     toolErrorFormatter,
     agentToolParentRunConfig,
     signal,
+    validateHandoffAgent,
   );
   const approvedToolResumed =
     approvedToolWillResume &&

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -2539,6 +2539,7 @@ export async function executeHandoffCalls<
   runner: Runner,
   runContext: RunContext<TContext>,
   parent?: Span<any>,
+  validateHandoffAgent?: (agent: Agent<any, any>) => void,
 ): Promise<import('./steps').SingleStepResult> {
   newStepItems = [...newStepItems];
 
@@ -2587,10 +2588,12 @@ export async function executeHandoffCalls<
         );
       }
 
+      validateHandoffAgent?.(handoff.agent);
       const newAgent = await handoff.onInvokeHandoff(
         runContext,
         actualHandoff.toolCall.arguments,
       );
+      validateHandoffAgent?.(newAgent);
 
       handoffSpan.spanData.to_agent = newAgent.name;
 

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { Agent } from '../agent';
+import { getAgentToolSourceAgent } from '../agentToolSourceRegistry';
 import type { Handoff } from '../handoff';
 import { ModelBehaviorError, ModelRefusalError } from '../errors';
 import {
@@ -284,6 +285,21 @@ export function preflightToolInvocations<TContext>(
   }
 
   return suppressed;
+}
+
+function validateAgentToolSources<TContext>(
+  functionRuns: ProcessedResponse<TContext>['functions'],
+  validateAgent?: (agent: Agent<any, any>) => void,
+): void {
+  if (!validateAgent) {
+    return;
+  }
+  for (const run of functionRuns) {
+    const sourceAgent = getAgentToolSourceAgent(run.tool);
+    if (sourceAgent) {
+      validateAgent(sourceAgent);
+    }
+  }
 }
 
 function isSuppressedToolCallItem(
@@ -974,6 +990,7 @@ export async function resolveInterruptedTurn<TContext>(
   toolErrorFormatter?: ToolErrorFormatter,
   agentToolParentRunConfig?: Partial<RunConfig>,
   signal?: AbortSignal,
+  validateHandoffAgent?: (agent: Agent<any, any>) => void,
 ): Promise<SingleStepResult> {
   const suppressedToolCalls = preflightToolInvocations(
     agent,
@@ -1082,6 +1099,7 @@ export async function resolveInterruptedTurn<TContext>(
     }
     return !completedFunctionCallIds.has(callId);
   });
+  validateAgentToolSources(functionToolRuns, validateHandoffAgent);
 
   const shellRuns = filterPendingActions(
     filterActionsByApproval(
@@ -1333,6 +1351,7 @@ export async function resolveTurnAfterModelResponse<
   signal?: AbortSignal,
   preflightedToolCalls?: ReadonlySet<ApprovalCapableToolCall>,
   attemptedErrors?: WeakSet<object>,
+  validateHandoffAgent?: (agent: Agent<any, any>) => void,
 ): Promise<SingleStepResult> {
   const suppressedToolCalls =
     preflightedToolCalls ??
@@ -1352,6 +1371,17 @@ export async function resolveTurnAfterModelResponse<
     appendIfNew(item);
   }
 
+  const handoffRuns = processedResponse.handoffs.filter(
+    (run) => !suppressedToolCalls.has(run.toolCall),
+  );
+  if (handoffRuns.length > 0) {
+    validateHandoffAgent?.(handoffRuns[0].handoff.agent);
+  }
+  const functionRuns = processedResponse.functions.filter(
+    (run) => !suppressedToolCalls.has(run.toolCall),
+  );
+  validateAgentToolSources(functionRuns, validateHandoffAgent);
+
   // Run function tools and computer actions in parallel; neither depends on the other's side effects.
   // Shell and apply_patch actions both mutate the sandbox filesystem, so preserve model order.
   const runFunctionTools = (
@@ -1360,9 +1390,7 @@ export async function resolveTurnAfterModelResponse<
   ) =>
     executeFunctionToolCalls(
       agent,
-      processedResponse.functions.filter(
-        (run) => !suppressedToolCalls.has(run.toolCall),
-      ),
+      functionRuns,
       runner,
       state,
       toolErrorFormatter,
@@ -1483,9 +1511,6 @@ export async function resolveTurnAfterModelResponse<
   }
 
   // process handoffs
-  const handoffRuns = processedResponse.handoffs.filter(
-    (run) => !suppressedToolCalls.has(run.toolCall),
-  );
   if (handoffRuns.length > 0) {
     if (signal?.aborted) {
       for (const { toolCall } of handoffRuns) {
@@ -1503,6 +1528,7 @@ export async function resolveTurnAfterModelResponse<
         runner,
         state._context,
         getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
+        validateHandoffAgent,
       );
     }
   }

--- a/packages/agents-core/test/modelTimeout.test.ts
+++ b/packages/agents-core/test/modelTimeout.test.ts
@@ -1,0 +1,788 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  Agent,
+  MemorySession,
+  ModelTimeoutError,
+  retryPolicies,
+  run,
+  Runner,
+  tool,
+} from '../src';
+import type {
+  Model,
+  ModelRequest,
+  ModelResponse,
+  ModelRetryAdviceRequest,
+} from '../src/model';
+import type { StreamEvent } from '../src/types/protocol';
+import { Usage } from '../src/usage';
+import {
+  getResponseWithRetry,
+  getStreamedResponseWithRetry,
+} from '../src/runner/modelRetry';
+import { modelResponse, ScriptedModel } from '../src/testing';
+
+function response(text: string): ModelResponse {
+  return {
+    usage: new Usage({ requests: 1 }),
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text }],
+      },
+    ],
+  };
+}
+
+async function waitForAbort(signal: AbortSignal | undefined): Promise<never> {
+  if (!signal) {
+    throw new Error('Expected model request signal');
+  }
+  return await new Promise<never>((_resolve, reject) => {
+    const onAbort = () => {
+      const fallback = new Error('The operation was aborted.');
+      fallback.name = 'AbortError';
+      reject(signal.reason ?? fallback);
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+class TimeoutThenResponseModel implements Model {
+  calls = 0;
+
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.calls += 1;
+    if (this.calls === 1) {
+      return await waitForAbort(request.signal);
+    }
+    return response('Recovered');
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    yield* [];
+  }
+}
+
+class TimeoutThenStreamModel implements Model {
+  calls = 0;
+
+  async getResponse(): Promise<ModelResponse> {
+    return response('unused');
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    this.calls += 1;
+    if (this.calls === 1) {
+      await waitForAbort(request.signal);
+      return;
+    }
+    yield { type: 'response_started' };
+    yield {
+      type: 'response_done',
+      response: {
+        id: 'response_timeout_recovered',
+        usage: new Usage({ requests: 1 }),
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'Stream recovered' }],
+          },
+        ],
+      },
+    };
+  }
+}
+
+class EventThenTimeoutStreamModel implements Model {
+  calls = 0;
+
+  async getResponse(): Promise<ModelResponse> {
+    return response('unused');
+  }
+
+  async *getStreamedResponse(
+    request: ModelRequest,
+  ): AsyncIterable<StreamEvent> {
+    this.calls += 1;
+    yield { type: 'response_started' };
+    await waitForAbort(request.signal);
+  }
+}
+
+class EventThenTimeoutWithFailingAdviceStreamModel extends EventThenTimeoutStreamModel {
+  getRetryAdvice(): never {
+    throw new Error('retry advice failed after stream timeout');
+  }
+}
+
+class ImmediateFailureWithSlowAdviceModel implements Model {
+  async getResponse(): Promise<ModelResponse> {
+    throw new Error('failed before timeout');
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    yield* [];
+  }
+
+  async getRetryAdvice(_args: ModelRetryAdviceRequest): Promise<undefined> {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return undefined;
+  }
+}
+
+class TimeoutWithSlowAdviceModel extends TimeoutThenResponseModel {
+  async getRetryAdvice(_args: ModelRetryAdviceRequest): Promise<undefined> {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return undefined;
+  }
+}
+
+class TimeoutWithFailingAdviceModel extends TimeoutThenResponseModel {
+  getRetryAdvice(): undefined {
+    throw new Error('retry advice failed');
+  }
+}
+
+class LateSuccessModel implements Model {
+  async getResponse(): Promise<ModelResponse> {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return response('Late success');
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    yield* [];
+  }
+}
+
+class LateEventThenStreamModel implements Model {
+  calls = 0;
+
+  async getResponse(): Promise<ModelResponse> {
+    return response('unused');
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    this.calls += 1;
+    if (this.calls === 1) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      yield { type: 'response_started' };
+      return;
+    }
+    yield { type: 'response_started' };
+    yield {
+      type: 'response_done',
+      response: {
+        id: 'response_after_late_event',
+        usage: new Usage({ requests: 1 }),
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'Recovered' }],
+          },
+        ],
+      },
+    };
+  }
+}
+
+class CompletedStreamModel implements Model {
+  async getResponse(): Promise<ModelResponse> {
+    return response('unused');
+  }
+
+  async *getStreamedResponse(): AsyncIterable<StreamEvent> {
+    yield {
+      type: 'response_done',
+      response: {
+        id: 'response_completed_before_timeout',
+        usage: new Usage({ requests: 1 }),
+        output: [
+          {
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_text', text: 'Completed' }],
+          },
+        ],
+      },
+    };
+  }
+}
+
+class GenericAbortThenResponseModel extends TimeoutThenResponseModel {
+  async getResponse(request: ModelRequest): Promise<ModelResponse> {
+    this.calls += 1;
+    if (this.calls === 1) {
+      try {
+        return await waitForAbort(request.signal);
+      } catch {
+        const error = new Error('generic abort');
+        error.name = 'AbortError';
+        throw error;
+      }
+    }
+    return response('Recovered from generic abort');
+  }
+}
+
+class GenericAbortWithAbortAdviceModel extends GenericAbortThenResponseModel {
+  getRetryAdvice() {
+    return { normalized: { isAbort: true } };
+  }
+}
+
+class TimeoutWithUnsafeReplayAdviceModel extends TimeoutThenResponseModel {
+  getRetryAdvice() {
+    return { replaySafety: 'unsafe' as const };
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+const approveUnsafeTimeoutRetry = () => ({
+  retry: true,
+  approveUnsafeReplay: true,
+});
+
+describe('model timeout', () => {
+  it('retries a timed-out non-streaming call with explicit unsafe replay approval', async () => {
+    vi.useFakeTimers();
+    const model = new TimeoutThenResponseModel();
+    const agent = new Agent({
+      name: 'ModelTimeoutAgent',
+      model,
+      modelSettings: {
+        timeoutMs: 25,
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy: approveUnsafeTimeoutRetry,
+        },
+      },
+    });
+
+    const resultPromise = run(agent, 'hello');
+    await vi.waitFor(() => expect(model.calls).toBe(1));
+    await vi.advanceTimersByTimeAsync(25);
+    const result = await resultPromise;
+
+    expect(result.finalOutput).toBe('Recovered');
+    expect(model.calls).toBe(2);
+  });
+
+  it('does not replay an ambiguous timeout through networkError policy alone', async () => {
+    vi.useFakeTimers();
+    const model = new TimeoutThenResponseModel();
+    const resultPromise = run(
+      new Agent({
+        name: 'AmbiguousTimeoutAgent',
+        model,
+        modelSettings: {
+          timeoutMs: 25,
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: retryPolicies.networkError(),
+          },
+        },
+      }),
+      'hello',
+    );
+    const rejection =
+      expect(resultPromise).rejects.toBeInstanceOf(ModelTimeoutError);
+
+    await vi.waitFor(() => expect(model.calls).toBe(1));
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+    expect(model.calls).toBe(1);
+  });
+
+  it('surfaces ModelTimeoutError when retry policy does not opt in', async () => {
+    vi.useFakeTimers();
+    const model = new TimeoutThenResponseModel();
+    const resultPromise = run(
+      new Agent({
+        name: 'NoRetryAgent',
+        model,
+        modelSettings: { timeoutMs: 25 },
+      }),
+      'hello',
+    );
+    const errorPromise = resultPromise.catch((error: unknown) => error);
+    await vi.waitFor(() => expect(model.calls).toBe(1));
+    await vi.advanceTimersByTimeAsync(25);
+
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(ModelTimeoutError);
+    expect((error as ModelTimeoutError).state).toBeDefined();
+    expect(model.calls).toBe(1);
+  });
+
+  it('rejects invalid timeout values before calling the model', async () => {
+    const model = new TimeoutThenResponseModel();
+    const agent = new Agent({
+      name: 'InvalidTimeoutAgent',
+      model,
+      modelSettings: { timeoutMs: 2_147_483_648 },
+    });
+    const runner = new Runner();
+    const agentStart = vi.fn();
+    const session = new MemorySession();
+    const getItems = vi.spyOn(session, 'getItems');
+    const sessionInputCallback = vi.fn();
+    runner.on('agent_start', agentStart);
+
+    await expect(
+      runner.run(agent, 'hello', { session, sessionInputCallback }),
+    ).rejects.toThrow(
+      'modelSettings.timeoutMs must be a positive finite number',
+    );
+    expect(getItems).not.toHaveBeenCalled();
+    expect(sessionInputCallback).not.toHaveBeenCalled();
+    expect(agentStart).not.toHaveBeenCalled();
+    expect(model.calls).toBe(0);
+  });
+
+  it('rejects invalid agent-tool timeouts before tool side effects', async () => {
+    const inputBuilder = vi.fn(() => 'nested input');
+    const siblingExecute = vi.fn(() => 'sibling output');
+    const nestedAgent = new Agent({
+      name: 'InvalidNestedTimeoutAgent',
+      modelSettings: { timeoutMs: 0 },
+    });
+    const nestedTool = nestedAgent.asTool({
+      toolName: 'nested_agent',
+      toolDescription: 'Runs a nested agent.',
+      parameters: z.object({ input: z.string() }),
+      inputBuilder,
+    });
+    const siblingTool = tool({
+      name: 'sibling_tool',
+      description: 'Runs a sibling side effect.',
+      parameters: z.object({}),
+      execute: siblingExecute,
+    });
+    const parent = new Agent({
+      name: 'ParentAgent',
+      model: new ScriptedModel([
+        modelResponse({
+          output: [
+            {
+              type: 'function_call',
+              id: 'nested-call-id',
+              callId: 'nested-call',
+              name: 'nested_agent',
+              status: 'completed',
+              arguments: JSON.stringify({ input: 'hello' }),
+            },
+            {
+              type: 'function_call',
+              id: 'sibling-call-id',
+              callId: 'sibling-call',
+              name: 'sibling_tool',
+              status: 'completed',
+              arguments: '{}',
+            },
+          ],
+          usage: new Usage(),
+        }),
+      ]),
+      tools: [nestedTool, siblingTool],
+    });
+
+    await expect(run(parent, 'hello')).rejects.toThrow(
+      'modelSettings.timeoutMs must be a positive finite number',
+    );
+    expect(inputBuilder).not.toHaveBeenCalled();
+    expect(siblingExecute).not.toHaveBeenCalled();
+  });
+
+  it('preserves parent run cancellation as a non-retryable abort', async () => {
+    const model = new TimeoutThenResponseModel();
+    const policy = vi.fn().mockReturnValue(true);
+    const controller = new AbortController();
+    const agent = new Agent({
+      name: 'CancelledAgent',
+      model,
+      modelSettings: {
+        timeoutMs: 10_000,
+        retry: { maxRetries: 1, policy },
+      },
+    });
+
+    const resultPromise = new Runner().run(agent, 'hello', {
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(resultPromise).rejects.toMatchObject({ name: 'AbortError' });
+    expect(model.calls).toBe(1);
+    expect(policy).not.toHaveBeenCalled();
+  });
+
+  it('retries a streaming timeout only before stream output', async () => {
+    vi.useFakeTimers();
+    const model = new TimeoutThenStreamModel();
+    const agent = new Agent({
+      name: 'StreamingTimeoutAgent',
+      model,
+      modelSettings: {
+        timeoutMs: 25,
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy: approveUnsafeTimeoutRetry,
+        },
+      },
+    });
+
+    const result = await run(agent, 'hello', { stream: true });
+    const consume = (async () => {
+      for await (const _event of result) {
+        // Consume to completion.
+      }
+    })();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(25);
+    await consume;
+
+    expect(result.finalOutput).toBe('Stream recovered');
+    expect(model.calls).toBe(2);
+  });
+
+  it('does not retry a streaming timeout after stream output', async () => {
+    vi.useFakeTimers();
+    const model = new EventThenTimeoutStreamModel();
+    const agent = new Agent({
+      name: 'StreamingOutputTimeoutAgent',
+      model,
+      modelSettings: {
+        timeoutMs: 25,
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy: retryPolicies.networkError(),
+        },
+      },
+    });
+
+    const result = await run(agent, 'hello', { stream: true });
+    const consume = (async () => {
+      for await (const _event of result) {
+        // Consume until the timeout fails the stream.
+      }
+    })();
+    const rejection = expect(consume).rejects.toBeInstanceOf(ModelTimeoutError);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(model.calls).toBe(1);
+  });
+
+  it('reports a timed-out stream when retry advice replaces the surfaced error', async () => {
+    vi.useFakeTimers();
+    const onModelTimeout = vi.fn();
+    const iterator = getStreamedResponseWithRetry(
+      new EventThenTimeoutWithFailingAdviceStreamModel(),
+      {
+        modelSettings: { timeoutMs: 25 },
+      } as ModelRequest,
+      { onModelTimeout },
+    )[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: 'response_started' },
+    });
+    const rejection = expect(iterator.next()).rejects.toThrow(
+      'retry advice failed after stream timeout',
+    );
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(onModelTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the timeout timer when parent cancellation wins', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const resultPromise = getResponseWithRetry(new LateSuccessModel(), {
+      signal: controller.signal,
+      modelSettings: { timeoutMs: 10_000 },
+    } as ModelRequest);
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(2);
+    controller.abort();
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(50);
+    await rejection;
+  });
+
+  it('marks a timed-out stateful request as possibly accepted', async () => {
+    vi.useFakeTimers();
+    const model = new TimeoutThenResponseModel();
+    const markPossiblyAccepted = vi.fn();
+    const resultPromise = getResponseWithRetry(
+      model,
+      {
+        conversationId: 'conv-timeout',
+        modelSettings: { timeoutMs: 25 },
+      } as ModelRequest,
+      { onPossiblyAcceptedRequestFailure: markPossiblyAccepted },
+    );
+    const rejection =
+      expect(resultPromise).rejects.toBeInstanceOf(ModelTimeoutError);
+    await vi.waitFor(() => expect(model.calls).toBe(1));
+    await vi.advanceTimersByTimeAsync(25);
+
+    await rejection;
+    expect(markPossiblyAccepted).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a timed-out stateful request with explicit unsafe replay approval', async () => {
+    vi.useFakeTimers();
+    const model = new TimeoutWithUnsafeReplayAdviceModel();
+    const policy = vi.fn().mockReturnValue({
+      retry: true,
+      approveUnsafeReplay: true,
+    });
+    const resultPromise = getResponseWithRetry(model, {
+      conversationId: 'conv-unsafe-timeout',
+      modelSettings: {
+        timeoutMs: 25,
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy,
+        },
+      },
+    } as unknown as ModelRequest);
+    await vi.waitFor(() => expect(model.calls).toBe(1));
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(resultPromise).resolves.toMatchObject({
+      output: expect.any(Array),
+    });
+    expect(policy).toHaveBeenCalledTimes(1);
+    expect(model.calls).toBe(2);
+  });
+
+  it('does not turn post-failure retry advice time into a model timeout', async () => {
+    vi.useFakeTimers();
+    const markPossiblyAccepted = vi.fn();
+    const resultPromise = getResponseWithRetry(
+      new ImmediateFailureWithSlowAdviceModel(),
+      {
+        conversationId: 'conv-failed-before-timeout',
+        modelSettings: { timeoutMs: 25 },
+      } as ModelRequest,
+      { onPossiblyAcceptedRequestFailure: markPossiblyAccepted },
+    );
+    const rejection = expect(resultPromise).rejects.toThrow(
+      'failed before timeout',
+    );
+
+    await vi.advanceTimersByTimeAsync(50);
+    await rejection;
+    expect(markPossiblyAccepted).not.toHaveBeenCalled();
+  });
+
+  it('preserves parent abort precedence while retry advice is pending', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const resultPromise = getResponseWithRetry(
+      new TimeoutWithSlowAdviceModel(),
+      {
+        signal: controller.signal,
+        modelSettings: { timeoutMs: 25 },
+      } as ModelRequest,
+    );
+    const rejection = expect(resultPromise).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+
+    await vi.advanceTimersByTimeAsync(25);
+    controller.abort();
+    await vi.advanceTimersByTimeAsync(50);
+    await rejection;
+  });
+
+  it('marks an ambiguous stateful timeout when retry advice fails', async () => {
+    vi.useFakeTimers();
+    const markPossiblyAccepted = vi.fn();
+    const resultPromise = getResponseWithRetry(
+      new TimeoutWithFailingAdviceModel(),
+      {
+        conversationId: 'conv-advice-failure',
+        modelSettings: { timeoutMs: 25 },
+      } as ModelRequest,
+      { onPossiblyAcceptedRequestFailure: markPossiblyAccepted },
+    );
+    const rejection = expect(resultPromise).rejects.toThrow(
+      'retry advice failed',
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await rejection;
+    expect(markPossiblyAccepted).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a provider response that resolves after the timeout', async () => {
+    vi.useFakeTimers();
+    const resultPromise = getResponseWithRetry(new LateSuccessModel(), {
+      modelSettings: { timeoutMs: 25 },
+    } as ModelRequest);
+    const errorPromise = resultPromise.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(50);
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(ModelTimeoutError);
+    expect((error as ModelTimeoutError).cause).toBeUndefined();
+  });
+
+  it('does not wrap a late stream event timeout as its own cause', async () => {
+    vi.useFakeTimers();
+    const result = await run(
+      new Agent({
+        name: 'LateStreamEventTimeoutAgent',
+        model: new LateEventThenStreamModel(),
+        modelSettings: { timeoutMs: 25 },
+      }),
+      'hello',
+      { stream: true },
+    );
+    const consume = (async () => {
+      for await (const _event of result) {
+        // Consume until the late event fails the stream.
+      }
+    })();
+    const errorPromise = consume.catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(50);
+    const error = await errorPromise;
+    expect(error).toBeInstanceOf(ModelTimeoutError);
+    expect((error as ModelTimeoutError).cause).toBeUndefined();
+  });
+
+  it('retries before exposing a stream event that arrives after timeout', async () => {
+    vi.useFakeTimers();
+    const model = new LateEventThenStreamModel();
+    const result = await run(
+      new Agent({
+        name: 'LateStreamEventAgent',
+        model,
+        modelSettings: {
+          timeoutMs: 25,
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: approveUnsafeTimeoutRetry,
+          },
+        },
+      }),
+      'hello',
+      { stream: true },
+    );
+    const consume = (async () => {
+      for await (const _event of result) {
+        // Consume to completion.
+      }
+    })();
+
+    await vi.advanceTimersByTimeAsync(50);
+    await consume;
+    expect(result.finalOutput).toBe('Recovered');
+    expect(model.calls).toBe(2);
+  });
+
+  it('does not time out after yielding the terminal stream event', async () => {
+    vi.useFakeTimers();
+    const iterator = getStreamedResponseWithRetry(new CompletedStreamModel(), {
+      modelSettings: { timeoutMs: 25 },
+    } as ModelRequest)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { type: 'response_done' },
+    });
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(iterator.next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('retries a timeout when the provider throws a generic AbortError', async () => {
+    vi.useFakeTimers();
+    const model = new GenericAbortThenResponseModel();
+    const resultPromise = run(
+      new Agent({
+        name: 'GenericAbortTimeoutAgent',
+        model,
+        modelSettings: {
+          timeoutMs: 25,
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: approveUnsafeTimeoutRetry,
+          },
+        },
+      }),
+      'hello',
+    );
+
+    await vi.waitFor(() => expect(model.calls).toBe(1));
+    await vi.advanceTimersByTimeAsync(25);
+    const result = await resultPromise;
+    expect(result.finalOutput).toBe('Recovered from generic abort');
+    expect(model.calls).toBe(2);
+  });
+
+  it('does not let provider abort advice veto an SDK timeout', async () => {
+    vi.useFakeTimers();
+    const model = new GenericAbortWithAbortAdviceModel();
+    const resultPromise = run(
+      new Agent({
+        name: 'ProviderAbortAdviceTimeoutAgent',
+        model,
+        modelSettings: {
+          timeoutMs: 25,
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: approveUnsafeTimeoutRetry,
+          },
+        },
+      }),
+      'hello',
+    );
+
+    await vi.waitFor(() => expect(model.calls).toBe(1));
+    await vi.advanceTimersByTimeAsync(25);
+    const result = await resultPromise;
+    expect(result.finalOutput).toBe('Recovered from generic abort');
+    expect(model.calls).toBe(2);
+  });
+});

--- a/packages/agents-core/test/runState.pendingInput.test.ts
+++ b/packages/agents-core/test/runState.pendingInput.test.ts
@@ -4,6 +4,7 @@ import {
   Agent,
   InputGuardrailTripwireTriggered,
   ModelRefusalError,
+  ModelTimeoutError,
   RunInputItem,
   RunState,
   Runner,
@@ -115,6 +116,12 @@ class AbortBeforeEventStreamModel extends ScriptedModel {
 
   get streamCalls(): number {
     return this.calls.filter((call) => call.streamed).length;
+  }
+}
+
+class SafeTimeoutBeforeEventStreamModel extends AbortBeforeEventStreamModel {
+  async getRetryAdvice() {
+    return { replaySafety: 'safe' as const };
   }
 }
 
@@ -2778,6 +2785,83 @@ describe('RunState pending input', () => {
       state._generatedItems.filter((item) => item instanceof RunInputItem),
     ).toHaveLength(0);
     expect(model.calls).toHaveLength(1);
+  });
+
+  it('keeps staged input replayable after a provider-safe pre-event stream timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const model = new SafeTimeoutBeforeEventStreamModel();
+      const agent = new Agent({
+        name: 'safe-timeout-server-stream',
+        model,
+        modelSettings: { timeoutMs: 25 },
+      });
+      const state = createResumableState(agent);
+      state.setConversationContext('safe-timeout-stream-conversation');
+      state.addInput('replayable timed-out occurrence');
+
+      const streamed = await run(agent, state, {
+        conversationId: 'safe-timeout-stream-conversation',
+        stream: true,
+      });
+      const rejection = expect(streamed.completed).rejects.toBeInstanceOf(
+        ModelTimeoutError,
+      );
+      await model.started;
+      await vi.advanceTimersByTimeAsync(25);
+      await rejection;
+
+      expect(state.pendingInput).toEqual([
+        message('replayable timed-out occurrence'),
+      ]);
+      expect(
+        state._generatedItems.filter((item) => item instanceof RunInputItem),
+      ).toHaveLength(0);
+      expect(model.calls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('checkpoints an ambiguous pre-event stream timeout without pending input', async () => {
+    vi.useFakeTimers();
+    try {
+      const model = new AbortBeforeEventStreamModel();
+      const agent = new Agent({
+        name: 'ambiguous-timeout-server-stream',
+        model,
+        modelSettings: { timeoutMs: 25 },
+      });
+      const state = createResumableState(agent);
+      state.setConversationContext('ambiguous-timeout-stream-conversation');
+
+      const streamed = await run(agent, state, {
+        conversationId: 'ambiguous-timeout-stream-conversation',
+        stream: true,
+      });
+      const rejection = expect(streamed.completed).rejects.toBeInstanceOf(
+        ModelTimeoutError,
+      );
+      await model.started;
+      await vi.advanceTimersByTimeAsync(25);
+      await rejection;
+
+      expect(state.pendingInput).toEqual([]);
+      expect(state._currentStep).toMatchObject({
+        type: 'next_step_interruption',
+        data: { responseAccepted: true },
+      });
+
+      const restored = await RunState.fromString(agent, state.toString());
+      await expect(
+        run(agent, restored, {
+          conversationId: 'ambiguous-timeout-stream-conversation',
+        }),
+      ).rejects.toThrow(/accepted model response could not be processed/i);
+      expect(model.streamCalls).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('checkpoints server acceptance before surfacing a parallel staged-input guardrail failure', async () => {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -285,15 +285,29 @@ type SerializedShellContainerSkill = NonNullable<
 type SerializedShellContainerNetworkPolicy =
   SerializedShellContainerAutoEnvironment['networkPolicy'];
 
+const replaySafeWebSocketErrors = new WeakSet<object>();
+const transientNeverSentWebSocketErrors = new WeakSet<object>();
+
+function markReplaySafeWebSocketError(error: unknown): void {
+  if (typeof error === 'object' && error !== null) {
+    replaySafeWebSocketErrors.add(error);
+  }
+}
+
+function markTransientNeverSentWebSocketError(error: unknown): void {
+  if (typeof error === 'object' && error !== null) {
+    transientNeverSentWebSocketErrors.add(error);
+  }
+}
+
 function isNeverSentWebSocketError(error: unknown): boolean {
-  if (isWebSocketNotOpenError(error)) {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    transientNeverSentWebSocketErrors.has(error)
+  ) {
     return true;
   }
-
-  const errorCause =
-    error instanceof Error
-      ? (error as Error & { cause?: unknown }).cause
-      : undefined;
 
   if (
     error instanceof ResponsesWebSocketInternalError &&
@@ -302,14 +316,34 @@ function isNeverSentWebSocketError(error: unknown): boolean {
     return true;
   }
 
-  if (
+  const errorCause =
+    error instanceof Error
+      ? (error as Error & { cause?: unknown }).cause
+      : undefined;
+
+  return (
     errorCause instanceof ResponsesWebSocketInternalError &&
     errorCause.code === 'connection_closed_before_opening'
-  ) {
-    return true;
-  }
+  );
+}
 
-  return false;
+function isReplaySafeWebSocketError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    replaySafeWebSocketErrors.has(error)
+  );
+}
+
+function isTransientConnectionSetupError(error: unknown): boolean {
+  return (
+    (error instanceof ResponsesWebSocketInternalError &&
+      error.code === 'connection_closed_before_opening') ||
+    (error instanceof Error &&
+      error.message.startsWith(
+        'Responses websocket connection timed out before opening after ',
+      ))
+  );
 }
 
 function isAmbiguousWebSocketReplayError(error: unknown): boolean {
@@ -3843,6 +3877,14 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       };
     }
 
+    if (isReplaySafeWebSocketError(args.error)) {
+      return {
+        suggested: false,
+        replaySafety: 'safe',
+        reason: args.error instanceof Error ? args.error.message : undefined,
+      };
+    }
+
     if (isAmbiguousWebSocketReplayError(args.error)) {
       return (
         super.getRetryAdvice(args) ?? {
@@ -3920,15 +3962,15 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
   ): AsyncIterable<OpenAI.Responses.ResponseStreamEvent> {
     const requestTimeoutDeadline =
       this.#createWebSocketRequestTimeoutDeadline();
-    const releaseLock = await this.#acquireWebSocketRequestLock(
-      builtRequest.signal,
-      requestTimeoutDeadline,
-    );
-
+    let releaseLock: (() => void) | undefined;
     let replayMayBeUnsafe = false;
     let receivedServerFrame = false;
     let sawTerminalResponseEvent = false;
     try {
+      releaseLock = await this.#acquireWebSocketRequestLock(
+        builtRequest.signal,
+        requestTimeoutDeadline,
+      );
       throwIfAborted(builtRequest.signal);
       const { frame, wsURL, headers } = await this.#prepareWebSocketRequest(
         builtRequest,
@@ -3954,24 +3996,34 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       const serializedFrame = JSON.stringify(frame);
       const sendSerializedFrame = async () => {
         try {
-          await activeConnection.send(serializedFrame);
-        } catch (error) {
-          if (!isWebSocketNotOpenError(error)) {
-            throw error;
-          }
+          try {
+            await activeConnection.send(serializedFrame);
+          } catch (error) {
+            if (!isWebSocketNotOpenError(error)) {
+              throw error;
+            }
 
-          setActiveConnection(
-            await this.#reconnectWebSocketConnection(
-              wsURL,
-              headers,
-              builtRequest.signal,
-              requestTimeoutDeadline,
-            ),
-          );
-          await activeConnection.send(serializedFrame);
+            setActiveConnection(
+              await this.#reconnectWebSocketConnection(
+                wsURL,
+                headers,
+                builtRequest.signal,
+                requestTimeoutDeadline,
+              ),
+            );
+            await activeConnection.send(serializedFrame);
+          }
+        } catch (error) {
+          if (isWebSocketNotOpenError(error)) {
+            markTransientNeverSentWebSocketError(error);
+          }
+          throw error;
         }
       };
       await sendSerializedFrame();
+      // Once response.create leaves the client, a timeout or disconnect can
+      // race with server acceptance even before the first response frame.
+      replayMayBeUnsafe = true;
 
       while (true) {
         const rawFrame = await this.#nextWebSocketFrame(
@@ -4025,6 +4077,9 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
         }
       }
     } catch (error) {
+      if (!replayMayBeUnsafe) {
+        markReplaySafeWebSocketError(error);
+      }
       if (replayMayBeUnsafe) {
         markUnsafeWebSocketReplayError(error, receivedServerFrame);
       }
@@ -4039,16 +4094,21 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
         if (error instanceof Error) {
           (wrappedError as Error & { cause?: unknown }).cause = error;
         }
+        markReplaySafeWebSocketError(wrappedError);
+        if (isNeverSentWebSocketError(error)) {
+          markTransientNeverSentWebSocketError(wrappedError);
+        }
         throw wrappedError;
       }
       throw error;
     } finally {
       const shouldDropConnection =
         !sawTerminalResponseEvent || !this.#reuseConnection;
-      const dropConnectionPromise = shouldDropConnection
-        ? this.#dropWebSocketConnection()
-        : undefined;
-      releaseLock();
+      const dropConnectionPromise =
+        releaseLock && shouldDropConnection
+          ? this.#dropWebSocketConnection()
+          : undefined;
+      releaseLock?.();
       await dropConnectionPromise;
     }
   }
@@ -4226,14 +4286,21 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       (configuredTimeoutMs) =>
         `Responses websocket connection timed out before opening after ${configuredTimeoutMs}ms.`,
     );
-    this.#wsConnection = await ResponsesWebSocketConnection.connect(
-      wsURL,
-      headers,
-      signal,
-      connectTimeout.timeoutMs,
-      connectTimeout.errorMessage,
-      this.#websocketOptions,
-    );
+    try {
+      this.#wsConnection = await ResponsesWebSocketConnection.connect(
+        wsURL,
+        headers,
+        signal,
+        connectTimeout.timeoutMs,
+        connectTimeout.errorMessage,
+        this.#websocketOptions,
+      );
+    } catch (error) {
+      if (isTransientConnectionSetupError(error)) {
+        markTransientNeverSentWebSocketError(error);
+      }
+      throw error;
+    }
     this.#wsConnectionIdentity = identity;
     return { connection: this.#wsConnection, reused: false };
   }
@@ -4329,6 +4396,9 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       return releaseLock;
     } catch (error) {
       releaseLock();
+      if (!(error instanceof OpenAI.APIUserAbortError)) {
+        markTransientNeverSentWebSocketError(error);
+      }
       throw error;
     }
   }

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -628,6 +628,43 @@ describe('OpenAIResponsesWSModel', () => {
     ).toBeUndefined();
   });
 
+  it('does not suggest retrying deterministic pre-send auth failures', async () => {
+    const fakeClient = createFakeClient() as any;
+    fakeClient.authHeaders = vi.fn(() => {
+      const error = new Error('auth callback failed');
+      error.name = 'InvalidStateError';
+      throw error;
+    });
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: false,
+      replaySafety: 'safe',
+    });
+  });
+
   it('preserves NullableHeaders null unsets across websocket header merges', async () => {
     const fakeClient = createFakeClient() as any;
     fakeClient.authHeaders = vi.fn().mockResolvedValue({
@@ -1231,6 +1268,45 @@ describe('OpenAIResponsesWSModel', () => {
     expect(error.message).not.toContain('feature may not be enabled');
   });
 
+  it('keeps generic pre-send websocket open errors safe but non-suggested', async () => {
+    TestWebSocket.onCreate = (socket) => {
+      void Promise.resolve().then(() => {
+        (socket as any).emit('error', {
+          message: 'Responses websocket connection error.',
+        });
+      });
+    };
+
+    const fakeClient = createFakeClient();
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: false,
+      replaySafety: 'safe',
+    });
+  });
+
   it('fails fast when websocket closes before waitForOpen attaches listeners', async () => {
     class FailFastCloseWebSocket {
       static CONNECTING = 0;
@@ -1378,6 +1454,9 @@ describe('OpenAIResponsesWSModel', () => {
       } as any,
       false,
     );
+    const firstErrorPromise = firstResponsePromise.catch(
+      (error: unknown) => error,
+    );
     await firstSocketCreated;
 
     // The second request snapshots timeout at request start (before queue wait),
@@ -1394,9 +1473,22 @@ describe('OpenAIResponsesWSModel', () => {
       false,
     );
 
-    await expect(firstResponsePromise).rejects.toThrow(
+    const firstError = await firstErrorPromise;
+    expect(firstError).toBeInstanceOf(Error);
+    expect((firstError as Error).message).toContain(
       'Responses websocket connection timed out before opening after 25ms.',
     );
+    expect(
+      model.getRetryAdvice({
+        error: firstError,
+        request: baseRequest as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: true,
+      replaySafety: 'safe',
+    });
     await expect(secondResponsePromise).resolves.toMatchObject({
       id: 'resp_done_2',
     });
@@ -2072,6 +2164,79 @@ describe('OpenAIResponsesWSModel', () => {
     expect(TestWebSocket.instances[1]?.sent).toHaveLength(1);
   });
 
+  it('suggests retry after a pre-send race followed by transient reconnect failure', async () => {
+    const fakeClient = createFakeClient();
+    let socketCreateCount = 0;
+
+    TestWebSocket.onCreate = (socket) => {
+      socketCreateCount += 1;
+      if (socketCreateCount === 2) {
+        socket.readyState = -1;
+        return;
+      }
+      socket.onSend(() => {
+        socket.queueJSON({
+          type: 'response.created',
+          response: { id: 'resp_init_1' },
+          sequence_number: 0,
+        });
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_done_1',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 1,
+        });
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: undefined,
+    };
+
+    await (model as any)._fetchResponse(request as any, false);
+    (fakeClient as any).timeout = 25;
+    (fakeClient as any)._options = {
+      ...((fakeClient as any)._options ?? {}),
+      timeout: 25,
+    };
+    const firstSocket = TestWebSocket.instances[0]!;
+    firstSocket.send = (() => {
+      firstSocket.close();
+      const error = new Error('WebSocket closed before send');
+      error.name = 'InvalidStateError';
+      throw error;
+    }) as TestWebSocket['send'];
+
+    const error = await (model as any)
+      ._fetchResponse(request as any, false)
+      .catch((caughtError: unknown) => caughtError);
+
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: true,
+      replaySafety: 'safe',
+    });
+    expect(TestWebSocket.instances).toHaveLength(2);
+    expect(TestWebSocket.instances[1]?.sent).toHaveLength(0);
+  });
+
   it('reconnects when a reused websocket send throws ws readyState error', async () => {
     const fakeClient = createFakeClient();
     let socketCreateCount = 0;
@@ -2440,6 +2605,17 @@ describe('OpenAIResponsesWSModel', () => {
     await expect(queuedResponsePromise).rejects.toThrow(
       'Responses websocket request queue wait timed out after 25ms.',
     );
+    expect(
+      model.getRetryAdvice({
+        error: (queuedOutcome as any).error,
+        request: baseRequest as any,
+        stream: false,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      suggested: true,
+      replaySafety: 'safe',
+    });
   });
 
   it('does not send an already-aborted queued websocket request', async () => {
@@ -2587,6 +2763,51 @@ describe('OpenAIResponsesWSModel', () => {
       process.off('unhandledRejection', handler);
       await iterator.return?.();
     }
+  });
+
+  it('marks an abort after sending response.create as unsafe to replay', async () => {
+    const fakeClient = createFakeClient();
+    const abortController = new AbortController();
+
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        abortController.abort();
+      });
+    };
+
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+    const request = {
+      systemInstructions: undefined,
+      input: 'ping',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+      signal: abortController.signal,
+    };
+    const rawStream = (await (model as any)._fetchResponse(
+      request as any,
+      true,
+    )) as AsyncIterable<OpenAIResponseStreamEvent>;
+
+    let error: unknown;
+    try {
+      await rawStream[Symbol.asyncIterator]().next();
+    } catch (caughtError) {
+      error = caughtError;
+    }
+
+    expect(
+      model.getRetryAdvice({
+        error,
+        request: request as any,
+        stream: true,
+        attempt: 1,
+      }),
+    ).toMatchObject({
+      replaySafety: 'unsafe',
+    });
   });
 
   it('refreshes auth only after a queued websocket request acquires the request lock', async () => {


### PR DESCRIPTION
This pull request resolves #894.

This pull request adds provider-neutral per-model-call timeouts through `modelSettings.timeoutMs`.

The timeout uses a cooperative child abort signal for each model attempt and exports `ModelTimeoutError` with `code: 'ETIMEDOUT'`. Existing retry policies can retry timed-out calls, while streamed calls remain non-retryable after output begins and stateful calls require provider-confirmed replay safety.

The timeout is intentionally cooperative: providers and custom models must honor the supplied abort signal. The SDK does not use `Promise.race`, forcefully terminate signal-ignoring model implementations, or guarantee that a remote provider did not accept a timed-out request.

Timeouts apply per model attempt rather than to the full run. A run-level abort signal still cancels the entire run and takes precedence over timeout retry behavior. Stateful requests using `conversationId` or `previousResponseId` are not retried after timeout unless provider retry advice explicitly marks replay as safe.

Invalid timeout values fail before the affected agent starts model, sandbox, session, handoff, or lifecycle work. `timeoutMs` must be finite, greater than `0`, and less than or equal to `2147483647`.

`modelSettings.timeoutMs` is separate from run-level cancellation. The SDK does not currently expose a Runner-level timeout option; callers that need a deadline for the entire run can pass an abort signal such as `AbortSignal.timeout(...)` through run options. A run-level abort cancels the whole run and always takes precedence, while `modelSettings.timeoutMs` only aborts one model attempt and can still participate in retry behavior.