### PR TITLE
fix(realtime): handle non-finite audio rates

### DIFF
--- a/.changeset/fix-realtime-audio-rates.md
+++ b/.changeset/fix-realtime-audio-rates.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: fall back to 24kHz PCM for non-finite realtime audio rates

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -285,8 +285,17 @@ export function normalizeAudioFormat(
   format?: RealtimeAudioFormat | undefined,
 ): RealtimeAudioFormatDefinition | undefined {
   if (!format) return undefined;
-  if (typeof format === 'object')
+  if (typeof format === 'object') {
+    if (
+      format.type === 'audio/pcm' &&
+      typeof format.rate === 'number' &&
+      !Number.isFinite(format.rate)
+    ) {
+      return { type: 'audio/pcm', rate: 24000 };
+    }
+
     return format as RealtimeAudioFormatDefinition;
+  }
   const f = String(format);
   if (f === 'pcm16') return { type: 'audio/pcm', rate: 24000 };
   if (f === 'g711_ulaw') return { type: 'audio/pcmu' };

--- a/packages/agents-realtime/test/clientMessages.test.ts
+++ b/packages/agents-realtime/test/clientMessages.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeAudioFormat,
+  toNewSessionConfig,
+} from '../src/clientMessages';
+
+describe('normalizeAudioFormat', () => {
+  it.each([NaN, Infinity, -Infinity])(
+    'falls back to 24kHz PCM for non-finite rate %s',
+    (rate) => {
+      const format = { type: 'audio/pcm' as const, rate };
+
+      expect(normalizeAudioFormat(format)).toEqual({
+        type: 'audio/pcm',
+        rate: 24000,
+      });
+    },
+  );
+
+  it('preserves a finite structured PCM format', () => {
+    const format = { type: 'audio/pcm' as const, rate: 24000 };
+
+    expect(normalizeAudioFormat(format)).toBe(format);
+  });
+
+  it.each(['audio/pcmu', 'audio/pcma'] as const)(
+    'preserves structured telephony format %s',
+    (type) => {
+      const format = { type };
+
+      expect(normalizeAudioFormat(format)).toBe(format);
+    },
+  );
+
+  it('preserves unknown structured formats for forward compatibility', () => {
+    const format = { type: 'audio/future', rate: NaN };
+
+    expect(normalizeAudioFormat(format as any)).toBe(format);
+  });
+
+  it('normalizes non-finite PCM rates for both session audio directions', () => {
+    const format = { type: 'audio/pcm' as const, rate: NaN };
+
+    const config = toNewSessionConfig({
+      audio: {
+        input: { format },
+        output: { format },
+      },
+    });
+
+    expect(config.audio?.input?.format).toEqual({
+      type: 'audio/pcm',
+      rate: 24000,
+    });
+    expect(config.audio?.output?.format).toEqual({
+      type: 'audio/pcm',
+      rate: 24000,
+    });
+  });
+});


### PR DESCRIPTION
This pull request fixes Realtime structured PCM audio-format normalization when runtime callers provide `NaN`, `Infinity`, or `-Infinity` rates.

Non-finite numeric PCM rates now use the existing 24 kHz fallback before session configuration reaches the wire or WebSocket audio-duration calculation. Finite PCM rates, legacy shorthands, telephony formats, and unknown structured formats retain their existing behavior. This mirrors the useful hardening from https://github.com/openai/openai-agents-python/pull/4419.