### PR TITLE
feat: add run-scoped sandbox working directories

### DIFF
--- a/.changeset/bright-sandboxes-scope.md
+++ b/.changeset/bright-sandboxes-scope.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+feat: add run-scoped sandbox working directories

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -17,6 +17,7 @@ Most examples call a model through `run`, so set `OPENAI_API_KEY` in your shell 
 | `memory.ts` | `pnpm -F sandbox start:memory` | Uses workspace memory files plus a local snapshot resume. |
 | `memory-generation.ts` | `pnpm -F sandbox start:memory-generation` | Runs automatic Phase 1/Phase 2 sandbox memory generation when the session is flushed. |
 | `memory-multi-agent-multiturn.ts` | `pnpm -F sandbox start:memory-multi-agent-multiturn` | Shows separate workspace memory layouts for two agents sharing one sandbox workspace. |
+| `shared-session-workdirs.ts` | `pnpm -F sandbox start:shared-session-workdirs` | Runs two agents concurrently in different working directories on one shared session. |
 | `unix-local-pty.ts` | `pnpm -F sandbox start:unix-local-pty` | Exercises an interactive PTY in a Unix-local sandbox. |
 | `unix-local-runner.ts` | `pnpm -F sandbox start:unix-local-runner` | Runs directly against the Unix-local sandbox backend. |
 | `docker-runner.ts` | `pnpm -F sandbox start:docker-runner` | Runs directly against the Docker sandbox backend. |
@@ -24,5 +25,7 @@ Most examples call a model through `run`, so set `OPENAI_API_KEY` in your shell 
 ## Notes
 
 The JavaScript SDK now exposes generic remote snapshot and memory store interfaces. Cloud-specific convenience stores for S3, GCS, R2, or Azure are intentionally left to extension packages or application code so core does not pull in provider SDK dependencies.
+
+A run-scoped working directory changes relative path resolution only. It does not isolate runs from each other; use separate sandbox sessions when filesystem or compute isolation is required.
 
 The Python examples also include tax prep assets and tutorial/workflow scaffolds. Those assets do not exist in this repository, so they are not mirrored here yet.

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -19,6 +19,7 @@
     "start:docker-runner": "tsx docker-runner.ts",
     "start:memory-generation": "tsx memory-generation.ts",
     "start:memory-multi-agent-multiturn": "tsx memory-multi-agent-multiturn.ts",
+    "start:shared-session-workdirs": "tsx shared-session-workdirs.ts",
     "start:sandbox-agent-capabilities": "tsx sandbox-agent-capabilities.ts",
     "start:sandbox-agent-with-tools": "tsx sandbox-agent-with-tools.ts",
     "start:sandbox-agents-as-tools": "tsx sandbox-agents-as-tools.ts",

--- a/examples/sandbox/shared-session-workdirs.ts
+++ b/examples/sandbox/shared-session-workdirs.ts
@@ -1,0 +1,71 @@
+import { run } from '@openai/agents';
+import { Manifest, SandboxAgent, shell } from '@openai/agents/sandbox';
+import { UnixLocalSandboxClient } from '@openai/agents/sandbox/local';
+import {
+  DEFAULT_MODEL,
+  getStringArg,
+  requireOpenAIKey,
+  runExampleMain,
+} from './support';
+
+function buildManifest() {
+  return new Manifest({
+    entries: {
+      'tasks/a/brief.md': {
+        type: 'file',
+        content: '# Project Alpha\n\nOwner: Ada\n',
+      },
+      'tasks/b/brief.md': {
+        type: 'file',
+        content: '# Project Beta\n\nOwner: Grace\n',
+      },
+      'shared/context.md': {
+        type: 'file',
+        content:
+          'Both projects use the same developer-owned sandbox session.\n',
+      },
+    },
+  });
+}
+
+function buildAgent(name: string, model: string) {
+  return new SandboxAgent({
+    name,
+    model,
+    instructions:
+      'Read brief.md with exec_command, then report the project name and owner in one sentence. Use relative paths.',
+    capabilities: [shell()],
+    modelSettings: { toolChoice: 'required' },
+  });
+}
+
+async function main() {
+  requireOpenAIKey();
+
+  const model = getStringArg('--model', DEFAULT_MODEL);
+  const client = new UnixLocalSandboxClient();
+  const session = await client.create(buildManifest());
+  const alphaAgent = buildAgent('Alpha assistant', model);
+  const betaAgent = buildAgent('Beta assistant', model);
+
+  try {
+    const [alpha, beta] = await Promise.all([
+      run(alphaAgent, 'Summarize your assigned project.', {
+        sandbox: { session, cwd: 'tasks/a' },
+      }),
+      run(betaAgent, 'Summarize your assigned project.', {
+        sandbox: { session, cwd: 'tasks/b' },
+      }),
+    ]);
+
+    console.log(`[tasks/a] ${alpha.finalOutput}`);
+    console.log(`[tasks/b] ${beta.finalOutput}`);
+    console.log(
+      '[note] The working directories change relative path resolution; they are not isolation boundaries.',
+    );
+  } finally {
+    await session.close?.().catch(() => {});
+  }
+}
+
+await runExampleMain(main);

--- a/packages/agents-core/src/sandbox/capabilities/base.ts
+++ b/packages/agents-core/src/sandbox/capabilities/base.ts
@@ -7,6 +7,7 @@ import { SandboxConfigurationError } from '../errors';
 import type { Manifest } from '../manifest';
 import type { SandboxSessionLike } from '../session';
 import type { SandboxUser } from '../users';
+import type { SandboxWorkspaceScope } from '../workspacePaths';
 
 export type CapabilityInstructionsResult =
   string | null | Promise<string | null>;
