### PR TITLE
feat: add trusted process environment values

### DIFF
--- a/.changeset/trusted-process-environment-values.md
+++ b/.changeset/trusted-process-environment-values.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+feat: add trusted process environment values for Docker sandboxes

--- a/packages/agents-core/src/sandbox/index.ts
+++ b/packages/agents-core/src/sandbox/index.ts
@@ -8,6 +8,7 @@ export {
   Environment,
   EnvValueReference,
   Manifest,
+  ProcessEnvValue,
   cloneManifest,
   isEnvValueReference,
   isSerializedEnvValueReference,
@@ -29,6 +30,7 @@ export type {
   ManifestMountTarget,
   RenderManifestDescriptionOptions,
   SerializedEnvValueReference,
+  ProcessEnvironmentAccessOptions,
 } from './manifest';
 export * from './pathGrants';
 export * from './permissions';

--- a/packages/agents-core/src/sandbox/internal.ts
+++ b/packages/agents-core/src/sandbox/internal.ts
@@ -1,4 +1,5 @@
 export {
+  assertProcessEnvironmentDestinationsPreserved,
   assertHostPathGrantsRebound,
   deserializeMountCredentialRedactionMetadata,
   deserializeHostPathGrantRedactionMetadata,
@@ -56,8 +57,22 @@ export type {
 } from './mountSecurity';
 export { stableJsonStringify } from './shared/stableJson';
 export {
+  getRunStateSessionTrustedConfig,
+  markRunStateDeserializationInput,
+} from './internal/sessionStateTrust';
+export {
+  assertProcessEnvironmentAccessBound,
+  assertProcessEnvValuesUnsupported,
+  bindProcessEnvironmentAccess,
+  cloneManifestWithProcessEnvironmentAccess,
+  copyProcessEnvironmentProtection,
   copyManifestMountCredentialExposurePolicy,
+  environmentWithoutProcessEnvValues,
+  manifestHasProcessEnvValues,
+  protectProcessEnvironmentSessionStateManifest,
+  processEnvironmentDestinationNames,
   replaceManifestMountCredentialExposurePolicy,
+  withProcessEnvironmentErrorRedaction,
 } from './manifest';
 export {
   elapsedSeconds,

--- a/packages/agents-core/src/sandbox/internal/sessionStateTrust.ts
+++ b/packages/agents-core/src/sandbox/internal/sessionStateTrust.ts
@@ -20,12 +20,19 @@ export function markRunStateSessionState<TState extends SandboxSessionState>(
   return state;
 }
 
-export function isRunStateSessionState(state: SandboxSessionState): boolean {
+export function markRunStateDeserializationInput<
+  TState extends Record<string, unknown>,
+>(state: TState, trustedConfig: RunStateSessionTrustedConfig = {}): TState {
+  runStateSessionTrust.set(state, trustedConfig);
+  return state;
+}
+
+export function isRunStateSessionState(state: object): boolean {
   return runStateSessionTrust.has(state);
 }
 
 export function getRunStateSessionTrustedConfig(
-  state: SandboxSessionState,
+  state: object,
 ): RunStateSessionTrustedConfig | undefined {
   return runStateSessionTrust.get(state);
 }

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -30,7 +30,12 @@ import {
   relativePosixPathWithinRoot,
 } from './shared/posixPath';
 import { isRecord } from './shared/typeGuards';
-import { SandboxGitSubpathError } from './errors';
+import {
+  SandboxGitSubpathError,
+  SandboxLifecycleError,
+  SandboxUnsupportedFeatureError,
+} from './errors';
+import { UserError } from '../errors';
 import { typedMountProviderConfig } from './shared/typedMountConfig';
 
 export type EnvResolver = () => string | Promise<string>;
@@ -45,6 +50,20 @@ export type EnvValue = {
 export type SerializedEnvValueReference = {
   type: string;
   [key: string]: unknown;
+};
+
+export type ProcessEnvironmentAccessOptions = {
+  /**
+   * Grants same-name bindings from each SDK process environment key to the
+   * matching sandbox environment destination.
+   */
+  allowedProcessEnvironmentKeys?: readonly string[];
+  /**
+   * Grants exact sandbox destination to SDK process environment source
+   * bindings. A destination listed here must map to the same source declared
+   * by its `ProcessEnvValue`.
+   */
+  processEnvironmentBindings?: Readonly<Record<string, string>>;
 };
 
 export type EnvEntry =
@@ -433,6 +452,409 @@ export abstract class EnvValueReference extends Environment {
   }
 }
 
+const processEnvironmentSources = new WeakMap<ProcessEnvValue, string>();
+const processEnvironmentBindings = new WeakMap<
+  Manifest,
+  ReadonlyMap<string, string>
+>();
+const protectedProcessEnvironmentSessionStates = new WeakSet<object>();
+
+/**
+ * A serializable reference to a value in the current SDK process environment.
+ *
+ * The source name defaults to the containing manifest environment key. Access
+ * is granted only by trusted sandbox client configuration and is never
+ * serialized with the reference.
+ */
+export class ProcessEnvValue extends EnvValueReference {
+  static readonly type = 'openai.agents.process_env';
+  readonly name?: string;
+
+  constructor(
+    options: {
+      name?: string;
+      description?: string;
+    } = {},
+  ) {
+    if ('ephemeral' in options) {
+      throw new TypeError(
+        'ProcessEnvValue does not support ephemeral references because safe resume requires persisting the non-secret reference marker.',
+      );
+    }
+    super(
+      options.description === undefined
+        ? {}
+        : { description: options.description },
+    );
+    if (options.name !== undefined) {
+      validateProcessEnvironmentName(options.name);
+      this.name = options.name;
+    }
+  }
+
+  serialize(): Record<string, unknown> {
+    return {
+      ...(this.name ? { name: this.name } : {}),
+      ...(this.description ? { description: this.description } : {}),
+    };
+  }
+
+  async resolve(): Promise<string> {
+    const sourceName = processEnvironmentSources.get(this);
+    if (!sourceName) {
+      throw new TypeError(
+        'ProcessEnvValue must be resolved through a sandbox client with explicit process environment access.',
+      );
+    }
+    const value = process.env[sourceName];
+    if (value === undefined) {
+      throw new TypeError(
+        `Process environment variable "${sourceName}" is not set.`,
+      );
+    }
+    return value;
+  }
+}
+
+registerEnvValueReference(ProcessEnvValue, (payload) => {
+  if ('ephemeral' in payload) {
+    throw new TypeError(
+      'Serialized ProcessEnvValue references must not include ephemeral.',
+    );
+  }
+  const name = payload.name;
+  if (name !== undefined && typeof name !== 'string') {
+    throw new TypeError('ProcessEnvValue name must be a string.');
+  }
+  return new ProcessEnvValue({
+    ...(name === undefined ? {} : { name }),
+    ...(typeof payload.description === 'string'
+      ? { description: payload.description }
+      : {}),
+  });
+});
+
+export function manifestHasProcessEnvValues(manifest: Manifest): boolean {
+  return processEnvironmentDestinationNames(manifest).length > 0;
+}
+
+export function processEnvironmentDestinationNames(
+  manifest: Manifest,
+): readonly string[] {
+  const destinations = new Set(
+    processEnvironmentBindings.get(manifest)?.keys(),
+  );
+  for (const [destination, value] of Object.entries(manifest.environment)) {
+    if (value instanceof ProcessEnvValue) {
+      destinations.add(destination);
+    }
+  }
+  return [...destinations];
+}
+
+export function copyProcessEnvironmentProtection(
+  target: Manifest,
+  ...sources: Manifest[]
+): void {
+  const bindings = new Map<string, string>();
+  for (const source of sources) {
+    const sourceBindings = processEnvironmentBindings.get(source) ?? [];
+    for (const [destination, sourceName] of sourceBindings) {
+      const existingSource = bindings.get(destination);
+      if (existingSource !== undefined && existingSource !== sourceName) {
+        throw new TypeError(
+          `Conflicting protected process environment bindings for destination "${destination}".`,
+        );
+      }
+      bindings.set(destination, sourceName);
+    }
+    for (const [destination, sourceValue] of Object.entries(
+      source.environment,
+    )) {
+      if (!(sourceValue instanceof ProcessEnvValue)) {
+        continue;
+      }
+      const sourceName = processEnvironmentSources.get(sourceValue);
+      const targetValue = target.environment[destination];
+      if (
+        sourceName !== undefined &&
+        targetValue instanceof ProcessEnvValue &&
+        (targetValue.name ?? destination) === sourceName
+      ) {
+        processEnvironmentSources.set(targetValue, sourceName);
+      }
+    }
+  }
+  if (bindings.size > 0) {
+    processEnvironmentBindings.set(target, bindings);
+  }
+}
+
+export function invalidProtectedProcessEnvironmentReferences(
+  manifest: Manifest,
+): readonly string[] {
+  const bindings = processEnvironmentBindings.get(manifest);
+  if (!bindings) {
+    return [];
+  }
+  const destinations = new Set([
+    ...bindings.keys(),
+    ...Object.entries(manifest.environment)
+      .filter(([, value]) => value instanceof ProcessEnvValue)
+      .map(([destination]) => destination),
+  ]);
+  const invalid: string[] = [];
+  for (const destination of destinations) {
+    const sourceName = bindings.get(destination);
+    const value = manifest.environment[destination];
+    if (
+      sourceName === undefined ||
+      !(value instanceof ProcessEnvValue) ||
+      (value.name ?? destination) !== sourceName ||
+      processEnvironmentSources.get(value) !== sourceName
+    ) {
+      invalid.push(destination);
+    }
+  }
+  return invalid;
+}
+
+export function protectProcessEnvironmentSessionStateManifest<
+  TState extends { manifest: Manifest },
+>(state: TState): TState {
+  if (protectedProcessEnvironmentSessionStates.has(state)) {
+    return state;
+  }
+  const expectedBindings = processEnvironmentBindings.get(state.manifest);
+  if (!expectedBindings || expectedBindings.size === 0) {
+    return state;
+  }
+
+  const requiredBindings = new Map(expectedBindings);
+  let currentManifest = state.manifest;
+  Object.defineProperty(state, 'manifest', {
+    enumerable: true,
+    configurable: false,
+    get: () => currentManifest,
+    set: (nextManifest: Manifest) => {
+      const nextBindings =
+        nextManifest instanceof Manifest
+          ? processEnvironmentBindings.get(nextManifest)
+          : undefined;
+      const declaredBindings =
+        nextManifest instanceof Manifest
+          ? new Map(
+              Object.entries(nextManifest.environment)
+                .filter(
+                  (entry): entry is [string, ProcessEnvValue] =>
+                    entry[1] instanceof ProcessEnvValue,
+                )
+                .map(([destination, value]) => [
+                  destination,
+                  value.name ?? destination,
+                ]),
+            )
+          : undefined;
+      const validReplacement =
+        nextBindings !== undefined &&
+        declaredBindings !== undefined &&
+        nextBindings.size === requiredBindings.size &&
+        declaredBindings.size === requiredBindings.size &&
+        [...requiredBindings].every(
+          ([destination, sourceName]) =>
+            nextBindings.get(destination) === sourceName &&
+            declaredBindings.get(destination) === sourceName,
+        ) &&
+        invalidProtectedProcessEnvironmentReferences(nextManifest).length === 0;
+      if (!validReplacement) {
+        throw new UserError(
+          'A live sandbox manifest cannot remove or replace protected ProcessEnvValue bindings. Create a fresh Docker sandbox session instead.',
+        );
+      }
+      currentManifest = nextManifest;
+    },
+  });
+  protectedProcessEnvironmentSessionStates.add(state);
+  return state;
+}
+
+export function unmatchedProcessEnvironmentReferences(
+  persistedManifest: Manifest,
+  trustedManifest: Manifest,
+): readonly string[] {
+  const destinations = new Set([
+    ...processEnvironmentDestinationNames(persistedManifest),
+    ...processEnvironmentDestinationNames(trustedManifest),
+  ]);
+  const unmatched: string[] = [];
+  for (const destination of destinations) {
+    const persistedValue = persistedManifest.environment[destination];
+    const trustedValue = trustedManifest.environment[destination];
+    if (
+      !(persistedValue instanceof ProcessEnvValue) ||
+      !(trustedValue instanceof ProcessEnvValue) ||
+      (trustedValue.name ?? destination) !==
+        (persistedValue.name ?? destination)
+    ) {
+      unmatched.push(destination);
+    }
+  }
+  return unmatched;
+}
+
+export function environmentWithoutProcessEnvValues(
+  manifest: Manifest,
+  environment: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const processDestinations = new Set(
+    processEnvironmentDestinationNames(manifest),
+  );
+  return Object.fromEntries(
+    Object.entries(environment).filter(
+      ([destination]) => !processDestinations.has(destination),
+    ),
+  );
+}
+
+export function bindProcessEnvironmentAccess(
+  manifest: Manifest,
+  options: ProcessEnvironmentAccessOptions,
+): Manifest {
+  const bindings = normalizeProcessEnvironmentAccess(options);
+  const boundBindings = new Map<string, string>();
+  for (const [destination, value] of Object.entries(manifest.environment)) {
+    if (!(value instanceof ProcessEnvValue)) {
+      continue;
+    }
+    validateProcessEnvironmentName(destination);
+    const sourceName = value.name ?? destination;
+    const configuredSource = bindings.get(destination);
+    if (configuredSource !== sourceName) {
+      throw new TypeError(
+        `Process environment binding "${sourceName}" -> "${destination}" is not granted; configure the sandbox client with an allowed process environment binding.`,
+      );
+    }
+    if (process.env[sourceName] === undefined) {
+      throw new TypeError(
+        `Process environment variable "${sourceName}" is not set.`,
+      );
+    }
+    processEnvironmentSources.set(value, sourceName);
+    boundBindings.set(destination, sourceName);
+  }
+  if (boundBindings.size > 0) {
+    processEnvironmentBindings.set(manifest, boundBindings);
+  }
+  return manifest;
+}
+
+export function cloneManifestWithProcessEnvironmentAccess(
+  manifest: Manifest,
+  options: ProcessEnvironmentAccessOptions,
+): Manifest {
+  if (!manifestHasProcessEnvValues(manifest)) {
+    return manifest;
+  }
+  const invalidReferences =
+    invalidProtectedProcessEnvironmentReferences(manifest);
+  if (invalidReferences.length > 0) {
+    throw new UserError(
+      `A bound sandbox manifest contains changed ProcessEnvValue references: ${invalidReferences.join(', ')}. Create a fresh Docker sandbox session instead.`,
+    );
+  }
+  return bindProcessEnvironmentAccess(cloneManifest(manifest), options);
+}
+
+export function assertProcessEnvValuesUnsupported(
+  manifest: Manifest,
+  backendId: string,
+): void {
+  if (!manifestHasProcessEnvValues(manifest)) {
+    return;
+  }
+  throw new SandboxUnsupportedFeatureError(
+    `${backendId} does not support ProcessEnvValue because it cannot transport protected values through an isolated provider-native creation environment. Use DockerSandboxClient instead.`,
+  );
+}
+
+export function assertProcessEnvironmentAccessBound(manifest: Manifest): void {
+  for (const [destination, value] of Object.entries(manifest.environment)) {
+    if (!(value instanceof ProcessEnvValue)) {
+      continue;
+    }
+    const sourceName = value.name ?? destination;
+    if (processEnvironmentSources.get(value) !== sourceName) {
+      throw new SandboxUnsupportedFeatureError(
+        'The configured sandbox client cannot prepare ProcessEnvValue references through trusted runtime options. Use DockerSandboxClient instead.',
+      );
+    }
+  }
+}
+
+export async function withProcessEnvironmentErrorRedaction<T>(
+  manifest: Manifest,
+  context: {
+    provider: string;
+    operation: string;
+    details?: Readonly<Record<string, unknown>>;
+  },
+  callback: () => Promise<T>,
+): Promise<T> {
+  const shouldRedact = manifestHasProcessEnvValues(manifest);
+  try {
+    return await callback();
+  } catch (error) {
+    if (!shouldRedact) {
+      throw error;
+    }
+    throw new SandboxLifecycleError(
+      `${context.provider} ${context.operation} failed for a sandbox with protected process environment values.`,
+      {
+        provider: context.provider,
+        operation: context.operation,
+        ...context.details,
+      },
+    );
+  }
+}
+
+function normalizeProcessEnvironmentAccess(
+  options: ProcessEnvironmentAccessOptions,
+): Map<string, string> {
+  const normalized = new Map<string, string>();
+  for (const key of options.allowedProcessEnvironmentKeys ?? []) {
+    validateProcessEnvironmentName(key);
+    normalized.set(key, key);
+  }
+  for (const [destination, sourceName] of Object.entries(
+    options.processEnvironmentBindings ?? {},
+  )) {
+    validateProcessEnvironmentName(destination);
+    validateProcessEnvironmentName(sourceName);
+    const existing = normalized.get(destination);
+    if (existing !== undefined && existing !== sourceName) {
+      throw new TypeError(
+        `Process environment client configuration has conflicting bindings for destination "${destination}".`,
+      );
+    }
+    normalized.set(destination, sourceName);
+  }
+  return normalized;
+}
+
+function validateProcessEnvironmentName(name: string): void {
+  if (!name) {
+    throw new TypeError(
+      'Process environment variable names must not be empty.',
+    );
+  }
+  if (name.includes('=') || name.includes('\0')) {
+    throw new TypeError(
+      'Process environment variable names must not contain "=" or NUL.',
+    );
+  }
+}
+
 /**
  * Registers one environment reference subtype for JSON reconstruction.
  *
@@ -662,6 +1084,7 @@ export function cloneManifest(manifest: ManifestInput): Manifest {
   });
   if (manifest instanceof Manifest) {
     copyManifestMountCredentialExposurePolicy(cloned, manifest);
+    copyProcessEnvironmentProtection(cloned, manifest);
   }
   return cloned;
 }

--- a/packages/agents-core/src/sandbox/mountSecurity.ts
+++ b/packages/agents-core/src/sandbox/mountSecurity.ts
@@ -8,7 +8,9 @@ import {
   Manifest,
   MOUNT_CREDENTIAL_EXPOSURE_POLICY_KEYS,
   normalizeRelativePath,
+  ProcessEnvValue,
   replaceManifestMountCredentialExposurePolicy,
+  withProcessEnvironmentErrorRedaction,
   type InContainerMountCredentialExposureAuthority,
 } from './manifest';
 import { stableJsonStringify } from './shared/stableJson';
@@ -377,14 +379,21 @@ export function assertSandboxSessionStateUsable(state: object): void {
 }
 
 export async function withExclusiveSandboxManifestMutation<T>(
-  state: object,
+  state: { manifest: Manifest },
   operation: () => Promise<T>,
 ): Promise<T> {
   const pendingCount = pendingManifestMutationCounts.get(state) ?? 0;
   pendingManifestMutationCounts.set(state, pendingCount + 1);
   sandboxStateGenerations.set(state, sandboxStateGeneration(state) + 1);
   try {
-    return await withExclusiveSandboxStateAccess(state, operation);
+    return await withProcessEnvironmentErrorRedaction(
+      state.manifest,
+      {
+        provider: 'sandbox',
+        operation: 'manifest mutation',
+      },
+      async () => await withExclusiveSandboxStateAccess(state, operation),
+    );
   } finally {
     const remaining = (pendingManifestMutationCounts.get(state) ?? 1) - 1;
     if (remaining > 0) {
@@ -1041,6 +1050,12 @@ export function validateMountEnvironmentCredentialBoundaries(
 export async function resolveAndValidateMountEnvironment(
   manifest: Manifest,
 ): Promise<Manifest> {
+  const resolved = cloneManifest(manifest);
+  for (const [name, original] of Object.entries(manifest.environment)) {
+    if (original instanceof ProcessEnvValue) {
+      resolved.environment[name] = original;
+    }
+  }
   if (
     !manifest
       .mountTargets()
@@ -1048,12 +1063,14 @@ export async function resolveAndValidateMountEnvironment(
         ENVIRONMENT_CREDENTIAL_STRATEGIES.has(mountStrategyType(entry)),
       )
   ) {
-    return cloneManifest(manifest);
+    return resolved;
   }
   const environment = await manifest.resolveEnvironment();
   validateMountEnvironmentCredentialBoundaries(manifest, environment);
-  const resolved = cloneManifest(manifest);
   for (const [name, original] of Object.entries(manifest.environment)) {
+    if (original instanceof ProcessEnvValue) {
+      continue;
+    }
     resolved.environment[name] = new Environment({
       value: environment[name] ?? '',
       ...(original.ephemeral ? { ephemeral: true } : {}),

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -15,10 +15,17 @@ import type {
 } from '../client';
 import { SandboxLifecycleError, SandboxMountError } from '../errors';
 import {
+  assertProcessEnvironmentAccessBound,
+  assertProcessEnvValuesUnsupported,
   cloneManifest,
+  copyProcessEnvironmentProtection,
+  environmentWithoutProcessEnvValues,
   isEnvValueReference,
   Manifest,
+  manifestHasProcessEnvValues,
   replaceManifestMountCredentialExposurePolicy,
+  unmatchedProcessEnvironmentReferences,
+  withProcessEnvironmentErrorRedaction,
 } from '../manifest';
 import {
   captureLiveMountCredentialAuthorityIfAbsent,
@@ -856,10 +863,18 @@ export class SandboxRuntimeManager<TContext> {
     if (this.sandboxConfig?.session) {
       const session = this.sandboxConfig.session;
       assertSandboxSessionStateUsable(session.state);
-      this.applyArchiveLimits(session);
       const configuredManifest = this.resolveConfiguredManifest(agent, {
         providedSession: session,
       });
+      assertProcessEnvValuesUnsupported(
+        session.state.manifest,
+        'provided sandbox sessions',
+      );
+      assertProcessEnvValuesUnsupported(
+        configuredManifest.manifest,
+        'provided sandbox sessions',
+      );
+      this.applyArchiveLimits(session);
       // Provided sessions are already running, so only a safe additive manifest delta can
       // be applied instead of reprovisioning root, env, users, groups, or mounts.
       await applyManifestToProvidedSession(
@@ -899,50 +914,93 @@ export class SandboxRuntimeManager<TContext> {
         'Sandbox execution requires a sandbox client with create() support.',
       );
     }
-    const createManifest = await resolveAndValidateMountEnvironment(
+    const trustedCreateManifest = manifestHasProcessEnvValues(
       configuredManifest.manifest,
-    );
+    )
+      ? resolveTrustedManifestForResume(
+          client,
+          configuredManifest.manifest,
+          this.sandboxConfig?.options,
+        )!
+      : configuredManifest.manifest;
+    if (manifestHasProcessEnvValues(configuredManifest.manifest)) {
+      assertProcessEnvironmentAccessBound(trustedCreateManifest);
+    }
     const createSession = client.create.bind(client);
-    const createArgs: SandboxClientCreateArgs = {
-      snapshot: this.resolveSnapshotSpec(client),
-      options: this.sandboxConfig?.options,
-      concurrencyLimits: this.sandboxConfig?.concurrencyLimits,
-      archiveLimits: this.sandboxConfig?.archiveLimits,
-    };
-    if (configuredManifest.passToCreate) {
-      createArgs.manifest = createManifest;
-    }
-
-    const session = await withSandboxSpan(
-      'sandbox.create_session',
-      {
-        agent_name: agent.name,
-        backend_id: client.backendId,
+    return await withProcessEnvironmentErrorRedaction(
+      trustedCreateManifest,
+      { provider: 'sandbox', operation: 'session setup' },
+      async () => {
+        const createManifest = manifestHasProcessEnvValues(
+          trustedCreateManifest,
+        )
+          ? trustedCreateManifest
+          : await resolveAndValidateMountEnvironment(trustedCreateManifest);
+        if (manifestHasProcessEnvValues(createManifest)) {
+          validateMountEnvironmentCredentialBoundaries(
+            createManifest,
+            environmentWithoutProcessEnvValues(
+              createManifest,
+              await createManifest.resolveEnvironment(),
+            ),
+          );
+        }
+        const createArgs: SandboxClientCreateArgs = {
+          snapshot: this.resolveSnapshotSpec(client),
+          options: this.sandboxConfig?.options,
+          concurrencyLimits: this.sandboxConfig?.concurrencyLimits,
+          archiveLimits: this.sandboxConfig?.archiveLimits,
+        };
+        if (configuredManifest.passToCreate) {
+          createArgs.manifest = createManifest;
+        }
+        const session = await withSandboxSpan(
+          'sandbox.create_session',
+          {
+            agent_name: agent.name,
+            backend_id: client.backendId,
+          },
+          async () => await createSession(createArgs),
+          tracingParent,
+        );
+        try {
+          if (configuredManifest.passToCreate) {
+            session.state.environment = {
+              ...(session.state.environment ?? {}),
+              ...(await createManifest.resolveEnvironment()),
+            };
+            const manifestWithTrustedPolicies =
+              manifestWithTrustedRuntimePolicies(
+                session.state.manifest,
+                manifestHasProcessEnvValues(createManifest)
+                  ? createManifest
+                  : configuredManifest.manifest,
+              );
+            recordLiveMountCredentialAuthority(
+              manifestWithTrustedPolicies,
+              session.state.manifest,
+            );
+            session.state.manifest = manifestWithTrustedPolicies;
+          }
+          this.applyArchiveLimits(session);
+          await this.ensureSessionStarted(session, agent, 'create', {
+            tracingParent,
+          });
+          this.registerSessionForAgent(agent, session, { owned: true });
+          return session;
+        } catch (error) {
+          try {
+            await cleanupSandboxSession(session, { reason: 'create_failed' });
+          } catch (cleanupError) {
+            throw new SandboxLifecycleError(
+              'Sandbox session setup failed and cleanup could not complete.',
+              { errors: [error, cleanupError] },
+            );
+          }
+          throw error;
+        }
       },
-      async () => await createSession(createArgs),
-      tracingParent,
     );
-    if (configuredManifest.passToCreate) {
-      session.state.environment = {
-        ...(session.state.environment ?? {}),
-        ...(await createManifest.resolveEnvironment()),
-      };
-      const manifestWithTrustedPolicies = manifestWithTrustedRuntimePolicies(
-        session.state.manifest,
-        configuredManifest.manifest,
-      );
-      recordLiveMountCredentialAuthority(
-        manifestWithTrustedPolicies,
-        session.state.manifest,
-      );
-      session.state.manifest = manifestWithTrustedPolicies;
-    }
-    this.applyArchiveLimits(session);
-    await this.ensureSessionStarted(session, agent, 'create', {
-      tracingParent,
-    });
-    this.registerSessionForAgent(agent, session, { owned: true });
-    return session;
   }
 
   private applyArchiveLimits(
@@ -1009,9 +1067,14 @@ export class SandboxRuntimeManager<TContext> {
       {
         agent_name: agent.name,
       },
-      async () => {
-        await session.start!({ reason });
-      },
+      async () =>
+        await withProcessEnvironmentErrorRedaction(
+          session.state.manifest,
+          { provider: 'sandbox', operation: 'session start' },
+          async () => {
+            await session.start!({ reason });
+          },
+        ),
       options.tracingParent,
     );
     if (options.oncePerSession) {
@@ -1104,6 +1167,13 @@ export class SandboxRuntimeManager<TContext> {
     const explicitSessionStateInput = this.sandboxConfig?.sessionState;
     const hasExplicitSessionState = explicitSessionStateInput !== undefined;
     if (explicitSessionStateInput) {
+      if (client.backendId !== 'docker') {
+        assertProcessEnvValuesUnsupported(trustedManifest, client.backendId);
+        assertProcessEnvValuesUnsupported(
+          explicitSessionStateInput.manifest,
+          client.backendId,
+        );
+      }
       client.validateSessionStateForResume?.(
         { source: 'explicit', state: explicitSessionStateInput },
         {
@@ -1251,6 +1321,11 @@ export class SandboxRuntimeManager<TContext> {
       trustedManifest,
       this.sandboxConfig?.options,
     )!;
+    assertTrustedProcessEnvironmentReferences(
+      persistedState.manifest,
+      resolvedTrustedManifest,
+      'Sandbox session state',
+    );
     if (
       client.backendId === 'docker' &&
       Object.keys(persistedState.manifest.environment).some(
@@ -1278,33 +1353,39 @@ export class SandboxRuntimeManager<TContext> {
         'mount_config_invalid',
       );
     }
-    const materializedTrustedManifest =
-      await resolveAndValidateMountEnvironment(resolvedTrustedManifest);
-    const credentialReboundState = rebindPersistedMountCredentials(
-      topologyReboundState,
-      materializedTrustedManifest,
-    );
-    const sessionState = rebindPersistedPathGrants(
-      credentialReboundState,
-      materializedTrustedManifest,
-      {
-        replaceWithTrustedManifest: client.backendId === 'docker',
+    return await withProcessEnvironmentErrorRedaction(
+      resolvedTrustedManifest,
+      { provider: client.backendId, operation: 'session state preparation' },
+      async () => {
+        const materializedTrustedManifest =
+          await resolveAndValidateMountEnvironment(resolvedTrustedManifest);
+        const credentialReboundState = rebindPersistedMountCredentials(
+          topologyReboundState,
+          materializedTrustedManifest,
+        );
+        const sessionState = rebindPersistedPathGrants(
+          credentialReboundState,
+          materializedTrustedManifest,
+          {
+            replaceWithTrustedManifest: client.backendId === 'docker',
+          },
+        );
+        if (client.backendId === 'docker') {
+          sessionState.environment = {
+            ...(sessionState.environment ?? {}),
+            ...(await materializedTrustedManifest.resolveEnvironment()),
+          };
+        }
+        assertMountCredentialsRebound(sessionState);
+        validateMountCredentialBoundaries(sessionState.manifest);
+        validateMountEnvironmentCredentialBoundaries(
+          sessionState.manifest,
+          sessionState.environment ?? {},
+        );
+        assertHostPathGrantsRebound(sessionState);
+        return sessionState;
       },
     );
-    if (client.backendId === 'docker') {
-      sessionState.environment = {
-        ...(sessionState.environment ?? {}),
-        ...(await materializedTrustedManifest.resolveEnvironment()),
-      };
-    }
-    assertMountCredentialsRebound(sessionState);
-    validateMountCredentialBoundaries(sessionState.manifest);
-    validateMountEnvironmentCredentialBoundaries(
-      sessionState.manifest,
-      sessionState.environment ?? {},
-    );
-    assertHostPathGrantsRebound(sessionState);
-    return sessionState;
   }
 
   private async inspectLivePreservedOwnedSessionReuse(args: {
@@ -1321,6 +1402,19 @@ export class SandboxRuntimeManager<TContext> {
     });
     if (!liveEntry) {
       return undefined;
+    }
+
+    if (args.client.backendId !== 'docker') {
+      if (args.trustedManifest) {
+        assertProcessEnvValuesUnsupported(
+          args.trustedManifest,
+          args.client.backendId,
+        );
+      }
+      assertProcessEnvValuesUnsupported(
+        liveEntry.session.state.manifest,
+        args.client.backendId,
+      );
     }
 
     assertTrustedManifestForDockerRunState(args.client, args.trustedManifest);
@@ -1364,6 +1458,13 @@ export class SandboxRuntimeManager<TContext> {
       args.trustedManifest,
       this.sandboxConfig?.options,
     );
+    if (trustedManifest) {
+      assertTrustedProcessEnvironmentReferences(
+        liveEntry.session.state.manifest,
+        trustedManifest,
+        'Preserved sandbox session state',
+      );
+    }
     if (
       !trustedManifest ||
       manifestHasNonResumableMountAuthority(trustedManifest) ||
@@ -1416,11 +1517,25 @@ export class SandboxRuntimeManager<TContext> {
     if (args.client.backendId === 'docker') {
       candidateState.environment = {
         ...(liveEntry.session.state.environment ?? {}),
-        ...(await trustedManifest.resolveEnvironment()),
+        ...(await withProcessEnvironmentErrorRedaction(
+          trustedManifest,
+          {
+            provider: args.client.backendId,
+            operation: 'preserved session reuse preparation',
+          },
+          async () => await trustedManifest.resolveEnvironment(),
+        )),
       };
     }
     if (!canReuse) {
-      const trustedEnvironment = await trustedManifest.resolveEnvironment();
+      const trustedEnvironment = await withProcessEnvironmentErrorRedaction(
+        trustedManifest,
+        {
+          provider: args.client.backendId,
+          operation: 'preserved session reuse preparation',
+        },
+        async () => await trustedManifest.resolveEnvironment(),
+      );
       if (
         !liveMountEnvironmentAuthorityMatches(
           liveEntry.session.state.manifest,
@@ -1674,11 +1789,7 @@ export class SandboxRuntimeManager<TContext> {
       sessionAgentNamesByKey: this.sessionAgentNamesByKey,
       ownedSessionAgentKeys: this.ownedSessionAgentKeys,
       trustedManifestForAgentKey: (agentKey) =>
-        resolveTrustedManifestForResume(
-          this.sandboxConfig!.client!,
-          this.resolveTrustedManifestForAgentKey(agentKey),
-          this.sandboxConfig?.options,
-        ),
+        this.resolveTrustedManifestForAgentKey(agentKey),
       clientOptions: this.sandboxConfig?.options,
       includeOwnedSessions: args.includeOwnedSessions,
       preferredCurrentAgentKey,
@@ -1938,7 +2049,26 @@ function manifestWithTrustedRuntimePolicies(
     ],
   });
   replaceManifestMountCredentialExposurePolicy(merged, trustedManifest);
+  copyProcessEnvironmentProtection(merged, trustedManifest, manifest);
   return merged;
+}
+
+function assertTrustedProcessEnvironmentReferences(
+  persistedManifest: Manifest,
+  trustedManifest: Manifest,
+  stateDescription: string,
+): void {
+  const unmatchedDestinations = unmatchedProcessEnvironmentReferences(
+    persistedManifest,
+    trustedManifest,
+  );
+  if (unmatchedDestinations.length === 0) {
+    assertProcessEnvironmentAccessBound(trustedManifest);
+    return;
+  }
+  throw new UserError(
+    `${stateDescription} contains ProcessEnvValue references that do not exactly match the current trusted manifest: ${unmatchedDestinations.join(', ')}. Create a fresh Docker sandbox from the current trusted manifest instead.`,
+  );
 }
 
 async function refreshLiveEnvironmentReferences(

--- a/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
@@ -1,5 +1,5 @@
 import type { SandboxClient, SandboxClientOptions } from '../client';
-import type { Manifest } from '../manifest';
+import { assertProcessEnvValuesUnsupported, type Manifest } from '../manifest';
 import {
   assertSandboxSessionStateUsable,
   withExclusiveSandboxStateInspection,
@@ -11,6 +11,7 @@ import {
 } from '../session';
 import {
   getPreviousSerializedSessionsByAgent,
+  resolveTrustedManifestForResume,
   toSessionStateEnvelope,
   type SerializedSandboxSessionEntry,
   type SerializedSandboxState,
@@ -65,6 +66,19 @@ export async function serializeSandboxRuntimeState(args: {
       async () =>
         await withExclusiveSandboxStateInspection(session.state, async () => {
           assertSandboxSessionStateUsable(session.state);
+          const trustedManifest = trustedManifestForAgentKey?.(currentAgentKey);
+          if (client.backendId !== 'docker') {
+            assertProcessEnvValuesUnsupported(
+              session.state.manifest,
+              client.backendId,
+            );
+            if (trustedManifest) {
+              assertProcessEnvValuesUnsupported(
+                trustedManifest,
+                client.backendId,
+              );
+            }
+          }
           if (
             isOwnedSession &&
             !includeOwnedSessions &&
@@ -79,8 +93,11 @@ export async function serializeSandboxRuntimeState(args: {
             client.canReusePreservedOwnedSession
               ? await client.canReusePreservedOwnedSession(session.state, {
                   clientOptions,
-                  trustedManifest:
-                    trustedManifestForAgentKey?.(currentAgentKey),
+                  trustedManifest: resolveTrustedManifestForResume(
+                    client,
+                    trustedManifest,
+                    clientOptions,
+                  ),
                 })
               : true;
           const requiresFreshCreation =

--- a/packages/agents-core/src/sandbox/runtime/sessionState.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionState.ts
@@ -4,10 +4,14 @@ import type { RunState } from '../../runState';
 import type { Agent, AgentOutputType } from '../../agent';
 import type { SandboxClient, SandboxClientOptions } from '../client';
 import {
+  assertProcessEnvironmentAccessBound,
+  assertProcessEnvValuesUnsupported,
   isEnvValueReference,
   isSerializedEnvValueReference,
   type Manifest,
   type ManifestEnvironment,
+  unmatchedProcessEnvironmentReferences,
+  withProcessEnvironmentErrorRedaction,
 } from '../manifest';
 import {
   SANDBOX_SESSION_STATE_VERSION,
@@ -41,6 +45,7 @@ import {
   validateMountEnvironmentCredentialBoundaries,
 } from '../mountSecurity';
 import {
+  markRunStateDeserializationInput,
   markRunStateSessionState,
   type RunStateSessionTrustedConfig,
 } from '../internal/sessionStateTrust';
@@ -234,6 +239,18 @@ export async function deserializeSandboxSessionStateEntry(
       'RunState sandbox backend does not match the configured sandbox client.',
     );
   }
+  const envelope = serializedEntry.sessionState;
+  assertSessionStateEnvelope(client, envelope);
+  if (!trustedManifest) {
+    assertTrustedEnvironmentForPersistedReferences(envelope, undefined);
+  }
+  const persistedManifest = deserializeManifest(envelope.manifest);
+  if (client.backendId !== 'docker') {
+    if (trustedManifest) {
+      assertProcessEnvValuesUnsupported(trustedManifest, client.backendId);
+    }
+    assertProcessEnvValuesUnsupported(persistedManifest, client.backendId);
+  }
   const resolvedTrustedManifest = resolveTrustedManifestForResume(
     client,
     trustedManifest,
@@ -245,13 +262,11 @@ export async function deserializeSandboxSessionStateEntry(
       'Sandbox client must implement deserializeSessionState() to resume RunState sandbox state.',
     );
   }
-  const envelope = serializedEntry.sessionState;
-  assertSessionStateEnvelope(client, envelope);
   assertTrustedEnvironmentForPersistedReferences(
     envelope,
     resolvedTrustedManifest,
   );
-  if (manifestHasInContainerMounts(deserializeManifest(envelope.manifest))) {
+  if (manifestHasInContainerMounts(persistedManifest)) {
     throw new SandboxMountError(
       'Sandbox session state with in-container mounts cannot be resumed safely. Create a fresh sandbox so mount helpers are recreated from current trusted configuration.',
       undefined,
@@ -260,7 +275,7 @@ export async function deserializeSandboxSessionStateEntry(
   }
   const prevalidatedPersistedState = rebindPersistedMountCredentials(
     {
-      manifest: deserializeManifest(envelope.manifest),
+      manifest: persistedManifest,
       ...deserializeMountCredentialRedactionMetadata(envelope.providerState),
     },
     resolvedTrustedManifest,
@@ -277,40 +292,54 @@ export async function deserializeSandboxSessionStateEntry(
     },
     { clientOptions: trustedConfig.clientOptions },
   );
-  const materializedTrustedManifest = resolvedTrustedManifest
-    ? await resolveAndValidateMountEnvironment(resolvedTrustedManifest)
-    : undefined;
-  const state = await client.deserializeSessionState(
-    providerStateWithSdkEnvelopeFields(
-      envelope,
-      prevalidatedPersistedState.manifest,
-      materializedTrustedManifest,
-    ),
-  );
-  if (client.backendId === 'docker') {
-    delete state.sessionIdentity;
-  }
-  const credentialReboundState = rebindPersistedMountCredentials(
+  return await withProcessEnvironmentErrorRedaction(
+    resolvedTrustedManifest ?? prevalidatedPersistedState.manifest,
     {
-      ...state,
-      ...deserializeHostPathGrantRedactionMetadata(envelope.providerState),
-      ...deserializeMountCredentialRedactionMetadata(envelope.providerState),
+      provider: client.backendId,
+      operation: 'sandbox state deserialization',
     },
-    materializedTrustedManifest,
-  );
-  const reboundState = rebindPersistedPathGrants(
-    credentialReboundState,
-    materializedTrustedManifest,
-    {
-      replaceWithTrustedManifest:
-        client.backendId === 'docker' &&
-        materializedTrustedManifest !== undefined,
+    async () => {
+      const materializedTrustedManifest = resolvedTrustedManifest
+        ? await resolveAndValidateMountEnvironment(resolvedTrustedManifest)
+        : undefined;
+      const state = await client.deserializeSessionState!(
+        markRunStateDeserializationInput(
+          providerStateWithSdkEnvelopeFields(
+            envelope,
+            prevalidatedPersistedState.manifest,
+            materializedTrustedManifest,
+          ),
+          trustedConfig,
+        ),
+      );
+      if (client.backendId === 'docker') {
+        delete state.sessionIdentity;
+      }
+      const credentialReboundState = rebindPersistedMountCredentials(
+        {
+          ...state,
+          ...deserializeHostPathGrantRedactionMetadata(envelope.providerState),
+          ...deserializeMountCredentialRedactionMetadata(
+            envelope.providerState,
+          ),
+        },
+        materializedTrustedManifest,
+      );
+      const reboundState = rebindPersistedPathGrants(
+        credentialReboundState,
+        materializedTrustedManifest,
+        {
+          replaceWithTrustedManifest:
+            client.backendId === 'docker' &&
+            materializedTrustedManifest !== undefined,
+        },
+      );
+      assertMountCredentialsRebound(reboundState);
+      validateMountCredentialBoundaries(reboundState.manifest);
+      assertHostPathGrantsRebound(reboundState);
+      return markRunStateSessionState(reboundState, trustedConfig);
     },
   );
-  assertMountCredentialsRebound(reboundState);
-  validateMountCredentialBoundaries(reboundState.manifest);
-  assertHostPathGrantsRebound(reboundState);
-  return markRunStateSessionState(reboundState, trustedConfig);
 }
 
 export function resolveTrustedManifestForResume(
@@ -320,6 +349,9 @@ export function resolveTrustedManifestForResume(
 ): Manifest | undefined {
   if (!trustedManifest) {
     return undefined;
+  }
+  if (client.backendId !== 'docker') {
+    assertProcessEnvValuesUnsupported(trustedManifest, client.backendId);
   }
   const resolved = client.resolveTrustedManifestForResume
     ? client.resolveTrustedManifestForResume(trustedManifest, clientOptions)
@@ -396,24 +428,40 @@ function assertTrustedEnvironmentForPersistedReferences(
   trustedManifest: Manifest | undefined,
 ): void {
   const persistedEnvironment = envelope.manifest.environment;
-  if (
-    !persistedEnvironment ||
+  const persistedEnvironmentIsInvalid =
+    persistedEnvironment === null ||
     typeof persistedEnvironment !== 'object' ||
-    Array.isArray(persistedEnvironment)
-  ) {
+    Array.isArray(persistedEnvironment);
+  const persistedEnvironmentRecord = persistedEnvironmentIsInvalid
+    ? {}
+    : (persistedEnvironment as Record<string, unknown>);
+
+  const referenceKeys = Object.entries(persistedEnvironmentRecord)
+    .filter(([, value]) => isSerializedEnvValueReference(value))
+    .map(([key]) => key);
+  if (!trustedManifest) {
+    if (referenceKeys.length > 0) {
+      throw new UserError(
+        'RunState sandbox session state with environment value references requires a current trusted manifest for the sandbox agent.',
+      );
+    }
     return;
   }
 
-  const referenceKeys = Object.entries(persistedEnvironment)
-    .filter(([, value]) => isSerializedEnvValueReference(value))
-    .map(([key]) => key);
+  const unmatchedProcessReferences = unmatchedProcessEnvironmentReferences(
+    deserializeManifest({
+      ...envelope.manifest,
+      environment: persistedEnvironmentRecord,
+    }),
+    trustedManifest,
+  );
+  if (unmatchedProcessReferences.length > 0) {
+    throw new UserError(
+      `RunState sandbox session state contains ProcessEnvValue references that do not exactly match the current trusted manifest: ${unmatchedProcessReferences.join(', ')}. Create a fresh Docker sandbox from the current trusted manifest instead.`,
+    );
+  }
   if (referenceKeys.length === 0) {
     return;
-  }
-  if (!trustedManifest) {
-    throw new UserError(
-      'RunState sandbox session state with environment value references requires a current trusted manifest for the sandbox agent.',
-    );
   }
 
   const missingReferenceKeys = referenceKeys.filter(
@@ -426,6 +474,7 @@ function assertTrustedEnvironmentForPersistedReferences(
       `RunState sandbox session state contains environment value references that are not present in the current trusted manifest: ${missingReferenceKeys.join(', ')}.`,
     );
   }
+  assertProcessEnvironmentAccessBound(trustedManifest);
 }
 
 function cloneManifestEnvironment(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -57,10 +57,18 @@ import type {
 } from '../client';
 import { normalizeSandboxClientCreateArgs } from '../client';
 import {
+  bindProcessEnvironmentAccess,
   cloneManifest,
+  cloneManifestWithProcessEnvironmentAccess,
   copyManifestMountCredentialExposurePolicy,
+  copyProcessEnvironmentProtection,
+  environmentWithoutProcessEnvValues,
   isEnvValueReference,
+  manifestHasProcessEnvValues,
   Manifest,
+  ProcessEnvValue,
+  type ProcessEnvironmentAccessOptions,
+  withProcessEnvironmentErrorRedaction,
 } from '../manifest';
 import {
   WorkspacePathPolicy,
@@ -90,8 +98,11 @@ import {
   pathExists,
 } from './shared/localWorkspace';
 import {
+  assertProcessEnvironmentDestinationsPreserved,
+  assertProcessEnvironmentReferencesSerializable,
   assertHostPathGrantsRebound,
   assertMountCredentialsRebound,
+  deserializeManifest,
   mergeManifestEntryDelta,
   mergeManifestDelta,
   sanitizeEnvironmentForPersistence,
@@ -109,6 +120,7 @@ import {
   isSandboxSessionStateUnsafe,
   liveMountEnvironmentAuthorityMatches,
   manifestHasInContainerMounts,
+  mountCredentialEnvironmentForEntry,
   mountCredentialFileReferences,
   markSandboxSessionStateUnsafe,
   recordLiveMountCredentialAuthority,
@@ -155,6 +167,7 @@ import { sandboxPathGrantHostPath } from '../shared/hostPath';
 import {
   getRunStateSessionTrustedConfig,
   isRunStateSessionState,
+  markRunStateSessionState,
 } from '../internal/sessionStateTrust';
 import { stableJsonStringify } from '../shared/stableJson';
 
@@ -168,10 +181,71 @@ const DOCKER_OWNERSHIP_LABEL = 'openai-agents-sandbox';
 const DOCKER_SESSION_IDENTITY_LABEL = 'openai-agents-sandbox.session-identity';
 const DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL =
   'openai-agents-sandbox.mount-authority-fingerprint';
+const DOCKER_PRIVILEGED_ENVIRONMENT = {
+  PATH: '/usr/sbin:/usr/bin:/sbin:/bin',
+  HOME: '/root',
+  LD_PRELOAD: '',
+  LD_LIBRARY_PATH: '',
+  LD_AUDIT: '',
+} as const;
+const DOCKER_PROTECTED_SHELL_MANAGED_DESTINATIONS = new Set([
+  '_',
+  'BASH',
+  'BASHOPTS',
+  'BASHPID',
+  'BASH_ARGC',
+  'BASH_ARGV',
+  'BASH_COMMAND',
+  'BASH_LINENO',
+  'BASH_REMATCH',
+  'BASH_SOURCE',
+  'BASH_SUBSHELL',
+  'BASH_VERSINFO',
+  'DIRSTACK',
+  'EGID',
+  'EPOCHREALTIME',
+  'EPOCHSECONDS',
+  'EUID',
+  'FUNCNAME',
+  'GID',
+  'GROUPS',
+  'IFS',
+  'LINENO',
+  'OLDPWD',
+  'OPTIND',
+  'PIPESTATUS',
+  'PPID',
+  'PWD',
+  'RANDOM',
+  'SECONDS',
+  'SHELLOPTS',
+  'SHLVL',
+  'SRANDOM',
+  'UID',
+]);
+const DOCKER_PROTECTED_SHELL_MANAGED_PREFIXES = ['BASH', 'KSH', 'ZSH'];
+const DOCKER_PROTECTED_WORKLOAD_BOOTSTRAP = [
+  'set -eu',
+  'if [ -t 0 ]; then protected_stty_command=$(command -v stty); protected_stty_state=$("$protected_stty_command" -g); trap \'"$protected_stty_command" "$protected_stty_state"\' EXIT HUP INT TERM; "$protected_stty_command" -echo -icanon min 1 time 0; printf %s "$1"; fi',
+  'IFS= read -r protected_environment_payload',
+  'if [ -t 0 ]; then "$protected_stty_command" "$protected_stty_state"; trap - EXIT HUP INT TERM; fi',
+  'eval "$(printf %s "$protected_environment_payload" | base64 -d)"',
+  'shift',
+  'exec "$@"',
+].join('\n');
 
 type DockerNetworkMode = 'none';
 
-export interface DockerSandboxClientOptions extends SandboxClientOptions {
+function dockerUserMayBeRoot(user: string | undefined): boolean {
+  if (user === undefined) {
+    return true;
+  }
+  const userNameOrId = user.split(':', 1)[0];
+  return userNameOrId === 'root' || /^0+$/u.test(userNameOrId);
+}
+
+export interface DockerSandboxClientOptions
+  extends SandboxClientOptions, ProcessEnvironmentAccessOptions {
   image?: string;
   exposedPorts?: number[];
   networkMode?: DockerNetworkMode;
@@ -337,6 +411,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
   }
 
   override async materializeEntry(args: MaterializeEntryArgs): Promise<void> {
+    assertDockerProtectedEnvironmentDestinationsSupported(this.state.manifest);
     const entry = structuredClone(args.entry);
     if (!isMount(entry) || !isDockerInContainerMount(entry)) {
       await super.materializeEntry({ ...args, entry });
@@ -434,8 +509,13 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     manifest: Manifest,
     runAs?: string,
   ): Promise<void> {
+    assertProcessEnvironmentDestinationsPreserved(
+      this.state.manifest,
+      manifest,
+    );
     const previousManifest = this.state.manifest;
     const nextManifest = mergeManifestDelta(this.state.manifest, manifest);
+    assertDockerProtectedEnvironmentDestinationsSupported(nextManifest);
     assertExistingMountTopologyPreserved(this.state.manifest, nextManifest);
     validateMountCredentialBoundaries(nextManifest);
     assertDockerManifestDeltaSupported(this.state.manifest, manifest);
@@ -495,10 +575,7 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
         }
       }
       await applyDockerInContainerMounts(this, manifest, preparedMounts);
-      const committedManifest = mergeDockerIdentityMetadata(
-        mergeManifestDelta(this.state.manifest, materializedManifest),
-        manifest,
-      );
+      const committedManifest = nextManifest;
       copyValidatedMountEffectivePaths(
         committedManifest,
         this.state.manifest,
@@ -610,12 +687,49 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
     if (args.tty) {
       dockerArgs.splice(2, 0, '-t');
     }
-    for (const [key, value] of Object.entries(this.state.environment)) {
+    for (const [key, value] of Object.entries(
+      environmentWithoutProcessEnvValues(
+        this.state.manifest,
+        this.state.environment,
+      ),
+    )) {
       dockerArgs.push('-e', `${key}=${value}`);
     }
     const runAs = args.runAs ?? this.state.defaultUser;
     if (runAs) {
       dockerArgs.push('-u', runAs);
+    }
+    const protectedEnvironment = dockerProtectedEnvironment(
+      this.state.manifest,
+      this.state.environment,
+    );
+    if (Object.keys(protectedEnvironment).length > 0) {
+      const readyMarker = `openai-agents-protected-env-${randomUUID()}`;
+      const workloadReadyMarker = `openai-agents-workload-ready-${randomUUID()}`;
+      const workloadCommand = args.tty
+        ? `printf %s ${shellQuote(workloadReadyMarker)}\n${command}`
+        : command;
+      dockerArgs.push(
+        this.state.containerId,
+        '/bin/sh',
+        '-c',
+        DOCKER_PROTECTED_WORKLOAD_BOOTSTRAP,
+        'openai-agents-protected-workload',
+        readyMarker,
+        shellPath,
+        flag,
+        workloadCommand,
+      );
+      const child = args.tty
+        ? spawnInPseudoTerminal('docker', dockerArgs)
+        : spawn('docker', dockerArgs, { stdio: 'pipe' });
+      await deliverDockerProtectedWorkloadEnvironment(
+        child,
+        protectedEnvironment,
+        args.tty === true ? readyMarker : undefined,
+        args.tty === true ? workloadReadyMarker : undefined,
+      );
+      return child;
     }
     dockerArgs.push(this.state.containerId, shellPath, flag, command);
 
@@ -780,12 +894,20 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
       environment?: Record<string, string>;
     } = {},
   ): Promise<string> {
+    const environment = options.environment ?? this.stagedMountEnvironment;
     let result: SandboxProcessResult;
     try {
       result = await this.runDockerFilesystemCommand(command, {
         runAs: 'root',
         input: options.input,
-        environment: options.environment ?? this.stagedMountEnvironment,
+        environment,
+        protectedEnvironment:
+          options.environment === undefined
+            ? undefined
+            : dockerProtectedEnvironment(
+                this.state.manifest,
+                options.environment,
+              ),
       });
     } catch {
       throw new UserError(`DockerSandboxClient failed to ${action}.`);
@@ -836,49 +958,82 @@ export class DockerSandboxSession extends UnixLocalSandboxSession<DockerSandboxS
       runAs?: string;
       input?: string | Uint8Array;
       environment?: Record<string, string>;
+      protectedEnvironment?: Record<string, string>;
     } = {},
   ): Promise<SandboxProcessResult> {
     this.assertSessionUsable();
     const dockerArgs = ['exec', '-i', '-w', '/'];
-    for (const [key, value] of Object.entries(
+    const runAs = options.runAs || this.state.defaultUser || undefined;
+    const environment = environmentWithoutProcessEnvValues(
+      this.state.manifest,
       options.environment ?? this.state.environment,
-    )) {
+    );
+    if (dockerUserMayBeRoot(runAs)) {
+      Object.assign(environment, DOCKER_PRIVILEGED_ENVIRONMENT);
+    }
+    for (const [key, value] of Object.entries(environment)) {
       dockerArgs.push('-e', `${key}=${value}`);
     }
-    const runAs = options.runAs ?? this.state.defaultUser;
     if (runAs) {
       dockerArgs.push('-u', runAs);
     }
+    const protectedEnvironment = options.protectedEnvironment ?? {};
+    if (Object.keys(protectedEnvironment).length > 0) {
+      dockerArgs.push(this.state.containerId, '/bin/sh', '-s');
+      return await runDockerProcess(
+        dockerArgs,
+        dockerProtectedEnvironmentBootstrap(
+          command,
+          protectedEnvironment,
+          options.input,
+        ),
+      );
+    }
     dockerArgs.push(this.state.containerId, '/bin/sh', '-lc', command);
-
     return await runDockerProcess(dockerArgs, options.input);
   }
 
   override async close(): Promise<void> {
-    let cleanupError: unknown;
-    if (!this.containerClosed) {
-      try {
-        await removeDockerContainer(this.state.containerId, {
-          ignoreMissing: true,
-        });
-        this.containerClosed = true;
-      } catch (error) {
-        cleanupError = error;
-      }
-    }
-    try {
-      await removeDockerVolumes(this.state.dockerVolumeNames ?? []);
-    } catch (error) {
-      cleanupError ??= error;
-    }
-    try {
-      await super.close();
-    } catch (error) {
-      cleanupError ??= error;
-    }
-    if (cleanupError) {
-      throw cleanupError;
-    }
+    await withProcessEnvironmentErrorRedaction(
+      this.state.manifest,
+      {
+        provider: 'docker',
+        operation: 'sandbox shutdown',
+        details: {
+          containerId: this.state.containerId,
+        },
+      },
+      async () => {
+        let cleanupError: unknown;
+        if (!this.containerClosed) {
+          try {
+            await removeDockerContainer(this.state.containerId, {
+              ignoreMissing: true,
+            });
+            this.containerClosed = true;
+          } catch (error) {
+            cleanupError = error;
+          }
+        }
+        try {
+          if (manifestHasProcessEnvValues(this.state.manifest)) {
+            await removeDockerVolumesStrict(this.state.dockerVolumeNames ?? []);
+          } else {
+            await removeDockerVolumes(this.state.dockerVolumeNames ?? []);
+          }
+        } catch (error) {
+          cleanupError ??= error;
+        }
+        try {
+          await super.close();
+        } catch (error) {
+          cleanupError ??= error;
+        }
+        if (cleanupError) {
+          throw cleanupError;
+        }
+      },
+    );
   }
 
   private async invalidateAfterFailedPrivilegedManifestTransition(): Promise<void> {
@@ -1014,13 +1169,26 @@ export class DockerSandboxClient implements SandboxClient<
     this.options = options;
   }
 
+  resolveTrustedManifestForResume(
+    manifest: Manifest,
+    options: DockerSandboxClientOptions = {},
+  ): Manifest {
+    const trustedManifest = cloneManifestWithProcessEnvironmentAccess(
+      manifest,
+      {
+        ...this.options,
+        ...options,
+      },
+    );
+    assertDockerProtectedEnvironmentDestinationsSupported(trustedManifest);
+    return trustedManifest;
+  }
+
   async create(
     args?: SandboxClientCreateArgs<DockerSandboxClientOptions> | Manifest,
     manifestOptions?: DockerSandboxClientOptions,
   ): Promise<DockerSandboxSession> {
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
-    const manifest = createArgs.manifest;
-    assertDockerManifestSupported(manifest);
     const resolvedOptions = {
       ...this.options,
       ...createArgs.options,
@@ -1034,93 +1202,139 @@ export class DockerSandboxClient implements SandboxClient<
         ? { archiveLimits: createArgs.archiveLimits }
         : {}),
     };
+    const manifest = cloneManifestWithProcessEnvironmentAccess(
+      createArgs.manifest,
+      resolvedOptions,
+    );
+    assertDockerManifestSupported(manifest);
     const { configuredExposedPorts, networkMode } =
       resolveDockerNetworkConfiguration(this.options, createArgs.options);
-    const environment = await manifest.resolveEnvironment();
-    validateMountEnvironmentCredentialBoundaries(manifest, environment);
-    await ensureDockerAvailable();
-    await this.retryFailedCreateCleanups();
-    const workspaceRootPath = await mkdtemp(
-      join(
-        resolvedOptions.workspaceBaseDir ?? tmpdir(),
-        'openai-agents-docker-sandbox-',
-      ),
-    );
-
-    await materializeLocalWorkspaceManifest(manifest, workspaceRootPath, {
-      concurrencyLimits: resolvedOptions.concurrencyLimits,
-      allowLocalBindMounts: false,
-      allowIdentityMetadata: true,
-      supportsMount: isSupportedDockerCreateMount,
-      materializeMount: async ({ logicalPath, entry }) => {
-        await materializeDockerMountPoint(
-          workspaceRootPath,
-          manifest.root,
-          logicalPath,
-          entry,
-        );
-      },
-    });
-    await prepareDockerWorkspaceRoot(workspaceRootPath, manifest);
-    const image = resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE;
-    const defaultUser = getHostDockerUser();
-    const sessionIdentity = randomUUID();
-    const container = await startDockerContainer({
-      image,
+    const lifecycleDetails: Record<string, unknown> = {};
+    return await withProcessEnvironmentErrorRedaction(
       manifest,
-      manifestRoot: manifest.root,
-      workspaceRootPath,
-      sessionIdentity,
-      environment,
-      defaultUser,
-      exposedPorts: configuredExposedPorts,
-      networkMode,
-    });
-    const session = new DockerSandboxSession({
-      state: {
-        sessionIdentity,
-        materializedEntriesFingerprint:
-          dockerMaterializedEntriesFingerprint(manifest),
-        manifest,
-        workspaceRootPath,
-        workspaceRootOwned: true,
-        environment,
-        snapshotSpec: resolvedOptions.snapshot ?? null,
-        snapshot: null,
-        image,
-        containerId: container.containerId,
-        defaultUser,
-        configuredExposedPorts,
-        networkMode,
-        dockerVolumeNames: container.volumeNames,
+      {
+        provider: 'docker',
+        operation: 'sandbox creation',
+        details: lifecycleDetails,
       },
-      archiveLimits: resolvedOptions.archiveLimits,
-    });
-    try {
-      await provisionDockerAccounts(container.containerId, manifest);
-      await applyDockerInContainerMounts(session, manifest);
-      captureLiveMountCredentialAuthority(manifest, environment);
-    } catch (error) {
-      const cleanupToken = {
-        containerId: container.containerId,
-        volumeNames: container.volumeNames,
-        workspaceRootPath,
-        removeWorkspace: true,
-      } satisfies StartedDockerCleanupToken;
-      this.failedCreateCleanupTokens.set(container.containerId, cleanupToken);
-      try {
-        await cleanupStartedDockerContainer(cleanupToken);
-        this.failedCreateCleanupTokens.delete(container.containerId);
-      } catch (cleanupError) {
-        throw new SandboxLifecycleError(
-          'Docker sandbox creation failed and cleanup could not complete.',
-          { errors: [error, cleanupError] },
+      async () => {
+        const environment = await manifest.resolveEnvironment();
+        validateMountEnvironmentCredentialBoundaries(manifest, environment);
+        await ensureDockerAvailable();
+        await this.retryFailedCreateCleanups(lifecycleDetails);
+        const workspaceRootPath = await mkdtemp(
+          join(
+            resolvedOptions.workspaceBaseDir ?? tmpdir(),
+            'openai-agents-docker-sandbox-',
+          ),
         );
-      }
-      throw error;
-    }
 
-    return session;
+        await materializeLocalWorkspaceManifest(manifest, workspaceRootPath, {
+          concurrencyLimits: resolvedOptions.concurrencyLimits,
+          allowLocalBindMounts: false,
+          allowIdentityMetadata: true,
+          supportsMount: isSupportedDockerCreateMount,
+          materializeMount: async ({ logicalPath, entry }) => {
+            await materializeDockerMountPoint(
+              workspaceRootPath,
+              manifest.root,
+              logicalPath,
+              entry,
+            );
+          },
+        });
+        await prepareDockerWorkspaceRoot(workspaceRootPath, manifest);
+        const image = resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE;
+        const defaultUser = getHostDockerUser();
+        const sessionIdentity = randomUUID();
+        const preparedContainer = await prepareDockerContainerStart({
+          image,
+          manifest,
+          manifestRoot: manifest.root,
+          workspaceRootPath,
+          sessionIdentity,
+          environment,
+          defaultUser,
+          exposedPorts: configuredExposedPorts,
+          networkMode,
+        });
+        const cleanupToken: StartedDockerCleanupToken = {
+          containerId: preparedContainer.containerName,
+          volumeNames: preparedContainer.volumeNames,
+          workspaceRootPath,
+          removeWorkspace: true,
+          redactErrors: manifestHasProcessEnvValues(manifest),
+        };
+        this.failedCreateCleanupTokens.set(
+          cleanupToken.containerId,
+          cleanupToken,
+        );
+        try {
+          const preparedContainerName = cleanupToken.containerId;
+          const container = await startDockerContainer(
+            preparedContainer,
+            manifest,
+          );
+          this.failedCreateCleanupTokens.delete(preparedContainerName);
+          cleanupToken.containerId = container.containerId;
+          this.failedCreateCleanupTokens.set(
+            cleanupToken.containerId,
+            cleanupToken,
+          );
+          const session = new DockerSandboxSession({
+            state: {
+              sessionIdentity,
+              materializedEntriesFingerprint:
+                dockerMaterializedEntriesFingerprint(manifest),
+              manifest,
+              workspaceRootPath,
+              workspaceRootOwned: true,
+              environment,
+              snapshotSpec: resolvedOptions.snapshot ?? null,
+              snapshot: null,
+              image,
+              containerId: container.containerId,
+              defaultUser,
+              configuredExposedPorts,
+              networkMode,
+              dockerVolumeNames: container.volumeNames,
+            },
+            archiveLimits: resolvedOptions.archiveLimits,
+          });
+          await provisionDockerAccounts(container.containerId, manifest);
+          await applyDockerInContainerMounts(session, manifest);
+          captureLiveMountCredentialAuthority(manifest, environment);
+          this.failedCreateCleanupTokens.delete(cleanupToken.containerId);
+          return session;
+        } catch (error) {
+          if (error instanceof DockerContainerStartError && error.timedOut) {
+            cleanupToken.containerRemovalPending = true;
+          }
+          try {
+            const cleanupComplete =
+              await cleanupStartedDockerContainer(cleanupToken);
+            if (cleanupComplete) {
+              this.failedCreateCleanupTokens.delete(cleanupToken.containerId);
+            } else {
+              recordFailedDockerReplacementIdentifiers(
+                lifecycleDetails,
+                cleanupToken,
+              );
+            }
+          } catch (cleanupError) {
+            recordFailedDockerReplacementIdentifiers(
+              lifecycleDetails,
+              cleanupToken,
+            );
+            throw new SandboxLifecycleError(
+              'Docker sandbox creation failed and cleanup could not complete.',
+              { errors: [error, cleanupError] },
+            );
+          }
+          throw error;
+        }
+      },
+    );
   }
 
   async resume(
@@ -1164,28 +1378,87 @@ export class DockerSandboxClient implements SandboxClient<
         };
       }
     }
+    const processEnvironmentOptions = this.processEnvironmentOptionsForState(
+      resumeState,
+      options.clientOptions,
+    );
+    const manifest = cloneManifestWithProcessEnvironmentAccess(
+      resumeState.manifest,
+      processEnvironmentOptions,
+    );
+    resumeState.manifest = manifest;
+    const hasProtectedProcessEnvironment =
+      manifestHasProcessEnvValues(manifest);
+    if (hasProtectedProcessEnvironment) {
+      resumeState = { ...resumeState, manifest };
+      if (trustedConfig) {
+        markRunStateSessionState(resumeState, trustedConfig);
+      }
+    }
+    const previousContainerId = state.containerId;
+    const lifecycleDetails: Record<string, unknown> = {
+      containerId: previousContainerId,
+    };
     assertMountCredentialsRebound(resumeState);
     assertHostPathGrantsRebound(resumeState);
-    assertDockerManifestSupported(resumeState.manifest);
-    validateMountEnvironmentCredentialBoundaries(
-      resumeState.manifest,
-      resumeState.environment,
-    );
-    await ensureDockerAvailable();
-    await this.retryFailedCreateCleanups();
+    assertDockerManifestSupported(manifest);
     const archiveLimits =
       options.archiveLimits === undefined
         ? this.options.archiveLimits
         : options.archiveLimits;
-    const restoredState = await this.restoreIfNeeded(
-      resumeState,
-      archiveLimits,
-    );
+    return await withProcessEnvironmentErrorRedaction(
+      manifest,
+      {
+        provider: 'docker',
+        operation: 'sandbox resume',
+        details: lifecycleDetails,
+      },
+      async () => {
+        const restoringRunState = isRunStateSessionState(resumeState);
+        if (restoringRunState) {
+          resumeState = {
+            ...resumeState,
+            environment: {
+              ...environmentWithoutProcessEnvValues(
+                manifest,
+                resumeState.environment,
+              ),
+              ...(await resolveDockerRunStateEnvironment(resumeState)),
+            },
+          };
+          if (trustedConfig) {
+            markRunStateSessionState(resumeState, trustedConfig);
+          }
+        } else if (hasProtectedProcessEnvironment) {
+          resumeState.environment = {
+            ...environmentWithoutProcessEnvValues(
+              manifest,
+              resumeState.environment,
+            ),
+            ...(await manifest.resolveEnvironment()),
+          };
+        }
+        validateMountEnvironmentCredentialBoundaries(
+          manifest,
+          resumeState.environment,
+        );
+        await ensureDockerAvailable();
+        await this.retryFailedCreateCleanups(lifecycleDetails);
+        const restoredState = await this.restoreIfNeeded(
+          resumeState,
+          archiveLimits,
+          hasProtectedProcessEnvironment,
+          {
+            lifecycleDetails,
+          },
+        );
 
-    return new DockerSandboxSession({
-      state: restoredState,
-      archiveLimits,
-    });
+        return new DockerSandboxSession({
+          state: restoredState,
+          archiveLimits,
+        });
+      },
+    );
   }
 
   validateSessionStateForResume(
@@ -1219,6 +1492,9 @@ export class DockerSandboxClient implements SandboxClient<
       state.networkMode,
       state.configuredExposedPorts,
     );
+    if (manifestHasProcessEnvValues(state.manifest)) {
+      return false;
+    }
     if (isSandboxSessionStateUnsafe(state)) {
       return false;
     }
@@ -1280,6 +1556,7 @@ export class DockerSandboxClient implements SandboxClient<
     options: SandboxSessionSerializationOptions = {},
   ): Promise<Record<string, unknown>> {
     assertSandboxSessionStateUsable(state);
+    assertProcessEnvironmentReferencesSerializable(state.manifest);
     validateMountEnvironmentCredentialBoundaries(
       state.manifest,
       state.environment,
@@ -1342,25 +1619,50 @@ export class DockerSandboxClient implements SandboxClient<
       state.networkMode,
       configuredExposedPorts,
     );
-    const baseState = await deserializeLocalSandboxSessionStateValues(
-      state,
-      this.options.snapshot,
-    );
-    return {
-      ...baseState,
-      sessionIdentity: readOptionalString(state, 'sessionIdentity'),
-      image: readString(state, 'image'),
-      containerId: readString(state, 'containerId'),
-      defaultUser:
-        readOptionalString(state, 'defaultUser') ?? getHostDockerUser(),
-      networkMode,
-      dockerVolumeNames: readStringArray(state.dockerVolumeNames),
+    const trustedConfig = getRunStateSessionTrustedConfig(state);
+    const resolvedOptions = {
+      ...this.options,
+      ...(trustedConfig?.clientOptions as
+        DockerSandboxClientOptions | undefined),
     };
+    const manifest = bindProcessEnvironmentAccess(
+      deserializeManifest(
+        state.manifest as Record<string, unknown> | undefined,
+      ),
+      resolvedOptions,
+    );
+    assertDockerProtectedEnvironmentDestinationsSupported(manifest);
+    return await withProcessEnvironmentErrorRedaction(
+      manifest,
+      { provider: 'docker', operation: 'sandbox state deserialization' },
+      async () => {
+        const baseState = await deserializeLocalSandboxSessionStateValues(
+          state,
+          resolvedOptions.snapshot,
+          () => manifest,
+        );
+        return {
+          ...baseState,
+          sessionIdentity: readOptionalString(state, 'sessionIdentity'),
+          image: readString(state, 'image'),
+          containerId: readString(state, 'containerId'),
+          defaultUser:
+            readOptionalString(state, 'defaultUser') ?? getHostDockerUser(),
+          configuredExposedPorts,
+          networkMode,
+          dockerVolumeNames: readStringArray(state.dockerVolumeNames),
+        };
+      },
+    );
   }
 
   private async restoreIfNeeded(
     state: DockerSandboxSessionState,
     archiveLimits?: SandboxArchiveLimits | null,
+    forceProcessEnvironmentReplacement = false,
+    protectedReplacement?: {
+      lifecycleDetails: Record<string, unknown>;
+    },
   ): Promise<DockerSandboxSessionState> {
     attachDockerSnapshotExcludedPaths(state);
     if (isRunStateSessionState(state)) {
@@ -1381,7 +1683,7 @@ export class DockerSandboxClient implements SandboxClient<
         sessionIdentity: undefined,
         materializedEntriesFingerprint: undefined,
         image: resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE,
-        environment: await resolveDockerRunStateEnvironment(state),
+        environment: { ...state.environment },
         snapshotSpec:
           (trustedConfig?.snapshot as LocalSandboxSnapshotSpec | undefined) ??
           resolvedOptions.snapshot ??
@@ -1402,10 +1704,27 @@ export class DockerSandboxClient implements SandboxClient<
         trustedState,
         archiveLimits,
         resolvedOptions.workspaceBaseDir,
+        protectedReplacement?.lifecycleDetails,
       );
     }
-    const containerRunning = await inspectContainerRunning(state.containerId);
+    const containerStatus = await inspectDockerContainerStatus(
+      state.containerId,
+    );
+    const containerRunning = containerStatus === 'running';
     const workspaceExists = await pathExists(state.workspaceRootPath);
+
+    if (forceProcessEnvironmentReplacement) {
+      if (!protectedReplacement) {
+        throw new Error('Protected Docker replacement context is required.');
+      }
+      return await this.replaceProtectedDockerState(
+        state,
+        containerStatus,
+        workspaceExists,
+        protectedReplacement,
+        archiveLimits,
+      );
+    }
 
     if (workspaceExists) {
       if (containerRunning) {
@@ -1469,16 +1788,118 @@ export class DockerSandboxClient implements SandboxClient<
     return await this.restoreSnapshotIntoNewWorkspace(state, archiveLimits);
   }
 
+  private async replaceProtectedDockerState(
+    state: DockerSandboxSessionState,
+    containerStatus: DockerContainerStatus,
+    workspaceExists: boolean,
+    protectedReplacement: {
+      lifecycleDetails: Record<string, unknown>;
+    },
+    archiveLimits?: SandboxArchiveLimits | null,
+  ): Promise<DockerSandboxSessionState> {
+    let authenticatedPrevious:
+      { containerId: string; dockerVolumeNames: string[] } | undefined;
+    if (containerStatus !== 'missing') {
+      const inspection = await inspectRunningDockerContainerForReuse(state);
+      const canonicalContainerId = await inspectDockerCanonicalContainerId(
+        state.containerId,
+      );
+      if (
+        !inspection.ownershipVerified ||
+        !inspection.dockerVolumeNames ||
+        !canonicalContainerId
+      ) {
+        throw new UserError(
+          'Docker sandbox resource ownership could not be verified. Refusing to replace the container.',
+        );
+      }
+      authenticatedPrevious = {
+        containerId: canonicalContainerId,
+        dockerVolumeNames: inspection.dockerVolumeNames,
+      };
+    }
+
+    let replacement: DockerSandboxSessionState;
+    if (workspaceExists && (await canReuseLocalSnapshotWorkspace(state))) {
+      replacement = await this.restartContainer(
+        state,
+        state.workspaceRootPath,
+        archiveLimits,
+        protectedReplacement.lifecycleDetails,
+      );
+    } else {
+      if (!(await localSnapshotIsRestorable(state))) {
+        throw new UserError(
+          'Docker sandbox resources are unavailable and no local snapshot could be restored.',
+        );
+      }
+      if (authenticatedPrevious) {
+        replacement = await this.restoreSnapshotIntoNewWorkspace(
+          state,
+          archiveLimits,
+          this.options.workspaceBaseDir,
+          protectedReplacement.lifecycleDetails,
+        );
+      } else if (workspaceExists) {
+        const restoredState = await restoreLocalSnapshotToWorkspace(
+          state,
+          state.workspaceRootPath,
+          { archiveLimits },
+        );
+        replacement = await this.restartContainer(
+          restoredState,
+          restoredState.workspaceRootPath,
+          archiveLimits,
+          protectedReplacement.lifecycleDetails,
+        );
+      } else {
+        replacement = await this.restoreSnapshotIntoNewWorkspace(
+          state,
+          archiveLimits,
+          this.options.workspaceBaseDir,
+          protectedReplacement.lifecycleDetails,
+        );
+      }
+    }
+
+    if (!authenticatedPrevious) {
+      return replacement;
+    }
+    return await this.retireProtectedDockerResources(
+      state,
+      replacement,
+      authenticatedPrevious,
+      protectedReplacement.lifecycleDetails,
+    );
+  }
+
+  private processEnvironmentOptionsForState(
+    state: DockerSandboxSessionState,
+    clientOptions?: DockerSandboxClientOptions,
+  ): ProcessEnvironmentAccessOptions {
+    const trustedConfig = isRunStateSessionState(state)
+      ? getRunStateSessionTrustedConfig(state)
+      : undefined;
+    return {
+      ...this.options,
+      ...(trustedConfig?.clientOptions as
+        DockerSandboxClientOptions | undefined),
+      ...clientOptions,
+    };
+  }
+
   private async restoreSnapshotIntoNewWorkspace(
     state: DockerSandboxSessionState,
     archiveLimits?: SandboxArchiveLimits | null,
     workspaceBaseDir = this.options.workspaceBaseDir,
+    lifecycleDetails?: Record<string, unknown>,
   ): Promise<DockerSandboxSessionState> {
     const workspaceRootPath = await mkdtemp(
       join(workspaceBaseDir ?? tmpdir(), 'openai-agents-docker-sandbox-'),
     );
+    let restoredState: DockerSandboxSessionState;
     try {
-      const restoredState = await restoreLocalSnapshotToWorkspace(
+      restoredState = await restoreLocalSnapshotToWorkspace(
         {
           ...state,
           workspaceRootPath,
@@ -1487,15 +1908,33 @@ export class DockerSandboxClient implements SandboxClient<
         workspaceRootPath,
         { archiveLimits },
       );
-      return await this.restartContainer(
-        restoredState,
-        workspaceRootPath,
-        archiveLimits,
-      );
     } catch (error) {
       await rm(workspaceRootPath, { recursive: true, force: true }).catch(
         () => undefined,
       );
+      throw error;
+    }
+    try {
+      return await this.restartContainer(
+        restoredState,
+        workspaceRootPath,
+        archiveLimits,
+        lifecycleDetails,
+        true,
+      );
+    } catch (error) {
+      const deferredCleanupOwnsWorkspace = [
+        ...this.failedCreateCleanupTokens.values(),
+      ].some(
+        (token) =>
+          token.removeWorkspace &&
+          token.workspaceRootPath === workspaceRootPath,
+      );
+      if (!deferredCleanupOwnsWorkspace) {
+        await rm(workspaceRootPath, { recursive: true, force: true }).catch(
+          () => undefined,
+        );
+      }
       throw error;
     }
   }
@@ -1507,10 +1946,46 @@ export class DockerSandboxClient implements SandboxClient<
     await removeDockerVolumes(state.dockerVolumeNames ?? []);
   }
 
+  private async retireProtectedDockerResources(
+    previous: DockerSandboxSessionState,
+    replacement: DockerSandboxSessionState,
+    authenticatedPrevious: {
+      containerId: string;
+      dockerVolumeNames: string[];
+    },
+    lifecycleDetails: Record<string, unknown>,
+  ): Promise<DockerSandboxSessionState> {
+    try {
+      await cleanupProtectedDockerResources(
+        authenticatedPrevious.containerId,
+        authenticatedPrevious.dockerVolumeNames,
+      );
+      if (
+        previous.workspaceRootOwned &&
+        previous.workspaceRootPath !== replacement.workspaceRootPath
+      ) {
+        await rm(previous.workspaceRootPath, { recursive: true, force: true });
+      }
+    } catch (retirementError) {
+      lifecycleDetails.previousContainerId = authenticatedPrevious.containerId;
+      lifecycleDetails.previousDockerVolumeNames = [
+        ...authenticatedPrevious.dockerVolumeNames,
+      ];
+      lifecycleDetails.replacementContainerId = replacement.containerId;
+      lifecycleDetails.replacementDockerVolumeNames = [
+        ...(replacement.dockerVolumeNames ?? []),
+      ];
+      throw retirementError;
+    }
+    return replacement;
+  }
+
   private async restartContainer(
     state: DockerSandboxSessionState,
     workspaceRootPath: string,
     archiveLimits?: SandboxArchiveLimits | null,
+    lifecycleDetails?: Record<string, unknown>,
+    removeWorkspaceOnFailure = false,
   ): Promise<DockerSandboxSessionState> {
     await materializeLocalWorkspaceManifestMounts(
       state.manifest,
@@ -1531,7 +2006,7 @@ export class DockerSandboxClient implements SandboxClient<
     );
     await prepareDockerWorkspaceRoot(workspaceRootPath, state.manifest);
     const sessionIdentity = state.sessionIdentity ?? randomUUID();
-    const container = await startDockerContainer({
+    const preparedContainer = await prepareDockerContainerStart({
       image: state.image,
       manifest: state.manifest,
       manifestRoot: state.manifest.root,
@@ -1542,36 +2017,65 @@ export class DockerSandboxClient implements SandboxClient<
       exposedPorts: state.configuredExposedPorts,
       networkMode: state.networkMode,
     });
-    const nextState = {
-      ...state,
-      sessionIdentity,
-      materializedEntriesFingerprint: dockerMaterializedEntriesFingerprint(
-        state.manifest,
-      ),
+    const cleanupToken: StartedDockerCleanupToken = {
+      containerId: preparedContainer.containerName,
+      volumeNames: preparedContainer.volumeNames,
       workspaceRootPath,
-      containerId: container.containerId,
-      dockerVolumeNames: container.volumeNames,
-      exposedPorts: undefined,
+      removeWorkspace: removeWorkspaceOnFailure,
+      redactErrors: manifestHasProcessEnvValues(state.manifest),
     };
-    const session = new DockerSandboxSession({
-      state: nextState,
-      archiveLimits,
-    });
-    const cleanupToken = {
-      containerId: container.containerId,
-      volumeNames: container.volumeNames,
-      workspaceRootPath,
-      removeWorkspace: false,
-    } satisfies StartedDockerCleanupToken;
-    this.failedCreateCleanupTokens.set(container.containerId, cleanupToken);
+    this.failedCreateCleanupTokens.set(cleanupToken.containerId, cleanupToken);
     try {
+      const preparedContainerName = cleanupToken.containerId;
+      const container = await startDockerContainer(
+        preparedContainer,
+        state.manifest,
+      );
+      this.failedCreateCleanupTokens.delete(preparedContainerName);
+      cleanupToken.containerId = container.containerId;
+      this.failedCreateCleanupTokens.set(
+        cleanupToken.containerId,
+        cleanupToken,
+      );
+      const nextState = {
+        ...state,
+        sessionIdentity,
+        materializedEntriesFingerprint: dockerMaterializedEntriesFingerprint(
+          state.manifest,
+        ),
+        workspaceRootPath,
+        containerId: container.containerId,
+        dockerVolumeNames: container.volumeNames,
+        exposedPorts: undefined,
+      };
+      const session = new DockerSandboxSession({
+        state: nextState,
+        archiveLimits,
+      });
       await provisionDockerAccounts(container.containerId, state.manifest);
       await applyDockerInContainerMounts(session, state.manifest);
+      this.failedCreateCleanupTokens.delete(cleanupToken.containerId);
+      return nextState;
     } catch (error) {
+      if (error instanceof DockerContainerStartError && error.timedOut) {
+        cleanupToken.containerRemovalPending = true;
+      }
       try {
-        await cleanupStartedDockerContainer(cleanupToken);
-        this.failedCreateCleanupTokens.delete(container.containerId);
+        const cleanupComplete =
+          await cleanupStartedDockerContainer(cleanupToken);
+        if (cleanupComplete) {
+          this.failedCreateCleanupTokens.delete(cleanupToken.containerId);
+        } else {
+          recordFailedDockerReplacementIdentifiers(
+            lifecycleDetails,
+            cleanupToken,
+          );
+        }
       } catch (cleanupError) {
+        recordFailedDockerReplacementIdentifiers(
+          lifecycleDetails,
+          cleanupToken,
+        );
         throw new SandboxLifecycleError(
           'Docker sandbox restart failed and cleanup could not complete.',
           { errors: [error, cleanupError] },
@@ -1579,13 +2083,37 @@ export class DockerSandboxClient implements SandboxClient<
       }
       throw error;
     }
-    this.failedCreateCleanupTokens.delete(container.containerId);
-    return nextState;
   }
 
-  private async retryFailedCreateCleanups(): Promise<void> {
+  private async retryFailedCreateCleanups(
+    lifecycleDetails?: Record<string, unknown>,
+  ): Promise<void> {
     for (const [containerId, cleanupToken] of this.failedCreateCleanupTokens) {
-      await cleanupStartedDockerContainer(cleanupToken);
+      try {
+        const cleanupComplete =
+          await cleanupStartedDockerContainer(cleanupToken);
+        if (!cleanupComplete) {
+          continue;
+        }
+      } catch (error) {
+        if (!cleanupToken.redactErrors) {
+          throw error;
+        }
+        recordFailedDockerReplacementIdentifiers(
+          lifecycleDetails,
+          cleanupToken,
+        );
+        throw new SandboxLifecycleError(
+          'Docker sandbox cleanup failed for a resource that used protected process environment values.',
+          {
+            provider: 'docker',
+            operation: 'deferred cleanup',
+            containerId,
+            replacementContainerId: cleanupToken.containerId,
+            replacementDockerVolumeNames: [...cleanupToken.volumeNames],
+          },
+        );
+      }
       this.failedCreateCleanupTokens.delete(containerId);
     }
   }
@@ -1596,26 +2124,68 @@ type StartedDockerCleanupToken = {
   volumeNames: string[];
   workspaceRootPath: string;
   removeWorkspace: boolean;
+  redactErrors: boolean;
+  containerRemovalPending?: boolean;
 };
+
+function recordFailedDockerReplacementIdentifiers(
+  details: Record<string, unknown> | undefined,
+  cleanupToken: StartedDockerCleanupToken,
+): void {
+  if (!details || !cleanupToken.redactErrors) {
+    return;
+  }
+  details.replacementContainerId = cleanupToken.containerId;
+  details.replacementDockerVolumeNames = [...cleanupToken.volumeNames];
+}
 
 async function cleanupStartedDockerContainer(
   args: StartedDockerCleanupToken,
-): Promise<void> {
+): Promise<boolean> {
   let containerRemovalError: unknown;
-  try {
-    await removeDockerContainer(args.containerId, { ignoreMissing: true });
-  } catch (error) {
-    containerRemovalError = error;
+  let volumeRemovalError: unknown;
+  let workspaceRemovalError: unknown;
+  if (args.containerRemovalPending) {
+    const containerRemoved = await removeDockerContainer(args.containerId, {
+      ignoreMissing: true,
+    });
+    if (!containerRemoved) {
+      return false;
+    }
+    args.containerRemovalPending = false;
+  } else {
+    try {
+      await removeDockerContainer(args.containerId, { ignoreMissing: true });
+    } catch (error) {
+      containerRemovalError = error;
+    }
   }
-  await removeDockerVolumes(args.volumeNames);
+  try {
+    if (args.redactErrors) {
+      await removeDockerVolumesStrict(args.volumeNames);
+    } else {
+      await removeDockerVolumes(args.volumeNames);
+    }
+  } catch (error) {
+    volumeRemovalError = error;
+  }
   if (args.removeWorkspace) {
-    await rm(args.workspaceRootPath, { recursive: true, force: true }).catch(
-      () => undefined,
-    );
+    try {
+      await rm(args.workspaceRootPath, { recursive: true, force: true });
+    } catch (error) {
+      workspaceRemovalError = error;
+    }
   }
   if (containerRemovalError) {
     throw containerRemovalError;
   }
+  if (volumeRemovalError) {
+    throw volumeRemovalError;
+  }
+  if (workspaceRemovalError) {
+    throw workspaceRemovalError;
+  }
+  return true;
 }
 
 async function resolveDockerRunStateEnvironment(
@@ -1634,6 +2204,18 @@ async function resolveDockerRunStateEnvironment(
 }
 
 function assertDockerManifestSupported(manifest: Manifest): void {
+  assertDockerProtectedEnvironmentDestinationsSupported(manifest);
+  for (const key of ['LD_PRELOAD', 'LD_LIBRARY_PATH', 'LD_AUDIT']) {
+    if (manifest.environment[key] instanceof ProcessEnvValue) {
+      throw new SandboxUnsupportedFeatureError(
+        `DockerSandboxClient does not support ProcessEnvValue for "${key}" because trusted path resolution must clear dynamic-loader environment variables. Use an ordinary explicit environment value or a different protected destination name.`,
+        {
+          provider: 'DockerSandboxClient',
+          feature: `manifest.environment.${key}`,
+        },
+      );
+    }
+  }
   validateMountCredentialBoundaries(manifest);
   assertDockerManifestRootSupported(manifest);
   for (const grant of manifest.extraPathGrants) {
@@ -1650,9 +2232,33 @@ function assertDockerManifestSupported(manifest: Manifest): void {
   );
 }
 
+function assertDockerProtectedEnvironmentDestinationsSupported(
+  manifest: Manifest,
+): void {
+  for (const [destination, value] of Object.entries(manifest.environment)) {
+    if (
+      value instanceof ProcessEnvValue &&
+      (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(destination) ||
+        DOCKER_PROTECTED_SHELL_MANAGED_DESTINATIONS.has(destination) ||
+        DOCKER_PROTECTED_SHELL_MANAGED_PREFIXES.some((prefix) =>
+          destination.startsWith(prefix),
+        ))
+    ) {
+      throw new SandboxUnsupportedFeatureError(
+        `DockerSandboxClient does not support ProcessEnvValue for "${destination}" because protected workload destinations must be assignable POSIX shell identifiers and cannot use shell-managed names. Map a compatible sandbox destination to the original SDK process source with processEnvironmentBindings instead.`,
+        {
+          provider: 'DockerSandboxClient',
+          feature: `manifest.environment.${destination}`,
+        },
+      );
+    }
+  }
+}
+
 type DockerContainerReuseInspection = {
   ownershipVerified: boolean;
   reusable: boolean;
+  dockerVolumeNames?: string[];
 };
 
 async function inspectRunningDockerContainerForReuse(
@@ -1679,7 +2285,7 @@ async function inspectRunningDockerContainerForReuse(
   const manifestBindMountsBeforeInspect = await resolveDockerManifestBindMounts(
     state.manifest,
   );
-  const actualBindMounts = await inspectDockerBindMounts(state.containerId);
+  const actualMounts = await inspectDockerContainerMounts(state.containerId);
 
   const workspaceMountAfterInspect = await resolveDockerWorkspaceMount(
     state.workspaceRootPath,
@@ -1691,14 +2297,14 @@ async function inspectRunningDockerContainerForReuse(
   const manifestBindMountsAfterInspect = await resolveDockerManifestBindMounts(
     state.manifest,
   );
-  if (!actualBindMounts) {
+  if (!actualMounts) {
     return { ownershipVerified: false, reusable: false };
   }
 
   const expectedWorkspaceMount = dockerBindMountsFromAuthority([
     workspaceMountAfterInspect,
   ])[0]!;
-  const ownershipVerified = actualBindMounts.some((mount) =>
+  const ownershipVerified = actualMounts.bindMounts.some((mount) =>
     dockerBindMountsEqual(mount, expectedWorkspaceMount),
   );
   if (!ownershipVerified) {
@@ -1713,9 +2319,13 @@ async function inspectRunningDockerContainerForReuse(
     ...pathGrantMountsAfterInspect,
     ...manifestBindMountsAfterInspect,
   ]);
+  const dockerVolumeNames = verifiedDockerVolumeNames(
+    state.manifest,
+    actualMounts.volumeMounts,
+  );
   const recordedFingerprint = labels[DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL];
   if (recordedFingerprint === undefined) {
-    return { ownershipVerified: true, reusable: false };
+    return { ownershipVerified: true, reusable: false, dockerVolumeNames };
   }
   const fingerprintBeforeInspect = dockerMountAuthorityFingerprint(
     sessionIdentity,
@@ -1733,10 +2343,12 @@ async function inspectRunningDockerContainerForReuse(
   );
   return {
     ownershipVerified: true,
+    dockerVolumeNames,
     reusable:
+      dockerVolumeNames !== undefined &&
       fingerprintBeforeInspect === fingerprintAfterInspect &&
       recordedFingerprint === fingerprintAfterInspect &&
-      dockerBindMountSetsEqual(actualBindMounts, expectedBindMounts),
+      dockerBindMountSetsEqual(actualMounts.bindMounts, expectedBindMounts),
   };
 }
 
@@ -1759,7 +2371,7 @@ async function inspectLegacyDockerContainerForReuse(
   const manifestBindMountsBeforeInspect = await resolveDockerManifestBindMounts(
     state.manifest,
   );
-  const actualBindMounts = await inspectDockerBindMounts(state.containerId);
+  const actualMounts = await inspectDockerContainerMounts(state.containerId);
   const workspaceMountAfterInspect = await resolveDockerWorkspaceMount(
     state.workspaceRootPath,
     state.manifest.root,
@@ -1767,22 +2379,28 @@ async function inspectLegacyDockerContainerForReuse(
   const manifestBindMountsAfterInspect = await resolveDockerManifestBindMounts(
     state.manifest,
   );
-  if (!actualBindMounts) {
+  if (!actualMounts) {
     return { ownershipVerified: false, reusable: false };
   }
 
   const expectedWorkspaceMount = dockerBindMountsFromAuthority([
     workspaceMountAfterInspect,
   ])[0]!;
-  const ownershipVerified = actualBindMounts.some((mount) =>
+  const ownershipVerified = actualMounts.bindMounts.some((mount) =>
     dockerBindMountsEqual(mount, expectedWorkspaceMount),
   );
   const networkConfigurationMatches =
     ownershipVerified && (await dockerNetworkConfigurationMatches(state));
+  const dockerVolumeNames = verifiedDockerVolumeNames(
+    state.manifest,
+    actualMounts.volumeMounts,
+  );
   return {
     ownershipVerified,
+    dockerVolumeNames,
     reusable:
       networkConfigurationMatches &&
+      dockerVolumeNames !== undefined &&
       dockerMountAuthoritiesEqual(
         workspaceMountBeforeInspect,
         workspaceMountAfterInspect,
@@ -1792,7 +2410,7 @@ async function inspectLegacyDockerContainerForReuse(
         manifestBindMountsAfterInspect,
       ) &&
       state.manifest.extraPathGrants.length === 0 &&
-      dockerBindMountSetsEqual(actualBindMounts, [
+      dockerBindMountSetsEqual(actualMounts.bindMounts, [
         expectedWorkspaceMount,
         ...dockerBindMountsFromAuthority(manifestBindMountsAfterInspect),
       ]),
@@ -1897,6 +2515,7 @@ function sortDockerMountAuthorities(
 type DockerInspectMount = {
   Type?: unknown;
   Source?: unknown;
+  Name?: unknown;
   Destination?: unknown;
   RW?: unknown;
 };
@@ -1905,6 +2524,16 @@ type DockerBindMount = {
   source: string;
   target: string;
   readWrite: boolean;
+};
+
+type DockerVolumeMount = {
+  name: string;
+  target: string;
+};
+
+type DockerContainerMounts = {
+  bindMounts: DockerBindMount[];
+  volumeMounts: DockerVolumeMount[];
 };
 
 type DockerMountAuthority = {
@@ -1934,7 +2563,7 @@ async function inspectDockerContainerLabels(
       timeoutMs: DOCKER_FAST_COMMAND_TIMEOUT_MS,
     },
   );
-  if (result.status !== 0) {
+  if (result.timedOut || result.status !== 0) {
     return undefined;
   }
 
@@ -1950,9 +2579,9 @@ async function inspectDockerContainerLabels(
   }
 }
 
-async function inspectDockerBindMounts(
+async function inspectDockerContainerMounts(
   containerId: string,
-): Promise<DockerBindMount[] | undefined> {
+): Promise<DockerContainerMounts | undefined> {
   const result = await runSandboxProcess(
     'docker',
     [
@@ -1975,32 +2604,64 @@ async function inspectDockerBindMounts(
     if (!Array.isArray(mounts)) {
       return undefined;
     }
-    return await Promise.all(
-      mounts
-        .filter(
-          (mount): mount is DockerInspectMount =>
-            typeof mount === 'object' &&
-            mount !== null &&
-            (mount as DockerInspectMount).Type === 'bind',
-        )
-        .map(async (mount): Promise<DockerBindMount> => {
-          if (
-            typeof mount.Source !== 'string' ||
-            typeof mount.Destination !== 'string' ||
-            typeof mount.RW !== 'boolean'
-          ) {
-            throw new Error('Invalid Docker bind mount inspection result.');
-          }
-          return {
-            source: await realpath(mount.Source),
-            target: mount.Destination,
-            readWrite: mount.RW,
-          };
-        }),
-    );
+    const bindMounts: DockerBindMount[] = [];
+    const volumeMounts: DockerVolumeMount[] = [];
+    for (const value of mounts) {
+      if (typeof value !== 'object' || value === null) {
+        continue;
+      }
+      const mount = value as DockerInspectMount;
+      if (mount.Type === 'bind') {
+        if (
+          typeof mount.Source !== 'string' ||
+          typeof mount.Destination !== 'string' ||
+          typeof mount.RW !== 'boolean'
+        ) {
+          throw new Error('Invalid Docker bind mount inspection result.');
+        }
+        bindMounts.push({
+          source: await realpath(mount.Source),
+          target: mount.Destination,
+          readWrite: mount.RW,
+        });
+      } else if (mount.Type === 'volume') {
+        if (
+          typeof mount.Name !== 'string' ||
+          typeof mount.Destination !== 'string'
+        ) {
+          throw new Error('Invalid Docker volume mount inspection result.');
+        }
+        volumeMounts.push({
+          name: mount.Name,
+          target: mount.Destination,
+        });
+      }
+    }
+    return { bindMounts, volumeMounts };
   } catch {
     return undefined;
   }
+}
+
+function verifiedDockerVolumeNames(
+  manifest: Manifest,
+  actualVolumeMounts: DockerVolumeMount[],
+): string[] | undefined {
+  const expectedTargets = manifest
+    .mountTargetsForMaterialization()
+    .filter(({ entry }) => isDockerVolumeMount(entry))
+    .map(({ mountPath }) => mountPath)
+    .sort();
+  const sortedActual = [...actualVolumeMounts].sort((left, right) =>
+    left.target.localeCompare(right.target),
+  );
+  if (
+    sortedActual.length !== expectedTargets.length ||
+    sortedActual.some((mount, index) => mount.target !== expectedTargets[index])
+  ) {
+    return undefined;
+  }
+  return sortedActual.map((mount) => mount.name);
 }
 
 function dockerBindMountsEqual(
@@ -2297,9 +2958,21 @@ async function provisionDockerAccounts(
   manifest: Manifest,
 ): Promise<void> {
   for (const command of dockerAccountProvisionCommands(manifest)) {
+    const environmentArgs = Object.entries(
+      DOCKER_PRIVILEGED_ENVIRONMENT,
+    ).flatMap(([key, value]) => ['-e', `${key}=${value}`]);
     const result = await runSandboxProcess(
       'docker',
-      ['exec', '-u', 'root', containerId, '/bin/sh', '-c', command],
+      [
+        'exec',
+        ...environmentArgs,
+        '-u',
+        'root',
+        containerId,
+        '/bin/sh',
+        '-c',
+        command,
+      ],
       {
         timeoutMs: DOCKER_FAST_COMMAND_TIMEOUT_MS,
       },
@@ -2360,20 +3033,8 @@ function stripDockerIdentityMetadata(manifest: Manifest): Manifest {
     remoteMountCommandAllowlist: manifest.remoteMountCommandAllowlist,
   });
   copyManifestMountCredentialExposurePolicy(stripped, manifest);
+  copyProcessEnvironmentProtection(stripped, manifest);
   return stripped;
-}
-
-function mergeDockerIdentityMetadata(
-  current: Manifest,
-  delta: Manifest,
-): Manifest {
-  return mergeManifestDelta(
-    current,
-    new Manifest({
-      users: delta.users,
-      groups: delta.groups,
-    }),
-  );
 }
 
 async function ensureDockerAvailable(): Promise<void> {
@@ -2388,7 +3049,11 @@ async function ensureDockerAvailable(): Promise<void> {
   }
 }
 
-async function inspectContainerRunning(containerId: string): Promise<boolean> {
+type DockerContainerStatus = 'running' | 'stopped' | 'missing';
+
+async function inspectDockerContainerStatus(
+  containerId: string,
+): Promise<DockerContainerStatus> {
   const result = await runSandboxProcess(
     'docker',
     [
@@ -2406,7 +3071,7 @@ async function inspectContainerRunning(containerId: string): Promise<boolean> {
 
   if (result.status !== 0) {
     if (isMissingDockerContainerError(result)) {
-      return false;
+      return 'missing';
     }
     throw new UserError(
       `Failed to inspect Docker sandbox container: ${formatSandboxProcessError(result)}`,
@@ -2414,14 +3079,32 @@ async function inspectContainerRunning(containerId: string): Promise<boolean> {
   }
   const running = result.stdout.trim();
   if (running === 'true') {
-    return true;
+    return 'running';
   }
   if (running === 'false') {
-    return false;
+    return 'stopped';
   }
   throw new UserError(
     `Failed to inspect Docker sandbox container: unexpected running state "${running}".`,
   );
+}
+
+async function inspectContainerRunning(containerId: string): Promise<boolean> {
+  return (await inspectDockerContainerStatus(containerId)) === 'running';
+}
+
+async function inspectDockerCanonicalContainerId(
+  containerId: string,
+): Promise<string | undefined> {
+  const result = await runSandboxProcess(
+    'docker',
+    ['inspect', '--type', 'container', '--format', '{{.Id}}', containerId],
+    { timeoutMs: DOCKER_FAST_COMMAND_TIMEOUT_MS },
+  );
+  if (result.status !== 0) {
+    return undefined;
+  }
+  return result.stdout.trim() || undefined;
 }
 
 async function runDockerProcess(
@@ -2466,18 +3149,19 @@ async function runDockerProcess(
 async function removeDockerContainer(
   containerId: string,
   options: { ignoreMissing?: boolean } = {},
-): Promise<void> {
+): Promise<boolean> {
   const result = await runSandboxProcess('docker', ['rm', '-f', containerId], {
     timeoutMs: DOCKER_CONTAINER_REMOVE_TIMEOUT_MS,
   });
   if (result.status !== 0) {
     if (options.ignoreMissing && isMissingDockerContainerError(result)) {
-      return;
+      return false;
     }
     throw new UserError(
       `Failed to remove Docker sandbox container: ${formatSandboxProcessError(result)}`,
     );
   }
+  return true;
 }
 
 function isMissingDockerContainerError(result: SandboxProcessResult): boolean {
@@ -2487,7 +3171,7 @@ function isMissingDockerContainerError(result: SandboxProcessResult): boolean {
   );
 }
 
-async function startDockerContainer(args: {
+type DockerContainerStartOptions = {
   image: string;
   manifest: Manifest;
   manifestRoot: string;
@@ -2497,12 +3181,30 @@ async function startDockerContainer(args: {
   defaultUser?: string;
   exposedPorts?: number[];
   networkMode?: DockerNetworkMode;
-}): Promise<{ containerId: string; volumeNames: string[] }> {
+};
+
+type PreparedDockerContainerStart = {
+  containerName: string;
+  volumeNames: string[];
+  processArgs: string[];
+};
+
+class DockerContainerStartError extends UserError {
+  readonly timedOut: boolean;
+
+  constructor(message: string, timedOut: boolean) {
+    super(message);
+    this.timedOut = timedOut;
+  }
+}
+
+async function prepareDockerContainerStart(
+  args: DockerContainerStartOptions,
+): Promise<PreparedDockerContainerStart> {
   validateDockerNetworkConfiguration(args.networkMode, args.exposedPorts);
-  const envArgs = Object.entries(args.environment).flatMap(([key, value]) => [
-    '-e',
-    `${key}=${value}`,
-  ]);
+  const envArgs = Object.entries(
+    environmentWithoutProcessEnvValues(args.manifest, args.environment),
+  ).flatMap(([key, value]) => ['-e', `${key}=${value}`]);
   const userArgs = args.defaultUser ? ['--user', args.defaultUser] : [];
   const portArgs = normalizeExposedPorts(args.exposedPorts).flatMap((port) => [
     '-p',
@@ -2524,9 +3226,10 @@ async function startDockerContainer(args: {
     manifestBindMounts,
   );
   const privilegeArgs = dockerInContainerMountPrivilegeArgs(args.manifest);
-  const result = await runSandboxProcess(
-    'docker',
-    [
+  return {
+    containerName,
+    volumeNames,
+    processArgs: [
       'run',
       '-d',
       '--name',
@@ -2553,20 +3256,33 @@ async function startDockerContainer(args: {
       '-c',
       DEFAULT_CONTAINER_COMMAND,
     ],
-    {
-      timeoutMs: DOCKER_CONTAINER_START_TIMEOUT_MS,
-    },
-  );
+  };
+}
+
+async function startDockerContainer(
+  prepared: PreparedDockerContainerStart,
+  manifest: Manifest,
+): Promise<{ containerId: string; volumeNames: string[] }> {
+  const result = await runSandboxProcess('docker', prepared.processArgs, {
+    timeoutMs: DOCKER_CONTAINER_START_TIMEOUT_MS,
+  });
 
   if (result.status !== 0) {
-    throw new UserError(
+    if (manifestHasProcessEnvValues(manifest)) {
+      throw new DockerContainerStartError(
+        `Failed to start Docker sandbox container with exit status ${result.status}.`,
+        result.timedOut,
+      );
+    }
+    throw new DockerContainerStartError(
       `Failed to start Docker sandbox container: ${formatSandboxProcessError(result)}`,
+      result.timedOut,
     );
   }
 
   return {
     containerId: result.stdout.trim(),
-    volumeNames,
+    volumeNames: prepared.volumeNames,
   };
 }
 
@@ -2887,7 +3603,10 @@ async function prepareDockerMountCredentialFiles(
     environment,
   );
   if (references.length === 0) {
-    return { entry: structuredClone(entry), environment };
+    return {
+      entry: structuredClone(entry),
+      environment: dockerMountCommandEnvironment(manifest, entry, environment),
+    };
   }
   const resolveEffectivePath = async (path: string): Promise<string> => {
     const candidate = path.startsWith('/')
@@ -2962,8 +3681,139 @@ async function prepareDockerMountCredentialFiles(
   }
   return {
     entry: preparedEntry as Mount | TypedMount,
-    environment: preparedEnvironment,
+    environment: dockerMountCommandEnvironment(
+      manifest,
+      entry,
+      preparedEnvironment,
+    ),
   };
+}
+
+function dockerMountCommandEnvironment(
+  manifest: Manifest,
+  entry: Mount | TypedMount,
+  environment: Record<string, string>,
+): Record<string, string> {
+  return {
+    ...environmentWithoutProcessEnvValues(manifest, environment),
+    ...mountCredentialEnvironmentForEntry(entry, environment),
+  };
+}
+
+function dockerProtectedEnvironment(
+  manifest: Manifest,
+  environment: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(environment).filter(
+      ([name]) => manifest.environment[name] instanceof ProcessEnvValue,
+    ),
+  );
+}
+
+async function deliverDockerProtectedWorkloadEnvironment(
+  child: ChildProcessWithoutNullStreams,
+  environment: Record<string, string>,
+  readyMarker?: string,
+  workloadReadyMarker?: string,
+): Promise<void> {
+  let workloadReady: Promise<void> | undefined;
+  if (readyMarker !== undefined) {
+    await waitForDockerProtectedWorkloadReady(child, readyMarker);
+    if (workloadReadyMarker !== undefined) {
+      workloadReady = waitForDockerProtectedWorkloadReady(
+        child,
+        workloadReadyMarker,
+      );
+    }
+  }
+  const exports = Object.entries(environment)
+    .map(([name, value]) => `export ${shellQuote(`${name}=${value}`)}`)
+    .join('\n');
+  child.stdin.write(`${Buffer.from(exports).toString('base64')}\n`);
+  await workloadReady;
+}
+
+async function waitForDockerProtectedWorkloadReady(
+  child: ChildProcessWithoutNullStreams,
+  readyMarker: string,
+): Promise<void> {
+  const marker = Buffer.from(readyMarker);
+  await new Promise<void>((resolve, reject) => {
+    let buffered = Buffer.alloc(0);
+    const timeout = setTimeout(() => {
+      cleanup();
+      child.kill('SIGKILL');
+      reject(
+        new UserError(
+          'DockerSandboxClient timed out while preparing protected process environment values for a sandbox command.',
+        ),
+      );
+    }, DOCKER_FAST_COMMAND_TIMEOUT_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off('data', onData);
+      child.off('error', onError);
+      child.off('close', onClose);
+    };
+    const fail = () => {
+      cleanup();
+      reject(
+        new UserError(
+          'DockerSandboxClient failed to prepare protected process environment values for a sandbox command.',
+        ),
+      );
+    };
+    const onError = () => fail();
+    const onClose = () => fail();
+    const onData = (chunk: Buffer | string) => {
+      buffered = Buffer.concat([
+        buffered,
+        Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk),
+      ]);
+      const markerIndex = buffered.indexOf(marker);
+      if (markerIndex < 0) {
+        return;
+      }
+      cleanup();
+      const visibleOutput = Buffer.concat([
+        buffered.subarray(0, markerIndex),
+        buffered.subarray(markerIndex + marker.length),
+      ]);
+      child.stdout.pause();
+      if (visibleOutput.length > 0) {
+        child.stdout.unshift(visibleOutput);
+      }
+      setImmediate(() => child.stdout.resume());
+      resolve();
+    };
+    child.stdout.on('data', onData);
+    child.once('error', onError);
+    child.once('close', onClose);
+  });
+}
+
+function dockerProtectedEnvironmentBootstrap(
+  command: string,
+  environment: Record<string, string>,
+  input?: string | Uint8Array,
+): string {
+  const exports = Object.entries(environment).map(
+    ([name, value]) => `export ${shellQuote(`${name}=${value}`)}`,
+  );
+  if (input === undefined) {
+    return [...exports, `exec /bin/sh -lc ${shellQuote(command)}`].join('\n');
+  }
+  const inputPath = `/tmp/openai-agents-docker-stdin-${randomUUID()}`;
+  const encodedInput = Buffer.from(input).toString('base64');
+  return [
+    'set -eu',
+    ...exports,
+    `input_path=${shellQuote(inputPath)}`,
+    'trap \'rm -f -- "$input_path"\' EXIT HUP INT TERM',
+    `(umask 077 && printf %s ${shellQuote(encodedInput)} | base64 -d > "$input_path")`,
+    `/bin/sh -lc ${shellQuote(command)} < "$input_path"`,
+  ].join('\n');
 }
 
 async function resolveTrustedDockerPath(
@@ -2973,7 +3823,12 @@ async function resolveTrustedDockerPath(
 ): Promise<string> {
   const dockerArgs = ['exec', '-i', '-w', '/'];
   const clearedEnvironment = new Set([
-    ...Object.keys(session.state.environment),
+    ...Object.keys(
+      environmentWithoutProcessEnvValues(
+        session.state.manifest,
+        session.state.environment,
+      ),
+    ),
     'LD_PRELOAD',
     'LD_LIBRARY_PATH',
     'LD_AUDIT',
@@ -2981,11 +3836,10 @@ async function resolveTrustedDockerPath(
   for (const key of clearedEnvironment) {
     dockerArgs.push('-e', `${key}=`);
   }
+  for (const [key, value] of Object.entries(DOCKER_PRIVILEGED_ENVIRONMENT)) {
+    dockerArgs.push('-e', `${key}=${value}`);
+  }
   dockerArgs.push(
-    '-e',
-    'PATH=/usr/bin:/bin',
-    '-e',
-    'HOME=/root',
     '-u',
     'root',
     session.state.containerId,
@@ -4768,6 +5622,53 @@ async function removeDockerVolumes(volumeNames: string[]): Promise<void> {
       }).catch(() => undefined);
     }),
   );
+}
+
+async function removeDockerVolumesStrict(volumeNames: string[]): Promise<void> {
+  const results = await Promise.all(
+    volumeNames.map(async (volumeName) => {
+      try {
+        const result = await runSandboxProcess(
+          'docker',
+          ['volume', 'rm', '-f', volumeName],
+          { timeoutMs: DOCKER_FAST_COMMAND_TIMEOUT_MS },
+        );
+        return result.status === 0 || isMissingDockerVolumeError(result);
+      } catch {
+        return false;
+      }
+    }),
+  );
+  if (results.some((removed) => !removed)) {
+    throw new UserError('Failed to remove Docker sandbox volumes.');
+  }
+}
+
+function isMissingDockerVolumeError(result: SandboxProcessResult): boolean {
+  const message = formatSandboxProcessError(result).toLowerCase();
+  return (
+    message.includes('no such volume') || message.includes('no such object')
+  );
+}
+
+async function cleanupProtectedDockerResources(
+  containerId: string,
+  volumeNames: string[],
+): Promise<void> {
+  let cleanupError: unknown;
+  try {
+    await removeDockerContainer(containerId, { ignoreMissing: true });
+  } catch (error) {
+    cleanupError = error;
+  }
+  try {
+    await removeDockerVolumesStrict(volumeNames);
+  } catch (error) {
+    cleanupError ??= error;
+  }
+  if (cleanupError) {
+    throw cleanupError;
+  }
 }
 
 function dockerRcloneS3Options(entry: S3Mount): Record<string, string> {

--- a/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/manifestPersistence.ts
@@ -3,8 +3,12 @@ import { UserError } from '../../../errors';
 import {
   cloneManifest,
   copyManifestMountCredentialExposurePolicy,
+  copyProcessEnvironmentProtection,
+  invalidProtectedProcessEnvironmentReferences,
   isEnvValueReference,
   Manifest,
+  ProcessEnvValue,
+  processEnvironmentDestinationNames,
   type EnvValue,
 } from '../../manifest';
 import type { SandboxSessionState } from '../../session';
@@ -179,6 +183,7 @@ export function serializeManifestRecord(
   manifest: Manifest,
 ): Record<string, unknown> {
   validateMountCredentialBoundaries(manifest);
+  assertProcessEnvironmentReferencesSerializable(manifest);
   return {
     version: manifest.version,
     root: manifest.root,
@@ -193,6 +198,18 @@ export function serializeManifestRecord(
     }),
     remoteMountCommandAllowlist: [...manifest.remoteMountCommandAllowlist],
   };
+}
+
+export function assertProcessEnvironmentReferencesSerializable(
+  manifest: Manifest,
+): void {
+  const invalidProcessEnvironmentReferences =
+    invalidProtectedProcessEnvironmentReferences(manifest);
+  if (invalidProcessEnvironmentReferences.length > 0) {
+    throw new UserError(
+      `Sandbox session state cannot be serialized because protected ProcessEnvValue references changed after binding: ${invalidProcessEnvironmentReferences.join(', ')}. Create a fresh Docker sandbox session instead.`,
+    );
+  }
 }
 
 export function deserializeManifest(
@@ -221,10 +238,17 @@ export function serializeEnvironmentForPersistence(
 ): Record<string, EnvValue> {
   const runtimeEnvironment = state.environment ?? {};
   const ephemeralKeys = new Set<string>();
+  const protectedKeys = new Set(
+    processEnvironmentDestinationNames(state.manifest),
+  );
   const serialized: Record<string, EnvValue> = {};
 
   for (const [key, value] of Object.entries(state.manifest.environment)) {
-    if (value.ephemeral || isEnvValueReference(value)) {
+    if (
+      protectedKeys.has(key) ||
+      value.ephemeral ||
+      isEnvValueReference(value)
+    ) {
       ephemeralKeys.add(key);
       continue;
     }
@@ -236,7 +260,11 @@ export function serializeEnvironmentForPersistence(
   }
 
   for (const [key, value] of Object.entries(runtimeEnvironment)) {
-    if (key in state.manifest.environment || ephemeralKeys.has(key)) {
+    if (
+      key in state.manifest.environment ||
+      ephemeralKeys.has(key) ||
+      protectedKeys.has(key)
+    ) {
       continue;
     }
     // Provider startup may add runtime env vars that are not in the manifest; keep them
@@ -270,7 +298,28 @@ export function mergeManifestDelta(base: Manifest, update: Manifest): Manifest {
       : base.remoteMountCommandAllowlist,
   });
   copyManifestMountCredentialExposurePolicy(merged, base, update);
+  copyProcessEnvironmentProtection(merged, base, update);
   return merged;
+}
+
+export function assertProcessEnvironmentDestinationsPreserved(
+  base: Manifest,
+  update: Manifest,
+): void {
+  const protectedDestinations = new Set(
+    processEnvironmentDestinationNames(base),
+  );
+  const rejectedDestinations = Object.entries(update.environment)
+    .filter(
+      ([key, value]) =>
+        protectedDestinations.has(key) || value instanceof ProcessEnvValue,
+    )
+    .map(([key]) => key);
+  if (rejectedDestinations.length > 0) {
+    throw new UserError(
+      `Sandbox manifests cannot add or replace protected process environment destinations: ${rejectedDestinations.join(', ')}. Start a new Docker sandbox session instead.`,
+    );
+  }
 }
 
 function cloneManifestEnvironment(

--- a/packages/agents-core/src/sandbox/sandboxes/shared/sessionStateValues.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/sessionStateValues.ts
@@ -32,9 +32,10 @@ export type LocalSandboxSessionStateValues = {
 export async function deserializeLocalSandboxSessionStateValues(
   state: Record<string, unknown>,
   configuredSnapshot: LocalSandboxSnapshotSpec | null | undefined,
+  prepareManifest: (manifest: Manifest) => Manifest = (manifest) => manifest,
 ): Promise<LocalSandboxSessionStateValues> {
-  const manifest = deserializeManifest(
-    state.manifest as Record<string, unknown> | undefined,
+  const manifest = prepareManifest(
+    deserializeManifest(state.manifest as Record<string, unknown> | undefined),
   );
   const persistedEnvironment = readEnvironmentState(state.environment);
   const runtimeEnvironment = Object.fromEntries(

--- a/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/unixLocal.ts
@@ -48,7 +48,13 @@ import {
   type WriteStdinArgs,
   type WorkspaceArchiveOptions,
 } from '../session';
-import { cloneManifest, Manifest, normalizeRelativePath } from '../manifest';
+import {
+  assertProcessEnvValuesUnsupported,
+  cloneManifest,
+  Manifest,
+  normalizeRelativePath,
+  protectProcessEnvironmentSessionStateManifest,
+} from '../manifest';
 import {
   SandboxConfigurationError,
   SandboxUnsupportedFeatureError,
@@ -182,7 +188,7 @@ export class UnixLocalSandboxSession<
     defaultShell?: string;
     archiveLimits?: SandboxArchiveLimits | null;
   }) {
-    this.state = args.state;
+    this.state = protectProcessEnvironmentSessionStateManifest(args.state);
     this.defaultShell = args.defaultShell;
     this.setArchiveLimits(args.archiveLimits);
   }
@@ -472,6 +478,7 @@ export class UnixLocalSandboxSession<
   }
 
   async applyManifest(manifest: Manifest, runAs?: string): Promise<void> {
+    assertProcessEnvValuesUnsupported(manifest, 'unix_local');
     const manifestSnapshot = cloneManifest(manifest);
     return await withExclusiveSandboxManifestMutation(this.state, async () =>
       this.applyManifestExclusive(manifestSnapshot, runAs),
@@ -967,6 +974,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
   ): Promise<UnixLocalSandboxSession> {
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     const manifest = createArgs.manifest;
+    assertProcessEnvValuesUnsupported(manifest, 'unix_local');
     const resolvedOptions = {
       ...this.options,
       ...createArgs.options,
@@ -1020,6 +1028,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
     state: UnixLocalSandboxSessionState,
     options: SandboxClientResumeOptions = {},
   ): Promise<UnixLocalSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'unix_local');
     assertMountCredentialsRebound(state);
     validateMountCredentialBoundaries(state.manifest);
     assertHostPathGrantsRebound(state);
@@ -1039,6 +1048,7 @@ export class UnixLocalSandboxClient implements SandboxClient<
   async serializeSessionState(
     state: UnixLocalSandboxSessionState,
   ): Promise<Record<string, unknown>> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'unix_local');
     assertSandboxSessionStateUsable(state);
     const stateGeneration = captureSandboxStateGeneration(state);
     assertUnixLocalHostPathGrantsUnsupported(state.manifest);
@@ -1073,6 +1083,10 @@ export class UnixLocalSandboxClient implements SandboxClient<
     return deserializeLocalSandboxSessionStateValues(
       state,
       this.options.snapshot,
+      (manifest) => {
+        assertProcessEnvValuesUnsupported(manifest, 'unix_local');
+        return manifest;
+      },
     );
   }
 

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -7,11 +7,13 @@ import {
   EnvValueReference,
   FileMode,
   Manifest,
+  ProcessEnvValue,
   normalizeRelativePath,
   Permissions,
   registerEnvValueReference,
   renderManifestDescription,
   SandboxGitSubpathError,
+  SandboxLifecycleError,
   type Dir,
   type File,
   type GitRepo,
@@ -29,6 +31,12 @@ import {
   type S3FilesMount,
   type S3Mount,
 } from '../src/sandbox';
+import {
+  bindProcessEnvironmentAccess,
+  cloneManifestWithProcessEnvironmentAccess,
+  serializeManifestRecord,
+  withProcessEnvironmentErrorRedaction,
+} from '../src/sandbox/internal';
 
 let currentReferencedSecret = 'initial-secret';
 
@@ -298,6 +306,296 @@ describe('Manifest', () => {
       unregister();
     }
   });
+
+  it('round-trips process environment references without serializing values or authority', async () => {
+    process.env.AGENTS_TEST_PROCESS_SOURCE = 'process-secret';
+    try {
+      const manifest = new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_PROCESS_SOURCE',
+            description: 'Trusted process token',
+          }),
+        },
+      });
+
+      const serialized = JSON.stringify(manifest);
+      const payload = JSON.parse(serialized);
+
+      expect(serialized).not.toContain('process-secret');
+      expect(payload.environment.SANDBOX_TOKEN).toEqual({
+        type: 'openai.agents.process_env',
+        name: 'AGENTS_TEST_PROCESS_SOURCE',
+        description: 'Trusted process token',
+      });
+      const restored = new Manifest(payload);
+      expect(restored.environment.SANDBOX_TOKEN).toBeInstanceOf(
+        ProcessEnvValue,
+      );
+      await expect(restored.resolveEnvironment()).rejects.toThrow(
+        /explicit process environment access/u,
+      );
+    } finally {
+      delete process.env.AGENTS_TEST_PROCESS_SOURCE;
+    }
+  });
+
+  it('preserves bound process environment authority only across runtime clones', async () => {
+    process.env.AGENTS_TEST_PROCESS_SOURCE = 'process-secret';
+    try {
+      const manifest = bindProcessEnvironmentAccess(
+        new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_PROCESS_SOURCE',
+            }),
+          },
+        }),
+        {
+          processEnvironmentBindings: {
+            SANDBOX_TOKEN: 'AGENTS_TEST_PROCESS_SOURCE',
+          },
+        },
+      );
+
+      const cloned = cloneManifest(manifest);
+      await expect(cloned.resolveEnvironment()).resolves.toEqual({
+        SANDBOX_TOKEN: 'process-secret',
+      });
+
+      const restored = new Manifest(JSON.parse(JSON.stringify(cloned)));
+      await expect(restored.resolveEnvironment()).rejects.toThrow(
+        /explicit process environment access/u,
+      );
+    } finally {
+      delete process.env.AGENTS_TEST_PROCESS_SOURCE;
+    }
+  });
+
+  it('keeps unbound process environment clones serializable and unbound', async () => {
+    const cloned = cloneManifest(
+      new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_PROCESS_SOURCE',
+          }),
+        },
+      }),
+    );
+
+    expect(serializeManifestRecord(cloned).environment).toEqual({
+      SANDBOX_TOKEN: {
+        type: 'openai.agents.process_env',
+        name: 'AGENTS_TEST_PROCESS_SOURCE',
+      },
+    });
+    await expect(cloned.resolveEnvironment()).rejects.toThrow(
+      /explicit process environment access/u,
+    );
+  });
+
+  it.each([
+    ['deleting the reference', undefined],
+    [
+      'replacing the reference with an ordinary value',
+      new Environment('ordinary-value'),
+    ],
+    [
+      'replacing the reference with a different source',
+      new ProcessEnvValue({ name: 'AGENTS_TEST_OTHER_PROCESS_SOURCE' }),
+    ],
+  ])('rejects serialization after %s', (_description, replacement) => {
+    process.env.AGENTS_TEST_PROCESS_SOURCE = 'process-secret';
+    try {
+      const manifest = bindProcessEnvironmentAccess(
+        new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_PROCESS_SOURCE',
+            }),
+          },
+        }),
+        {
+          processEnvironmentBindings: {
+            SANDBOX_TOKEN: 'AGENTS_TEST_PROCESS_SOURCE',
+          },
+        },
+      );
+
+      if (replacement === undefined) {
+        delete manifest.environment.SANDBOX_TOKEN;
+      } else {
+        manifest.environment.SANDBOX_TOKEN = replacement;
+      }
+
+      expect(() => serializeManifestRecord(manifest)).toThrow(
+        'protected ProcessEnvValue references changed after binding: SANDBOX_TOKEN',
+      );
+      expect(() =>
+        cloneManifestWithProcessEnvironmentAccess(manifest, {
+          processEnvironmentBindings: {
+            SANDBOX_TOKEN: 'AGENTS_TEST_PROCESS_SOURCE',
+          },
+        }),
+      ).toThrow(
+        'bound sandbox manifest contains changed ProcessEnvValue references: SANDBOX_TOKEN',
+      );
+    } finally {
+      delete process.env.AGENTS_TEST_PROCESS_SOURCE;
+    }
+  });
+
+  it('rejects serialization after adding an unbound process environment reference', () => {
+    process.env.AGENTS_TEST_PROCESS_SOURCE = 'process-secret';
+    try {
+      const manifest = bindProcessEnvironmentAccess(
+        new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_PROCESS_SOURCE',
+            }),
+          },
+        }),
+        {
+          processEnvironmentBindings: {
+            SANDBOX_TOKEN: 'AGENTS_TEST_PROCESS_SOURCE',
+          },
+        },
+      );
+      manifest.environment.ADDED_TOKEN = new ProcessEnvValue({
+        name: 'AGENTS_TEST_OTHER_PROCESS_SOURCE',
+      });
+
+      expect(() => serializeManifestRecord(manifest)).toThrow(
+        'protected ProcessEnvValue references changed after binding: ADDED_TOKEN',
+      );
+      expect(() =>
+        cloneManifestWithProcessEnvironmentAccess(manifest, {
+          processEnvironmentBindings: {
+            SANDBOX_TOKEN: 'AGENTS_TEST_PROCESS_SOURCE',
+          },
+        }),
+      ).toThrow(
+        'bound sandbox manifest contains changed ProcessEnvValue references: ADDED_TOKEN',
+      );
+    } finally {
+      delete process.env.AGENTS_TEST_PROCESS_SOURCE;
+    }
+  });
+
+  it('rejects invalid process environment source names', () => {
+    expect(() => new ProcessEnvValue({ name: '' })).toThrow(
+      /must not be empty/u,
+    );
+    expect(() => new ProcessEnvValue({ name: 'INVALID=NAME' })).toThrow(
+      /must not contain/u,
+    );
+    expect(() => new ProcessEnvValue({ name: 'INVALID\0NAME' })).toThrow(
+      /must not contain/u,
+    );
+  });
+
+  it('rejects ephemeral process environment references before persistence', () => {
+    expect(
+      () =>
+        new ProcessEnvValue({
+          ephemeral: true,
+        } as unknown as ConstructorParameters<typeof ProcessEnvValue>[0]),
+    ).toThrow(/does not support ephemeral references/u);
+    expect(
+      () =>
+        new Manifest({
+          environment: {
+            TOKEN: {
+              type: ProcessEnvValue.type,
+              ephemeral: true,
+            },
+          },
+        }),
+    ).toThrow(/must not include ephemeral/u);
+  });
+
+  it('keeps the unqualified process_env discriminator available to custom references', () => {
+    class CustomProcessEnvironmentReference extends EnvValueReference {
+      static readonly type = 'process_env';
+
+      constructor() {
+        super();
+      }
+
+      serialize(): Record<string, unknown> {
+        return {};
+      }
+
+      async resolve(): Promise<string> {
+        return 'custom';
+      }
+    }
+
+    const unregister = registerEnvValueReference(
+      CustomProcessEnvironmentReference,
+      () => new CustomProcessEnvironmentReference(),
+    );
+    try {
+      const manifest = new Manifest({
+        environment: { TOKEN: { type: 'process_env' } },
+      });
+      expect(manifest.environment.TOKEN).toBeInstanceOf(
+        CustomProcessEnvironmentReference,
+      );
+    } finally {
+      unregister();
+    }
+  });
+
+  it.each([
+    new Error('ordinary protected secret'),
+    new SandboxLifecycleError('spoofed protected details', {
+      previousSandboxId: 'spoofed-previous-secret',
+      replacementSandboxId: 'spoofed-replacement-secret',
+    }),
+  ])(
+    'keeps protected error redaction active after manifest mutation',
+    async (originalError) => {
+      const manifest = new Manifest({
+        environment: {
+          PROTECTED: new ProcessEnvValue(),
+        },
+      });
+
+      let thrown: unknown;
+      try {
+        await withProcessEnvironmentErrorRedaction(
+          manifest,
+          {
+            provider: 'test',
+            operation: 'mutation',
+            details: { trustedResourceId: 'trusted-resource' },
+          },
+          async () => {
+            manifest.environment.PROTECTED = new Environment({
+              value: 'ordinary',
+            });
+            throw originalError;
+          },
+        );
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+      expect(JSON.stringify(thrown)).not.toContain('protected secret');
+      expect(JSON.stringify(thrown)).not.toContain('spoofed-previous-secret');
+      expect(JSON.stringify(thrown)).not.toContain(
+        'spoofed-replacement-secret',
+      );
+      expect((thrown as SandboxLifecycleError).details).toEqual({
+        provider: 'test',
+        operation: 'mutation',
+        trustedResourceId: 'trusted-resource',
+      });
+    },
+  );
 
   it('rejects unknown, unregistered, duplicate, and inherited environment reference types', () => {
     class UnregisteredReference extends EnvValueReference {

--- a/packages/agents-core/test/sandboxMountSecurity.test.ts
+++ b/packages/agents-core/test/sandboxMountSecurity.test.ts
@@ -5,16 +5,19 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   boxMount,
   dockerVolumeMountStrategy,
+  Environment,
   file,
   gcsMount,
   inContainerMountStrategy,
   Manifest,
+  ProcessEnvValue,
   s3Mount,
   s3FilesMount,
   type MountStrategy,
 } from '../src/sandbox';
 import {
   assertExistingMountTopologyPreserved,
+  bindProcessEnvironmentAccess,
   captureLiveMountCredentialAuthorityIfAbsent,
   deserializeManifest,
   deserializeMountCredentialRedactionMetadata,
@@ -25,6 +28,7 @@ import {
   NON_RESUMABLE_MOUNT_AUTHORITY_KEY,
   recordLiveMountCredentialAuthority,
   rebindPersistedMountCredentials,
+  resolveAndValidateMountEnvironment,
   sanitizeMountCredentialEnvironmentForPersistence,
   serializeManifestRecord,
   serializeMountCredentialRedactionMetadata,
@@ -70,6 +74,44 @@ function credentialedS3Manifest(
 }
 
 describe('sandbox mount credential boundaries', () => {
+  it('preserves protected process environment references while validating mount credentials', async () => {
+    process.env.AGENTS_TEST_MOUNT_PROCESS_SOURCE = 'process-secret';
+    const manifest = bindProcessEnvironmentAccess(
+      new Manifest({
+        environment: {
+          AWS_ACCESS_KEY_ID: new Environment({ value: 'access-key' }),
+          AWS_SECRET_ACCESS_KEY: new Environment({ value: 'secret-key' }),
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_MOUNT_PROCESS_SOURCE',
+          }),
+        },
+        entries: {
+          remote: s3Mount({
+            bucket: 'example',
+            mountStrategy: inContainerMountStrategy(),
+          }),
+        },
+      }).withInContainerMountBroadCredentialExposureAcknowledged('remote'),
+      {
+        processEnvironmentBindings: {
+          SANDBOX_TOKEN: 'AGENTS_TEST_MOUNT_PROCESS_SOURCE',
+        },
+      },
+    );
+
+    const resolved = await resolveAndValidateMountEnvironment(manifest);
+
+    expect(resolved.environment.AWS_ACCESS_KEY_ID).toBeInstanceOf(Environment);
+    expect(resolved.environment.SANDBOX_TOKEN).toBe(
+      manifest.environment.SANDBOX_TOKEN,
+    );
+    expect(resolved.environment.SANDBOX_TOKEN).toBeInstanceOf(ProcessEnvValue);
+    await expect(resolved.resolveEnvironment()).resolves.toMatchObject({
+      SANDBOX_TOKEN: 'process-secret',
+    });
+    expect(JSON.stringify(resolved)).not.toContain('process-secret');
+  });
+
   it('rejects credential-bearing in-container mounts without exposing values', () => {
     const manifest = credentialedS3Manifest(inContainerMountStrategy());
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -48,14 +48,18 @@ import {
 } from '../src';
 import { SandboxRuntimeManager } from '../src/sandbox/runtime';
 import {
+  bindProcessEnvironmentAccess,
   captureLiveMountCredentialAuthority,
+  environmentWithoutProcessEnvValues,
   liveMountCredentialAuthorityMatches,
   liveMountEnvironmentAuthorityMatches,
   markSandboxSessionStateUnsafe,
   NON_RESUMABLE_MOUNT_AUTHORITY_KEY,
   recordLiveMountCredentialAuthority,
+  sanitizeEnvironmentForPersistence,
   serializeManifestRecord,
   mergeManifestDelta,
+  mergeMaterializedEnvironment,
   withExclusiveSandboxManifestMutation,
 } from '../src/sandbox/internal';
 import {
@@ -76,7 +80,10 @@ import {
 } from '../src/sandbox/runtime/sessionLifecycle';
 import {
   Capability,
+  addSandboxEventSink,
+  clearSandboxEventSinks,
   compaction,
+  cloneManifest,
   Entry,
   EnvValueReference,
   file,
@@ -84,6 +91,7 @@ import {
   isEnvValueReference,
   Manifest,
   memory,
+  ProcessEnvValue,
   type MemoryStore,
   SANDBOX_SESSION_STATE_VERSION,
   StaticCompactionPolicy,
@@ -1248,6 +1256,127 @@ describe('sandbox runner integration', () => {
     },
   );
 
+  it('rejects explicit Docker ordinary state when the trusted manifest adds a ProcessEnvValue', async () => {
+    const client = new FakeSandboxClient();
+    Object.defineProperty(client, 'backendId', { value: 'docker' });
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: new Manifest({
+        environment: { SANDBOX_TOKEN: new ProcessEnvValue() },
+      }),
+    });
+    const sessionState: FakeSandboxSessionState = {
+      manifest: new Manifest(),
+      sessionId: 'persisted',
+    };
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: { client, sessionState },
+      runState,
+    });
+
+    await expect(
+      manager.prepareAgent({
+        currentAgent: sandboxAgent,
+        turnInput: [],
+      }),
+    ).rejects.toThrow(
+      'Sandbox session state contains ProcessEnvValue references that do not exactly match the current trusted manifest: SANDBOX_TOKEN.',
+    );
+    expect(client.resumeCalls).toHaveLength(0);
+    expect(client.closeCalls).toHaveLength(0);
+  });
+
+  it('rejects unbound protected explicit state before a custom client resumes', async () => {
+    const client = new FakeSandboxClient();
+    const protectedManifest = new Manifest({
+      environment: {
+        SANDBOX_TOKEN: new ProcessEnvValue({ name: 'SANDBOX_SOURCE' }),
+      },
+    });
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: protectedManifest,
+    });
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: {
+        client,
+        sessionState: {
+          manifest: cloneManifest(protectedManifest),
+          sessionId: 'persisted',
+        },
+      },
+      runState,
+    });
+
+    await expect(
+      manager.prepareAgent({
+        currentAgent: sandboxAgent,
+        turnInput: [],
+      }),
+    ).rejects.toThrow(/Use DockerSandboxClient instead/u);
+    expect(client.resumeCalls).toHaveLength(0);
+  });
+
+  it('rejects protected explicit state before non-Docker resume validation hooks', async () => {
+    const validateSessionStateForResume = vi.fn();
+    const resolveTrustedManifestForResume = vi.fn((manifest: Manifest) =>
+      cloneManifest(manifest),
+    );
+    const client = Object.assign(new FakeSandboxClient(), {
+      validateSessionStateForResume,
+      resolveTrustedManifestForResume,
+    });
+    const resume = vi.spyOn(client, 'resume');
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: new Manifest(),
+    });
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: {
+        client,
+        sessionState: {
+          manifest: new Manifest({
+            environment: {
+              SANDBOX_TOKEN: new ProcessEnvValue({ name: 'SANDBOX_SOURCE' }),
+            },
+          }),
+          sessionId: 'persisted',
+        },
+      },
+      runState,
+    });
+
+    await expect(
+      manager.prepareAgent({
+        currentAgent: sandboxAgent,
+        turnInput: [],
+      }),
+    ).rejects.toThrow(/Use DockerSandboxClient instead/u);
+
+    expect(validateSessionStateForResume).not.toHaveBeenCalled();
+    expect(resolveTrustedManifestForResume).not.toHaveBeenCalled();
+    expect(resume).not.toHaveBeenCalled();
+    expect(client.createCalls).toHaveLength(0);
+  });
+
   it.each([false, true])(
     'persists reordered equal-content session input when a sandbox capability clones context (stream=%s)',
     async (stream) => {
@@ -2142,6 +2271,7 @@ describe('sandbox runner integration', () => {
   });
 
   afterEach(() => {
+    clearSandboxEventSinks();
     setTraceProcessors([]);
     setTracingDisabled(true);
     setTracingContextStorage(undefined);
@@ -3123,6 +3253,69 @@ describe('sandbox runner integration', () => {
     },
   );
 
+  it('rejects persisted ordinary state when the trusted manifest adds a ProcessEnvValue before deserialization', async () => {
+    const client = new FakeSandboxClient();
+    Object.defineProperty(client, 'backendId', { value: 'docker' });
+    const deserializeSessionState = vi.spyOn(client, 'deserializeSessionState');
+
+    await expect(
+      deserializeSandboxSessionStateEntry(
+        client,
+        {
+          backendId: 'docker',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          sessionState: fakeSandboxSessionStateEnvelope(
+            { sessionId: 'persisted' },
+            {
+              backendId: 'docker',
+              manifest: serializeManifestRecord(new Manifest()),
+            },
+          ),
+        },
+        new Manifest({
+          environment: { TOKEN: new ProcessEnvValue() },
+        }),
+      ),
+    ).rejects.toThrow(
+      'RunState sandbox session state contains ProcessEnvValue references that do not exactly match the current trusted manifest: TOKEN.',
+    );
+    expect(deserializeSessionState).not.toHaveBeenCalled();
+  });
+
+  it('rejects persisted-only protected RunState before custom resolution or deserialization', async () => {
+    const resolveTrustedManifestForResume = vi.fn((manifest: Manifest) =>
+      cloneManifest(manifest),
+    );
+    const client = Object.assign(new FakeSandboxClient(), {
+      resolveTrustedManifestForResume,
+    });
+    const deserializeSessionState = vi.spyOn(client, 'deserializeSessionState');
+    const protectedManifest = new Manifest({
+      environment: {
+        TOKEN: new ProcessEnvValue({ name: 'PERSISTED_SOURCE' }),
+      },
+    });
+
+    await expect(
+      deserializeSandboxSessionStateEntry(
+        client,
+        {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          sessionState: fakeSandboxSessionStateEnvelope(
+            { sessionId: 'persisted' },
+            { manifest: serializeManifestRecord(protectedManifest) },
+          ),
+        },
+        new Manifest(),
+      ),
+    ).rejects.toThrow(/Use DockerSandboxClient instead/u);
+    expect(resolveTrustedManifestForResume).not.toHaveBeenCalled();
+    expect(deserializeSessionState).not.toHaveBeenCalled();
+  });
+
   it('rejects explicit non-resumable state before resolving trusted secrets', async () => {
     let resolveCalls = 0;
 
@@ -3730,6 +3923,129 @@ describe('sandbox runner integration', () => {
     await manager.cleanup(runState);
   });
 
+  it('preserves process environment authority for explicit Docker session state without mounts', async () => {
+    process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE = 'manager-secret';
+    try {
+      const client = Object.assign(new FakeSandboxClient(), {
+        resolveTrustedManifestForResume(
+          manifest: Manifest,
+          options: Record<string, unknown> = {},
+        ) {
+          return bindProcessEnvironmentAccess(cloneManifest(manifest), options);
+        },
+      });
+      Object.defineProperty(client, 'backendId', { value: 'docker' });
+      const trustedManifest = new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+          }),
+        },
+      });
+      const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+        name: 'SandboxWorker',
+        model: new RecordingModel([]),
+        defaultManifest: trustedManifest,
+      });
+      const sessionState: FakeSandboxSessionState = {
+        manifest: cloneManifest(trustedManifest),
+        sessionId: 'persisted',
+        environment: {},
+      };
+      const runState = new RunState<
+        unknown,
+        SandboxAgent<unknown, AgentOutputType>
+      >(new RunContext(), 'Hello', sandboxAgent, 1);
+      const manager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent,
+        sandboxConfig: {
+          client,
+          sessionState,
+          options: {
+            processEnvironmentBindings: {
+              SANDBOX_TOKEN: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            },
+          },
+        },
+        runState,
+      });
+
+      await manager.prepareAgent({
+        currentAgent: sandboxAgent,
+        turnInput: [],
+      });
+
+      expect(client.resumeCalls[0]?.state.environment).toEqual({
+        SANDBOX_TOKEN: 'manager-secret',
+      });
+      expect(
+        client.resumeCalls[0]?.state.manifest.environment.SANDBOX_TOKEN,
+      ).toBeInstanceOf(ProcessEnvValue);
+      expect(sessionState.environment).toEqual({});
+
+      await manager.cleanup(runState);
+    } finally {
+      delete process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE;
+    }
+  });
+
+  it.each([
+    [
+      'an ordinary value',
+      new Manifest({
+        environment: { SANDBOX_TOKEN: 'ordinary-value' },
+      }),
+    ],
+    [
+      'a different source',
+      new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({ name: 'NEW_SOURCE' }),
+        },
+      }),
+    ],
+  ])(
+    'rejects explicit Docker protected state when the trusted reference becomes %s',
+    async (_description, trustedManifest) => {
+      const client = new FakeSandboxClient();
+      Object.defineProperty(client, 'backendId', { value: 'docker' });
+      const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+        name: 'SandboxWorker',
+        model: new RecordingModel([]),
+        defaultManifest: trustedManifest,
+      });
+      const sessionState: FakeSandboxSessionState = {
+        manifest: new Manifest({
+          environment: { SANDBOX_TOKEN: new ProcessEnvValue() },
+        }),
+        sessionId: 'persisted',
+        environment: { SANDBOX_TOKEN: 'old-process-secret' },
+      };
+      const runState = new RunState<
+        unknown,
+        SandboxAgent<unknown, AgentOutputType>
+      >(new RunContext(), 'Hello', sandboxAgent, 1);
+      const manager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent,
+        sandboxConfig: { client, sessionState },
+        runState,
+      });
+
+      await expect(
+        manager.prepareAgent({
+          currentAgent: sandboxAgent,
+          turnInput: [],
+        }),
+      ).rejects.toThrow(
+        'Sandbox session state contains ProcessEnvValue references that do not exactly match the current trusted manifest: SANDBOX_TOKEN.',
+      );
+      expect(client.resumeCalls).toHaveLength(0);
+      expect(sessionState.environment).toEqual({
+        SANDBOX_TOKEN: 'old-process-secret',
+      });
+    },
+  );
+
   it('rejects explicit Docker session state when trusted environment removes a key', async () => {
     const client = new FakeSandboxClient();
     Object.defineProperty(client, 'backendId', { value: 'docker' });
@@ -4329,6 +4645,139 @@ describe('sandbox runner integration', () => {
     }
   });
 
+  it.each([
+    [
+      'an ordinary value',
+      new Manifest({ environment: { TOKEN: 'ordinary-value' } }),
+    ],
+    [
+      'a different source',
+      new Manifest({
+        environment: {
+          TOKEN: new ProcessEnvValue({ name: 'CURRENT_SOURCE' }),
+        },
+      }),
+    ],
+  ])(
+    'rejects a persisted ProcessEnvValue when the trusted reference becomes %s before deserialization',
+    async (_description, trustedManifest) => {
+      const client = new FakeSandboxClient();
+      Object.defineProperty(client, 'backendId', { value: 'docker' });
+      const deserializeSessionState = vi.spyOn(
+        client,
+        'deserializeSessionState',
+      );
+
+      await expect(
+        deserializeSandboxSessionStateEntry(
+          client,
+          {
+            backendId: 'docker',
+            currentAgentKey: 'SandboxWorker',
+            currentAgentName: 'SandboxWorker',
+            sessionState: fakeSandboxSessionStateEnvelope(
+              { sessionId: 'persisted' },
+              {
+                backendId: 'docker',
+                manifest: serializeManifestRecord(
+                  new Manifest({
+                    environment: {
+                      TOKEN: new ProcessEnvValue({
+                        name: 'PERSISTED_SOURCE',
+                      }),
+                    },
+                  }),
+                ),
+              },
+            ),
+          },
+          trustedManifest,
+        ),
+      ).rejects.toThrow(
+        'RunState sandbox session state contains ProcessEnvValue references that do not exactly match the current trusted manifest: TOKEN.',
+      );
+      expect(deserializeSessionState).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ['missing', undefined],
+    ['an array', []],
+  ])(
+    'rejects a newly trusted ProcessEnvValue when the persisted environment is %s before deserialization',
+    async (_description, persistedEnvironment) => {
+      const client = new FakeSandboxClient();
+      Object.defineProperty(client, 'backendId', { value: 'docker' });
+      const deserializeSessionState = vi.spyOn(
+        client,
+        'deserializeSessionState',
+      );
+      const persistedManifest: Record<string, unknown> = {
+        version: 1,
+        root: '/workspace',
+        entries: {},
+      };
+      if (persistedEnvironment !== undefined) {
+        persistedManifest.environment = persistedEnvironment;
+      }
+
+      await expect(
+        deserializeSandboxSessionStateEntry(
+          client,
+          {
+            backendId: 'docker',
+            currentAgentKey: 'SandboxWorker',
+            currentAgentName: 'SandboxWorker',
+            sessionState: fakeSandboxSessionStateEnvelope(
+              { sessionId: 'persisted' },
+              { backendId: 'docker', manifest: persistedManifest },
+            ),
+          },
+          new Manifest({
+            environment: {
+              TOKEN: new ProcessEnvValue({ name: 'CURRENT_SOURCE' }),
+            },
+          }),
+        ),
+      ).rejects.toThrow(
+        'RunState sandbox session state contains ProcessEnvValue references that do not exactly match the current trusted manifest: TOKEN.',
+      );
+      expect(deserializeSessionState).not.toHaveBeenCalled();
+    },
+  );
+
+  it('resumes an ordinary legacy manifest without an environment field', async () => {
+    const client = new FakeSandboxClient();
+    const deserializeSessionState = vi.spyOn(client, 'deserializeSessionState');
+
+    const state = await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: 'fake-sandbox',
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: fakeSandboxSessionStateEnvelope(
+          { sessionId: 'persisted' },
+          {
+            manifest: {
+              version: 1,
+              root: '/workspace',
+              entries: {},
+            },
+          },
+        ),
+      },
+      new Manifest({ environment: { ORDINARY: 'current-value' } }),
+    );
+
+    expect(deserializeSessionState).toHaveBeenCalledTimes(1);
+    expect(deserializeSessionState.mock.calls[0]).toHaveLength(1);
+    expect(state?.sessionId).toBe('persisted');
+    expect(await state?.manifest.resolveEnvironment()).toEqual({
+      ORDINARY: 'current-value',
+    });
+  });
+
   it('rejects persisted mount topology before resolving trusted environment references', async () => {
     let resolveCalls = 0;
     class ObservableSecretReference extends EnvValueReference {
@@ -4602,6 +5051,19 @@ describe('sandbox runner integration', () => {
     await transition;
     await serializing;
     expect(serializeSessionState).toHaveBeenCalledOnce();
+  });
+
+  it('preserves ordinary manifest mutation error identity', async () => {
+    const original = new Error('ordinary mutation failure');
+
+    await expect(
+      withExclusiveSandboxManifestMutation(
+        { manifest: new Manifest() },
+        async () => {
+          throw original;
+        },
+      ),
+    ).rejects.toBe(original);
   });
 
   it('holds manifest mutations across awaited persistence checks', async () => {
@@ -7625,6 +8087,428 @@ describe('sandbox runner integration', () => {
     expect(applyManifest).not.toHaveBeenCalled();
   });
 
+  it('retains process environment authority after managed sandbox creation', async () => {
+    process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE = 'manager-secret';
+    try {
+      const client = Object.assign(new FakeSandboxClient(), {
+        resolveTrustedManifestForResume(
+          manifest: Manifest,
+          options: Record<string, unknown> = {},
+        ) {
+          return bindProcessEnvironmentAccess(cloneManifest(manifest), options);
+        },
+      });
+      Object.defineProperty(client, 'backendId', { value: 'docker' });
+      const sandboxAgent = new SandboxAgent({
+        name: 'SandboxWorker',
+        defaultManifest: new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            }),
+          },
+        }),
+      });
+      const manager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent as Agent<unknown, any>,
+        sandboxConfig: {
+          client,
+          options: {
+            processEnvironmentBindings: {
+              SANDBOX_TOKEN: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            },
+          },
+        },
+      });
+
+      await withTrace('managed process environment test', async () => {
+        await manager.prepareAgent({
+          currentAgent: sandboxAgent as Agent<unknown, any>,
+          turnInput: [],
+        });
+      });
+
+      expect(client.createdSessions).toHaveLength(1);
+      expect(client.createdSessions[0]?.state.environment).toMatchObject({
+        SANDBOX_TOKEN: 'manager-secret',
+      });
+      const state = client.createdSessions[0]!.state;
+      const additiveManifest = mergeManifestDelta(
+        state.manifest,
+        new Manifest({ environment: { ORDINARY: 'added' } }),
+      );
+      await expect(
+        mergeMaterializedEnvironment(
+          state.manifest,
+          additiveManifest,
+          state.environment ?? {},
+        ),
+      ).resolves.toEqual({
+        SANDBOX_TOKEN: 'manager-secret',
+        ORDINARY: 'added',
+      });
+      delete state.manifest.environment.SANDBOX_TOKEN;
+      expect(
+        environmentWithoutProcessEnvValues(
+          state.manifest,
+          state.environment ?? {},
+        ),
+      ).not.toHaveProperty('SANDBOX_TOKEN');
+      expect(sanitizeEnvironmentForPersistence(state)).not.toHaveProperty(
+        'SANDBOX_TOKEN',
+      );
+      expect(() => serializeManifestRecord(state.manifest)).toThrow(
+        'protected ProcessEnvValue references changed after binding: SANDBOX_TOKEN',
+      );
+    } finally {
+      delete process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE;
+    }
+  });
+
+  it('redacts protected environment resolver errors before managed sandbox instrumentation', async () => {
+    process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE = 'manager-resolver-secret';
+    try {
+      const client = Object.assign(new FakeSandboxClient(), {
+        resolveTrustedManifestForResume(
+          manifest: Manifest,
+          options: Record<string, unknown> = {},
+        ) {
+          return bindProcessEnvironmentAccess(cloneManifest(manifest), options);
+        },
+      });
+      Object.defineProperty(client, 'backendId', { value: 'docker' });
+      const events: unknown[] = [];
+      addSandboxEventSink((event) => {
+        events.push(event);
+      });
+      const sandboxAgent = new SandboxAgent({
+        name: 'SandboxWorker',
+        defaultManifest: new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            }),
+            FAILING: async () => {
+              throw Object.assign(
+                new Error('resolver echoed manager-resolver-secret'),
+                { cause: new Error('nested manager-resolver-secret') },
+              );
+            },
+          },
+        }),
+      });
+      const manager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent as Agent<unknown, any>,
+        sandboxConfig: {
+          client,
+          options: {
+            processEnvironmentBindings: {
+              SANDBOX_TOKEN: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            },
+          },
+        },
+      });
+
+      let thrown: unknown;
+      try {
+        await withTrace(
+          'managed process environment resolver failure',
+          async () => {
+            await manager.prepareAgent({
+              currentAgent: sandboxAgent as Agent<unknown, any>,
+              turnInput: [],
+            });
+          },
+        );
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(String(thrown)).not.toContain('manager-resolver-secret');
+      expect(JSON.stringify(thrown)).not.toContain('manager-resolver-secret');
+      expect((thrown as Error & { cause?: unknown }).cause).toBeUndefined();
+      expect(JSON.stringify(events)).not.toContain('manager-resolver-secret');
+      expect(client.createdSessions).toHaveLength(0);
+    } finally {
+      delete process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE;
+    }
+  });
+
+  it('redacts protected session start errors before sandbox instrumentation', async () => {
+    process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE = 'manager-secret';
+    try {
+      class FailingStartClient extends FakeSandboxClient {
+        override readonly backendId = 'docker';
+
+        resolveTrustedManifestForResume(
+          manifest: Manifest,
+          options: Record<string, unknown> = {},
+        ) {
+          return bindProcessEnvironmentAccess(cloneManifest(manifest), options);
+        }
+
+        protected override lifecycleHandlers(
+          state: FakeSandboxSessionState,
+        ): Partial<SandboxSessionLike<FakeSandboxSessionState>> {
+          return {
+            start: async () => {
+              throw Object.assign(new Error('start echoed manager-secret'), {
+                cause: new Error('nested manager-secret'),
+              });
+            },
+            close: async () => {
+              this.closeCalls.push(state.sessionId);
+            },
+          };
+        }
+      }
+
+      const events: unknown[] = [];
+      addSandboxEventSink((event) => {
+        events.push(event);
+      });
+      const client = new FailingStartClient();
+      const sandboxAgent = new SandboxAgent({
+        name: 'SandboxWorker',
+        defaultManifest: new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            }),
+          },
+        }),
+      });
+      const manager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent as Agent<unknown, any>,
+        sandboxConfig: {
+          client,
+          options: {
+            processEnvironmentBindings: {
+              SANDBOX_TOKEN: 'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            },
+          },
+        },
+      });
+
+      let thrown: unknown;
+      try {
+        await withTrace(
+          'managed process environment start failure',
+          async () => {
+            await manager.prepareAgent({
+              currentAgent: sandboxAgent as Agent<unknown, any>,
+              turnInput: [],
+            });
+          },
+        );
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(String(thrown)).not.toContain('manager-secret');
+      expect(JSON.stringify(thrown)).not.toContain('manager-secret');
+      expect(JSON.stringify(events)).not.toContain('manager-secret');
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: 'sandbox_operation',
+          name: 'sandbox.start',
+          phase: 'error',
+          error: expect.objectContaining({
+            message:
+              'sandbox session start failed for a sandbox with protected process environment values.',
+          }),
+        }),
+      );
+      expect(client.closeCalls).toEqual(['session-1']);
+    } finally {
+      delete process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE;
+    }
+  });
+
+  it('rejects process environment values before invoking a non-Docker client resolver', async () => {
+    process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE = 'manager-secret';
+    try {
+      const resolveTrustedManifestForResume = vi.fn(
+        (manifest: Manifest, options: Record<string, unknown> = {}) =>
+          bindProcessEnvironmentAccess(cloneManifest(manifest), options),
+      );
+      const client = Object.assign(new FakeSandboxClient(), {
+        resolveTrustedManifestForResume,
+      });
+      const sandboxAgent = new SandboxAgent({
+        name: 'SandboxWorker',
+        defaultManifest: new Manifest({
+          environment: {
+            AGENTS_TEST_MANAGER_PROCESS_SOURCE: new ProcessEnvValue(),
+          },
+        }),
+      });
+      const manager = new SandboxRuntimeManager({
+        startingAgent: sandboxAgent as Agent<unknown, any>,
+        sandboxConfig: {
+          client,
+          options: {
+            allowedProcessEnvironmentKeys: [
+              'AGENTS_TEST_MANAGER_PROCESS_SOURCE',
+            ],
+          },
+        },
+      });
+
+      await expect(
+        withTrace('unsupported managed process environment test', async () => {
+          await manager.prepareAgent({
+            currentAgent: sandboxAgent as Agent<unknown, any>,
+            turnInput: [],
+          });
+        }),
+      ).rejects.toThrow(/Use DockerSandboxClient instead/u);
+
+      expect(resolveTrustedManifestForResume).not.toHaveBeenCalled();
+      expect(client.createCalls).toHaveLength(0);
+    } finally {
+      delete process.env.AGENTS_TEST_MANAGER_PROCESS_SOURCE;
+    }
+  });
+
+  it.each([false, true])(
+    'rejects protected non-Docker state before persistence hooks (preserve=%s)',
+    async (includeOwnedSessions) => {
+      const canPersistOwnedSessionState = vi.fn(async () => true);
+      const canReusePreservedOwnedSession = vi.fn(async () => true);
+      const serializeSessionState = vi.fn(async () => ({}));
+      const client = Object.assign(new FakeSandboxClient(), {
+        canPersistOwnedSessionState,
+        canReusePreservedOwnedSession,
+        serializeSessionState,
+      });
+      const session = client.makeSession({
+        manifest: new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({ name: 'SANDBOX_SOURCE' }),
+          },
+        }),
+        sessionId: 'protected-session',
+      });
+
+      await expect(
+        serializeSandboxRuntimeState({
+          client,
+          sandboxState: undefined,
+          sessionsByAgentKey: new Map([['SandboxWorker', session]]),
+          sessionAgentNamesByKey: new Map([['SandboxWorker', 'SandboxWorker']]),
+          ownedSessionAgentKeys: new Set(['SandboxWorker']),
+          trustedManifestForAgentKey: () => new Manifest(),
+          includeOwnedSessions,
+        }),
+      ).rejects.toThrow(/Use DockerSandboxClient instead/u);
+
+      expect(canPersistOwnedSessionState).not.toHaveBeenCalled();
+      expect(canReusePreservedOwnedSession).not.toHaveBeenCalled();
+      expect(serializeSessionState).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects process environment values already present in a provided session before side effects', async () => {
+    const applyManifest = vi.fn();
+    const setArchiveLimits = vi.fn();
+    const manifest = new Manifest({
+      environment: { TOKEN: new ProcessEnvValue() },
+    });
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      defaultManifest: manifest,
+    });
+    const providedSession: SandboxSessionLike<FakeSandboxSessionState> = {
+      state: {
+        sessionId: 'provided-session',
+        manifest,
+      },
+      createEditor: () => new StubEditor(),
+      execCommand: async () => 'ok',
+      viewImage: async () => ({
+        type: 'image',
+        image: {
+          data: Uint8Array.from([137, 80, 78, 71]),
+          mediaType: 'image/png',
+        },
+      }),
+      applyManifest,
+      setArchiveLimits,
+    };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        session: providedSession,
+        archiveLimits: { maxMembers: 10 },
+      },
+    });
+
+    await expect(
+      withTrace('provided session process environment test', async () => {
+        await manager.prepareAgent({
+          currentAgent: sandboxAgent as Agent<unknown, any>,
+          turnInput: [],
+        });
+      }),
+    ).rejects.toThrow(/provided sandbox sessions/u);
+
+    expect(setArchiveLimits).not.toHaveBeenCalled();
+    expect(applyManifest).not.toHaveBeenCalled();
+  });
+
+  it('rejects configured process environment values for a provided session before side effects', async () => {
+    const applyManifest = vi.fn();
+    const setArchiveLimits = vi.fn();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      defaultManifest: new Manifest({
+        environment: { TOKEN: new ProcessEnvValue() },
+      }),
+    });
+    const providedSession: SandboxSessionLike<FakeSandboxSessionState> = {
+      state: {
+        sessionId: 'provided-session',
+        manifest: new Manifest(),
+      },
+      createEditor: () => new StubEditor(),
+      execCommand: async () => 'ok',
+      viewImage: async () => ({
+        type: 'image',
+        image: {
+          data: Uint8Array.from([137, 80, 78, 71]),
+          mediaType: 'image/png',
+        },
+      }),
+      applyManifest,
+      setArchiveLimits,
+    };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        session: providedSession,
+        archiveLimits: { maxMembers: 10 },
+      },
+    });
+
+    await expect(
+      withTrace(
+        'provided session configured process environment test',
+        async () => {
+          await manager.prepareAgent({
+            currentAgent: sandboxAgent as Agent<unknown, any>,
+            turnInput: [],
+          });
+        },
+      ),
+    ).rejects.toThrow(/provided sandbox sessions/u);
+
+    expect(setArchiveLimits).not.toHaveBeenCalled();
+    expect(applyManifest).not.toHaveBeenCalled();
+  });
+
   it('preserves an existing provider-native mount in additive provided-session overrides', async () => {
     const liveManifest = new Manifest({
       root: '/workspace',
@@ -9880,6 +10764,110 @@ describe('sandbox runner integration', () => {
     ).rejects.toThrow('Unknown process session 1');
     expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
 
+    await secondManager.cleanup(state);
+  });
+
+  it('rejects a preserved ordinary live session when the trusted manifest adds a ProcessEnvValue', async () => {
+    const client = new DockerRevalidatingLiveProcessFakeSandboxClient();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: new Manifest(),
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+    const reuseCheckCount = client.reuseChecks.length;
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest: new Manifest({
+          environment: { TOKEN: new ProcessEnvValue() },
+        }),
+      },
+      runState: state,
+    });
+
+    await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      'Preserved sandbox session state contains ProcessEnvValue references that do not exactly match the current trusted manifest: TOKEN.',
+    );
+    expect(client.reuseChecks).toHaveLength(reuseCheckCount);
+    expect(client.resumeCalls).toHaveLength(0);
+    expect(client.closeCalls).toHaveLength(0);
+
+    await secondManager.cleanup(state);
+  });
+
+  it('rejects a protected non-Docker live session before reuse callbacks', async () => {
+    const resolveTrustedManifestForResume = vi.fn((manifest: Manifest) =>
+      cloneManifest(manifest),
+    );
+    const client = Object.assign(
+      new RevalidatingLiveProcessFakeSandboxClient(),
+      { resolveTrustedManifestForResume },
+    );
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest: new Manifest() },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+    const resolverCallCount = resolveTrustedManifestForResume.mock.calls.length;
+    const reuseCheckCount = client.reuseChecks.length;
+    const liveSession = client.createdSessions[0]!;
+    liveSession.state.manifest = new Manifest({
+      environment: {
+        SANDBOX_TOKEN: new ProcessEnvValue({ name: 'SANDBOX_SOURCE' }),
+      },
+    });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest: new Manifest() },
+      runState: state,
+    });
+
+    await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      /Use DockerSandboxClient instead/u,
+    );
+    expect(resolveTrustedManifestForResume).toHaveBeenCalledTimes(
+      resolverCallCount,
+    );
+    expect(client.reuseChecks).toHaveLength(reuseCheckCount);
+    expect(client.resumeCalls).toHaveLength(0);
+
+    liveSession.state.manifest = new Manifest();
     await secondManager.cleanup(state);
   });
 

--- a/packages/agents-core/test/sandboxes/docker.test.ts
+++ b/packages/agents-core/test/sandboxes/docker.test.ts
@@ -8,6 +8,7 @@ import {
   inContainerMountStrategy,
   Manifest,
   NoopSnapshotSpec,
+  ProcessEnvValue,
 } from '../../src/sandbox/local';
 
 const ONE_BY_ONE_PNG = Uint8Array.from(
@@ -68,6 +69,149 @@ describe('DockerSandboxClient', () => {
           }).withInContainerMountCredentialExposureAcknowledged('mounted'),
         ),
       ).rejects.toThrow(/SDK-supported strategy/u);
+    },
+    DOCKER_TEST_TIMEOUT_MS,
+  );
+
+  itIfDocker(
+    'delivers protected values to workloads without persisting them in the container environment',
+    async () => {
+      rootDir = await mkdtemp(
+        join(tmpdir(), 'agents-core-docker-sandbox-test-'),
+      );
+      process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE =
+        'docker-protected-environment-sentinel';
+      process.env.AGENTS_TEST_DOCKER_LARGE_PROCESS_SOURCE = 'x'.repeat(8192);
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        image: DOCKER_TEST_IMAGE,
+        processEnvironmentBindings: {
+          SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          LARGE_TOKEN: 'AGENTS_TEST_DOCKER_LARGE_PROCESS_SOURCE',
+        },
+      });
+      try {
+        const session = await client.create(
+          new Manifest({
+            environment: {
+              SANDBOX_TOKEN: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+              }),
+              LARGE_TOKEN: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_LARGE_PROCESS_SOURCE',
+              }),
+            },
+          }),
+        );
+        cleanupContainerIds.add(session.state.containerId);
+
+        const environment = await session.exec({ cmd: 'env' });
+        const ttyEnvironment = await session.exec({
+          cmd: 'printf %s "$SANDBOX_TOKEN"',
+          tty: true,
+        });
+        const started = await session.execCommand({
+          cmd: 'printf "%s:%s:ready\\n" "$SANDBOX_TOKEN" "${#LARGE_TOKEN}"; read value; printf "%s\\n" "$value"',
+          tty: true,
+          yieldTimeMs: 0,
+        });
+        const sessionId = Number(
+          started.match(/Process running with session ID (\d+)/)?.[1],
+        );
+        const finished = await writeUntilExit(
+          { writeStdin: (args) => session.writeStdin(args) },
+          sessionId,
+          'protected stdin remains available\n',
+        );
+        const controlStarted = await session.execCommand({
+          cmd: 'while :; do sleep 1; done',
+          tty: true,
+          yieldTimeMs: 0,
+        });
+        const controlSessionId = Number(
+          controlStarted.match(/Process running with session ID (\d+)/)?.[1],
+        );
+        const controlFinished = await writeUntilExit(
+          { writeStdin: (args) => session.writeStdin(args) },
+          controlSessionId,
+          '\u0003',
+        );
+        const initEnvironment = await session.exec({
+          cmd: "tr '\\000' '\\n' < /proc/1/environ",
+        });
+        expect(environment.stdout).toContain(
+          'docker-protected-environment-sentinel',
+        );
+        expect(ttyEnvironment.stdout).toContain(
+          'docker-protected-environment-sentinel',
+        );
+        expect(ttyEnvironment.stdout).not.toContain(
+          Buffer.from(
+            "export 'SANDBOX_TOKEN=docker-protected-environment-sentinel'",
+          ).toString('base64'),
+        );
+        expect(finished).toContain('protected stdin remains available');
+        expect(controlFinished).toContain('Process exited with code');
+        expect(initEnvironment.stdout).not.toContain(
+          'docker-protected-environment-sentinel',
+        );
+      } finally {
+        delete process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE;
+        delete process.env.AGENTS_TEST_DOCKER_LARGE_PROCESS_SOURCE;
+      }
+    },
+    DOCKER_TEST_TIMEOUT_MS,
+  );
+
+  itIfDocker(
+    'restores TTY state before starting a workload with a protected PATH',
+    async () => {
+      rootDir = await mkdtemp(
+        join(tmpdir(), 'agents-core-docker-sandbox-test-'),
+      );
+      process.env.AGENTS_TEST_DOCKER_PATH_SOURCE = '/does-not-exist';
+      process.env.AGENTS_TEST_DOCKER_STTY_COMMAND_SOURCE = 'command-value';
+      process.env.AGENTS_TEST_DOCKER_STTY_STATE_SOURCE = 'state-value';
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        image: DOCKER_TEST_IMAGE,
+        processEnvironmentBindings: {
+          PATH: 'AGENTS_TEST_DOCKER_PATH_SOURCE',
+          protected_stty_command: 'AGENTS_TEST_DOCKER_STTY_COMMAND_SOURCE',
+          protected_stty_state: 'AGENTS_TEST_DOCKER_STTY_STATE_SOURCE',
+        },
+      });
+      try {
+        const session = await client.create(
+          new Manifest({
+            environment: {
+              PATH: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_PATH_SOURCE',
+              }),
+              protected_stty_command: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_STTY_COMMAND_SOURCE',
+              }),
+              protected_stty_state: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_STTY_STATE_SOURCE',
+              }),
+            },
+          }),
+        );
+        cleanupContainerIds.add(session.state.containerId);
+
+        const result = await session.exec({
+          cmd: 'printf "%s:%s:%s" protected-path-workload-started "$protected_stty_command" "$protected_stty_state"',
+          tty: true,
+        });
+
+        expect(result.stdout).toContain(
+          'protected-path-workload-started:command-value:state-value',
+        );
+      } finally {
+        delete process.env.AGENTS_TEST_DOCKER_PATH_SOURCE;
+        delete process.env.AGENTS_TEST_DOCKER_STTY_COMMAND_SOURCE;
+        delete process.env.AGENTS_TEST_DOCKER_STTY_STATE_SOURCE;
+      }
     },
     DOCKER_TEST_TIMEOUT_MS,
   );

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -1,4 +1,5 @@
 import {
+  chmod,
   lstat,
   mkdir,
   mkdtemp,
@@ -24,9 +25,13 @@ import {
   deserializeSandboxSessionStateEntry,
   toSessionStateEnvelope,
 } from '../../src/sandbox/runtime/sessionState';
+import { cleanupSandboxSession } from '../../src/sandbox/runtime/sessionLifecycle';
 import {
+  bindProcessEnvironmentAccess,
   liveMountCredentialAuthorityMatches,
+  markRunStateDeserializationInput,
   rebindPersistedMountCredentials,
+  serializeManifestRecord,
 } from '../../src/sandbox/internal';
 
 const dockerStdinWrites: Array<string | Uint8Array> = [];
@@ -58,11 +63,15 @@ import {
   DockerSandboxClient,
   DockerSandboxSession,
   type DockerSandboxSessionState,
+  cloneManifest,
+  Environment,
   EnvValueReference,
   inContainerMountStrategy,
   Manifest,
+  ProcessEnvValue,
   NoopSnapshotSpec,
   registerEnvValueReference,
+  SandboxLifecycleError,
   SandboxMountError,
   s3Mount,
   skills,
@@ -82,6 +91,14 @@ const failure = (stderr: string): SandboxProcessResult => ({
   stdout: '',
   stderr,
   timedOut: false,
+});
+
+const timedOut = (): SandboxProcessResult => ({
+  status: null,
+  signal: 'SIGTERM',
+  stdout: '',
+  stderr: '',
+  timedOut: true,
 });
 
 function dockerRunLabels(args: string[]): Record<string, string> {
@@ -112,7 +129,13 @@ function dockerWorkspaceMount(source: string, target = '/workspace') {
 
 type DockerContainerInspection = {
   labels: Record<string, string>;
-  mounts: ReturnType<typeof dockerWorkspaceMount>;
+  mounts: Array<{
+    Type: string;
+    Source?: string;
+    Name?: string;
+    Destination: string;
+    RW: boolean;
+  }>;
   networkMode: string;
   networks: unknown;
 };
@@ -121,7 +144,7 @@ function dockerRunInspection(args: string[]): DockerContainerInspection {
   const workspaceMountIndex = args.indexOf('-v');
   const workspaceMount = args[workspaceMountIndex + 1] ?? '';
   const separatorIndex = workspaceMount.indexOf(':');
-  const mounts = dockerWorkspaceMount(
+  const mounts: DockerContainerInspection['mounts'] = dockerWorkspaceMount(
     workspaceMount.slice(0, separatorIndex),
     workspaceMount.slice(separatorIndex + 1),
   );
@@ -140,15 +163,21 @@ function dockerRunInspection(args: string[]): DockerContainerInspection {
             ];
       }),
     );
-    if (options.type !== 'bind') {
-      continue;
+    if (options.type === 'bind') {
+      mounts.push({
+        Type: 'bind',
+        Source: String(options.source),
+        Destination: String(options.target),
+        RW: options.readonly !== true,
+      });
+    } else if (options.type === 'volume') {
+      mounts.push({
+        Type: 'volume',
+        Name: String(options.source),
+        Destination: String(options.target),
+        RW: options.readonly !== true,
+      });
     }
-    mounts.push({
-      Type: 'bind',
-      Source: String(options.source),
-      Destination: String(options.target),
-      RW: options.readonly !== true,
-    });
   }
   const networkArgIndex = args.indexOf('--network');
   const networkMode =
@@ -179,6 +208,9 @@ function dockerInspectionResult(
     return success(
       `${JSON.stringify(inspection?.networkMode ?? '')}\n${JSON.stringify(inspection?.networks ?? null)}\n`,
     );
+  }
+  if (args[4] === '{{.Id}}') {
+    return inspection ? success(`${args[5]}\n`) : failure('No such container');
   }
   return undefined;
 }
@@ -239,6 +271,11 @@ describe('DockerSandboxClient unit behavior', () => {
   });
 
   afterEach(async () => {
+    delete process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE;
+    delete process.env.AGENTS_TEST_DOCKER_ACCESS_SOURCE;
+    delete process.env.AGENTS_TEST_DOCKER_SECRET_SOURCE;
+    delete process.env.AGENTS_TEST_DOCKER_UNRELATED_SOURCE;
+    delete process.env['AGENTS-TEST-DOCKER-SOURCE'];
     await rm(rootDir, { recursive: true, force: true });
   });
 
@@ -484,6 +521,1693 @@ describe('DockerSandboxClient unit behavior', () => {
     );
 
     await session.close();
+  });
+
+  it('passes granted process environment values to Docker without persisting them', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-process-secret';
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-process-env-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    const clientOptions = {
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    };
+
+    const session = await client.create({
+      manifest: new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountPath: '/mnt/logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+      options: clientOptions,
+    });
+    const runCall = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCall?.[1]).not.toContain('SANDBOX_TOKEN=docker-process-secret');
+    session.state.environment.RUNTIME_ENV = 'runtime-only';
+
+    const serialized = await client.serializeSessionState(session.state);
+    expect(JSON.stringify(serialized)).not.toContain('docker-process-secret');
+    expect(serialized.environment).toEqual({ RUNTIME_ENV: 'runtime-only' });
+
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+    const restored = await client.deserializeSessionState(
+      markRunStateDeserializationInput(serialized, { clientOptions }),
+    );
+    const authenticatedPreviousVolumeName =
+      session.state.dockerVolumeNames?.[0];
+    expect(authenticatedPreviousVolumeName).toBeDefined();
+    restored.dockerVolumeNames = ['forged-unrelated-volume'];
+    expect(restored.environment).toEqual({
+      RUNTIME_ENV: 'runtime-only',
+      SANDBOX_TOKEN: 'rotated-process-secret',
+    });
+    restored.manifest = new Manifest({
+      ...restored.manifest,
+      environment: {
+        ...restored.manifest.environment,
+        MUTATE_RESUME_STATE: async () => {
+          restored.manifest = new Manifest();
+          return 'mutated';
+        },
+      },
+    });
+    const resumed = await client.resume(restored, { clientOptions });
+    expect(resumed.state.containerId).toBe('container-process-env-2');
+    expect(resumed.state.manifest.environment.SANDBOX_TOKEN).toBeInstanceOf(
+      ProcessEnvValue,
+    );
+    const runCalls = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[1]?.[1]).toEqual(
+      expect.arrayContaining(['-e', 'RUNTIME_ENV=runtime-only']),
+    );
+    expect(runCalls[1]?.[1]).not.toContain(
+      'SANDBOX_TOKEN=rotated-process-secret',
+    );
+    expect(resumed.state.environment.RUNTIME_ENV).toBe('runtime-only');
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-process-env-1'],
+      { timeoutMs: 30_000 },
+    );
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      ['volume', 'rm', '-f', authenticatedPreviousVolumeName],
+      { timeoutMs: 10_000 },
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['volume', 'rm', '-f', 'forged-unrelated-volume'],
+      { timeoutMs: 10_000 },
+    );
+    const replacementStartIndex =
+      processMocks.runSandboxProcess.mock.calls.indexOf(runCalls[1]!);
+    const previousRemovalIndex =
+      processMocks.runSandboxProcess.mock.calls.findIndex(
+        ([, args]) =>
+          args[0] === 'rm' && args.includes('container-process-env-1'),
+      );
+    expect(replacementStartIndex).toBeLessThan(previousRemovalIndex);
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    childProcessMocks.spawn.mockClear();
+    dockerStdinWrites.length = 0;
+    expect(() => {
+      resumed.state.manifest = new Manifest();
+    }).toThrow(/cannot remove or replace protected ProcessEnvValue bindings/u);
+    const unboundReplacement = cloneManifest(resumed.state.manifest);
+    unboundReplacement.environment.EXTRA_TOKEN = new ProcessEnvValue({
+      name: 'AGENTS_TEST_EXTRA_PROCESS_SOURCE',
+    });
+    expect(() => {
+      resumed.state.manifest = unboundReplacement;
+    }).toThrow(/cannot remove or replace protected ProcessEnvValue bindings/u);
+    await resumed.execCommand({ cmd: 'env', yieldTimeMs: 0 });
+    expect(JSON.stringify(childProcessMocks.spawn.mock.calls)).not.toContain(
+      'rotated-process-secret',
+    );
+    expect(dockerStdinWrites).toHaveLength(1);
+    expect(
+      Buffer.from(String(dockerStdinWrites[0]).trim(), 'base64').toString(
+        'utf8',
+      ),
+    ).toContain("export 'SANDBOX_TOKEN=rotated-process-secret'");
+    const resumedSerialized = await client.serializeSessionState(resumed.state);
+    expect(JSON.stringify(resumedSerialized)).not.toContain(
+      'rotated-process-secret',
+    );
+    expect(resumedSerialized.environment).not.toHaveProperty('SANDBOX_TOKEN');
+
+    const mutatedState = await client.deserializeSessionState(
+      markRunStateDeserializationInput(serialized, { clientOptions }),
+    );
+    mutatedState.manifest.environment.SANDBOX_TOKEN = new Environment(
+      'ordinary-value',
+    );
+    processMocks.runSandboxProcess.mockClear();
+    await expect(
+      client.resume(mutatedState, { clientOptions }),
+    ).rejects.toThrow(
+      /bound sandbox manifest contains changed ProcessEnvValue references/u,
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+  });
+
+  it('transports only selected protected mount environment through stdin', async () => {
+    process.env.AGENTS_TEST_DOCKER_ACCESS_SOURCE = 'protected-access-key';
+    process.env.AGENTS_TEST_DOCKER_SECRET_SOURCE = 'protected-secret-key';
+    process.env.AGENTS_TEST_DOCKER_UNRELATED_SOURCE =
+      'unrelated-protected-secret';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-protected-mount\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        AWS_ACCESS_KEY_ID: 'AGENTS_TEST_DOCKER_ACCESS_SOURCE',
+        AWS_SECRET_ACCESS_KEY: 'AGENTS_TEST_DOCKER_SECRET_SOURCE',
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_UNRELATED_SOURCE',
+      },
+    });
+    await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountStrategy: inContainerMountStrategy({
+              pattern: { type: 'rclone' },
+            }),
+          },
+        },
+        environment: {
+          AWS_ACCESS_KEY_ID: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_ACCESS_SOURCE',
+          }),
+          AWS_SECRET_ACCESS_KEY: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_SECRET_SOURCE',
+          }),
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_UNRELATED_SOURCE',
+          }),
+          HTTPS_PROXY: 'http://proxy.example.test',
+        },
+      }).withInContainerMountBroadCredentialExposureAcknowledged('logs'),
+    );
+
+    const spawnArgs = childProcessMocks.spawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toEqual(
+      expect.arrayContaining([
+        'exec',
+        '-i',
+        'container-protected-mount',
+        '/bin/sh',
+        '-s',
+      ]),
+    );
+    expect(JSON.stringify(spawnArgs)).not.toContain('protected-access-key');
+    expect(JSON.stringify(spawnArgs)).not.toContain('protected-secret-key');
+    expect(JSON.stringify(spawnArgs)).not.toContain(
+      'unrelated-protected-secret',
+    );
+    expect(spawnArgs).toEqual(
+      expect.arrayContaining(['-e', 'HTTPS_PROXY=http://proxy.example.test']),
+    );
+    const stdin = dockerStdinWrites.join('');
+    expect(stdin).toContain('protected-access-key');
+    expect(stdin).toContain('protected-secret-key');
+    expect(stdin).not.toContain('unrelated-protected-secret');
+    const runArgs = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    )?.[1];
+    expect(JSON.stringify(runArgs)).not.toContain('protected-access-key');
+    expect(JSON.stringify(runArgs)).not.toContain('protected-secret-key');
+    expect(JSON.stringify(runArgs)).not.toContain('unrelated-protected-secret');
+  });
+
+  it('rejects mutated protected bindings before Docker snapshot effects', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-process-secret';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-process-env-mutation\n');
+        }
+        return success();
+      },
+    );
+    const snapshotBaseDir = join(rootDir, 'mutation-snapshots');
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: { type: 'local', baseDir: snapshotBaseDir },
+    });
+    const session = await client.create({
+      manifest: new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+      options: {
+        processEnvironmentBindings: {
+          SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+        },
+      },
+    });
+    delete session.state.manifest.environment.SANDBOX_TOKEN;
+
+    await expect(client.serializeSessionState(session.state)).rejects.toThrow(
+      /protected ProcessEnvValue references changed after binding/u,
+    );
+    await expect(readdir(snapshotBaseDir)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+
+    await session.close();
+  });
+
+  it('keeps the running Docker container when protected replacement startup fails', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-process-secret';
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 2) {
+            return failure('replacement startup failed');
+          }
+          const containerId = 'container-process-env-original';
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          const inspection = dockerInspectionResult(inspections, args);
+          if (inspection) {
+            return inspection;
+          }
+          return success('true\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    const clientOptions = {
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    };
+    const session = await client.create({
+      manifest: new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+      options: clientOptions,
+    });
+    const serialized = await client.serializeSessionState(session.state);
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+    const restored = await client.deserializeSessionState(
+      markRunStateDeserializationInput(serialized, { clientOptions }),
+    );
+    restored.manifest.environment.MUTATING = new Environment({
+      value: 'safe',
+      resolve: () => {
+        delete restored.manifest.environment.SANDBOX_TOKEN;
+        return 'safe';
+      },
+    });
+
+    await expect(client.resume(restored, { clientOptions })).rejects.toThrow(
+      /protected process environment values/u,
+    );
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-process-env-original'],
+      { timeoutMs: 30_000 },
+    );
+  });
+
+  it('keeps an authenticated stopped container when protected replacement startup fails', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-process-secret';
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 2) {
+            return failure('replacement startup failed');
+          }
+          const containerId = 'container-process-env-stopped';
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (
+          args[0] === 'inspect' &&
+          args[4] === '{{.State.Running}}' &&
+          args[5] === 'container-process-env-stopped'
+        ) {
+          return success('false\n');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+    );
+    session.state.dockerVolumeNames = ['forged-unrelated-volume'];
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+
+    await expect(client.resume(session.state)).rejects.toThrow(
+      /protected process environment values/u,
+    );
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-process-env-stopped'],
+      { timeoutMs: 30_000 },
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['volume', 'rm', '-f', 'forged-unrelated-volume'],
+      { timeoutMs: 10_000 },
+    );
+  });
+
+  it('preserves protected creation identifiers when Docker run and cleanup fail', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'protected-run-secret';
+    let candidateName: string | undefined;
+    let candidateVolumeName: string | undefined;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          candidateName = args[args.indexOf('--name') + 1];
+          candidateVolumeName = dockerRunInspection(args).mounts.find(
+            (mount) => mount.Type === 'volume',
+          )?.Name;
+          return failure('docker run echoed protected-run-secret');
+        }
+        if (args[0] === 'rm' && args[2] === candidateName) {
+          return failure('container cleanup echoed protected-run-secret');
+        }
+        if (
+          args[0] === 'volume' &&
+          args[1] === 'rm' &&
+          args[3] === candidateVolumeName
+        ) {
+          return failure('volume cleanup echoed protected-run-secret');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+
+    const error = await client
+      .create(
+        new Manifest({
+          entries: {
+            logs: {
+              type: 's3_mount',
+              bucket: 'agent-logs',
+              mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+            },
+          },
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+            }),
+          },
+        }),
+      )
+      .then(
+        () => undefined,
+        (caught: unknown) => caught,
+      );
+
+    expect(candidateName).toBeDefined();
+    expect(candidateVolumeName).toBeDefined();
+    expect(error).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(error)).not.toContain('protected-run-secret');
+    expect((error as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'sandbox creation',
+      replacementContainerId: candidateName,
+      replacementDockerVolumeNames: [candidateVolumeName],
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it('preserves protected replacement identifiers when Docker run and cleanup fail', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-secret';
+    let runCount = 0;
+    let candidateName: string | undefined;
+    let candidateVolumeName: string | undefined;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 1) {
+            inspections.set(
+              'protected-run-original',
+              dockerRunInspection(args),
+            );
+            return success('protected-run-original\n');
+          }
+          candidateName = args[args.indexOf('--name') + 1];
+          candidateVolumeName = dockerRunInspection(args).mounts.find(
+            (mount) => mount.Type === 'volume',
+          )?.Name;
+          return failure('docker run echoed rotated-secret');
+        }
+        if (args[0] === 'rm' && args[2] === candidateName) {
+          return failure('container cleanup echoed rotated-secret');
+        }
+        if (
+          args[0] === 'volume' &&
+          args[1] === 'rm' &&
+          args[3] === candidateVolumeName
+        ) {
+          return failure('volume cleanup echoed rotated-secret');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+    );
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-secret';
+
+    const error = await client.resume(session.state).then(
+      () => undefined,
+      (caught: unknown) => caught,
+    );
+
+    expect(candidateName).toBeDefined();
+    expect(candidateVolumeName).toBeDefined();
+    expect(error).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(error)).not.toContain('rotated-secret');
+    expect((error as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'sandbox resume',
+      containerId: 'protected-run-original',
+      replacementContainerId: candidateName,
+      replacementDockerVolumeNames: [candidateVolumeName],
+    });
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'protected-run-original'],
+      { timeoutMs: 30_000 },
+    );
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it('does not clean persisted Docker identifiers when the protected container is missing', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-process-secret';
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-process-env-missing-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (
+          args[0] === 'inspect' &&
+          args[4] === '{{.State.Running}}' &&
+          args[5] === 'container-process-env-missing-1'
+        ) {
+          return failure('No such container');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+    );
+    inspections.delete('container-process-env-missing-1');
+    session.state.dockerVolumeNames = ['forged-unrelated-volume'];
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.containerId).toBe('container-process-env-missing-2');
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-process-env-missing-1'],
+      { timeoutMs: 30_000 },
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['volume', 'rm', '-f', 'forged-unrelated-volume'],
+      { timeoutMs: 10_000 },
+    );
+  });
+
+  it('preserves the Docker replacement after ambiguous previous-container retirement', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-process-secret';
+    let runCount = 0;
+    let previousRemovalCompleted = false;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-process-env-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'rm' && args.includes('container-process-env-1')) {
+          previousRemovalCompleted = true;
+          inspections.delete('container-process-env-1');
+          return failure('container removal response was lost');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    const clientOptions = {
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    };
+    const session = await client.create({
+      manifest: new Manifest({
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+      options: clientOptions,
+    });
+    const serialized = await client.serializeSessionState(session.state);
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+    const restored = await client.deserializeSessionState(
+      markRunStateDeserializationInput(serialized, { clientOptions }),
+    );
+
+    let thrown: unknown;
+    try {
+      await client.resume(restored, { clientOptions });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(previousRemovalCompleted).toBe(true);
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect((thrown as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'sandbox resume',
+      containerId: 'container-process-env-1',
+      previousContainerId: 'container-process-env-1',
+      previousDockerVolumeNames: [],
+      replacementContainerId: 'container-process-env-2',
+      replacementDockerVolumeNames: [],
+    });
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-process-env-2'],
+      { timeoutMs: 30_000 },
+    );
+  });
+
+  it('preserves the Docker replacement when previous volume retirement fails', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-process-secret';
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-process-env-volume-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (
+          args[0] === 'volume' &&
+          args[1] === 'rm' &&
+          args[3] === previousVolumeName
+        ) {
+          return failure('volume cleanup echoed initial-process-secret');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountPath: '/mnt/logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+    );
+    const previousVolumeName = session.state.dockerVolumeNames?.[0];
+    expect(previousVolumeName).toBeDefined();
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+
+    let thrown: unknown;
+    try {
+      await client.resume(session.state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    const replacementVolumeName = inspections
+      .get('container-process-env-volume-2')
+      ?.mounts.find((mount) => mount.Type === 'volume')?.Name;
+    expect(replacementVolumeName).toBeDefined();
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(thrown)).not.toContain('initial-process-secret');
+    expect((thrown as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'sandbox resume',
+      containerId: 'container-process-env-volume-1',
+      previousContainerId: 'container-process-env-volume-1',
+      previousDockerVolumeNames: [previousVolumeName],
+      replacementContainerId: 'container-process-env-volume-2',
+      replacementDockerVolumeNames: [replacementVolumeName],
+    });
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-process-env-volume-2'],
+      { timeoutMs: 30_000 },
+    );
+  });
+
+  it('removes a distinct previous owned workspace after protected replacement', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-process-secret';
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-process-env-workspace-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: { type: 'local', baseDir: join(rootDir, 'snapshots') },
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'snapshot.txt': { type: 'file', content: 'snapshot\n' },
+        },
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+    await client.serializeSessionState(session.state);
+    const previousWorkspaceRootPath = session.state.workspaceRootPath;
+    await writeFile(join(previousWorkspaceRootPath, 'changed.txt'), 'changed');
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.workspaceRootPath).not.toBe(previousWorkspaceRootPath);
+    await expect(stat(previousWorkspaceRootPath)).rejects.toThrow();
+    await expect(
+      readFile(join(resumed.state.workspaceRootPath, 'snapshot.txt'), 'utf8'),
+    ).resolves.toBe('snapshot\n');
+  });
+
+  it('preserves a previous owned workspace when protected retirement fails', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-process-secret';
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-process-env-workspace-failure-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (
+          args[0] === 'rm' &&
+          args.includes('container-process-env-workspace-failure-1')
+        ) {
+          return failure('retirement failed');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: { type: 'local', baseDir: join(rootDir, 'snapshots') },
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          'snapshot.txt': { type: 'file', content: 'snapshot\n' },
+        },
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+    await client.serializeSessionState(session.state);
+    const previousWorkspaceRootPath = session.state.workspaceRootPath;
+    await writeFile(join(previousWorkspaceRootPath, 'changed.txt'), 'changed');
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-process-secret';
+
+    await expect(client.resume(session.state)).rejects.toThrow(
+      /protected process environment values/u,
+    );
+
+    await expect(stat(previousWorkspaceRootPath)).resolves.toBeTruthy();
+  });
+
+  it('rejects ungranted process environment values before Docker effects', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'unused-secret';
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+
+    await expect(
+      client.create(
+        new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+            }),
+          },
+        }),
+      ),
+    ).rejects.toThrow(/is not granted/u);
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+  });
+
+  it.each(['LD_PRELOAD', 'LD_LIBRARY_PATH', 'LD_AUDIT'])(
+    'rejects protected %s before Docker effects',
+    async (destination) => {
+      process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'unused-secret';
+      const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+
+      await expect(
+        client.create({
+          manifest: new Manifest({
+            environment: {
+              [destination]: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+              }),
+            },
+          }),
+          options: {
+            processEnvironmentBindings: {
+              [destination]: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+            },
+          },
+        }),
+      ).rejects.toThrow(
+        new RegExp(
+          `does not support ProcessEnvValue for "${destination}"`,
+          'u',
+        ),
+      );
+      expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    'API-TOKEN',
+    'A B',
+    '9TOKEN',
+    'PPID',
+    'UID',
+    'EUID',
+    'SHELLOPTS',
+    'IFS',
+    'BASH',
+    'BASH_EXECUTION_STRING',
+    'BASH_VERSION',
+    'ZSH_VERSION',
+    'KSH_VERSION',
+  ])(
+    'rejects unsupported protected destination %s before Docker effects',
+    async (destination) => {
+      process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'unused-secret';
+      const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+
+      await expect(
+        client.create({
+          manifest: new Manifest({
+            environment: {
+              [destination]: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+              }),
+            },
+          }),
+          options: {
+            processEnvironmentBindings: {
+              [destination]: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+            },
+          },
+        }),
+      ).rejects.toThrow(/assignable POSIX shell identifiers/u);
+      expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a non-POSIX protected destination during trusted resume preparation', () => {
+    process.env['AGENTS-TEST-DOCKER-SOURCE'] = 'unused-secret';
+    const resolver = vi.fn(async () => 'unresolved');
+    const client = new DockerSandboxClient({
+      processEnvironmentBindings: {
+        API_TOKEN: 'AGENTS-TEST-DOCKER-SOURCE',
+      },
+    });
+
+    expect(() =>
+      client.resolveTrustedManifestForResume(
+        new Manifest({
+          environment: {
+            'API-TOKEN': new ProcessEnvValue({
+              name: 'AGENTS-TEST-DOCKER-SOURCE',
+            }),
+            PROBE: resolver,
+          },
+        }),
+        {
+          processEnvironmentBindings: {
+            'API-TOKEN': 'AGENTS-TEST-DOCKER-SOURCE',
+          },
+        },
+      ),
+    ).toThrow(/assignable POSIX shell identifiers/u);
+    expect(resolver).not.toHaveBeenCalled();
+  });
+
+  it('rejects a serialized non-POSIX protected destination before rehydration', async () => {
+    const resolver = vi.fn(async () => 'unresolved');
+    class ProbeReference extends EnvValueReference {
+      static readonly type = 'test.docker_destination_probe';
+
+      constructor() {
+        super();
+      }
+
+      override serialize(): Record<string, unknown> {
+        return {};
+      }
+
+      override async resolve(): Promise<string> {
+        return await resolver();
+      }
+    }
+
+    process.env['AGENTS-TEST-DOCKER-SOURCE'] = 'unused-secret';
+    const unregister = registerEnvValueReference(
+      ProbeReference,
+      () => new ProbeReference(),
+    );
+    try {
+      const client = new DockerSandboxClient({
+        processEnvironmentBindings: {
+          'API-TOKEN': 'AGENTS-TEST-DOCKER-SOURCE',
+        },
+      });
+      const serialized = {
+        manifest: serializeManifestRecord(
+          new Manifest({
+            environment: {
+              'API-TOKEN': new ProcessEnvValue({
+                name: 'AGENTS-TEST-DOCKER-SOURCE',
+              }),
+              PROBE: new ProbeReference(),
+            },
+          }),
+        ),
+        workspaceRootPath: rootDir,
+        workspaceRootOwned: false,
+        environment: {},
+        containerId: 'container-invalid-destination-state',
+        image: 'test:image',
+      };
+
+      await expect(client.deserializeSessionState(serialized)).rejects.toThrow(
+        /assignable POSIX shell identifiers/u,
+      );
+      expect(resolver).not.toHaveBeenCalled();
+    } finally {
+      unregister();
+    }
+  });
+
+  it('rejects a mutated non-POSIX protected destination before live effects', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'unused-secret';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-invalid-destination-mutation\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        API_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          API_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+    );
+    session.state.manifest.environment['API-TOKEN'] = new ProcessEnvValue({
+      name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+    });
+    const resolver = vi.fn(async () => 'unresolved');
+    processMocks.runSandboxProcess.mockClear();
+
+    await expect(
+      session.materializeEntry({
+        path: 'materialized.txt',
+        entry: { type: 'file', content: 'not written' },
+      }),
+    ).rejects.toThrow(/assignable POSIX shell identifiers/u);
+    await expect(stat(join(rootDir, 'materialized.txt'))).rejects.toMatchObject(
+      { code: 'ENOENT' },
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          entries: {
+            'marker.txt': { type: 'file', content: 'not written' },
+          },
+          environment: { PROBE: resolver },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SandboxLifecycleError);
+
+    expect(resolver).not.toHaveBeenCalled();
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    await expect(stat(join(rootDir, 'marker.txt'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
+
+  it('redacts Docker startup errors when process environment values are present', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-secret-in-error';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return failure('provider echoed docker-secret-in-error');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+
+    let thrown: unknown;
+    try {
+      await client.create(
+        new Manifest({
+          environment: {
+            AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+          },
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(UserError);
+    expect(String(thrown)).not.toContain('docker-secret-in-error');
+    expect(String(thrown)).toContain('protected process environment values');
+  });
+
+  it('redacts mixed environment resolver errors before Docker effects', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-resolver-secret';
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+
+    let thrown: unknown;
+    try {
+      await client.create(
+        new Manifest({
+          environment: {
+            AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+            FAILING: async () => {
+              throw Object.assign(
+                new Error('resolver echoed docker-resolver-secret'),
+                { cause: new Error('nested docker-resolver-secret') },
+              );
+            },
+          },
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(thrown)).not.toContain('docker-resolver-secret');
+    expect(JSON.stringify(thrown)).not.toContain('docker-resolver-secret');
+    expect((thrown as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+  });
+
+  it('redacts resolver errors while applying a manifest to a protected Docker session', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-apply-secret';
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          const containerId = 'container-apply-secret';
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+    processMocks.runSandboxProcess.mockClear();
+
+    let thrown: unknown;
+    try {
+      await session.applyManifest(
+        new Manifest({
+          environment: {
+            FAILING: async () => {
+              throw Object.assign(
+                new Error('resolver echoed docker-apply-secret'),
+                { cause: new Error('nested docker-apply-secret') },
+              );
+            },
+          },
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(thrown)).not.toContain('docker-apply-secret');
+    expect(JSON.stringify(thrown)).not.toContain('docker-apply-secret');
+    expect((thrown as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+  });
+
+  it('retains protected destination authority after a successful manifest mutation', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-mutation-secret';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-mutation-authority\n');
+        }
+        return success();
+      },
+    );
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+
+    await session.applyManifest(
+      new Manifest({
+        environment: {
+          SAFE: async () => {
+            delete session.state.manifest.environment
+              .AGENTS_TEST_DOCKER_PROCESS_SOURCE;
+            return 'safe';
+          },
+        },
+      }),
+    );
+    await session.pathExists('marker', 'root');
+    const serialized = await client.serializeSessionState(session.state);
+
+    expect(
+      session.state.manifest.environment.AGENTS_TEST_DOCKER_PROCESS_SOURCE,
+    ).toBeInstanceOf(ProcessEnvValue);
+    expect(childProcessMocks.spawn).not.toHaveBeenCalledWith(
+      'docker',
+      expect.arrayContaining([
+        '-e',
+        'AGENTS_TEST_DOCKER_PROCESS_SOURCE=docker-mutation-secret',
+      ]),
+      expect.anything(),
+    );
+    expect(JSON.stringify(serialized)).not.toContain('docker-mutation-secret');
+    expect(serialized.environment).not.toHaveProperty(
+      'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+    );
+  });
+
+  it('rejects replacing a protected Docker environment destination', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-protected-secret';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-protected-delta\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+    processMocks.runSandboxProcess.mockClear();
+    const replacementResolver = vi.fn(async () => 'ordinary');
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          environment: {
+            AGENTS_TEST_DOCKER_PROCESS_SOURCE: replacementResolver,
+          },
+        }),
+      ),
+    ).rejects.toThrow(/protected process environment values/u);
+
+    expect(replacementResolver).not.toHaveBeenCalled();
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    expect(
+      session.state.manifest.environment.AGENTS_TEST_DOCKER_PROCESS_SOURCE,
+    ).toBeInstanceOf(ProcessEnvValue);
+    const serialized = await client.serializeSessionState(session.state);
+    const restored = await client.deserializeSessionState(
+      markRunStateDeserializationInput(serialized, {
+        clientOptions: {
+          allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+        },
+      }),
+    );
+    expect(
+      restored.manifest.environment.AGENTS_TEST_DOCKER_PROCESS_SOURCE,
+    ).toBeInstanceOf(ProcessEnvValue);
+  });
+
+  it('rejects importing bound process environment authority into a live Docker session', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-import-secret';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-ordinary-delta\n');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    const session = await client.create(new Manifest());
+    const boundDelta = cloneManifest(
+      bindProcessEnvironmentAccess(
+        new Manifest({
+          environment: {
+            IMPORTED_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+            }),
+          },
+        }),
+        {
+          processEnvironmentBindings: {
+            IMPORTED_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          },
+        },
+      ),
+    );
+    processMocks.runSandboxProcess.mockClear();
+
+    await expect(session.applyManifest(boundDelta)).rejects.toThrow(
+      /protected process environment destinations/u,
+    );
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    expect(session.state.manifest.environment).not.toHaveProperty(
+      'IMPORTED_TOKEN',
+    );
+  });
+
+  it('redacts mixed environment resolver errors during Docker resume', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-resume-secret';
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const state: DockerSandboxSessionState = {
+      manifest: new Manifest({
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+          FAILING: async () => {
+            throw Object.assign(
+              new Error('resolver echoed docker-resume-secret'),
+              { cause: new Error('nested docker-resume-secret') },
+            );
+          },
+        },
+      }),
+      workspaceRootPath: rootDir,
+      workspaceRootOwned: false,
+      environment: {},
+      containerId: 'container-resolver-error',
+      image: 'test:image',
+    };
+
+    let thrown: unknown;
+    try {
+      await client.resume(state);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(thrown)).not.toContain('docker-resume-secret');
+    expect(JSON.stringify(thrown)).not.toContain('docker-resume-secret');
+    expect((thrown as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+  });
+
+  it('redacts serializable environment reference errors during Docker deserialization', async () => {
+    class ThrowingDockerReference extends EnvValueReference {
+      static readonly type = 'test.throwing_docker_reference';
+
+      constructor() {
+        super();
+      }
+
+      override serialize(): Record<string, unknown> {
+        return {};
+      }
+
+      override async resolve(): Promise<string> {
+        throw Object.assign(
+          new Error('reference echoed docker-deserialize-secret'),
+          { cause: new Error('nested docker-deserialize-secret') },
+        );
+      }
+    }
+
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-deserialize-secret';
+    const unregister = registerEnvValueReference(
+      ThrowingDockerReference,
+      () => new ThrowingDockerReference(),
+    );
+    try {
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+      });
+      const serialized = {
+        manifest: serializeManifestRecord(
+          new Manifest({
+            environment: {
+              AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+              FAILING: new ThrowingDockerReference(),
+            },
+          }),
+        ),
+        workspaceRootPath: rootDir,
+        workspaceRootOwned: false,
+        environment: {},
+        containerId: 'container-deserialize-error',
+        image: 'test:image',
+      };
+
+      let thrown: unknown;
+      try {
+        await client.deserializeSessionState(serialized);
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+      expect(String(thrown)).not.toContain('docker-deserialize-secret');
+      expect(JSON.stringify(thrown)).not.toContain('docker-deserialize-secret');
+      expect((thrown as Error & { cause?: unknown }).cause).toBeUndefined();
+    } finally {
+      unregister();
+    }
+  });
+
+  it('redacts Docker post-start and cleanup errors for process environment values', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-secret-in-error';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-process-env\n');
+        }
+        if (args[0] === 'exec') {
+          return failure('provisioning echoed docker-secret-in-error');
+        }
+        if (args[0] === 'rm') {
+          return failure('cleanup echoed docker-secret-in-error');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+
+    let thrown: unknown;
+    try {
+      await client.create(
+        new Manifest({
+          environment: {
+            AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+          },
+          users: [{ name: 'sandbox-user' }],
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(thrown)).not.toContain('docker-secret-in-error');
+    expect(JSON.stringify(thrown)).not.toContain('docker-secret-in-error');
+    expect((thrown as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'sandbox creation',
+      replacementContainerId: 'container-process-env',
+      replacementDockerVolumeNames: [],
+    });
+
+    let deferredCleanupError: unknown;
+    try {
+      await client.create(new Manifest());
+    } catch (error) {
+      deferredCleanupError = error;
+    }
+    expect(deferredCleanupError).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(deferredCleanupError)).not.toContain(
+      'docker-secret-in-error',
+    );
+    expect(JSON.stringify(deferredCleanupError)).not.toContain(
+      'docker-secret-in-error',
+    );
+    expect((deferredCleanupError as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'deferred cleanup',
+      containerId: 'container-process-env',
+      replacementContainerId: 'container-process-env',
+      replacementDockerVolumeNames: [],
+    });
+  });
+
+  it('retries protected candidate volume cleanup after setup failure', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-cleanup-secret';
+    let runCount = 0;
+    let volumeRemovalAttempts = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-protected-cleanup-${runCount}\n`);
+        }
+        if (
+          args[0] === 'exec' &&
+          args.includes('container-protected-cleanup-1')
+        ) {
+          return failure('account provisioning failed');
+        }
+        if (args[0] === 'volume' && args[1] === 'rm') {
+          volumeRemovalAttempts += 1;
+          return volumeRemovalAttempts === 1
+            ? failure('volume cleanup echoed docker-cleanup-secret')
+            : success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+
+    let thrown: unknown;
+    try {
+      await client.create(
+        new Manifest({
+          entries: {
+            logs: {
+              type: 's3_mount',
+              bucket: 'agent-logs',
+              mountPath: '/mnt/logs',
+              mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+            },
+          },
+          environment: {
+            AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+          },
+          users: [{ name: 'sandbox-user' }],
+        }),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(thrown)).not.toContain('docker-cleanup-secret');
+    expect(volumeRemovalAttempts).toBe(1);
+
+    const later = await client.create(new Manifest());
+    expect(volumeRemovalAttempts).toBe(2);
+    await later.close();
   });
 
   it('passes bind and Docker volume mounts to container creation', async () => {
@@ -986,6 +2710,85 @@ describe('DockerSandboxClient unit behavior', () => {
     await session.close();
   });
 
+  it('uses a safe environment when the Docker filesystem user may be root', async () => {
+    childProcessMocks.spawn.mockImplementation(() =>
+      dockerSpawnResult({ status: 0 }),
+    );
+    const manifest = new Manifest({
+      entries: {
+        mounted: s3Mount({
+          bucket: 'fixture',
+          mountStrategy: inContainerMountStrategy(),
+        }),
+      },
+      environment: {
+        PATH: '/workspace/bin:/usr/bin:/bin',
+      },
+    });
+    const session = new DockerSandboxSession({
+      state: {
+        manifest,
+        workspaceRootPath: rootDir,
+        workspaceRootOwned: false,
+        environment: {
+          PATH: '/workspace/bin:/usr/bin:/bin',
+          HOME: '/workspace/home',
+          LD_PRELOAD: '/workspace/loader.so',
+          LD_LIBRARY_PATH: '/workspace/lib',
+          LD_AUDIT: '/workspace/audit.so',
+        },
+        containerId: 'container-implicit-root',
+        image: 'test:image',
+      },
+    });
+
+    for (const { runAs, defaultUser } of [
+      { runAs: undefined, defaultUser: undefined },
+      { runAs: '0', defaultUser: undefined },
+      { runAs: '0:0', defaultUser: undefined },
+      { runAs: 'root:root', defaultUser: undefined },
+      { runAs: undefined, defaultUser: '0:0' },
+      { runAs: '', defaultUser: undefined },
+      { runAs: undefined, defaultUser: '' },
+    ]) {
+      childProcessMocks.spawn.mockClear();
+      session.state.defaultUser = defaultUser;
+
+      await expect(session.pathExists('mounted/file.txt', runAs)).resolves.toBe(
+        true,
+      );
+
+      const command = (
+        childProcessMocks.spawn.mock.calls[0]?.[1] as string[]
+      ).join(' ');
+      expect(command).toContain('-e PATH=/usr/sbin:/usr/bin:/sbin:/bin');
+      expect(command).toContain('-e HOME=/root');
+      expect(command).toContain('-e LD_PRELOAD=');
+      expect(command).toContain('-e LD_LIBRARY_PATH=');
+      expect(command).toContain('-e LD_AUDIT=');
+      expect(command).not.toContain('/workspace/bin:/usr/bin:/bin');
+    }
+
+    for (const { runAs, defaultUser } of [
+      { runAs: 'node', defaultUser: undefined },
+      { runAs: '', defaultUser: 'node' },
+    ]) {
+      childProcessMocks.spawn.mockClear();
+      session.state.defaultUser = defaultUser;
+      await expect(session.pathExists('mounted/file.txt', runAs)).resolves.toBe(
+        true,
+      );
+      const nonRootCommand = (
+        childProcessMocks.spawn.mock.calls[0]?.[1] as string[]
+      ).join(' ');
+      expect(nonRootCommand).toContain('-e PATH=/workspace/bin:/usr/bin:/bin');
+      expect(nonRootCommand).toContain('-u node');
+      expect(nonRootCommand).not.toContain(
+        '-e PATH=/usr/sbin:/usr/bin:/sbin:/bin',
+      );
+    }
+  });
+
   it('removes the container and workspace when in-container mount application fails during create', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
@@ -1100,6 +2903,318 @@ describe('DockerSandboxClient unit behavior', () => {
     ).toEqual(['container-1', 'container-1', 'container-2']);
   });
 
+  it('retains cleanup tracking when a timed-out create is not visible yet', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'protected-create-secret';
+    let runCount = 0;
+    let timedOutContainerName: string | undefined;
+    let timedOutContainerRemovalCount = 0;
+    let timedOutVolumeName: string | undefined;
+    let timedOutVolumeRemovalCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 1) {
+            timedOutContainerName = args[args.indexOf('--name') + 1];
+            timedOutVolumeName = dockerRunInspection(args).mounts.find(
+              (mount) => mount.Type === 'volume',
+            )?.Name;
+            return timedOut();
+          }
+          return success('later-container\n');
+        }
+        if (args[0] === 'rm') {
+          if (args[2] === timedOutContainerName) {
+            timedOutContainerRemovalCount += 1;
+            return timedOutContainerRemovalCount === 2
+              ? success()
+              : failure('No such container');
+          }
+          return success();
+        }
+        if (
+          args[0] === 'volume' &&
+          args[1] === 'rm' &&
+          args[3] === timedOutVolumeName
+        ) {
+          timedOutVolumeRemovalCount += 1;
+          return timedOutVolumeRemovalCount === 1
+            ? failure('volume cleanup failed')
+            : success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const manifest = new Manifest({
+      entries: {
+        logs: {
+          type: 's3_mount',
+          bucket: 'agent-logs',
+          mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+        },
+      },
+      environment: {
+        SANDBOX_TOKEN: new ProcessEnvValue({
+          name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+        }),
+      },
+    });
+
+    const error = await client.create(manifest).then(
+      () => undefined,
+      (caught: unknown) => caught,
+    );
+
+    expect(timedOutContainerName).toBeDefined();
+    expect(timedOutVolumeName).toBeDefined();
+    expect(error).toBeInstanceOf(SandboxLifecycleError);
+    expect((error as SandboxLifecycleError).details).toMatchObject({
+      provider: 'docker',
+      operation: 'sandbox creation',
+      replacementContainerId: timedOutContainerName,
+    });
+    expect(timedOutContainerRemovalCount).toBe(1);
+
+    await expect(client.create(new Manifest())).rejects.toThrow(
+      'Docker sandbox cleanup failed for a resource that used protected process environment values.',
+    );
+    const later = await client.create(new Manifest());
+    await later.close();
+
+    expect(timedOutContainerRemovalCount).toBe(3);
+    expect(timedOutVolumeRemovalCount).toBe(2);
+    expect(
+      processMocks.runSandboxProcess.mock.calls
+        .filter(([, args]) => args[0] === 'rm')
+        .map(([, args]) => args[2]),
+    ).toEqual([
+      timedOutContainerName,
+      timedOutContainerName,
+      timedOutContainerName,
+      'later-container',
+    ]);
+  });
+
+  it('retries owned workspace cleanup after a timed-out create', async () => {
+    let runCount = 0;
+    let timedOutContainerName: string | undefined;
+    let timedOutWorkspaceRoot: string | undefined;
+    let timedOutContainerRemovalCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 1) {
+            timedOutContainerName = args[args.indexOf('--name') + 1];
+            timedOutWorkspaceRoot = dockerRunInspection(args).mounts.find(
+              (mount) => mount.Type === 'bind',
+            )?.Source;
+            return timedOut();
+          }
+          return success(`container-${runCount}\n`);
+        }
+        if (args[0] === 'rm') {
+          if (args[2] === timedOutContainerName) {
+            timedOutContainerRemovalCount += 1;
+            return timedOutContainerRemovalCount === 2
+              ? success()
+              : failure('No such container');
+          }
+          return success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+
+    await expect(client.create(new Manifest())).rejects.toThrow(
+      'Failed to start Docker sandbox container',
+    );
+
+    expect(timedOutContainerName).toBeDefined();
+    expect(timedOutWorkspaceRoot).toBeDefined();
+    await chmod(rootDir, 0o500);
+    try {
+      await expect(client.create(new Manifest())).rejects.toThrow();
+      await expect(stat(timedOutWorkspaceRoot!)).resolves.toBeDefined();
+    } finally {
+      await chmod(rootDir, 0o700);
+    }
+
+    const later = await client.create(new Manifest());
+    await expect(stat(timedOutWorkspaceRoot!)).rejects.toThrow();
+    await later.close();
+
+    expect(timedOutContainerRemovalCount).toBe(3);
+  });
+
+  it('preserves protected creation identifiers when setup cleanup fails', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'protected-create-secret';
+    let replacementVolumeName: string | undefined;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          const inspection = dockerRunInspection(args);
+          replacementVolumeName = inspection.mounts.find(
+            (mount) => mount.Type === 'volume',
+          )?.Name;
+          return success('protected-create-replacement\n');
+        }
+        if (args[0] === 'exec') {
+          return failure('account provisioning echoed protected-create-secret');
+        }
+        if (args[0] === 'rm') {
+          return failure('container cleanup echoed protected-create-secret');
+        }
+        if (args[0] === 'volume' && args[1] === 'rm') {
+          return failure('volume cleanup echoed protected-create-secret');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+
+    const error = await client
+      .create(
+        new Manifest({
+          entries: {
+            logs: {
+              type: 's3_mount',
+              bucket: 'agent-logs',
+              mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+            },
+          },
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+            }),
+          },
+          users: [{ name: 'sandbox-user' }],
+        }),
+      )
+      .then(
+        () => undefined,
+        (caught: unknown) => caught,
+      );
+
+    expect(replacementVolumeName).toBeDefined();
+    expect(error).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(error)).not.toContain('protected-create-secret');
+    expect((error as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'sandbox creation',
+      replacementContainerId: 'protected-create-replacement',
+      replacementDockerVolumeNames: [replacementVolumeName],
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it('preserves protected replacement identifiers when setup cleanup fails', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-secret';
+    let runCount = 0;
+    let replacementVolumeName: string | undefined;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `protected-replacement-${runCount}`;
+          const inspection = dockerRunInspection(args);
+          inspections.set(containerId, inspection);
+          if (runCount === 2) {
+            replacementVolumeName = inspection.mounts.find(
+              (mount) => mount.Type === 'volume',
+            )?.Name;
+          }
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'exec') {
+          return args.includes('protected-replacement-2')
+            ? failure('account provisioning echoed rotated-secret')
+            : success();
+        }
+        if (args[0] === 'rm' && args[2] === 'protected-replacement-2') {
+          return failure('container cleanup echoed rotated-secret');
+        }
+        if (
+          args[0] === 'volume' &&
+          args[1] === 'rm' &&
+          args[3] === replacementVolumeName
+        ) {
+          return failure('volume cleanup echoed rotated-secret');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+        users: [{ name: 'sandbox-user' }],
+      }),
+    );
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-secret';
+
+    const error = await client.resume(session.state).then(
+      () => undefined,
+      (caught: unknown) => caught,
+    );
+
+    expect(replacementVolumeName).toBeDefined();
+    expect(error).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(error)).not.toContain('rotated-secret');
+    expect((error as SandboxLifecycleError).details).toEqual({
+      provider: 'docker',
+      operation: 'sandbox resume',
+      containerId: 'protected-replacement-1',
+      replacementContainerId: 'protected-replacement-2',
+      replacementDockerVolumeNames: [replacementVolumeName],
+    });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
   it('retries failed restart cleanup before a later create', async () => {
     let containerCount = 0;
     let replacementRemoveAttempts = 0;
@@ -1119,7 +3234,7 @@ describe('DockerSandboxClient unit behavior', () => {
           return success(`${containerId}\n`);
         }
         if (args[0] === 'exec') {
-          return args[3] === 'container-2'
+          return args.includes('container-2')
             ? failure('account provisioning failed')
             : success();
         }
@@ -1160,6 +3275,277 @@ describe('DockerSandboxClient unit behavior', () => {
         .filter(([, args]) => args[0] === 'rm')
         .map(([, args]) => args[2]),
     ).toEqual(['container-1', 'container-2', 'container-2', 'container-3']);
+  });
+
+  it('continues timed-out restart cleanup after container removal', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'initial-secret';
+    let runCount = 0;
+    let timedOutContainerName: string | undefined;
+    let timedOutContainerRemovalCount = 0;
+    let timedOutVolumeName: string | undefined;
+    let timedOutVolumeRemovalCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 2) {
+            timedOutContainerName = args[args.indexOf('--name') + 1];
+            timedOutVolumeName = dockerRunInspection(args).mounts.find(
+              (mount) => mount.Type === 'volume',
+            )?.Name;
+            return timedOut();
+          }
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'rm') {
+          if (args[2] === timedOutContainerName) {
+            timedOutContainerRemovalCount += 1;
+            return timedOutContainerRemovalCount === 2
+              ? success()
+              : failure('No such object');
+          }
+          return success();
+        }
+        if (
+          args[0] === 'volume' &&
+          args[1] === 'rm' &&
+          args[3] === timedOutVolumeName
+        ) {
+          timedOutVolumeRemovalCount += 1;
+          return timedOutVolumeRemovalCount === 1
+            ? failure('volume cleanup failed')
+            : success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    });
+    const original = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
+      }),
+    );
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'rotated-secret';
+
+    await expect(client.resume(original.state)).rejects.toBeInstanceOf(
+      SandboxLifecycleError,
+    );
+
+    expect(timedOutContainerName).toBeDefined();
+    expect(timedOutVolumeName).toBeDefined();
+    expect(timedOutContainerRemovalCount).toBe(1);
+
+    await expect(client.create(new Manifest())).rejects.toThrow(
+      'Docker sandbox cleanup failed for a resource that used protected process environment values.',
+    );
+    const later = await client.create(new Manifest());
+    await later.close();
+    await original.close();
+
+    expect(timedOutContainerRemovalCount).toBe(3);
+    expect(timedOutVolumeRemovalCount).toBe(2);
+  });
+
+  it('retains a restored workspace while a timed-out restart is not visible', async () => {
+    let runCount = 0;
+    let timedOutContainerName: string | undefined;
+    let timedOutContainerRemovalCount = 0;
+    let timedOutWorkspaceRoot: string | undefined;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 2) {
+            timedOutContainerName = args[args.indexOf('--name') + 1];
+            const inspection = dockerRunInspection(args);
+            timedOutWorkspaceRoot = inspection.mounts.find(
+              (mount) => mount.Type === 'bind',
+            )?.Source;
+            return timedOut();
+          }
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'rm') {
+          if (args[2] === timedOutContainerName) {
+            timedOutContainerRemovalCount += 1;
+            return timedOutContainerRemovalCount === 1
+              ? failure('No such object')
+              : success();
+          }
+          return success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'local',
+        baseDir: join(rootDir, 'snapshots'),
+      },
+    });
+    const original = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+      }),
+    );
+    const serializedState = await client.serializeSessionState(original.state);
+    original.state.snapshot =
+      serializedState.snapshot as DockerSandboxSessionState['snapshot'];
+    original.state.snapshotExcludedPaths =
+      serializedState.snapshotExcludedPaths as string[] | undefined;
+    await rm(original.state.workspaceRootPath, {
+      recursive: true,
+      force: true,
+    });
+    const error = await client.resume(original.state).then(
+      () => undefined,
+      (caught: unknown) => caught,
+    );
+
+    expect(timedOutContainerName).toBeDefined();
+    expect(timedOutWorkspaceRoot).toBeDefined();
+    await expect(stat(timedOutWorkspaceRoot!)).resolves.toBeDefined();
+    expect(error).toBeInstanceOf(UserError);
+    expect(String(error)).toContain('Failed to start Docker sandbox container');
+    expect(timedOutContainerRemovalCount).toBe(1);
+
+    const later = await client.create(new Manifest());
+    await expect(stat(timedOutWorkspaceRoot!)).rejects.toThrow();
+    await later.close();
+    await original.close();
+
+    expect(timedOutContainerRemovalCount).toBe(2);
+    expect(
+      processMocks.runSandboxProcess.mock.calls
+        .filter(([, args]) => args[0] === 'rm')
+        .map(([, args]) => args[2]),
+    ).toEqual([
+      'container-1',
+      timedOutContainerName,
+      timedOutContainerName,
+      'container-3',
+      'container-1',
+    ]);
+  });
+
+  it('retries restored workspace cleanup after a timed-out restart', async () => {
+    let runCount = 0;
+    let timedOutContainerName: string | undefined;
+    let timedOutContainerRemovalCount = 0;
+    let timedOutWorkspaceRoot: string | undefined;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          if (runCount === 2) {
+            timedOutContainerName = args[args.indexOf('--name') + 1];
+            timedOutWorkspaceRoot = dockerRunInspection(args).mounts.find(
+              (mount) => mount.Type === 'bind',
+            )?.Source;
+            return timedOut();
+          }
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'rm') {
+          if (args[2] === timedOutContainerName) {
+            timedOutContainerRemovalCount += 1;
+            return timedOutContainerRemovalCount === 2
+              ? success()
+              : failure('No such object');
+          }
+          return success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'local',
+        baseDir: join(rootDir, 'snapshots'),
+      },
+    });
+    const original = await client.create(new Manifest());
+    const serializedState = await client.serializeSessionState(original.state);
+    original.state.snapshot =
+      serializedState.snapshot as DockerSandboxSessionState['snapshot'];
+    original.state.snapshotExcludedPaths =
+      serializedState.snapshotExcludedPaths as string[] | undefined;
+    await rm(original.state.workspaceRootPath, {
+      recursive: true,
+      force: true,
+    });
+
+    await expect(client.resume(original.state)).rejects.toThrow(
+      'Failed to start Docker sandbox container',
+    );
+
+    expect(timedOutContainerName).toBeDefined();
+    expect(timedOutWorkspaceRoot).toBeDefined();
+    await chmod(rootDir, 0o500);
+    try {
+      await expect(client.create(new Manifest())).rejects.toThrow();
+      await expect(stat(timedOutWorkspaceRoot!)).resolves.toBeDefined();
+    } finally {
+      await chmod(rootDir, 0o700);
+    }
+
+    const later = await client.create(new Manifest());
+    await expect(stat(timedOutWorkspaceRoot!)).rejects.toThrow();
+    await later.close();
+    await original.close();
+
+    expect(timedOutContainerRemovalCount).toBe(3);
   });
 
   it('applies Azure Blob blobfuse options for Docker in-container mounts', async () => {
@@ -1713,28 +4099,46 @@ describe('DockerSandboxClient unit behavior', () => {
     expect(childProcessMocks.spawn).not.toHaveBeenCalled();
   });
 
-  it('rejects symlink-aliased rclone config before Docker mount effects', async () => {
+  it('redacts symlink-aliased rclone config failures for protected Docker sessions', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'protected-secret';
     const session = new DockerSandboxSession({
       state: {
-        manifest: new Manifest({
-          entries: {
-            'secret.conf': {
-              type: 'file',
-              content: '[custom]\npassword = serialized\n',
+        manifest: bindProcessEnvironmentAccess(
+          new Manifest({
+            entries: {
+              'secret.conf': {
+                type: 'file',
+                content: '[custom]\npassword = serialized\n',
+              },
+              seed: {
+                type: 's3_mount',
+                bucket: 'seed',
+                mountStrategy: inContainerMountStrategy(),
+              },
             },
-            seed: {
-              type: 's3_mount',
-              bucket: 'seed',
-              mountStrategy: inContainerMountStrategy(),
+            environment: {
+              PATH: new ProcessEnvValue(),
+              HOME: new ProcessEnvValue(),
+              SANDBOX_TOKEN: new ProcessEnvValue({
+                name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+              }),
+            },
+          }),
+          {
+            processEnvironmentBindings: {
+              PATH: 'PATH',
+              HOME: 'HOME',
+              SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
             },
           },
-        }),
+        ),
         workspaceRootPath: rootDir,
         workspaceRootOwned: false,
         environment: {
           PATH: '/workspace/model-bin',
           HOME: '/workspace/model-home',
           LD_PRELOAD: '/workspace/model-loader.so',
+          SANDBOX_TOKEN: 'protected-secret',
         },
         containerId: 'container-credential-alias',
         image: 'test:image',
@@ -1754,6 +4158,13 @@ describe('DockerSandboxClient unit behavior', () => {
     await expect(
       session.applyManifest(
         new Manifest({
+          environment: {
+            SAFE: async () => {
+              delete session.state.manifest.environment.PATH;
+              delete session.state.manifest.environment.HOME;
+              return 'safe';
+            },
+          },
           entries: {
             data: {
               type: 's3_mount',
@@ -1769,7 +4180,7 @@ describe('DockerSandboxClient unit behavior', () => {
           },
         }).withInContainerMountBroadCredentialExposureAcknowledged('data'),
       ),
-    ).rejects.toThrow(/resolve to a serialized manifest entry/u);
+    ).rejects.toThrow(/protected process environment values/u);
 
     const commands = childProcessMocks.spawn.mock.calls.map(([, args]) =>
       (args as string[]).join(' '),
@@ -1781,15 +4192,17 @@ describe('DockerSandboxClient unit behavior', () => {
     for (const args of resolverArgs) {
       expect(args).not.toContain('/bin/sh');
       expect(args).not.toContain('-lc');
+      expect(args).not.toContain('SANDBOX_TOKEN=');
+      expect(args).not.toContain('PATH=');
+      expect(args).not.toContain('HOME=');
+      expect(args.join(' ')).not.toContain('protected-secret');
       expect(args).toEqual(
         expect.arrayContaining([
-          'PATH=',
-          'HOME=',
+          'PATH=/usr/sbin:/usr/bin:/sbin:/bin',
+          'HOME=/root',
           'LD_PRELOAD=',
           'LD_LIBRARY_PATH=',
           'LD_AUDIT=',
-          'PATH=/usr/bin:/bin',
-          'HOME=/root',
         ]),
       );
     }
@@ -2385,6 +4798,223 @@ describe('DockerSandboxClient unit behavior', () => {
     await expect(stat(workspaceRootPath)).rejects.toThrow();
   });
 
+  it('redacts protected Docker close errors for direct and managed cleanup', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-close-secret';
+    let removeCalls = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-process-env\n');
+        }
+        if (args[0] === 'rm') {
+          removeCalls += 1;
+          return removeCalls <= 2
+            ? failure('cleanup echoed docker-close-secret')
+            : success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+
+    for (const cleanup of [
+      () => session.close(),
+      () => cleanupSandboxSession(session),
+    ]) {
+      let thrown: unknown;
+      try {
+        await cleanup();
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+      expect(String(thrown)).not.toContain('docker-close-secret');
+      expect(JSON.stringify(thrown)).not.toContain('docker-close-secret');
+      expect((thrown as SandboxLifecycleError).details).toEqual({
+        provider: 'docker',
+        operation: 'sandbox shutdown',
+        containerId: 'container-process-env',
+      });
+    }
+
+    await session.close();
+    expect(removeCalls).toBe(3);
+  });
+
+  it('reports protected Docker volume cleanup failures after closing the workspace', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-close-secret';
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-process-env-volume-close\n');
+        }
+        if (args[0] === 'volume' && args[1] === 'rm') {
+          return failure('cleanup echoed docker-close-secret');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountPath: '/mnt/logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+    const workspaceRootPath = session.state.workspaceRootPath;
+    const volumeName = session.state.dockerVolumeNames?.[0];
+
+    let thrown: unknown;
+    try {
+      await session.close();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxLifecycleError);
+    expect(String(thrown)).not.toContain('docker-close-secret');
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      ['volume', 'rm', '-f', volumeName],
+      { timeoutMs: 10_000 },
+    );
+    await expect(stat(workspaceRootPath)).rejects.toThrow();
+  });
+
+  it('treats an already absent protected Docker volume as closed', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-close-secret';
+    let volumeRemovalCalls = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-process-env-volume-repeat\n');
+        }
+        if (args[0] === 'volume' && args[1] === 'rm') {
+          volumeRemovalCalls += 1;
+          return volumeRemovalCalls === 1
+            ? success()
+            : failure('Error response from daemon: no such volume');
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountPath: '/mnt/logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+
+    await session.close();
+    await session.close();
+
+    expect(volumeRemovalCalls).toBe(2);
+  });
+
+  it('converges when retrying partially removed protected Docker volumes', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'docker-close-secret';
+    const volumeRemovalCalls = new Map<string, number>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-process-env-volume-partial\n');
+        }
+        if (args[0] === 'volume' && args[1] === 'rm') {
+          const volumeName = args[3]!;
+          const attempt = (volumeRemovalCalls.get(volumeName) ?? 0) + 1;
+          volumeRemovalCalls.set(volumeName, attempt);
+          if (volumeName === session.state.dockerVolumeNames?.[0]) {
+            return attempt === 1
+              ? success()
+              : failure('Error response from daemon: no such object');
+          }
+          return attempt === 1 ? failure('volume is busy') : success();
+        }
+        return success();
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      allowedProcessEnvironmentKeys: ['AGENTS_TEST_DOCKER_PROCESS_SOURCE'],
+    });
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          logs: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            mountPath: '/mnt/logs',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+          cache: {
+            type: 's3_mount',
+            bucket: 'agent-cache',
+            mountPath: '/mnt/cache',
+            mountStrategy: dockerVolumeMountStrategy({ driver: 'rclone' }),
+          },
+        },
+        environment: {
+          AGENTS_TEST_DOCKER_PROCESS_SOURCE: new ProcessEnvValue(),
+        },
+      }),
+    );
+
+    await expect(session.close()).rejects.toThrow(
+      /protected process environment values/u,
+    );
+    await session.close();
+
+    expect([...volumeRemovalCalls.values()]).toEqual([2, 2]);
+  });
+
   it('treats missing Docker containers as already removed on close', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
@@ -2674,6 +5304,8 @@ describe('DockerSandboxClient unit behavior', () => {
   });
 
   it('provisions manifest identity metadata inside the container', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE =
+      '/workspace/bin:/usr/bin:/bin';
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
         if (args[0] === 'version') {
@@ -2690,10 +5322,18 @@ describe('DockerSandboxClient unit behavior', () => {
     );
     const client = new DockerSandboxClient({
       workspaceBaseDir: rootDir,
+      processEnvironmentBindings: {
+        PATH: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
     });
 
     await client.create(
       new Manifest({
+        environment: {
+          PATH: new ProcessEnvValue({
+            name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+          }),
+        },
         users: [{ name: 'sandbox-user' }],
         groups: [
           {
@@ -2704,9 +5344,10 @@ describe('DockerSandboxClient unit behavior', () => {
       }),
     );
 
-    const execCommands = processMocks.runSandboxProcess.mock.calls
-      .filter(([, args]) => args[0] === 'exec')
-      .map(([, args]) => args.at(-1));
+    const execCalls = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'exec',
+    );
+    const execCommands = execCalls.map(([, args]) => args.at(-1));
     expect(
       execCommands.some((command) => String(command).includes('groupadd')),
     ).toBe(true);
@@ -2716,6 +5357,25 @@ describe('DockerSandboxClient unit behavior', () => {
     expect(
       execCommands.some((command) => String(command).includes('usermod')),
     ).toBe(true);
+    for (const [, args] of execCalls) {
+      expect(args).toEqual(
+        expect.arrayContaining([
+          '-e',
+          'PATH=/usr/sbin:/usr/bin:/sbin:/bin',
+          '-e',
+          'HOME=/root',
+          '-e',
+          'LD_PRELOAD=',
+          '-e',
+          'LD_LIBRARY_PATH=',
+          '-e',
+          'LD_AUDIT=',
+          '-u',
+          'root',
+        ]),
+      );
+      expect(args).not.toContain('PATH=/workspace/bin:/usr/bin:/bin');
+    }
   });
 
   it('rejects unsupported manifest entry group metadata before starting docker', async () => {
@@ -5297,6 +7957,7 @@ describe('DockerSandboxClient unit behavior', () => {
     expect(restored.state.image).toBe('run:image');
     expect(restored.state.environment).toEqual({
       SECRET_ENV: 'refreshed-secret',
+      UNTRUSTED_ENV: 'untrusted-value',
     });
     expect(restored.state.defaultUser).not.toBe('root');
     expect(restored.state.configuredExposedPorts).toEqual([4000]);
@@ -5313,7 +7974,9 @@ describe('DockerSandboxClient unit behavior', () => {
       ]),
     );
     expect(restoredRunArgs).not.toContain('stale-secret');
-    expect(restoredRunArgs).not.toContain('UNTRUSTED_ENV=untrusted-value');
+    expect(restoredRunArgs).toEqual(
+      expect.arrayContaining(['-e', 'UNTRUSTED_ENV=untrusted-value']),
+    );
     expect(restoredRunArgs).not.toContain('127.0.0.1::9999');
     expect(restoredRunArgs).not.toContain('untrusted:image');
     await expect(
@@ -5507,6 +8170,90 @@ describe('DockerSandboxClient unit behavior', () => {
     } finally {
       unregister();
     }
+  });
+
+  it('preserves runtime-only environment while restoring protected Docker RunState', async () => {
+    process.env.AGENTS_TEST_DOCKER_PROCESS_SOURCE = 'run-state-secret';
+    let runCount = 0;
+    let ordinaryResolveCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-protected-run-state-${runCount}\n`);
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return success();
+      },
+    );
+    const clientOptions = {
+      processEnvironmentBindings: {
+        SANDBOX_TOKEN: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+      },
+    };
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: { type: 'local', baseDir: rootDir },
+    });
+    const manifest = new Manifest({
+      environment: {
+        SANDBOX_TOKEN: new ProcessEnvValue({
+          name: 'AGENTS_TEST_DOCKER_PROCESS_SOURCE',
+        }),
+        ROTATING_VALUE: async () => {
+          ordinaryResolveCount += 1;
+          return `ordinary-${ordinaryResolveCount}`;
+        },
+      },
+    });
+    const session = await client.create({ manifest, options: clientOptions });
+    session.state.environment.RUNTIME_ENV = 'runtime-only';
+    const serialized = await client.serializeSessionState(session.state);
+    ordinaryResolveCount = 0;
+
+    const persistedState = (await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: client.backendId,
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: toSessionStateEnvelope(
+          client.backendId,
+          session.state,
+          serialized,
+        ),
+      },
+      manifest,
+      { clientOptions },
+    )) as DockerSandboxSessionState;
+    const restored = await client.resume(persistedState, { clientOptions });
+
+    expect(ordinaryResolveCount).toBe(1);
+    expect(restored.state.environment).toEqual({
+      RUNTIME_ENV: 'runtime-only',
+      SANDBOX_TOKEN: 'run-state-secret',
+      ROTATING_VALUE: 'ordinary-1',
+    });
+    const runCalls = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(runCalls).toHaveLength(2);
+    expect(runCalls[1]?.[1]).toEqual(
+      expect.arrayContaining([
+        '-e',
+        'RUNTIME_ENV=runtime-only',
+        '-e',
+        'ROTATING_VALUE=ordinary-1',
+      ]),
+    );
+    expect(runCalls[1]?.[1]).not.toContain('SANDBOX_TOKEN=run-state-secret');
+    await restored.close();
+    await session.close();
   });
 
   it('restores untrusted stopped RunState into new Docker resources', async () => {
@@ -6087,7 +8834,8 @@ describe('DockerSandboxClient unit behavior', () => {
 
     processMocks.runSandboxProcess
       .mockResolvedValueOnce(success('Docker version test'))
-      .mockResolvedValueOnce(failure('pull failed'));
+      .mockResolvedValueOnce(failure('pull failed'))
+      .mockResolvedValueOnce(failure('no such container'));
 
     await expect(client.create(new Manifest())).rejects.toThrow(
       /Failed to start Docker sandbox container: pull failed/,

--- a/packages/agents-core/test/sandboxes/unixLocal.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.test.ts
@@ -19,6 +19,7 @@ import {
   Manifest,
   InMemoryRemoteSnapshotStore,
   NoopSnapshotSpec,
+  ProcessEnvValue,
   registerEnvValueReference,
   SandboxMountError,
   s3Mount,
@@ -33,7 +34,11 @@ import {
   materializeLocalWorkspaceManifestMounts,
   pathExists,
 } from '../../src/sandbox/sandboxes/shared/localWorkspace';
-import { rebindPersistedMountCredentials } from '../../src/sandbox/internal';
+import {
+  bindProcessEnvironmentAccess,
+  rebindPersistedMountCredentials,
+  serializeManifestRecord,
+} from '../../src/sandbox/internal';
 
 const ONE_BY_ONE_PNG = Uint8Array.from(
   Buffer.from(
@@ -52,6 +57,7 @@ describe('UnixLocalSandboxClient', () => {
   });
 
   afterEach(async () => {
+    delete process.env.AGENTS_TEST_UNIX_PROCESS_SOURCE;
     await rm(rootDir, { recursive: true, force: true });
   });
 
@@ -1274,6 +1280,73 @@ describe('UnixLocalSandboxClient', () => {
       },
     });
     expect(session.state.manifest.extraPathGrants).toEqual([]);
+
+    await session.close();
+  });
+
+  it('rejects protected process environment values before applying a manifest delta', async () => {
+    process.env.AGENTS_TEST_UNIX_PROCESS_SOURCE = 'unix-process-secret';
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+    const delta = bindProcessEnvironmentAccess(
+      new Manifest({
+        entries: {
+          'should-not-exist.txt': {
+            type: 'file',
+            content: 'not materialized\n',
+          },
+        },
+        environment: {
+          SANDBOX_TOKEN: new ProcessEnvValue({
+            name: 'AGENTS_TEST_UNIX_PROCESS_SOURCE',
+          }),
+        },
+      }),
+      {
+        processEnvironmentBindings: {
+          SANDBOX_TOKEN: 'AGENTS_TEST_UNIX_PROCESS_SOURCE',
+        },
+      },
+    );
+
+    await expect(session.applyManifest(delta)).rejects.toMatchObject({
+      code: 'unsupported_feature',
+      message: expect.stringContaining(
+        'unix_local does not support ProcessEnvValue',
+      ),
+    });
+    await expect(
+      stat(join(session.state.workspaceRootPath, 'should-not-exist.txt')),
+    ).rejects.toThrow();
+    expect(session.state.environment).not.toHaveProperty('SANDBOX_TOKEN');
+
+    await session.close();
+  });
+
+  it('rejects protected process environment values at persistence boundaries', async () => {
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    const session = await client.create(new Manifest());
+    const serialized = await client.serializeSessionState(session.state);
+    const protectedManifest = new Manifest({
+      environment: {
+        SANDBOX_TOKEN: new ProcessEnvValue({ name: 'SANDBOX_SOURCE' }),
+      },
+    });
+    session.state.manifest = protectedManifest;
+
+    await expect(client.serializeSessionState(session.state)).rejects.toThrow(
+      /Use DockerSandboxClient instead/u,
+    );
+
+    serialized.manifest = serializeManifestRecord(protectedManifest);
+    await expect(client.deserializeSessionState(serialized)).rejects.toThrow(
+      /Use DockerSandboxClient instead/u,
+    );
 
     await session.close();
   });

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -66,6 +66,7 @@ import {
   type ManifestMountMaterializationContext,
 } from '../shared';
 import {
+  assertProcessEnvValuesUnsupported,
   configuredMountCredentialFields,
   validateMountCredentialBoundaries,
 } from '@openai/agents-core/sandbox/internal';
@@ -862,6 +863,7 @@ export class BlaxelSandboxClient implements SandboxClient<
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('BlaxelSandboxClient', createArgs.snapshot);
     const manifest = createArgs.manifest;
+    assertProcessEnvValuesUnsupported(manifest, 'blaxel');
     const resolvedOptions = {
       ...this.options,
       ...createArgs.options,
@@ -1058,6 +1060,7 @@ export class BlaxelSandboxClient implements SandboxClient<
   async resume(
     state: BlaxelSandboxSessionState,
   ): Promise<BlaxelSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'blaxel');
     assertRemoteSandboxSessionStateCanResume(state);
     const SandboxInstance = await loadBlaxelSandboxClass();
     let sandbox: BlaxelSandboxLike;

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -30,6 +30,7 @@ import {
   validateSandboxArchiveLimits,
 } from '@openai/agents-core/sandbox';
 import {
+  assertProcessEnvValuesUnsupported,
   NON_RESUMABLE_MOUNT_AUTHORITY_KEY,
   stableJsonStringify,
   withExclusiveSandboxManifestMutation,
@@ -1143,6 +1144,7 @@ export class CloudflareSandboxClient implements SandboxClient<
       createArgs.snapshot,
     );
     const manifest = createArgs.manifest;
+    assertProcessEnvValuesUnsupported(manifest, 'cloudflare');
     const resolvedOptions = {
       ...this.options,
       ...(createArgs.options as Partial<CloudflareSandboxClientOptions>),
@@ -1309,6 +1311,7 @@ export class CloudflareSandboxClient implements SandboxClient<
   async resume(
     state: CloudflareSandboxSessionState,
   ): Promise<CloudflareSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'cloudflare');
     if (this.deserializedSessionStates.has(state)) {
       throw new UserError(
         'CloudflareSandboxClient cannot safely resume persisted session state. Create a fresh sandbox from current trusted options.',

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -26,6 +26,7 @@ import {
   validateSandboxArchiveLimits,
 } from '@openai/agents-core/sandbox';
 import {
+  assertProcessEnvValuesUnsupported,
   assertExistingMountTopologyPreserved,
   assertLiveMountCredentialAuthorityMatches,
   captureLiveMountCredentialAuthority,
@@ -1313,6 +1314,7 @@ export class DaytonaSandboxClient implements SandboxClient<
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('DaytonaSandboxClient', createArgs.snapshot);
     const manifest = createArgs.manifest;
+    assertProcessEnvValuesUnsupported(manifest, 'daytona');
     const resolvedOptions = {
       ...this.options,
       ...createArgs.options,
@@ -1483,6 +1485,7 @@ export class DaytonaSandboxClient implements SandboxClient<
   async resume(
     state: DaytonaSandboxSessionState,
   ): Promise<DaytonaSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'daytona');
     assertRemoteSandboxSessionStateCanResume(state);
     const client = await createDaytonaClient({
       ...this.options,

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -1,4 +1,5 @@
 import { UserError } from '@openai/agents-core';
+import { assertProcessEnvValuesUnsupported } from '@openai/agents-core/sandbox/internal';
 import {
   Manifest,
   SandboxProviderError,
@@ -884,6 +885,7 @@ export class E2BSandboxClient implements SandboxClient<
     const createArgs = normalizeSandboxClientCreateArgs(args, manifestOptions);
     assertCoreSnapshotUnsupported('E2BSandboxClient', createArgs.snapshot);
     const manifest = createArgs.manifest;
+    assertProcessEnvValuesUnsupported(manifest, 'e2b');
     return await withSandboxSpan(
       'sandbox.start',
       {
@@ -1034,6 +1036,7 @@ export class E2BSandboxClient implements SandboxClient<
   }
 
   async resume(state: E2BSandboxSessionState): Promise<E2BSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'e2b');
     assertRemoteSandboxSessionStateCanResume(state);
     const Sandbox = await loadE2BSandboxClass(state.sandboxType);
     const connect = Sandbox.connect ?? Sandbox.resume;

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -30,6 +30,7 @@ import {
 } from '@openai/agents-core/sandbox';
 import {
   liveMountEnvironmentAuthorityMatches,
+  assertProcessEnvValuesUnsupported,
   normalizePosixPath,
   relativePosixPathWithinRoot,
   shellQuote,
@@ -1359,6 +1360,7 @@ export class ModalSandboxClient implements SandboxClient<
     );
     assertCoreSnapshotUnsupported('ModalSandboxClient', createArgs.snapshot);
     const manifest = createArgs.manifest;
+    assertProcessEnvValuesUnsupported(manifest, 'modal');
     const resolvedOptions = resolveOptions(
       this.options,
       createArgs.options as ModalSandboxClientOptions | undefined,
@@ -1654,6 +1656,7 @@ export class ModalSandboxClient implements SandboxClient<
     state: ModalSandboxSessionState,
     options: SandboxClientResumeOptions<ModalSandboxClientOptions> = {},
   ): Promise<ModalSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'modal');
     assertRemoteSandboxSessionStateCanResume(state);
     const trustedResourceOptions = modalResourceOptionsFrom(
       resolveOptions(this.options, options.clientOptions),

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -21,6 +21,7 @@ import {
   type WorkspaceArchiveOptions,
 } from '@openai/agents-core/sandbox';
 import {
+  assertProcessEnvValuesUnsupported,
   assertLiveMountCredentialAuthorityMatches,
   captureLiveMountCredentialAuthority,
   copyManifestMountCredentialExposurePolicy,
@@ -1660,6 +1661,7 @@ export class RunloopSandboxClient implements SandboxClient<
       resolvedOptions.userParameters,
       false,
     );
+    assertProcessEnvValuesUnsupported(manifest, 'runloop');
     assertSandboxManifestMetadataSupported(
       'RunloopSandboxClient',
       manifest,
@@ -1923,6 +1925,7 @@ export class RunloopSandboxClient implements SandboxClient<
     state: RunloopSandboxSessionState,
     options: SandboxClientResumeOptions<RunloopSandboxClientOptions> = {},
   ): Promise<RunloopSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'runloop');
     assertRemoteSandboxSessionStateCanResume(state);
     const mountSecretAuthorityTrusted =
       trustedRunloopMountSecretAuthorityStates.has(state);

--- a/packages/agents-extensions/src/sandbox/shared/manifest.ts
+++ b/packages/agents-extensions/src/sandbox/shared/manifest.ts
@@ -14,9 +14,11 @@ import {
 } from '@openai/agents-core/sandbox';
 import {
   assertExistingMountTopologyPreserved,
+  assertProcessEnvironmentDestinationsPreserved,
   captureLiveMountCredentialAuthority,
   copyValidatedMountEffectivePaths,
   copyManifestMountCredentialExposurePolicy,
+  copyProcessEnvironmentProtection,
   deserializeManifest,
   mountCredentialFileReferences,
   mergeManifestDelta,
@@ -137,6 +139,7 @@ function cloneManifestWithOverrides(
   });
   // Preserve runtime-only trusted mount policy while cloning provider manifests.
   copyManifestMountCredentialExposurePolicy(cloned, manifest);
+  copyProcessEnvironmentProtection(cloned, manifest);
   return cloned;
 }
 
@@ -437,6 +440,10 @@ export async function prepareMaterializedManifestTransition<
 ): Promise<PreparedMaterializedManifestTransition> {
   const previousManifest = state.manifest;
   const deltaManifest = cloneManifestWithOverrides(manifest);
+  assertProcessEnvironmentDestinationsPreserved(
+    previousManifest,
+    deltaManifest,
+  );
   const nextManifest = mergeManifestDelta(previousManifest, deltaManifest);
   assertExistingMountTopologyPreserved(previousManifest, nextManifest);
   const nextEnvironment = await mergeMaterializedEnvironment(

--- a/packages/agents-extensions/src/sandbox/shared/sessionState.ts
+++ b/packages/agents-extensions/src/sandbox/shared/sessionState.ts
@@ -3,6 +3,7 @@ import type {
   SandboxSessionState,
 } from '@openai/agents-core/sandbox';
 import {
+  assertProcessEnvValuesUnsupported,
   assertMountCredentialsRebound,
   assertSandboxStateGenerationUnchanged,
   assertSandboxSessionStateUsable,
@@ -51,6 +52,7 @@ export function assertRemoteSandboxSessionStateUsable(
 export function serializeRemoteSandboxSessionState<
   TState extends RemoteSandboxSessionStateValues,
 >(state: TState, mutationState: object = state): Record<string, unknown> {
+  assertProcessEnvValuesUnsupported(state.manifest, 'remote sandbox providers');
   const stateGeneration = captureSandboxStateGeneration(mutationState);
   assertRemoteSandboxSessionStateUsable(state);
   validateMountEnvironmentCredentialBoundaries(
@@ -79,6 +81,7 @@ export function deserializeRemoteSandboxSessionStateValues(
   const manifest = deserializeManifest(
     state.manifest as Record<string, unknown> | undefined,
   );
+  assertProcessEnvValuesUnsupported(manifest, 'remote sandbox providers');
   return {
     manifest,
     environment: deserializeRemotePersistedEnvironmentForRuntime(
@@ -94,10 +97,17 @@ export function deserializeRemoteSandboxSessionStateValues(
 export async function rehydrateRemoteSandboxSessionStateValues(
   state: Record<string, unknown>,
   configuredEnvironment?: Record<string, string>,
+  prepareManifest: (manifest: Manifest) => Manifest = (manifest) => manifest,
 ): Promise<RemoteSandboxSessionStateValues> {
-  const manifest = deserializeManifest(
+  const persistedManifest = deserializeManifest(
     state.manifest as Record<string, unknown> | undefined,
   );
+  assertProcessEnvValuesUnsupported(
+    persistedManifest,
+    'remote sandbox providers',
+  );
+  const manifest = prepareManifest(persistedManifest);
+  assertProcessEnvValuesUnsupported(manifest, 'remote sandbox providers');
   return {
     manifest,
     environment: await rehydrateRemotePersistedEnvironmentForRuntime(

--- a/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/vercel/sandbox.ts
@@ -67,6 +67,7 @@ import {
 } from '../shared';
 import type { PreparedManifestMount } from '../shared/manifest';
 import {
+  assertProcessEnvValuesUnsupported,
   assertLiveMountCredentialAuthorityMatches,
   assertLiveMountEnvironmentAuthorityMatches,
   assertSandboxStateGenerationUnchanged,
@@ -1591,6 +1592,7 @@ export class VercelSandboxClient implements SandboxClient<
     );
     assertCoreSnapshotUnsupported('VercelSandboxClient', createArgs.snapshot);
     const resolvedManifest = resolveManifestRoot(createArgs.manifest);
+    assertProcessEnvValuesUnsupported(resolvedManifest, 'vercel');
     assertSandboxManifestMetadataSupported(
       'VercelSandboxClient',
       resolvedManifest,
@@ -1843,6 +1845,7 @@ export class VercelSandboxClient implements SandboxClient<
   async resume(
     state: VercelSandboxSessionState,
   ): Promise<VercelSandboxSession> {
+    assertProcessEnvValuesUnsupported(state.manifest, 'vercel');
     assertRemoteSandboxSessionStateCanResume(state);
     if (hasVercelMounts(state.manifest)) {
       // This is an intentional lifecycle boundary, not a missing restore path.

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -1,6 +1,7 @@
 import {
   boxMount,
   Manifest,
+  ProcessEnvValue,
   SandboxMountError,
   SandboxProviderError,
   SandboxUnsupportedFeatureError,
@@ -124,6 +125,25 @@ describe('DaytonaSandboxClient', () => {
         snapshot: { type: 'remote' },
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects process environment values before provider effects', async () => {
+    const client = new DaytonaSandboxClient();
+
+    await expect(
+      client.create(
+        new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_DAYTONA_PROCESS_SOURCE',
+            }),
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+
+    expect(daytonaConstructorMock).not.toHaveBeenCalled();
     expect(createMock).not.toHaveBeenCalled();
   });
 
@@ -696,6 +716,29 @@ describe('DaytonaSandboxClient', () => {
 
     expect(getMock).toHaveBeenCalledWith('daytona-test');
     expect(startMock).toHaveBeenCalledOnce();
+  });
+
+  test('rejects process environment values on resume before provider effects', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+    session.state.manifest = new Manifest({
+      environment: {
+        SANDBOX_TOKEN: new ProcessEnvValue({
+          name: 'AGENTS_TEST_DAYTONA_PROCESS_SOURCE',
+        }),
+      },
+    });
+    daytonaConstructorMock.mockClear();
+    getMock.mockClear();
+    startMock.mockClear();
+
+    await expect(client.resume(session.state)).rejects.toBeInstanceOf(
+      SandboxUnsupportedFeatureError,
+    );
+
+    expect(daytonaConstructorMock).not.toHaveBeenCalled();
+    expect(getMock).not.toHaveBeenCalled();
+    expect(startMock).not.toHaveBeenCalled();
   });
 
   test('rejects raw credentialed resume state before provider calls', async () => {
@@ -1695,6 +1738,28 @@ describe('DaytonaSandboxClient', () => {
       '/home/daytona/workspace',
       {},
     ]);
+  });
+
+  test('rejects process environment values in live manifest updates before provider effects', async () => {
+    const client = new DaytonaSandboxClient();
+    const session = await client.create(new Manifest());
+    executeCommandMock.mockClear();
+    uploadFileMock.mockClear();
+
+    await expect(
+      session.applyManifest(
+        new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_DAYTONA_PROCESS_SOURCE',
+            }),
+          },
+        }),
+      ),
+    ).rejects.toThrow(/new Docker sandbox session/);
+
+    expect(executeCommandMock).not.toHaveBeenCalled();
+    expect(uploadFileMock).not.toHaveBeenCalled();
   });
 
   test('rejects paused resume state containing cloud mounts', async () => {

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -1,6 +1,7 @@
 import {
   EnvValueReference,
   Manifest,
+  ProcessEnvValue,
   registerEnvValueReference,
   SandboxProviderError,
   SandboxUnsupportedFeatureError,
@@ -199,6 +200,27 @@ describe('E2BSandboxClient', () => {
       }),
     ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
     expect(createMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects process environment values before provider effects', async () => {
+    process.env.AGENTS_TEST_E2B_PROCESS_SOURCE = 'unused-secret';
+    try {
+      const client = new E2BSandboxClient();
+      await expect(
+        client.create(
+          new Manifest({
+            environment: {
+              SANDBOX_TOKEN: new ProcessEnvValue({
+                name: 'AGENTS_TEST_E2B_PROCESS_SOURCE',
+              }),
+            },
+          }),
+        ),
+      ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+      expect(createMock).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.AGENTS_TEST_E2B_PROCESS_SOURCE;
+    }
   });
 
   test('creates a sandbox, materializes the manifest, and executes commands', async () => {

--- a/packages/agents-extensions/test/sandbox/sharedSession.test.ts
+++ b/packages/agents-extensions/test/sandbox/sharedSession.test.ts
@@ -2,12 +2,16 @@ import {
   file,
   gcsMount,
   Manifest,
+  ProcessEnvValue,
   s3Mount,
   SandboxProviderError,
   SandboxUnsupportedFeatureError,
   type SandboxSessionState,
 } from '@openai/agents-core/sandbox';
-import { withExclusiveSandboxManifestMutation } from '@openai/agents-core/sandbox/internal';
+import {
+  bindProcessEnvironmentAccess,
+  withExclusiveSandboxManifestMutation,
+} from '@openai/agents-core/sandbox/internal';
 import { describe, expect, test, vi } from 'vitest';
 import { ONE_BY_ONE_PNG } from './imageFixture';
 import {
@@ -19,6 +23,7 @@ import {
   isProviderSandboxNotFoundError,
   closeRemoteSessionOnManifestError,
   serializeRemoteSandboxSessionState,
+  rehydrateRemoteSandboxSessionStateValues,
   withProviderError,
   providerErrorRetryability,
   RemoteSandboxSessionBase,
@@ -453,6 +458,64 @@ describe('shared sandbox session helpers', () => {
 
     releaseMutation();
     await mutation;
+  });
+
+  test('rejects protected process environment values at remote persistence boundaries', async () => {
+    const manifest = new Manifest({
+      environment: {
+        SANDBOX_TOKEN: new ProcessEnvValue({ name: 'SANDBOX_SOURCE' }),
+      },
+    });
+
+    expect(() =>
+      serializeRemoteSandboxSessionState({ manifest, environment: {} }),
+    ).toThrow(SandboxUnsupportedFeatureError);
+
+    const serialized = {
+      manifest: serializeManifestRecord(manifest),
+      environment: {},
+    };
+    expect(() =>
+      deserializeRemoteSandboxSessionStateValues(serialized),
+    ).toThrow(SandboxUnsupportedFeatureError);
+    const prepareManifest = vi.fn((value: Manifest) => value);
+    await expect(
+      rehydrateRemoteSandboxSessionStateValues(
+        serialized,
+        undefined,
+        prepareManifest,
+      ),
+    ).rejects.toBeInstanceOf(SandboxUnsupportedFeatureError);
+    expect(prepareManifest).not.toHaveBeenCalled();
+  });
+
+  test('rejects bound process environment values before remote manifest effects', async () => {
+    process.env.AGENTS_TEST_REMOTE_PROCESS_SOURCE = 'remote-process-secret';
+    try {
+      const session = new FakeRemoteSession();
+      const manifest = bindProcessEnvironmentAccess(
+        new Manifest({
+          environment: {
+            SANDBOX_TOKEN: new ProcessEnvValue({
+              name: 'AGENTS_TEST_REMOTE_PROCESS_SOURCE',
+            }),
+          },
+        }),
+        {
+          processEnvironmentBindings: {
+            SANDBOX_TOKEN: 'AGENTS_TEST_REMOTE_PROCESS_SOURCE',
+          },
+        },
+      );
+
+      await expect(session.applyManifest(manifest)).rejects.toThrow(
+        /protected process environment destinations/u,
+      );
+      expect(session.commands).toHaveLength(0);
+      expect(session.state.environment).not.toHaveProperty('SANDBOX_TOKEN');
+    } finally {
+      delete process.env.AGENTS_TEST_REMOTE_PROCESS_SOURCE;
+    }
   });
 
   test('retains actual mount authority for environment-only updates', async () => {


### PR DESCRIPTION
This pull request adds trusted process environment references to the JavaScript Agents SDK, bringing the sandbox capability introduced in `openai/openai-agents-python#4408` to the Docker and Daytona providers.

### Background

Sandbox manifests currently support literal environment values and custom environment resolvers. Literal values can be serialized into persisted manifests and session state, while arbitrary resolvers do not provide a safe, provider-neutral contract for accessing the SDK host process environment.

This change introduces `ProcessEnvValue`, a serializable reference that identifies a process environment variable without serializing its value or granting access to it. Host-environment authority remains exclusively in trusted runtime configuration.

see also: https://github.com/openai/openai-agents-python/pull/4408

### Trusted access configuration

Docker and Daytona clients can explicitly authorize process environment access using either:

- `allowedProcessEnvironmentKeys` for same-name mappings.
- `processEnvironmentBindings` for destination-to-source mappings.

For example, a manifest may declare `SANDBOX_TOKEN` as a reference to `HOST_TOKEN`, while the client separately grants the exact `SANDBOX_TOKEN -> HOST_TOKEN` binding.

A reference resolves only when all of the following are true:

- The selected provider supports protected process environment values.
- Trusted client configuration grants the exact destination and source pair.
- The referenced source variable exists in the current SDK process environment.
- The manifest was prepared through the trusted provider lifecycle.

Missing, malformed, conflicting, or ungranted bindings fail before provider-side sandbox creation or mutation begins.

### Serialization and resume behavior

Serialized manifests and sandbox session state retain only the `ProcessEnvValue` reference metadata. They never contain:

- The resolved host value.
- The trusted allowlist or binding configuration.
- Runtime authority to resolve the reference after deserialization.

Deserialized state must be rebound using current trusted client configuration. Docker and Daytona resume protected sessions by creating a replacement resource with the current host values and retiring the previous resource only after the replacement has been created successfully. This supports credential rotation without treating persisted state as a source of host-secret authority.

Run-scoped client options are forwarded through manifest preparation, deserialization, and resume so constructor-scoped and per-run grants follow the same contract.

### Provider behavior

Docker passes protected values only through the container creation environment. Daytona passes them only through the provider-native sandbox creation environment.

After creation, protected destinations are removed from ordinary execution paths, including:

- Shell commands and PTY sessions.
- Filesystem and runtime helper commands.
- Mount preparation and mount helper execution.
- Manifest application and other post-creation operations.

Other sandbox providers currently reject manifests containing `ProcessEnvValue` before invoking their provider APIs. Preconstructed or injected sandbox sessions are also rejected because the SDK cannot verify that those sessions were created through a trusted protected-environment transport.

Callers can continue using ordinary explicit manifest environment values when persistence is acceptable or when a provider does not support `ProcessEnvValue`.

### Error and telemetry protection

Once a protected reference has been bound, provider lifecycle failures are converted to generic `SandboxLifecycleError` instances. Raw provider errors, cleanup failures, nested causes, response bodies, and process output are not retained in caller-visible error graphs.

The redaction boundary is applied before sandbox tracing and event emission, preventing protected values from being recorded by custom spans, JSONL sinks, HTTP event sinks, or downstream error serialization.

Cleanup and replacement paths preserve safe lifecycle facts needed to diagnose incomplete cleanup without retaining the protected value or the original secret-bearing exception graph.

### Compatibility

Existing string values, resolver functions, custom `EnvValueReference` implementations, manifests, sandbox sessions, mount behavior, and provider configuration remain unchanged when a manifest does not contain `ProcessEnvValue`.