### PR TITLE
fix(mcp): keep cached tool arrays private

### DIFF
--- a/.changeset/tidy-tools-cache.md
+++ b/.changeset/tidy-tools-cache.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: keep cached MCP tool arrays private from callers

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -76,6 +76,10 @@ export interface MCPCallToolOptions {
 const MCP_FUNCTION_TOOL_NAME_MAX_LENGTH = 64;
 const MCP_FUNCTION_TOOL_HASH_LENGTH = 8;
 
+function snapshotMcpTools(tools: MCPTool[]): MCPTool[] {
+  return [...tools];
+}
+
 type PrefixedToolNameCandidate = {
   batchKey: string;
   baseName: string;
@@ -323,14 +327,15 @@ export class MCPServerStdio
   async listTools(): Promise<MCPTool[]> {
     const listingGeneration = this.toolsLifecycle.beginListing();
     if (this.cacheToolsList && this._cachedTools) {
-      return this._cachedTools;
+      return snapshotMcpTools(this._cachedTools);
     }
     const tools = await this.underlying.listTools();
     this.toolsLifecycle.assertListingIsCurrent(listingGeneration);
     if (this.cacheToolsList) {
-      this._cachedTools = tools;
+      this._cachedTools = snapshotMcpTools(tools);
+      return snapshotMcpTools(this._cachedTools);
     }
-    return tools;
+    return snapshotMcpTools(tools);
   }
   async callTool(
     toolName: string,
@@ -411,7 +416,8 @@ export class MCPServerStreamableHttp
     if (sessionId === undefined) {
       this.toolsLifecycle.invalidate();
       await this.invalidateToolsCaches();
-      return this.underlying.listTools();
+      const tools = await this.underlying.listTools();
+      return snapshotMcpTools(tools);
     }
 
     if (
@@ -419,15 +425,16 @@ export class MCPServerStreamableHttp
       this._cachedTools &&
       this._cachedToolsSessionId === sessionId
     ) {
-      return this._cachedTools;
+      return snapshotMcpTools(this._cachedTools);
     }
     const tools = await this.underlying.listTools();
     this.toolsLifecycle.assertListingIsCurrent(listingGeneration);
     if (this.cacheToolsList) {
-      this._cachedTools = tools;
+      this._cachedTools = snapshotMcpTools(tools);
       this._cachedToolsSessionId = sessionId;
+      return snapshotMcpTools(this._cachedTools);
     }
-    return tools;
+    return snapshotMcpTools(tools);
   }
   async callTool(
     toolName: string,
@@ -510,14 +517,15 @@ export class MCPServerSSE
   async listTools(): Promise<MCPTool[]> {
     const listingGeneration = this.toolsLifecycle.beginListing();
     if (this.cacheToolsList && this._cachedTools) {
-      return this._cachedTools;
+      return snapshotMcpTools(this._cachedTools);
     }
     const tools = await this.underlying.listTools();
     this.toolsLifecycle.assertListingIsCurrent(listingGeneration);
     if (this.cacheToolsList) {
-      this._cachedTools = tools;
+      this._cachedTools = snapshotMcpTools(tools);
+      return snapshotMcpTools(this._cachedTools);
     }
-    return tools;
+    return snapshotMcpTools(tools);
   }
   async callTool(
     toolName: string,
@@ -614,7 +622,7 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
   const serverName = server.name;
   // Use cache key generator injected from the outside, or the default if absent.
   if (server.cacheToolsList && _cachedTools[cacheKey]) {
-    return _cachedTools[cacheKey];
+    return snapshotMcpTools(_cachedTools[cacheKey]);
   }
   const cacheListing = beginServerToolsCacheListing(serverName);
 
@@ -678,7 +686,7 @@ async function getMcpToolsFromServer<TContext = UnknownContext>({
     }
     // Cache store
     if (server.cacheToolsList && cacheListing.isCurrent()) {
-      _cachedTools[cacheKey] = mcpTools;
+      _cachedTools[cacheKey] = snapshotMcpTools(mcpTools);
       if (!_cachedToolKeysByServer[serverName]) {
         _cachedToolKeysByServer[serverName] = new Set();
       }

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -1133,6 +1133,7 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
   let cachedTools: MCPTool[] | undefined;
   let cacheDirty = true;
   let invalidateCalls = 0;
+  let listCalls = 0;
   let connected = false;
   let connection = 0;
   let sessionId: string | undefined;
@@ -1171,6 +1172,7 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
       await closeOperation?.();
     },
     async listTools() {
+      listCalls += 1;
       if (!connected) {
         throw new Error(
           'Server not initialized. Make sure you call connect() first.',
@@ -1222,6 +1224,8 @@ function createStubUnderlying(name: string, initialTools: MCPTool[]) {
       listOperation = operation;
     },
     invalidateCalls: () => invalidateCalls,
+    listCalls: () => listCalls,
+    underlyingCachedTools: () => cachedTools,
   };
 }
 
@@ -1274,6 +1278,8 @@ describe.each(wrapperCacheCases)(
         setCloseOperation,
         setListOperation,
         invalidateCalls,
+        listCalls,
+        underlyingCachedTools,
       } = createStubUnderlying(serverName, [toolNamed('a')]);
       (server as unknown as { underlying: typeof stub }).underlying = stub;
       return {
@@ -1283,8 +1289,36 @@ describe.each(wrapperCacheCases)(
         setCloseOperation,
         setListOperation,
         invalidateCalls,
+        listCalls,
+        underlyingCachedTools,
       };
     }
+
+    it('does not expose its cached tools array to callers', async () => {
+      const { server, listCalls } = createHarness();
+      await server.connect();
+
+      const firstListing = await server.listTools();
+      const firstTool = firstListing[0];
+      firstListing.length = 0;
+
+      const secondListing = await server.listTools();
+
+      expect(secondListing.map((tool) => tool.name)).toEqual(['a']);
+      expect(secondListing[0]).toBe(firstTool);
+      expect(listCalls()).toBe(1);
+    });
+
+    it('does not expose underlying listed arrays without wrapper caching', async () => {
+      const { server, underlyingCachedTools } = createHarness();
+      server.cacheToolsList = false;
+      await server.connect();
+
+      const listing = await server.listTools();
+      listing.length = 0;
+
+      expect(underlyingCachedTools()?.map((tool) => tool.name)).toEqual(['a']);
+    });
 
     it('returns fresh shared tools after explicit invalidation', async () => {
       const { server, setTools, invalidateCalls } = createHarness();
@@ -1449,6 +1483,58 @@ describe.each(wrapperCacheCases)(
     });
   },
 );
+
+it('snapshots sessionless streamable HTTP tool listings', async () => {
+  const serverName = 'streamable-http-sessionless-tools';
+  await invalidateServerToolsCache(serverName);
+  const server = new MCPServerStreamableHttp({
+    url: 'http://localhost:1',
+    name: serverName,
+    cacheToolsList: true,
+  });
+  const listedTools = [toolNamed('a')];
+  const stub = {
+    name: serverName,
+    sessionId: undefined,
+    async connect() {},
+    async close() {},
+    async invalidateToolsCache() {},
+    async listTools() {
+      return listedTools;
+    },
+    async callToolResult(toolName: string) {
+      if (!listedTools.some((tool) => tool.name === toolName)) {
+        throw new Error(`Tool ${toolName} was not listed.`);
+      }
+      return { content: [{ type: 'text', text: 'ok' }] };
+    },
+  };
+  (server as unknown as { underlying: typeof stub }).underlying = stub;
+  await server.connect();
+
+  const returnedTools = await server.listTools();
+  returnedTools.length = 0;
+
+  await expect(server.callTool('a', {})).resolves.toEqual([
+    { type: 'text', text: 'ok' },
+  ]);
+
+  const uncachedServer = new MCPServerStreamableHttp({
+    url: 'http://localhost:1',
+    name: `${serverName}-uncached`,
+    cacheToolsList: false,
+  });
+  (uncachedServer as unknown as { underlying: typeof stub }).underlying = stub;
+  await uncachedServer.connect();
+
+  const uncachedReturnedTools = await uncachedServer.listTools();
+  expect(uncachedReturnedTools).not.toBe(listedTools);
+  uncachedReturnedTools.length = 0;
+
+  await expect(uncachedServer.callTool('a', {})).resolves.toEqual([
+    { type: 'text', text: 'ok' },
+  ]);
+});
 
 it('starts streamable HTTP close before yielding', async () => {
   const serverName = 'streamable-http-immediate-close';


### PR DESCRIPTION
This pull request fixes MCP tool cache ownership so callers cannot corrupt cached listings by mutating returned arrays.

Cached `listTools()` results from stdio, SSE, and streamable HTTP MCP servers now return fresh array containers while preserving MCPTool object identity, cache hits, invalidation behavior, HTTP session handling, and wrapper rebinding. The module-level MCP tool cache also retains its own shallow array snapshots before downstream FunctionTool conversion.

The regression coverage verifies that clearing one returned listing does not alter the next cache hit or trigger another underlying listing.