@@ -18,6 +19,7 @@ export abstract class Capability {
   protected _runAs?: string;
   protected _modelInstance?: Model;
   protected _tracingParent?: Span<any> | Trace;
+  protected _workspaceScope?: SandboxWorkspaceScope;
 
   clone(): this {
     const cloned = Object.create(Object.getPrototypeOf(this)) as this;
@@ -27,7 +29,8 @@ export abstract class Capability {
         key === '_session' ||
         key === '_runAs' ||
         key === '_modelInstance' ||
-        key === '_tracingParent'
+        key === '_tracingParent' ||
+        key === '_workspaceScope'
       ) {
         continue;
       }
@@ -55,6 +58,15 @@ export abstract class Capability {
   bindTracingParent(parent?: Span<any> | Trace): this {
     this._tracingParent = parent;
     return this;
+  }
+
+  bindWorkspaceScope(scope: SandboxWorkspaceScope): this {
+    this._workspaceScope = scope;
+    return this;
+  }
+
+  protected modelResourcePath(manifest: Manifest, path: string): string {
+    return this._workspaceScope?.modelResourcePath(manifest.root, path) ?? path;
   }
 
   protected tracingParent(

--- a/packages/agents-core/src/sandbox/capabilities/filesystem.ts
+++ b/packages/agents-core/src/sandbox/capabilities/filesystem.ts
@@ -27,6 +27,7 @@ import {
   supportsApplyPatchTransport,
   supportsStructuredToolOutputTransport,
 } from './transport';
+import type { SandboxWorkspaceScope } from '../workspacePaths';
 
 export type FilesystemArgs = {
   configureTools?: ConfigureCapabilityTools;
@@ -527,12 +528,15 @@ class FilesystemCapability extends Capability {
 
   override tools(): Tool<any>[] {
     const session = requireBoundSession(this.type, this._session);
-    const editor = session.createEditor?.(this._runAs);
-    if (!editor) {
+    const sessionEditor = session.createEditor?.(this._runAs);
+    if (!sessionEditor) {
       throw new UserError(
         'Filesystem sandbox sessions must provide createEditor().',
       );
     }
+    const editor = this._workspaceScope?.cwd
+      ? scopedEditor(sessionEditor, this._workspaceScope)
+      : sessionEditor;
 
     const tools: Tool<any>[] = [];
     const viewImage = async (
@@ -553,7 +557,7 @@ class FilesystemCapability extends Capability {
           },
           async () =>
             await session.viewImage!({
-              path,
+              path: this._workspaceScope?.anchor(path) ?? path,
               runAs: this._runAs,
             } satisfies ViewImageArgs),
           this.tracingParent(details),
@@ -619,6 +623,32 @@ class FilesystemCapability extends Capability {
 
     return this.configureTools ? this.configureTools([...tools]) : tools;
   }
+}
+
+function scopedEditor(editor: Editor, scope: SandboxWorkspaceScope): Editor {
+  return {
+    createFile: async (operation, context) =>
+      await editor.createFile(
+        { ...operation, path: scope.anchor(operation.path)! },
+        context,
+      ),
+    updateFile: async (operation, context) =>
+      await editor.updateFile(
+        {
+          ...operation,
+          path: scope.anchor(operation.path)!,
+          ...(operation.moveTo
+            ? { moveTo: scope.anchor(operation.moveTo)! }
+            : {}),
+        },
+        context,
+      ),
+    deleteFile: async (operation, context) =>
+      await editor.deleteFile(
+        { ...operation, path: scope.anchor(operation.path)! },
+        context,
+      ),
+  };
 }
 
 export type Filesystem = FilesystemCapability;

--- a/packages/agents-core/src/sandbox/capabilities/memory.ts
+++ b/packages/agents-core/src/sandbox/capabilities/memory.ts
@@ -104,7 +104,7 @@ class MemoryCapability extends Capability {
     return manifest;
   }
 
-  override async instructions(_manifest: Manifest): Promise<string | null> {
+  override async instructions(manifest: Manifest): Promise<string | null> {
     if (this.read === null) {
       return null;
     }
@@ -124,7 +124,7 @@ class MemoryCapability extends Capability {
     }
 
     return renderMemoryReadPrompt({
-      memoryDir: this.layout.memoriesDir,
+      memoryDir: this.modelResourcePath(manifest, this.layout.memoriesDir),
       memorySummary,
       liveUpdate: Boolean(this.read.liveUpdate),
     });

--- a/packages/agents-core/src/sandbox/capabilities/shell.ts
+++ b/packages/agents-core/src/sandbox/capabilities/shell.ts
@@ -122,7 +122,7 @@ class ShellCapability extends Capability {
             async () =>
               await session.execCommand!({
                 cmd,
-                workdir,
+                workdir: this._workspaceScope?.anchor(workdir) ?? workdir,
                 shell,
                 login,
                 tty,

--- a/packages/agents-core/src/sandbox/capabilities/skills.ts
+++ b/packages/agents-core/src/sandbox/capabilities/skills.ts
@@ -122,7 +122,10 @@ class SkillsCapability extends Capability {
             return {
               status: 'already_loaded',
               skill_name: match.name,
-              path: destinationPath,
+              path: this.modelResourcePath(
+                session.state.manifest,
+                destinationPath,
+              ),
             };
           }
 
@@ -138,7 +141,10 @@ class SkillsCapability extends Capability {
           return {
             status: 'loaded',
             skill_name: match.name,
-            path: destinationPath,
+            path: this.modelResourcePath(
+              session.state.manifest,
+              destinationPath,
+            ),
           };
         },
       }),
@@ -197,9 +203,14 @@ class SkillsCapability extends Capability {
       this,
       await this.resolveRuntimeMetadata(manifest),
       manifest,
-    );
+    ).map((skill) => ({
+      ...skill,
+      path: this.modelResourcePath(manifest, skill.path ?? skill.name),
+    }));
     if (metadata.length === 0 && this.from) {
-      return renderSkillsDiscoveryInstructions(this.skillsPath);
+      return renderSkillsDiscoveryInstructions(
+        this.modelResourcePath(manifest, this.skillsPath),
+      );
     }
     if (metadata.length === 0) {
       return null;

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -147,6 +147,10 @@ export type SandboxRunConfig<
   snapshot?: SnapshotSpec;
   concurrencyLimits?: SandboxConcurrencyLimits;
   archiveLimits?: SandboxArchiveLimits | null;
+  /**
+   * Workspace-relative POSIX working directory for built-in sandbox tools in this run.
+   */
+  cwd?: string;
 };
 
 export function normalizeSandboxClientCreateArgs<

--- a/packages/agents-core/src/sandbox/internal.ts
+++ b/packages/agents-core/src/sandbox/internal.ts
@@ -95,6 +95,7 @@ export {
 export { shellQuote } from './shared/shell';
 export {
   isSandboxPathNotFoundError,
+  probeSandboxDirectoryExists,
   probeSandboxPathExists,
   type SandboxPathProbeResult,
 } from './shared/pathProbe';

--- a/packages/agents-core/src/sandbox/runtime/agentPreparation.ts
+++ b/packages/agents-core/src/sandbox/runtime/agentPreparation.ts
@@ -16,6 +16,7 @@ import {
   renderRemoteMountPolicyInstructions,
 } from './prompts';
 import { manifestWithRunAsUser, sandboxRunAsName } from './runAsManifest';
+import { SandboxWorkspaceScope } from '../workspacePaths';
 
 export { getDefaultSandboxInstructions } from './prompts';
 
@@ -26,6 +27,7 @@ type PrepareSandboxAgentArgs<TContext, TOutput extends AgentOutputType> = {
   runConfigModel?: SandboxRuntimeModel;
   processManifest?: boolean;
   tracingParent?: Span<any> | Trace;
+  workspaceScope?: SandboxWorkspaceScope;
 };
 
 export type ResolvedSandboxRuntimeModel = {
@@ -48,6 +50,7 @@ export function prepareSandboxAgent<TContext, TOutput extends AgentOutputType>({
   runConfigModel,
   processManifest = true,
   tracingParent,
+  workspaceScope = new SandboxWorkspaceScope(),
 }: PrepareSandboxAgentArgs<TContext, TOutput>): SandboxAgent<
   TContext,
   TOutput
@@ -63,7 +66,8 @@ export function prepareSandboxAgent<TContext, TOutput extends AgentOutputType>({
       .bind(session)
       .bindRunAs(agent.runAs)
       .bindModel(resolvedModel, resolvedModelInstance)
-      .bindTracingParent(tracingParent),
+      .bindTracingParent(tracingParent)
+      .bindWorkspaceScope(workspaceScope),
   );
   const boundCapabilityTypes = new Set(
     boundCapabilities.map((capability) => capability.type),
@@ -171,7 +175,9 @@ export function prepareSandboxAgent<TContext, TOutput extends AgentOutputType>({
         );
       }
 
-      segments.push(renderFilesystemInstructions(runtimeManifest));
+      segments.push(
+        renderFilesystemInstructions(runtimeManifest, workspaceScope),
+      );
 
       return segments.join('\n\n');
     },

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -95,6 +95,7 @@ import {
 } from './sessionState';
 import { withSandboxSpan } from './spans';
 import { manifestWithRunAsUser, sandboxRunAsName } from './runAsManifest';
+import { SandboxWorkspaceScope } from '../workspacePaths';
 
 type SandboxPreparedAgent<TContext> = {
   executionAgent: Agent<TContext, AgentOutputType>;
@@ -131,6 +132,7 @@ const sandboxAgentIdentitiesByRunState = new WeakMap<
 
 export class SandboxRuntimeManager<TContext> {
   private readonly sandboxConfig?: SandboxRunConfig;
+  private readonly workspaceScope: SandboxWorkspaceScope;
   private readonly runState?: RunState<
     TContext,
     Agent<TContext, AgentOutputType>
@@ -177,6 +179,7 @@ export class SandboxRuntimeManager<TContext> {
     runState?: RunState<TContext, Agent<TContext, AgentOutputType>>;
   }) {
     this.sandboxConfig = args.sandboxConfig;
+    this.workspaceScope = new SandboxWorkspaceScope(args.sandboxConfig?.cwd);
     this.runState = args.runState;
     const existingIdentityRegistry = args.runState
       ? sandboxAgentIdentitiesByRunState.get(args.runState)
@@ -225,6 +228,10 @@ export class SandboxRuntimeManager<TContext> {
       async (prepareSpan) => {
         this.acquireAgent(currentAgent);
         const session = await this.ensureSession(currentAgent, prepareSpan);
+        await this.ensureWorkspaceScopeAccessible(
+          session,
+          sandboxRunAsName(currentAgent.runAs),
+        );
         // Bind a clone to the live session so capability tools and instructions can carry
         // per-session state without mutating the public SandboxAgent instance.
         const executionAgent = this.getPreparedAgent(
@@ -1004,11 +1011,34 @@ export class SandboxRuntimeManager<TContext> {
       runConfigModel,
       processManifest: false,
       tracingParent,
+      workspaceScope: this.workspaceScope,
     });
     this.preparedAgents.set(agentId, prepared);
     this.preparedSessions.set(agentId, session);
     this.preparedManifestSignatures.set(agentId, manifestSignature);
     return prepared;
+  }
+
+  private async ensureWorkspaceScopeAccessible(
+    session: SandboxSessionLike<SandboxSessionState>,
+    runAs?: string,
+  ): Promise<void> {
+    const cwd = this.workspaceScope.cwd;
+    if (cwd === undefined) {
+      return;
+    }
+    if (!session.directoryExists) {
+      throw new UserError(
+        'Sandbox sessions used with sandbox.cwd must provide directoryExists().',
+      );
+    }
+
+    const accessible = await session.directoryExists(cwd, runAs);
+    if (!accessible) {
+      throw new UserError(
+        `Sandbox working directory "${cwd}" does not exist or is not accessible.`,
+      );
+    }
   }
 
   private async resumeSessionForAgent(

--- a/packages/agents-core/src/sandbox/runtime/prompts.ts
+++ b/packages/agents-core/src/sandbox/runtime/prompts.ts
@@ -1,6 +1,7 @@
 import { renderManifestDescription } from '../manifest';
 import type { Manifest } from '../manifest';
 import { WorkspacePathPolicy } from '../workspacePaths';
+import type { SandboxWorkspaceScope } from '../workspacePaths';
 
 const DEFAULT_SANDBOX_INSTRUCTIONS = prompt`
 You are operating inside an isolated sandbox workspace.
@@ -41,12 +42,24 @@ export function getDefaultSandboxInstructions(): string {
   return DEFAULT_SANDBOX_INSTRUCTIONS;
 }
 
-export function renderFilesystemInstructions(manifest: Manifest): string {
+export function renderFilesystemInstructions(
+  manifest: Manifest,
+  workspaceScope?: SandboxWorkspaceScope,
+): string {
+  const absoluteCwd = workspaceScope?.absoluteCwd(manifest.root);
+  const runCwdInstructions = absoluteCwd
+    ? prompt`
+For this run, the working directory is \`${absoluteCwd}\`.
+Relative paths passed to the built-in \`exec_command\`, \`view_image\`, and \`apply_patch\` tools resolve from this directory. Other sandbox tools follow their own path contract.
+The session workspace root remains \`${manifest.root}\`. The working directory changes path resolution; it does not isolate this run from the rest of the session workspace. Files outside the working directory may be visible to or shared with other runs.
+`
+    : '';
   return prompt`
 # Filesystem
 You have access to a container with a filesystem. The filesystem layout is:
 
 ${renderManifestDescription(manifest, { depth: 3 }).text}
+${runCwdInstructions}
 `;
 }
 

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -135,7 +135,10 @@ import {
 import { resolveFallbackShellCommand } from './shared/shellCommand';
 import { shellQuote } from '../shared/shell';
 import { normalizePosixPath } from '../shared/posixPath';
-import { probeSandboxPathExists } from '../shared/pathProbe';
+import {
+  probeSandboxDirectoryExists,
+  probeSandboxPathExists,
+} from '../shared/pathProbe';
 import {
   deserializeLocalSandboxSessionStateValues,
   normalizeExposedPorts,
@@ -240,6 +243,25 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     }
     const absolutePath = this.resolveContainerFilesystemPath(path);
     return await probeSandboxPathExists({
+      path: absolutePath,
+      runCommand: async (command) =>
+        await this.runDockerFilesystemCommand(command, { runAs }),
+    });
+  }
+
+  override async directoryExists(
+    path: string,
+    runAs?: string,
+  ): Promise<boolean> {
+    const requiresContainerProbe = Boolean(
+      dockerVolumeMountContainingPath(this.state.manifest, path) ||
+      this.pathRequiresDockerFilesystem(path),
+    );
+    if (!runAs && !requiresContainerProbe) {
+      return await super.directoryExists(path);
+    }
+    const absolutePath = this.resolveContainerFilesystemPath(path);
+    return await probeSandboxDirectoryExists({
       path: absolutePath,
       runCommand: async (command) =>
         await this.runDockerFilesystemCommand(command, { runAs }),

--- a/packages/agents-core/src/sandbox/sandboxes/shared/runProcess.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/runProcess.ts
@@ -12,6 +12,8 @@ export type SandboxProcessResult = {
 export type RunSandboxProcessOptions = {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  uid?: number;
+  gid?: number;
   timeoutMs?: number;
   maxOutputBytes?: number;
 };
@@ -40,6 +42,8 @@ export async function runSandboxProcess(
     const child = spawn(command, args, {
       cwd: options.cwd,
       env: options.env,
+      uid: options.uid,
+      gid: options.gid,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
@@ -53,6 +53,7 @@ import {
   SandboxConfigurationError,
   SandboxUnsupportedFeatureError,
 } from '../errors';
+import { probeSandboxDirectoryExists } from '../shared/pathProbe';
 import {
   WorkspacePathPolicy,
   type ResolveSandboxPathOptions,
@@ -388,6 +389,20 @@ export class UnixLocalSandboxSession<
     this.assertSessionUsable();
     await this.resolveFilesystemRunAs(runAs);
     return await pathExists(this.resolveSandboxPath(path));
+  }
+
+  async directoryExists(path: string, runAs?: string): Promise<boolean> {
+    this.assertSessionUsable();
+    const identity = await this.resolveCommandRunAs(runAs);
+    const resolvedPath = this.resolveSandboxPath(path);
+    return await probeSandboxDirectoryExists({
+      path: resolvedPath,
+      runCommand: async (command) =>
+        await runSandboxProcess('/bin/sh', ['-c', command], {
+          timeoutMs: RUN_AS_LOOKUP_TIMEOUT_MS,
+          ...(identity ? { uid: identity.uid, gid: identity.gid } : {}),
+        }),
+    });
   }
 
   async readFile(args: ReadFileArgs): Promise<Uint8Array> {

--- a/packages/agents-core/src/sandbox/session.ts
+++ b/packages/agents-core/src/sandbox/session.ts
@@ -203,6 +203,7 @@ export interface SandboxSession<
   readFile?(args: ReadFileArgs): Promise<string | Uint8Array>;
   listDir?(args: ListDirectoryArgs): Promise<SandboxDirectoryEntry[]>;
   pathExists?(path: string, runAs?: string): Promise<boolean>;
+  directoryExists?(path: string, runAs?: string): Promise<boolean>;
   materializeEntry?(args: MaterializeEntryArgs): Promise<void>;
   applyManifest?(manifest: Manifest, runAs?: string): Promise<void>;
   persistWorkspace?(): Promise<Uint8Array>;

--- a/packages/agents-core/src/sandbox/shared/pathProbe.ts
+++ b/packages/agents-core/src/sandbox/shared/pathProbe.ts
@@ -180,6 +180,30 @@ export async function probeSandboxPathExists(
   throw createPathProbeError(options, result);
 }
 
+export async function probeSandboxDirectoryExists(
+  options: SandboxPathProbeOptions,
+): Promise<boolean> {
+  if (!(await probeSandboxPathExists(options))) {
+    return false;
+  }
+
+  const result = await options.runCommand(
+    `test -d ${shellQuote(options.path)} && test -x ${shellQuote(options.path)}`,
+  );
+  if (result.status === 0 && !hasProcessFailure(result)) {
+    return true;
+  }
+  if (
+    result.status === 1 &&
+    !hasProcessFailure(result) &&
+    !result.stdout?.trim() &&
+    !result.stderr?.trim()
+  ) {
+    return false;
+  }
+  throw createPathProbeError(options, result);
+}
+
 function hasProcessFailure(result: SandboxPathProbeResult): boolean {
   return Boolean(result.timedOut || result.signal || result.error);
 }

--- a/packages/agents-core/src/sandbox/workspacePaths.ts
+++ b/packages/agents-core/src/sandbox/workspacePaths.ts
@@ -29,6 +29,73 @@ export type ResolvedSandboxPath = {
   grant?: SandboxPathGrant;
 };
 
+export class SandboxWorkspaceScope {
+  readonly cwd?: string;
+
+  constructor(cwd?: string) {
+    this.cwd = cwd === undefined ? undefined : normalizeSandboxCwd(cwd);
+  }
+
+  static fromCwd(cwd?: string): SandboxWorkspaceScope {
+    return new SandboxWorkspaceScope(cwd);
+  }
+
+  anchor(path?: string): string | undefined {
+    if (this.cwd === undefined) {
+      return path;
+    }
+    const trimmed = path?.trim() ?? '';
+    if (!trimmed) {
+      return this.cwd;
+    }
+    if (trimmed.startsWith('/')) {
+      return trimmed;
+    }
+    return `${this.cwd}/${trimmed}`;
+  }
+
+  modelResourcePath(workspaceRoot: string, path: string): string {
+    if (this.cwd === undefined) {
+      return path;
+    }
+    const normalizedRoot = normalizeWorkspaceRoot(workspaceRoot);
+    const normalizedPath = normalizeWorkspaceRelativeResourcePath(path);
+    return normalizedPath
+      ? joinPosixPath(normalizedRoot, normalizedPath)
+      : normalizedRoot;
+  }
+
+  absoluteCwd(workspaceRoot: string): string | undefined {
+    return this.cwd === undefined
+      ? undefined
+      : this.modelResourcePath(workspaceRoot, this.cwd);
+  }
+}
+
+export function normalizeSandboxCwd(cwd: string): string {
+  if (typeof cwd !== 'string') {
+    throw new UserError('sandbox.cwd must be a string.');
+  }
+  const trimmed = cwd.trim();
+  if (!trimmed) {
+    throw new UserError('sandbox.cwd must be non-empty.');
+  }
+  if (hasBackslashPathSeparator(cwd)) {
+    throw new UserError('sandbox.cwd must use POSIX path separators.');
+  }
+  if (trimmed.startsWith('/')) {
+    throw new UserError('sandbox.cwd must be workspace-relative.');
+  }
+  if (hasParentPathSegment(cwd)) {
+    throw new UserError('sandbox.cwd must not contain parent segments.');
+  }
+  const normalized = normalizePosixPath(trimmed);
+  if (normalized === '.') {
+    throw new UserError('sandbox.cwd must be non-empty.');
+  }
+  return normalized;
+}
+
 export class WorkspacePathPolicy {
   readonly root: string;
   readonly extraPathGrants: SandboxPathGrant[];
@@ -111,6 +178,46 @@ function joinPosixPath(root: string, relativePath: string): string {
     return normalizePosixPath(root);
   }
   return normalizePosixPath(`${root.replace(/\/+$/u, '')}/${relativePath}`);
+}
+
+function normalizeWorkspaceRoot(root: string): string {
+  if (hasBackslashPathSeparator(root)) {
+    throw new UserError(
+      'Sandbox workspace root must use POSIX path separators.',
+    );
+  }
+  if (hasParentPathSegment(root)) {
+    throw new UserError(
+      'Sandbox workspace root must not contain parent segments.',
+    );
+  }
+  const normalized = normalizePosixPath(root);
+  if (!normalized.startsWith('/')) {
+    throw new UserError('Sandbox workspace root must be POSIX absolute.');
+  }
+  return normalized;
+}
+
+function normalizeWorkspaceRelativeResourcePath(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) {
+    throw new UserError('Sandbox resource path must be non-empty.');
+  }
+  if (hasBackslashPathSeparator(path)) {
+    throw new UserError(
+      'Sandbox resource path must use POSIX path separators.',
+    );
+  }
+  if (trimmed.startsWith('/')) {
+    throw new UserError('Sandbox resource path must be workspace-relative.');
+  }
+  if (hasParentPathSegment(path)) {
+    throw new UserError(
+      'Sandbox resource path must not contain parent segments.',
+    );
+  }
+  const normalized = normalizePosixPath(trimmed);
+  return normalized === '.' ? '' : normalized;
 }
 
 function normalizeSandboxPath(path: string, originalPath: string): string {

--- a/packages/agents-core/src/testing/scriptedSandboxSession.ts
+++ b/packages/agents-core/src/testing/scriptedSandboxSession.ts
@@ -214,6 +214,7 @@ const sandboxMethodModes = {
   readFile: 'async',
   listDir: 'async',
   pathExists: 'async',
+  directoryExists: 'async',
   materializeEntry: 'async',
   applyManifest: 'async',
   persistWorkspace: 'async',

--- a/packages/agents-core/test/sandboxPathProbe.test.ts
+++ b/packages/agents-core/test/sandboxPathProbe.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../src/sandbox';
 import {
   isSandboxPathNotFoundError,
+  probeSandboxDirectoryExists,
   probeSandboxPathExists,
 } from '../src/sandbox/shared/pathProbe';
 import { shellQuote } from '../src/sandbox/shared/shell';
@@ -47,6 +48,58 @@ describe('sandbox path probes', () => {
     ).resolves.toBe(true);
     expect(runCommand).toHaveBeenCalledOnce();
     expect(runCommand).toHaveBeenCalledWith("test -e '/workspace/exists'");
+  });
+
+  it('distinguishes directories from other existing paths', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 0 })
+      .mockResolvedValueOnce({ status: 1 });
+
+    await expect(
+      probeSandboxDirectoryExists({ path: '/workspace/file', runCommand }),
+    ).resolves.toBe(false);
+    expect(runCommand.mock.calls.map(([command]) => command)).toEqual([
+      "test -e '/workspace/file'",
+      "test -d '/workspace/file' && test -x '/workspace/file'",
+    ]);
+  });
+
+  it('rejects a directory that the execution identity cannot enter', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 0 })
+      .mockResolvedValueOnce({ status: 1 });
+
+    await expect(
+      probeSandboxDirectoryExists({ path: '/workspace/blocked', runCommand }),
+    ).resolves.toBe(false);
+    expect(runCommand).toHaveBeenLastCalledWith(
+      "test -d '/workspace/blocked' && test -x '/workspace/blocked'",
+    );
+  });
+
+  it('preserves failures from the directory-specific probe', async () => {
+    const failure = new Error('provider unavailable');
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 0 })
+      .mockRejectedValueOnce(failure);
+
+    await expect(
+      probeSandboxDirectoryExists({ path: '/workspace/tasks', runCommand }),
+    ).rejects.toBe(failure);
+  });
+
+  it('rejects diagnostics from a negative directory-specific probe', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 0 })
+      .mockResolvedValueOnce({ status: 1, stderr: 'authentication expired' });
+
+    await expect(
+      probeSandboxDirectoryExists({ path: '/workspace/tasks', runCommand }),
+    ).rejects.toBeInstanceOf(SandboxWorkspaceArchiveReadError);
   });
 
   it('diagnoses ambiguous missing-path probe results', async () => {

--- a/packages/agents-core/test/sandboxRunCwd.test.ts
+++ b/packages/agents-core/test/sandboxRunCwd.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest';
+import { RunContext } from '../src';
+import {
+  Manifest,
+  memory,
+  SandboxAgent,
+  SandboxRuntimeManager,
+  SandboxWorkspaceScope,
+  skills,
+} from '../src/sandbox';
+import { scriptedSandboxSession } from '../src/testing';
+
+describe('sandbox run cwd', () => {
+  it('keeps concurrent run scopes independent on a shared session', async () => {
+    const probedPaths: string[] = [];
+    const session = {
+      state: { manifest: new Manifest({ root: '/workspace' }) },
+      directoryExists: async (path: string) => {
+        await Promise.resolve();
+        probedPaths.push(path);
+        return true;
+      },
+    } as any;
+    const agents = ['sandbox-a', 'sandbox-b'].map(
+      (name) => new SandboxAgent({ name, capabilities: [] }),
+    );
+    const managers = ['tasks/a', 'tasks/b'].map(
+      (cwd, index) =>
+        new SandboxRuntimeManager({
+          startingAgent: agents[index] as any,
+          sandboxConfig: { session, cwd },
+        }),
+    );
+
+    const preparedAgents = await Promise.all(
+      managers.map((manager, index) =>
+        manager.prepareAgent({
+          currentAgent: agents[index] as any,
+          turnInput: [],
+        }),
+      ),
+    );
+    const prompts = await Promise.all(
+      preparedAgents.map(({ executionAgent }) =>
+        executionAgent.getSystemPrompt(new RunContext()),
+      ),
+    );
+
+    expect(probedPaths.sort()).toEqual(['tasks/a', 'tasks/b']);
+    expect(prompts[0]).toContain('/workspace/tasks/a');
+    expect(prompts[1]).toContain('/workspace/tasks/b');
+  });
+
+  it('validates a provided session cwd before preparing the agent', async () => {
+    const session = scriptedSandboxSession([
+      { method: 'directoryExists', result: true },
+    ]);
+    session.state.manifest = new Manifest({ root: '/workspace' });
+    const agent = new SandboxAgent({ name: 'sandbox', capabilities: [] });
+    const manager = new SandboxRuntimeManager({
+      startingAgent: agent as any,
+      sandboxConfig: { session, cwd: 'tasks/a' },
+    });
+
+    const prepared = await manager.prepareAgent({
+      currentAgent: agent as any,
+      turnInput: [],
+    });
+    const prompt = await prepared.executionAgent.getSystemPrompt(
+      new RunContext(),
+    );
+
+    expect(session.calls[0]).toMatchObject({
+      method: 'directoryExists',
+      args: ['tasks/a', undefined],
+    });
+    expect(prompt).toContain(
+      'For this run, the working directory is `/workspace/tasks/a`.',
+    );
+    expect(prompt).toContain(
+      'The working directory changes path resolution; it does not isolate this run',
+    );
+    session.assertComplete();
+  });
+
+  it('rejects an inaccessible cwd before agent preparation', async () => {
+    const session = {
+      state: { manifest: new Manifest({ root: '/workspace' }) },
+      directoryExists: async () => false,
+    } as any;
+    const agent = new SandboxAgent({ name: 'sandbox', capabilities: [] });
+    const manager = new SandboxRuntimeManager({
+      startingAgent: agent as any,
+      sandboxConfig: { session, cwd: 'tasks/missing' },
+    });
+
+    await expect(
+      manager.prepareAgent({ currentAgent: agent as any, turnInput: [] }),
+    ).rejects.toThrow(
+      'Sandbox working directory "tasks/missing" does not exist or is not accessible.',
+    );
+  });
+
+  it('rejects sessions without completed path probe APIs', async () => {
+    let execCommandCalls = 0;
+    const session = {
+      state: { manifest: new Manifest({ root: '/workspace' }) },
+      execCommand: async () => {
+        execCommandCalls += 1;
+        return 'Process running with session ID 1';
+      },
+    } as any;
+    const agent = new SandboxAgent({ name: 'sandbox', capabilities: [] });
+    const manager = new SandboxRuntimeManager({
+      startingAgent: agent as any,
+      sandboxConfig: { session, cwd: 'tasks/a' },
+    });
+
+    await expect(
+      manager.prepareAgent({ currentAgent: agent as any, turnInput: [] }),
+    ).rejects.toThrow(
+      'Sandbox sessions used with sandbox.cwd must provide directoryExists().',
+    );
+    expect(execCommandCalls).toBe(0);
+  });
+
+  it('preserves path probe errors and does not cache failures', async () => {
+    const providerError = Object.assign(new Error('credentials expired'), {
+      code: 'SANDBOX_AUTH_EXPIRED',
+      retryable: true,
+    });
+    let attempts = 0;
+    const session = {
+      state: { manifest: new Manifest({ root: '/workspace' }) },
+      directoryExists: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          throw providerError;
+        }
+        return true;
+      },
+    } as any;
+    const agent = new SandboxAgent({ name: 'sandbox', capabilities: [] });
+    const manager = new SandboxRuntimeManager({
+      startingAgent: agent as any,
+      sandboxConfig: { session, cwd: 'tasks/a' },
+    });
+
+    await expect(
+      manager.prepareAgent({ currentAgent: agent as any, turnInput: [] }),
+    ).rejects.toBe(providerError);
+    await manager.prepareAgent({ currentAgent: agent as any, turnInput: [] });
+
+    expect(attempts).toBe(2);
+  });
+
+  it('preserves directory probe errors', async () => {
+    const providerError = Object.assign(new Error('backend timed out'), {
+      code: 'SANDBOX_TIMEOUT',
+      retryable: true,
+    });
+    const session = scriptedSandboxSession([
+      { method: 'directoryExists', error: providerError },
+    ]);
+    session.state.manifest = new Manifest({ root: '/workspace' });
+    const agent = new SandboxAgent({ name: 'sandbox', capabilities: [] });
+    const manager = new SandboxRuntimeManager({
+      startingAgent: agent as any,
+      sandboxConfig: { session, cwd: 'tasks/a' },
+    });
+
+    await expect(
+      manager.prepareAgent({ currentAgent: agent as any, turnInput: [] }),
+    ).rejects.toBe(providerError);
+    session.assertComplete();
+  });
+
+  it('revalidates cwd before a later model turn', async () => {
+    let attempts = 0;
+    const session = {
+      state: { manifest: new Manifest({ root: '/workspace' }) },
+      directoryExists: async () => {
+        attempts += 1;
+        return attempts === 1;
+      },
+    } as any;
+    const agent = new SandboxAgent({ name: 'sandbox', capabilities: [] });
+    const manager = new SandboxRuntimeManager({
+      startingAgent: agent as any,
+      sandboxConfig: { session, cwd: 'tasks/a' },
+    });
+
+    await manager.prepareAgent({ currentAgent: agent as any, turnInput: [] });
+    await expect(
+      manager.prepareAgent({ currentAgent: agent as any, turnInput: [] }),
+    ).rejects.toThrow(
+      'Sandbox working directory "tasks/a" does not exist or is not accessible.',
+    );
+    expect(attempts).toBe(2);
+  });
+
+  it('keeps Memory and Skills session-owned while rendering stable model paths', async () => {
+    const scope = SandboxWorkspaceScope.fromCwd('tasks/a');
+    const manifest = new Manifest({ root: '/workspace' });
+    const memorySession = scriptedSandboxSession([
+      { method: 'readFile', result: 'remember this' },
+    ]);
+    memorySession.state.manifest = manifest;
+    const memoryCapability = memory({ read: { liveUpdate: false } })
+      .bind(memorySession)
+      .bindWorkspaceScope(scope);
+    const skillsCapability = skills({
+      skills: [
+        {
+          name: 'reviewer',
+          description: 'Review code.',
+          content: '# Reviewer',
+        },
+      ],
+    }).bindWorkspaceScope(scope);
+
+    const memoryInstructions = await memoryCapability.instructions(manifest);
+    const skillsInstructions = await skillsCapability.instructions(manifest);
+
+    expect(memorySession.calls[0]).toMatchObject({
+      method: 'readFile',
+      args: [{ path: 'memories/memory_summary.md' }],
+    });
+    expect(memoryInstructions).toContain(
+      '/workspace/memories/memory_summary.md',
+    );
+    expect(skillsInstructions).toContain('(file: /workspace/.agents/reviewer)');
+    memorySession.assertComplete();
+  });
+});

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -929,6 +929,18 @@ class ClosedHandleSerializedResumeFakeSandboxClient extends SerializedResumeFake
   }
 }
 
+class CwdAwareClosedHandleSerializedResumeFakeSandboxClient extends ClosedHandleSerializedResumeFakeSandboxClient {
+  override makeSession(
+    state: FakeSandboxSessionState,
+  ): SandboxSessionLike<FakeSandboxSessionState> {
+    const session = super.makeSession(state);
+    return {
+      ...session,
+      directoryExists: async () => true,
+    };
+  }
+}
+
 class ShutdownOnlyFakeSandboxClient extends FakeSandboxClient {
   protected override lifecycleHandlers(
     state: FakeSandboxSessionState,
@@ -6380,6 +6392,65 @@ describe('sandbox runner integration', () => {
     expect(client.resumeCalls).toHaveLength(1);
     expect(client.execCommandCalls).toHaveLength(1);
     expect(client.closeCalls).toEqual(['session-1', 'session-1']);
+  });
+
+  it('rebinds an approved shell call to the current cwd after interruption resume', async () => {
+    const client = new CwdAwareClosedHandleSerializedResumeFakeSandboxClient();
+    const sandboxModel = new RecordingModel([
+      modelResponse({
+        output: [
+          {
+            id: 'shell-cwd-approval-1',
+            type: 'function_call',
+            name: 'exec_command',
+            callId: 'shell-cwd-approval-1',
+            status: 'completed',
+            arguments: '{"cmd":"pwd"}',
+          } satisfies protocol.FunctionCallItem,
+        ],
+        usage: new Usage(),
+      }),
+      modelResponse({
+        output: [fakeModelMessage('sandbox done')],
+        usage: new Usage(),
+      }),
+    ]);
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: sandboxModel,
+      capabilities: [
+        shell({
+          configureTools: (tools) =>
+            tools.map((capabilityTool) =>
+              capabilityTool.type === 'function' &&
+              capabilityTool.name === 'exec_command'
+                ? { ...capabilityTool, needsApproval: async () => true }
+                : capabilityTool,
+            ),
+        }),
+      ],
+      defaultManifest: new Manifest({ root: '/workspace' }),
+    });
+    const runner = new Runner();
+
+    const firstResult = await runner.run(sandboxAgent, 'Hello', {
+      sandbox: { client, cwd: 'tasks/a' },
+    });
+    const approval = firstResult.interruptions?.[0];
+    if (!approval) {
+      throw new Error('Expected a shell approval interruption');
+    }
+    firstResult.state.approve(approval);
+
+    const resumedResult = await runner.run(sandboxAgent, firstResult.state, {
+      sandbox: { client, cwd: 'tasks/b' },
+    });
+
+    expect(resumedResult.finalOutput).toBe('sandbox done');
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(client.execCommandCalls).toEqual([
+      expect.objectContaining({ cmd: 'pwd', workdir: 'tasks/b' }),
+    ]);
   });
 
   it('reacquires preserved sessions when host approval completes the run', async () => {

--- a/packages/agents-core/test/sandboxTools.test.ts
+++ b/packages/agents-core/test/sandboxTools.test.ts
@@ -7,6 +7,7 @@ import {
   shell,
   prepareSandboxAgent,
   SandboxAgent,
+  SandboxWorkspaceScope,
 } from '../src/sandbox';
 import {
   ScriptedModel,
@@ -139,6 +140,36 @@ describe('sandbox shell tools', () => {
           },
         ],
       }),
+    ]);
+    session.assertComplete();
+  });
+
+  it('anchors omitted and explicit relative workdirs to the run cwd', async () => {
+    const capability = shell();
+    const session = scriptedSandboxSession([
+      { method: 'execCommand', result: 'default cwd' },
+      { method: 'execCommand', result: 'nested cwd' },
+      { method: 'execCommand', result: 'absolute cwd' },
+    ]);
+    capability
+      .bind(session)
+      .bindWorkspaceScope(SandboxWorkspaceScope.fromCwd('tasks/a'));
+    const execCommand = capability.tools()[0] as any;
+
+    await execCommand.invoke(new RunContext(), JSON.stringify({ cmd: 'pwd' }));
+    await execCommand.invoke(
+      new RunContext(),
+      JSON.stringify({ cmd: 'pwd', workdir: 'reports' }),
+    );
+    await execCommand.invoke(
+      new RunContext(),
+      JSON.stringify({ cmd: 'pwd', workdir: '/workspace/shared' }),
+    );
+
+    expect(session.calls.map((call) => (call.args[0] as any).workdir)).toEqual([
+      'tasks/a',
+      'tasks/a/reports',
+      '/workspace/shared',
     ]);
     session.assertComplete();
   });
@@ -291,6 +322,49 @@ describe('sandbox filesystem tools', () => {
       method: 'viewImage',
       args: [{ path: 'notes.txt', runAs: 'sandbox-user' }],
     });
+    session.assertComplete();
+  });
+
+  it('anchors view_image and apply_patch paths to the run cwd', async () => {
+    const { editor, session } = scriptedFilesystemSession([
+      {
+        method: 'viewImage',
+        result: { type: 'image', image: 'image-ref' },
+      },
+    ]);
+    const capability = filesystem();
+    capability
+      .bind(session)
+      .bindWorkspaceScope(SandboxWorkspaceScope.fromCwd('tasks/a'))
+      .bindModel('gpt-4o', new FakeChatCompletionsModel() as any);
+    const [viewImage, applyPatch] = capability.tools();
+
+    await (viewImage as any).invoke(
+      new RunContext(),
+      JSON.stringify({ path: 'plot.png' }),
+    );
+    await (applyPatch as any).invoke(
+      new RunContext(),
+      JSON.stringify({
+        type: 'update_file',
+        path: 'old.txt',
+        moveTo: 'archive/new.txt',
+        diff: '',
+      }),
+    );
+
+    expect(session.calls[1]).toMatchObject({
+      method: 'viewImage',
+      args: [{ path: 'tasks/a/plot.png' }],
+    });
+    expect(editor.calls).toEqual([
+      {
+        type: 'update_file',
+        path: 'tasks/a/old.txt',
+        moveTo: 'tasks/a/archive/new.txt',
+        diff: '',
+      },
+    ]);
     session.assertComplete();
   });
 

--- a/packages/agents-core/test/sandboxWorkspacePaths.test.ts
+++ b/packages/agents-core/test/sandboxWorkspacePaths.test.ts
@@ -1,8 +1,52 @@
 import { describe, expect, it } from 'vitest';
 import {
   SandboxInvalidManifestPathError,
+  SandboxWorkspaceScope,
   WorkspacePathPolicy,
 } from '../src/sandbox';
+
+describe('SandboxWorkspaceScope', () => {
+  it('anchors relative tool paths without changing absolute paths', () => {
+    const scope = SandboxWorkspaceScope.fromCwd('tasks/a');
+
+    expect(scope.anchor()).toBe('tasks/a');
+    expect(scope.anchor('reports/plot.png')).toBe('tasks/a/reports/plot.png');
+    expect(scope.anchor('/workspace/shared.txt')).toBe('/workspace/shared.txt');
+    expect(scope.modelResourcePath('/workspace', '.agents/reviewer')).toBe(
+      '/workspace/.agents/reviewer',
+    );
+    expect(scope.absoluteCwd('/workspace')).toBe('/workspace/tasks/a');
+  });
+
+  it('preserves root-relative behavior when cwd is omitted', () => {
+    const scope = new SandboxWorkspaceScope();
+
+    expect(scope.anchor('reports/plot.png')).toBe('reports/plot.png');
+    expect(scope.modelResourcePath('/workspace', '.agents/reviewer')).toBe(
+      '.agents/reviewer',
+    );
+    expect(scope.absoluteCwd('/workspace')).toBeUndefined();
+  });
+
+  it.each([
+    ['', /must be non-empty/u],
+    ['.', /must be non-empty/u],
+    ['./', /must be non-empty/u],
+    ['.//', /must be non-empty/u],
+    ['././', /must be non-empty/u],
+    ['/workspace/tasks/a', /must be workspace-relative/u],
+    ['tasks/../a', /must not contain parent segments/u],
+    ['tasks\\a', /must use POSIX path separators/u],
+  ])('rejects invalid cwd %j', (cwd, message) => {
+    expect(() => new SandboxWorkspaceScope(cwd)).toThrow(message);
+  });
+
+  it('rejects non-string cwd values at runtime', () => {
+    expect(() => new SandboxWorkspaceScope(42 as any)).toThrow(
+      'sandbox.cwd must be a string.',
+    );
+  });
+});
 
 describe('WorkspacePathPolicy', () => {
   it('resolves workspace-relative and absolute in-root paths', () => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -394,6 +394,9 @@ describe('DockerSandboxClient unit behavior', () => {
         return failure('unexpected docker command');
       },
     );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
     const client = new DockerSandboxClient({
       workspaceBaseDir: rootDir,
     });
@@ -458,6 +461,21 @@ describe('DockerSandboxClient unit behavior', () => {
       }),
     );
 
+    await expect(session.directoryExists('r2logs')).resolves.toBe(true);
+    expect(childProcessMocks.spawn).toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining([
+        'exec',
+        '-i',
+        '-w',
+        '/',
+        'container-123',
+        '/bin/sh',
+        '-lc',
+        "test -d '/workspace/r2logs' && test -x '/workspace/r2logs'",
+      ]),
+      expect.any(Object),
+    );
     await expect(session.pathExists('r2logs/app.log')).rejects.toThrow(
       /Docker volume mount path/,
     );

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -64,7 +64,10 @@ import {
   truncateOutput,
 } from '../shared/output';
 import { assertConfiguredExposedPort } from '../shared/ports';
-import { probeRemoteSandboxPathExists } from '../shared/pathProbe';
+import {
+  probeRemoteSandboxDirectoryExists,
+  probeRemoteSandboxPathExists,
+} from '../shared/pathProbe';
 import {
   addPtyWebSocketListener,
   appendPtyOutput,
@@ -95,6 +98,7 @@ import {
   manifestMaterializationOptionsWithRunAs,
   readRunAsRemoteFile,
   runAsRemotePathExists,
+  runAsRemoteDirectoryExists,
   sandboxUserShellCommand,
 } from '../shared/runAs';
 import {
@@ -402,6 +406,34 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       });
     }
     return await runAsRemotePathExists(
+      absolutePath,
+      runAs,
+      this.runAsCommandRunner.bind(this),
+      {
+        providerName: 'CloudflareSandboxClient',
+        providerId: 'cloudflare',
+      },
+    );
+  }
+
+  async directoryExists(path: string, runAs?: string): Promise<boolean> {
+    const absolutePath = await this.resolveRemotePath(path);
+    if (!runAs) {
+      return await probeRemoteSandboxDirectoryExists({
+        providerName: 'CloudflareSandboxClient',
+        providerId: 'cloudflare',
+        path: absolutePath,
+        runCommand: async (command) => {
+          const result = await this.execShell(command);
+          return {
+            status: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          };
+        },
+      });
+    }
+    return await runAsRemoteDirectoryExists(
       absolutePath,
       runAs,
       this.runAsCommandRunner.bind(this),

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -63,6 +63,7 @@ import {
   manifestMaterializationOptionsWithRunAs,
   persistRemoteWorkspaceTar,
   probeRemoteSandboxPathExists,
+  probeRemoteSandboxDirectoryExists,
   assertConfiguredExposedPort,
   getCachedExposedPortEndpoint,
   parseExposedPortEndpoint,
@@ -94,6 +95,7 @@ import {
   type RemoteSandboxPathOptions,
   type RemoteSandboxPathResolver,
   runAsRemotePathExists,
+  runAsRemoteDirectoryExists,
 } from '../shared';
 import {
   assertRcloneMountEnvironmentAuthorityMatches,
@@ -492,6 +494,39 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
       });
     }
     return await runAsRemotePathExists(
+      absolutePath,
+      runAs,
+      this.runAsCommandRunner.bind(this),
+      {
+        providerName: 'DaytonaSandboxClient',
+        providerId: 'daytona',
+      },
+    );
+  }
+
+  async directoryExists(path: string, runAs?: string): Promise<boolean> {
+    this.assertSessionUsable();
+    const absolutePath = await this.resolveRemotePath(path);
+    if (!runAs) {
+      return await probeRemoteSandboxDirectoryExists({
+        providerName: 'DaytonaSandboxClient',
+        providerId: 'daytona',
+        path: absolutePath,
+        runCommand: async (command) => {
+          const result = await this.sandbox.process.executeCommand(
+            command,
+            this.state.manifest.root,
+            this.state.environment,
+            5,
+          );
+          return {
+            status: result.exitCode,
+            stderr: result.exitCode === 0 ? '' : result.result,
+          };
+        },
+      });
+    }
+    return await runAsRemoteDirectoryExists(
       absolutePath,
       runAs,
       this.runAsCommandRunner.bind(this),

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -54,6 +54,7 @@ import {
   materializeEnvironment,
   persistRemoteWorkspaceTar,
   probeRemoteSandboxPathExists,
+  probeRemoteSandboxDirectoryExists,
   providerErrorMessage,
   assertConfiguredExposedPort,
   getCachedExposedPortEndpoint,
@@ -64,6 +65,7 @@ import {
   cloneManifestWithoutMountEntries,
   readRunAsRemoteFile,
   runAsRemotePathExists,
+  runAsRemoteDirectoryExists,
   sandboxUserShellCommand,
   serializeRemoteSandboxSessionState,
   truncateOutput,
@@ -558,6 +560,47 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
       });
     }
     return await runAsRemotePathExists(
+      absolutePath,
+      runAs,
+      this.runAsCommandRunner.bind(this),
+      {
+        providerName: 'ModalSandboxClient',
+        providerId: 'modal',
+      },
+    );
+  }
+
+  async directoryExists(path: string, runAs?: string): Promise<boolean> {
+    const absolutePath = await this.resolveRemotePath(path);
+    if (!runAs) {
+      return await probeRemoteSandboxDirectoryExists({
+        providerName: 'ModalSandboxClient',
+        providerId: 'modal',
+        path: absolutePath,
+        runCommand: async (command) => {
+          const argv = ['/bin/sh', '-c', command];
+          const process = await this.sandbox.exec(argv, {
+            mode: 'text',
+            workdir: this.state.manifest.root,
+            stdout: 'ignore',
+            stderr: 'pipe',
+          });
+          let stderr = '';
+          const stderrPump = startTextStreamPump(process.stderr, (chunk) => {
+            stderr += chunk;
+          });
+          try {
+            const status = await process.wait();
+            await stderrPump.promise;
+            return { status, stderr };
+          } catch (error) {
+            await stderrPump.cancel();
+            throw error;
+          }
+        },
+      });
+    }
+    return await runAsRemoteDirectoryExists(
       absolutePath,
       runAs,
       this.runAsCommandRunner.bind(this),

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -96,13 +96,17 @@ export {
   createRunAsRemoteEditor,
   manifestMaterializationOptionsWithRunAs,
   readRunAsRemoteFile,
+  runAsRemoteDirectoryExists,
   runAsRemotePathExists,
   sandboxUserShellCommand,
   writeRunAsRemoteText,
   type RemoteRunAsCommandResult,
   type RemoteRunAsCommandRunner,
 } from './runAs';
-export { probeRemoteSandboxPathExists } from './pathProbe';
+export {
+  probeRemoteSandboxDirectoryExists,
+  probeRemoteSandboxPathExists,
+} from './pathProbe';
 export {
   RemoteSandboxSessionBase,
   type RemoteSandboxCommandKind,

--- a/packages/agents-extensions/src/sandbox/shared/pathProbe.ts
+++ b/packages/agents-extensions/src/sandbox/shared/pathProbe.ts
@@ -1,5 +1,6 @@
 import { SandboxProviderError } from '@openai/agents-core/sandbox';
 import {
+  probeSandboxDirectoryExists,
   probeSandboxPathExists,
   type SandboxPathProbeResult,
 } from '@openai/agents-core/sandbox/internal';
@@ -13,20 +14,38 @@ export async function probeRemoteSandboxPathExists(args: {
   return await probeSandboxPathExists({
     path: args.path,
     runCommand: args.runCommand,
-    createError: (result) => {
-      const diagnostic = result.stderr?.trim() ?? '';
-      const suffix = diagnostic ? `: ${diagnostic}` : '';
-      return new SandboxProviderError(
-        `${args.providerName} failed to check path ${args.path}${suffix}`,
-        {
-          provider: args.providerId,
-          path: args.path,
-          status: result.status,
-          signal: result.signal,
-          timedOut: result.timedOut,
-          stdoutBytes: result.stdout?.length ?? 0,
-        },
-      );
-    },
+    createError: (result) => createRemotePathProbeError(args, result),
   });
+}
+
+export async function probeRemoteSandboxDirectoryExists(args: {
+  providerName: string;
+  providerId: string;
+  path: string;
+  runCommand: (command: string) => Promise<SandboxPathProbeResult>;
+}): Promise<boolean> {
+  return await probeSandboxDirectoryExists({
+    path: args.path,
+    runCommand: args.runCommand,
+    createError: (result) => createRemotePathProbeError(args, result),
+  });
+}
+
+function createRemotePathProbeError(
+  args: { providerName: string; providerId: string; path: string },
+  result: SandboxPathProbeResult,
+): Error {
+  const diagnostic = result.stderr?.trim() ?? '';
+  const suffix = diagnostic ? `: ${diagnostic}` : '';
+  return new SandboxProviderError(
+    `${args.providerName} failed to check path ${args.path}${suffix}`,
+    {
+      provider: args.providerId,
+      path: args.path,
+      status: result.status,
+      signal: result.signal,
+      timedOut: result.timedOut,
+      stdoutBytes: result.stdout?.length ?? 0,
+    },
+  );
 }

--- a/packages/agents-extensions/src/sandbox/shared/runAs.ts
+++ b/packages/agents-extensions/src/sandbox/shared/runAs.ts
@@ -2,7 +2,10 @@ import { SandboxProviderError, type Entry } from '@openai/agents-core/sandbox';
 import { RemoteSandboxEditor } from './editor';
 import type { ManifestMaterializationOptions } from './manifest';
 import { sandboxEntryPermissionsMode } from './metadata';
-import { probeRemoteSandboxPathExists } from './pathProbe';
+import {
+  probeRemoteSandboxDirectoryExists,
+  probeRemoteSandboxPathExists,
+} from './pathProbe';
 import { shellQuote } from './paths';
 import type {
   RemoteManifestWriter,
@@ -136,6 +139,25 @@ export async function runAsRemotePathExists(
   },
 ): Promise<boolean> {
   return await probeRemoteSandboxPathExists({
+    ...provider,
+    path,
+    runCommand: async (command) => await runCommand(command, { runAs }),
+  });
+}
+
+export async function runAsRemoteDirectoryExists(
+  path: string,
+  runAs: string | undefined,
+  runCommand: RemoteRunAsCommandRunner,
+  provider: {
+    providerName: string;
+    providerId: string;
+  } = {
+    providerName: 'RemoteSandboxClient',
+    providerId: 'remote',
+  },
+): Promise<boolean> {
+  return await probeRemoteSandboxDirectoryExists({
     ...provider,
     path,
     runCommand: async (command) => await runCommand(command, { runAs }),

--- a/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionBase.ts
@@ -66,7 +66,10 @@ import {
   parseExposedPortEndpoint,
   recordResolvedExposedPortEndpoint,
 } from './ports';
-import { probeRemoteSandboxPathExists } from './pathProbe';
+import {
+  probeRemoteSandboxDirectoryExists,
+  probeRemoteSandboxPathExists,
+} from './pathProbe';
 import { assertRunAsUnsupported } from './session';
 import {
   assertRemoteSandboxSessionStateUsable,
@@ -211,6 +214,23 @@ export abstract class RemoteSandboxSessionBase<
     this.assertFilesystemRunAs(runAs);
     const absolutePath = await this.resolveRemotePath(path);
     return await probeRemoteSandboxPathExists({
+      providerName: this.providerName,
+      providerId: this.providerId,
+      path: absolutePath,
+      runCommand: async (command) =>
+        await this.runRemoteCommand(command, {
+          kind: 'path',
+          workdir: this.state.manifest.root,
+          runAs,
+        }),
+    });
+  }
+
+  async directoryExists(path: string, runAs?: string): Promise<boolean> {
+    this.assertSessionUsable();
+    this.assertFilesystemRunAs(runAs);
+    const absolutePath = await this.resolveRemotePath(path);
+    return await probeRemoteSandboxDirectoryExists({
       providerName: this.providerName,
       providerId: this.providerId,
       path: absolutePath,

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -300,6 +300,7 @@ describe('CloudflareSandboxClient', () => {
 
     expect(() => session.createEditor('root')).not.toThrow();
     await expect(session.pathExists('README.md', 'root')).resolves.toBe(true);
+    await expect(session.directoryExists('.', 'root')).resolves.toBe(true);
 
     expect(
       vi

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -166,6 +166,7 @@ describe('DaytonaSandboxClient', () => {
 
     expect(() => session.createEditor('root')).not.toThrow();
     await expect(session.pathExists('README.md', 'root')).resolves.toBe(true);
+    await expect(session.directoryExists('.', 'root')).resolves.toBe(true);
 
     expect(
       executeCommandMock.mock.calls.some(([command]) =>

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -1166,11 +1166,13 @@ describe('ModalSandboxClient', () => {
       diff: '@@\n-# Hello from Modal\n+# Updated from Modal\n',
     });
     const exists = await session.pathExists('/workspace/README.md');
+    const directoryExists = await session.directoryExists('/workspace');
 
     expect(files.get('/workspace/README.md')).toEqual(
       new TextEncoder().encode('# Updated from Modal\n'),
     );
     expect(exists).toBe(true);
+    expect(directoryExists).toBe(true);
     await expect(
       session.pathExists('/workspace/../tmp/README.md'),
     ).rejects.toThrow(/escapes the workspace root/);

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -56,6 +56,7 @@ import {
   resolveSandboxAbsolutePath,
   resolveSandboxRelativePath,
   resolveSandboxWorkdir,
+  runAsRemoteDirectoryExists,
   runAsRemotePathExists,
   sandboxUserShellCommand,
   serializeRemoteSandboxSessionState,
@@ -2377,6 +2378,13 @@ describe('remote sandbox path helpers', () => {
     await expect(
       runAsRemotePathExists('/workspace/missing', 'sandbox-user', runCommand),
     ).resolves.toBe(false);
+    await expect(
+      runAsRemoteDirectoryExists(
+        '/workspace/exists',
+        'sandbox-user',
+        runCommand,
+      ),
+    ).resolves.toBe(true);
 
     expect(commands).toEqual([
       {
@@ -2393,6 +2401,14 @@ describe('remote sandbox path helpers', () => {
       },
       {
         command: expect.stringContaining('OPENAI_AGENTS_READ_PATH_PROBE_V1'),
+        options: { runAs: 'sandbox-user' },
+      },
+      {
+        command: "test -e '/workspace/exists'",
+        options: { runAs: 'sandbox-user' },
+      },
+      {
+        command: "test -d '/workspace/exists' && test -x '/workspace/exists'",
         options: { runAs: 'sandbox-user' },
       },
     ]);
@@ -2417,6 +2433,28 @@ describe('remote sandbox path helpers', () => {
         status: result.status,
       },
     });
+  });
+
+  test('checks directory searchability under the requested runAs identity', async () => {
+    const runCommand = vi
+      .fn()
+      .mockResolvedValueOnce({ status: 0 })
+      .mockResolvedValueOnce({ status: 1 });
+
+    await expect(
+      runAsRemoteDirectoryExists(
+        '/workspace/blocked',
+        'sandbox-user',
+        runCommand,
+      ),
+    ).resolves.toBe(false);
+    expect(runCommand.mock.calls).toEqual([
+      ["test -e '/workspace/blocked'", { runAs: 'sandbox-user' }],
+      [
+        "test -d '/workspace/blocked' && test -x '/workspace/blocked'",
+        { runAs: 'sandbox-user' },
+      ],
+    ]);
   });
 
   test('reports runAs command failures with provider context', async () => {

--- a/packages/agents-extensions/test/sandbox/sharedSession.test.ts
+++ b/packages/agents-extensions/test/sandbox/sharedSession.test.ts
@@ -73,6 +73,12 @@ class FakeRemoteSession extends RemoteSandboxSessionBase<FakeRemoteSessionState>
         status: this.files.has(path) || this.dirs.has(path) ? 0 : 1,
       };
     }
+    if (command.startsWith('test -d ')) {
+      const path = command
+        .slice('test -d '.length, command.indexOf(' && test -x '))
+        .replace(/^'|'$/g, '');
+      return { status: this.dirs.has(path) ? 0 : 1 };
+    }
     return {
       status: 0,
       stdout: `ran ${command}`,
@@ -810,6 +816,9 @@ describe('shared sandbox session helpers', () => {
 
     expect(await session.pathExists('image.png')).toBe(true);
     expect(await session.pathExists('missing.png')).toBe(false);
+    session.dirs.add('/workspace/tasks');
+    expect(await session.directoryExists('tasks')).toBe(true);
+    expect(await session.directoryExists('image.png')).toBe(false);
     expect(await session.running()).toBe(true);
 
     const image = await session.viewImage({ path: 'image.png' });


### PR DESCRIPTION
## Summary

- add an optional workspace-relative `SandboxRunConfig.cwd`
- resolve relative built-in sandbox tool paths from the run-scoped working directory
- validate the working directory before model and tool execution
- preserve session-owned Memory and Skills storage while rendering stable model-facing paths
- use the current trusted working directory when resuming interrupted runs
- add shared-session concurrency and interruption-resume regression coverage
- add a shared-session working-directory example

This implements the JavaScript equivalent of openai/openai-agents-python#4427.
