### PR TITLE
fix(openai): keep Chat Completions refusals that arrive with content

### DIFF
--- a/.changeset/chat-completions-refusal-with-content.md
+++ b/.changeset/chat-completions-refusal-with-content.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: keep Chat Completions refusals that arrive alongside content

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -227,34 +227,33 @@ export class OpenAIChatCompletionsModel implements Model {
         // Azure OpenAI returns empty string instead of null for tool calls, causing parser rejection
         !(message.tool_calls && message.content === '');
 
+      // A message can carry text and a refusal at once, so collect both instead
+      // of letting the text branch drop the refusal. This matches how the
+      // streaming converter assembles assistant content.
+      const messageContent: protocol.AssistantContent[] = [];
       if (hasContent) {
         const { content, ...rest } = message;
-        output.push({
-          id: response.id,
-          type: 'message',
-          role: 'assistant',
-          content: [
-            {
-              type: 'output_text',
-              text: content || '',
-              providerData: rest,
-            },
-          ],
-          status: 'completed',
+        messageContent.push({
+          type: 'output_text',
+          text: content || '',
+          providerData: rest,
         });
-      } else if (message.refusal) {
+      }
+      if (message.refusal) {
         const { refusal, ...rest } = message;
+        messageContent.push({
+          type: 'refusal',
+          refusal: refusal || '',
+          providerData: rest,
+        });
+      }
+
+      if (messageContent.length > 0) {
         output.push({
           id: response.id,
           type: 'message',
           role: 'assistant',
-          content: [
-            {
-              type: 'refusal',
-              refusal: refusal || '',
-              providerData: rest,
-            },
-          ],
+          content: messageContent,
           status: 'completed',
         });
       } else if (message.audio) {

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -230,8 +230,15 @@ export class OpenAIChatCompletionsModel implements Model {
       // A message can carry text and a refusal at once, so collect both instead
       // of letting the text branch drop the refusal. This matches how the
       // streaming converter assembles assistant content.
+      //
+      // An empty string is not an answer. Keeping it as a text part next to a
+      // refusal would hide the refusal from the runner, which treats any text
+      // part as a final output. The streaming converter skips empty content
+      // deltas for the same reason.
+      const hasTextContent =
+        hasContent && !(message.refusal && message.content === '');
       const messageContent: protocol.AssistantContent[] = [];
-      if (hasContent) {
+      if (hasTextContent) {
         const { content, ...rest } = message;
         messageContent.push({
           type: 'output_text',

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -1020,6 +1020,68 @@ describe('OpenAIChatCompletionsModel', () => {
     ]);
   });
 
+  it('keeps a refusal that arrives alongside content', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: 'partial answer', refusal: 'no' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const result = await withTrace('t', () => model.getResponse(req));
+
+    expect(result.output).toHaveLength(1);
+    expect(result.output[0]).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+      content: [
+        { type: 'output_text', text: 'partial answer' },
+        { type: 'refusal', refusal: 'no' },
+      ],
+    });
+  });
+
+  it('keeps a refusal when the provider reports empty content', async () => {
+    // Azure returns an empty string where OpenAI returns null.
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: '', refusal: 'no' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const result = await withTrace('t', () => model.getResponse(req));
+
+    expect(result.output[0]).toMatchObject({
+      content: [
+        { type: 'output_text', text: '' },
+        { type: 'refusal', refusal: 'no' },
+      ],
+    });
+  });
+
   it('preserves audio from a content-filtered message', async () => {
     const client = new FakeClient();
     const response = {

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -1052,8 +1052,10 @@ describe('OpenAIChatCompletionsModel', () => {
     });
   });
 
-  it('keeps a refusal when the provider reports empty content', async () => {
-    // Azure returns an empty string where OpenAI returns null.
+  it('drops empty content so a refusal stays the only output', async () => {
+    // Azure returns an empty string where OpenAI returns null. Keeping the
+    // empty text part would read as a final answer and mask the refusal, which
+    // is why the streaming converter ignores empty content deltas too.
     const client = new FakeClient();
     const response = {
       id: 'r',
@@ -1075,10 +1077,53 @@ describe('OpenAIChatCompletionsModel', () => {
     const result = await withTrace('t', () => model.getResponse(req));
 
     expect(result.output[0]).toMatchObject({
-      content: [
-        { type: 'output_text', text: '' },
-        { type: 'refusal', refusal: 'no' },
-      ],
+      content: [{ type: 'refusal', refusal: 'no' }],
+    });
+  });
+
+  it('surfaces a refusal to the runner when content is empty', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create.mockResolvedValue({
+      id: 'r',
+      choices: [{ message: { content: '', refusal: 'no' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    });
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const runner = new Runner({
+      model: 'gpt',
+      modelProvider: { getModel: () => model },
+      tracingDisabled: true,
+    });
+
+    await expect(
+      runner.run(new Agent({ name: 'Assistant' }), 'ask'),
+    ).rejects.toThrow(/no/);
+  });
+
+  it('keeps empty content when there is no refusal', async () => {
+    const client = new FakeClient();
+    const response = {
+      id: 'r',
+      choices: [{ message: { content: '' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const req: any = {
+      input: 'u',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: false,
+    };
+
+    const result = await withTrace('t', () => model.getResponse(req));
+
+    expect(result.output[0]).toMatchObject({
+      content: [{ type: 'output_text', text: '' }],
     });
   });
 


### PR DESCRIPTION
### Summary

A Chat Completions message can carry `content` and `refusal` at the same time. The non-streaming path built the assistant item with `if` / `else if`, so the text branch won and the refusal was thrown away:

```ts
if (hasContent) {
  output.push({ ...content: [{ type: 'output_text', ... }] });
} else if (message.refusal) {
  output.push({ ...content: [{ type: 'refusal', ... }] });
}
```

The refusal never reaches `result.output`, the run history, or the caller. It is not degraded, it is gone.

The streaming converter does not do this. It collects both parts into one message, and the suite already pins that shape. `emits protocol events for streamed chat completions` in `openaiChatCompletionsStreaming.test.ts` streams `content: 'hello'` plus `refusal: 'nope'` and asserts:

```ts
content: [
  { type: 'output_text', text: 'hello', providerData: { annotations: [] } },
  { type: 'refusal', refusal: 'nope' },
],
```

So the same provider message produced different protocol items depending on whether the caller streamed. The non-streaming behavior was untested, which is why the divergence went unnoticed.

Empty content makes it worse, and this is the case that actually breaks a run. `hasContent` is true for `''` when there are no tool calls, and the comment directly above it notes that Azure returns an empty string where OpenAI returns `null`. Streaming ignores empty content deltas, so it emits a refusal-only message and `turnResolution` raises `ModelRefusalError`. Non-streaming emitted an empty text part instead, and since the runner treats any text part as a final output, the refusal was swallowed and the caller got a blank successful result with no signal that the model refused.

### Fix

Collect both parts, mirroring the streaming converter, and treat empty content as absent when a refusal is present:

```ts
const hasTextContent =
  hasContent && !(message.refusal && message.content === '');

const messageContent: protocol.AssistantContent[] = [];
if (hasTextContent) { messageContent.push({ type: 'output_text', ... }); }
if (message.refusal) { messageContent.push({ type: 'refusal', ... }); }
if (messageContent.length > 0) { output.push({ ...content: messageContent }); }
else if (message.audio) { ... }
```

Resulting behavior, now matching streaming on every case:

| provider message | before | after |
| --- | --- | --- |
| `content: 'text'`, no refusal | text | unchanged |
| `content: null`, refusal | refusal | unchanged |
| `content: ''`, no refusal | empty text | unchanged |
| `content: 'text'`, refusal | text, refusal dropped | text and refusal |
| `content: ''`, refusal | empty text, refusal dropped, blank success | refusal only, `ModelRefusalError` raised |

The audio branch still applies only when there is neither text nor refusal, and the synthesized content-filter path sets `content: null`, so both are untouched. No existing test changed.

### Test plan

Four cases added to `packages/agents-openai/test/openaiChatCompletionsModel.test.ts`. Three fail on `main`, and `keeps empty content when there is no refusal` is a guard that passes in both states:

- `keeps a refusal that arrives alongside content`
- `drops empty content so a refusal stays the only output`
- `surfaces a refusal to the runner when content is empty` (asserts the `ModelRefusalError`, not just the item shape)
- `keeps empty content when there is no refusal` (guard)

Commands run locally on Windows:

- `pnpm test` for `packages/agents-openai`: 21 files, 671 tests passing, no existing test modified
- `tsc --noEmit -p packages/agents-openai/tsconfig.json` (0 errors)
- `pnpm lint`
- prettier clean on both changed files

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
