### PR TITLE
fix(realtime): restore function calls through history updates

### DIFF
--- a/.changeset/realtime-function-call-history.md
+++ b/.changeset/realtime-function-call-history.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: restore function calls through Realtime history updates (#645)

--- a/packages/agents-realtime/src/items.ts
+++ b/packages/agents-realtime/src/items.ts
@@ -51,6 +51,8 @@ export const realtimeMessageItemSchema = z.discriminatedUnion('role', [
 export const realtimeToolCallItem = z.object({
   itemId: z.string(),
   previousItemId: z.string().nullable().optional(),
+  callId: z.string().optional(),
+  outputItemId: z.string().optional(),
   type: z.literal('function_call'),
   status: z.enum(['in_progress', 'completed', 'incomplete']),
   arguments: z.string(),

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -1,4 +1,5 @@
-import { RuntimeEventEmitter, Usage } from '@openai/agents-core';
+import { RuntimeEventEmitter, Usage, UserError } from '@openai/agents-core';
+import { randomUUID } from '@openai/agents-core/_shims';
 import { normalizeHostedMcpRequireApproval } from '@openai/agents-core/utils';
 import {
   logModelActionError,
@@ -18,6 +19,8 @@ import {
 } from './clientMessages';
 import {
   RealtimeItem,
+  RealtimeMessageItem,
+  RealtimeToolCallItem,
   realtimeMcpCallApprovalRequestItem,
   RealtimeMcpCallApprovalRequestItem,
   realtimeMcpCallItem,
@@ -155,6 +158,117 @@ function cloneRealtimeEvent<T>(event: T): T {
   return JSON.parse(JSON.stringify(event)) as T;
 }
 
+function createFunctionCallOutputItemId(): string {
+  return `fco_${randomUUID().replace(/-/g, '').slice(0, 28)}`;
+}
+
+function createHistoryReplayEventId(): string {
+  return `history_${randomUUID().replace(/-/g, '')}`;
+}
+
+function withoutFunctionCallOutput(
+  item: RealtimeToolCallItem,
+): RealtimeToolCallItem {
+  const { outputItemId: _outputItemId, ...itemWithoutOutputId } = item;
+  return realtimeToolCallItem.parse({
+    ...itemWithoutOutputId,
+    status: item.status === 'completed' ? 'in_progress' : item.status,
+    output: null,
+  });
+}
+
+function isFunctionCallOutputCompletion(
+  oldItem: RealtimeItem | undefined,
+  updatedItem: RealtimeItem,
+): oldItem is RealtimeToolCallItem {
+  return (
+    oldItem?.type === 'function_call' &&
+    updatedItem.type === 'function_call' &&
+    oldItem.status === 'in_progress' &&
+    oldItem.output === null &&
+    oldItem.outputItemId === undefined &&
+    updatedItem.status === 'completed' &&
+    updatedItem.output !== null &&
+    oldItem.itemId === updatedItem.itemId &&
+    oldItem.previousItemId === updatedItem.previousItemId &&
+    oldItem.callId === updatedItem.callId &&
+    oldItem.name === updatedItem.name &&
+    oldItem.arguments === updatedItem.arguments
+  );
+}
+
+function assertUniqueFunctionCallOutputItemIds(
+  history: RealtimeItem[],
+  description: 'current' | 'updated',
+  additionalOutputItems: Pick<
+    RealtimeToolCallItem,
+    'itemId' | 'outputItemId'
+  >[] = [],
+): void {
+  const visibleItemIds = new Set(history.map((item) => item.itemId));
+  const outputItemOwners = new Map<string, string>();
+  const assertOutputItemId = (
+    item: Pick<RealtimeToolCallItem, 'itemId' | 'outputItemId'>,
+    allowExistingOwner: boolean,
+  ) => {
+    if (item.outputItemId === undefined) {
+      return;
+    }
+    if (visibleItemIds.has(item.outputItemId)) {
+      throw new UserError(
+        `Function call output item ${item.outputItemId} conflicts with a visible item ID in the ${description} history.`,
+      );
+    }
+    const existingOwner = outputItemOwners.get(item.outputItemId);
+    if (existingOwner !== undefined) {
+      if (allowExistingOwner && existingOwner === item.itemId) {
+        return;
+      }
+      throw new UserError(
+        `Function call output item ${item.outputItemId} appears more than once in the ${description} history.`,
+      );
+    }
+    outputItemOwners.set(item.outputItemId, item.itemId);
+  };
+  for (const item of history) {
+    if (item.type === 'function_call') {
+      assertOutputItemId(item, false);
+    }
+  }
+  for (const item of additionalOutputItems) {
+    assertOutputItemId(item, true);
+  }
+}
+
+type PendingHistoryReplayCreate = {
+  kind: 'create';
+  itemId: string;
+  item: RealtimeMessageItem | RealtimeToolCallItem;
+  projected: boolean;
+};
+
+type PendingHistoryCallDeletion = {
+  itemWithoutOutput: RealtimeToolCallItem;
+};
+
+type PendingHistoryReplayDelete = {
+  kind: 'delete';
+  itemId: string;
+  projection:
+    | { kind: 'item'; itemId: string }
+    | { kind: 'call_output'; deletion: PendingHistoryCallDeletion }
+    | { kind: 'call'; deletion: PendingHistoryCallDeletion };
+};
+
+type PendingHistoryReplayAck =
+  PendingHistoryReplayCreate | PendingHistoryReplayDelete;
+
+type PendingHistoryReplay = {
+  message: RealtimeMessageItem | undefined;
+  call: RealtimeToolCallItem | undefined;
+  output: RealtimeToolCallItem | undefined;
+};
+
 export abstract class OpenAIRealtimeBase
   extends EventEmitterDelegate<OpenAIRealtimeEventTypes>
   implements RealtimeTransportLayer
@@ -163,6 +277,10 @@ export abstract class OpenAIRealtimeBase
   #apiKey: ApiKey | undefined;
   #tracingConfig: RealtimeTracingConfig | null = null;
   #rawSessionConfig: Record<string, any> | null = null;
+  #pendingHistoryReplayAcks = new Map<string, PendingHistoryReplayAck>();
+  #pendingHistoryReplayCreates = new Map<string, string[]>();
+  #pendingHistoryReplayDeletes = new Map<string, string[]>();
+  #confirmedFunctionCallOutputIds = new Map<string, string>();
 
   protected eventEmitter: RuntimeEventEmitter<OpenAIRealtimeEventTypes> =
     new RuntimeEventEmitter<OpenAIRealtimeEventTypes>();
@@ -240,6 +358,15 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'error') {
+      const failedEventId =
+        typeof parsed.error?.event_id === 'string'
+          ? parsed.error.event_id
+          : parsed.error?.code === 'invalid_tool_call_id'
+            ? this.#getOldestPendingFunctionCallOutputEventId()
+            : undefined;
+      if (typeof failedEventId === 'string') {
+        this.#rejectPendingHistoryReplayAck(failedEventId);
+      }
       this.emit('error', { type: 'error', error: parsed });
     } else {
       this.emit(parsed.type, parsed);
@@ -308,6 +435,10 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'conversation.item.deleted') {
+      this.#forgetConfirmedFunctionCallOutput(parsed.item_id);
+      if (this.#consumePendingHistoryReplayDelete(parsed.item_id)) {
+        return;
+      }
       this.emit('item_deleted', {
         itemId: parsed.item_id,
       });
@@ -357,6 +488,13 @@ export abstract class OpenAIRealtimeBase
       parsed.type === 'conversation.item.done' ||
       parsed.type === 'conversation.item.retrieved'
     ) {
+      if (
+        parsed.type !== 'conversation.item.retrieved' &&
+        typeof parsed.item.id === 'string' &&
+        this.#consumePendingHistoryReplayCreate(parsed.item.id, parsed.type)
+      ) {
+        return;
+      }
       // Handle MCP list tools items (only act when done to ensure tools are present)
       if (
         parsed.item.type === 'mcp_list_tools' &&
@@ -475,6 +613,7 @@ export abstract class OpenAIRealtimeBase
       if (item.type === 'function_call' && item.status === 'completed') {
         const toolCall = realtimeToolCallItem.parse({
           itemId: item.id,
+          callId: item.call_id,
           type: item.type,
           status: 'in_progress', // we set it to in_progress for the UI as it will only be completed with the output
           arguments: item.arguments,
@@ -541,7 +680,297 @@ export abstract class OpenAIRealtimeBase
   }
 
   protected _onClose() {
+    this.#clearPendingHistoryReplayAcks();
     this.emit('disconnected');
+  }
+
+  #registerPendingHistoryReplayAck(
+    eventId: string,
+    pendingAck: PendingHistoryReplayAck,
+  ): void {
+    this.#pendingHistoryReplayAcks.set(eventId, pendingAck);
+    if (pendingAck.kind === 'create') {
+      const pendingCreates =
+        this.#pendingHistoryReplayCreates.get(pendingAck.itemId) ?? [];
+      pendingCreates.push(eventId);
+      this.#pendingHistoryReplayCreates.set(pendingAck.itemId, pendingCreates);
+      return;
+    }
+
+    const pendingDeletes =
+      this.#pendingHistoryReplayDeletes.get(pendingAck.itemId) ?? [];
+    pendingDeletes.push(eventId);
+    this.#pendingHistoryReplayDeletes.set(pendingAck.itemId, pendingDeletes);
+  }
+
+  #removePendingHistoryReplayAck(eventId: string): void {
+    const pendingAck = this.#pendingHistoryReplayAcks.get(eventId);
+    if (pendingAck === undefined) {
+      return;
+    }
+    this.#pendingHistoryReplayAcks.delete(eventId);
+
+    if (pendingAck.kind === 'create') {
+      const pendingCreates = this.#pendingHistoryReplayCreates.get(
+        pendingAck.itemId,
+      );
+      if (pendingCreates === undefined) {
+        return;
+      }
+      const remainingCreates = pendingCreates.filter(
+        (pendingCreateEventId) => pendingCreateEventId !== eventId,
+      );
+      if (remainingCreates.length === 0) {
+        this.#pendingHistoryReplayCreates.delete(pendingAck.itemId);
+      } else {
+        this.#pendingHistoryReplayCreates.set(
+          pendingAck.itemId,
+          remainingCreates,
+        );
+      }
+      return;
+    }
+
+    const pendingDeletes = this.#pendingHistoryReplayDeletes.get(
+      pendingAck.itemId,
+    );
+    if (pendingDeletes === undefined) {
+      return;
+    }
+    const remainingDeletes = pendingDeletes.filter(
+      (pendingDeleteEventId) => pendingDeleteEventId !== eventId,
+    );
+    if (remainingDeletes.length === 0) {
+      this.#pendingHistoryReplayDeletes.delete(pendingAck.itemId);
+    } else {
+      this.#pendingHistoryReplayDeletes.set(
+        pendingAck.itemId,
+        remainingDeletes,
+      );
+    }
+  }
+
+  #consumePendingHistoryReplayDelete(itemId: string): boolean {
+    const pendingEventId = this.#pendingHistoryReplayDeletes.get(itemId)?.[0];
+    if (pendingEventId === undefined) {
+      return false;
+    }
+    const pendingAck = this.#pendingHistoryReplayAcks.get(pendingEventId);
+    if (pendingAck?.kind !== 'delete') {
+      return false;
+    }
+    this.#retireProjectedHistoryReplayCreates(itemId);
+    if (pendingAck.projection.kind === 'item') {
+      this.emit('item_deleted', { itemId: pendingAck.projection.itemId });
+    } else if (pendingAck.projection.kind === 'call_output') {
+      const deletion = pendingAck.projection.deletion;
+      this.#removePendingHistoryReplayAck(pendingEventId);
+      const callDeleteEvent = this.#registerPendingHistoryCallDelete(deletion);
+      try {
+        this.emit('item_update', deletion.itemWithoutOutput);
+        this.sendEvent(callDeleteEvent);
+      } catch (error) {
+        this.#rejectPendingHistoryReplayAck(callDeleteEvent.event_id);
+        throw error;
+      }
+      return true;
+    } else {
+      this.emit('item_deleted', {
+        itemId: pendingAck.projection.deletion.itemWithoutOutput.itemId,
+      });
+    }
+    this.#removePendingHistoryReplayAck(pendingEventId);
+    return true;
+  }
+
+  #retireProjectedHistoryReplayCreates(itemId: string): void {
+    const pendingEventIds = [
+      ...(this.#pendingHistoryReplayCreates.get(itemId) ?? []),
+    ];
+    for (const eventId of pendingEventIds) {
+      const pendingAck = this.#pendingHistoryReplayAcks.get(eventId);
+      if (pendingAck?.kind === 'create' && pendingAck.projected) {
+        this.#removePendingHistoryReplayAck(eventId);
+      }
+    }
+  }
+
+  #consumePendingHistoryReplayCreate(
+    itemId: string,
+    eventType: 'conversation.item.added' | 'conversation.item.done',
+  ): boolean {
+    const pendingEventId = this.#pendingHistoryReplayCreates.get(itemId)?.[0];
+    if (pendingEventId === undefined) {
+      return false;
+    }
+    const pendingAck = this.#pendingHistoryReplayAcks.get(pendingEventId);
+    if (pendingAck?.kind !== 'create') {
+      return false;
+    }
+    if (!pendingAck.projected) {
+      pendingAck.projected = true;
+      this.emit('item_update', pendingAck.item);
+    }
+    if (eventType === 'conversation.item.done') {
+      if (
+        pendingAck.item.type === 'function_call' &&
+        pendingAck.item.output !== null &&
+        pendingAck.item.outputItemId === pendingAck.itemId
+      ) {
+        this.#confirmedFunctionCallOutputIds.set(
+          pendingAck.item.itemId,
+          pendingAck.itemId,
+        );
+      }
+      this.#removePendingHistoryReplayAck(pendingEventId);
+    }
+    return true;
+  }
+
+  #rejectPendingHistoryReplayAck(eventId: string): void {
+    const pendingAck = this.#pendingHistoryReplayAcks.get(eventId);
+    if (pendingAck === undefined) {
+      return;
+    }
+    const rejectedFunctionCallOutput =
+      pendingAck.kind === 'create' &&
+      pendingAck.projected &&
+      pendingAck.item.type === 'function_call' &&
+      pendingAck.item.output !== null &&
+      pendingAck.item.outputItemId === pendingAck.itemId
+        ? pendingAck.item
+        : undefined;
+    this.#removePendingHistoryReplayAck(eventId);
+    if (rejectedFunctionCallOutput !== undefined) {
+      this.emit(
+        'item_update',
+        withoutFunctionCallOutput(rejectedFunctionCallOutput),
+      );
+    }
+  }
+
+  #clearPendingHistoryReplayAcks(): void {
+    this.#pendingHistoryReplayAcks.clear();
+    this.#pendingHistoryReplayCreates.clear();
+    this.#pendingHistoryReplayDeletes.clear();
+    this.#confirmedFunctionCallOutputIds.clear();
+  }
+
+  #hasOwnedFunctionCallOutput(itemId: string): boolean {
+    if (this.#confirmedFunctionCallOutputIds.has(itemId)) {
+      return true;
+    }
+    for (const pendingAck of this.#pendingHistoryReplayAcks.values()) {
+      if (
+        pendingAck.kind === 'create' &&
+        pendingAck.item.type === 'function_call' &&
+        pendingAck.item.itemId === itemId &&
+        pendingAck.item.output !== null &&
+        pendingAck.item.outputItemId === pendingAck.itemId
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  #forgetConfirmedFunctionCallOutput(itemId: string): void {
+    this.#confirmedFunctionCallOutputIds.delete(itemId);
+    for (const [callItemId, outputItemId] of this
+      .#confirmedFunctionCallOutputIds) {
+      if (outputItemId === itemId) {
+        this.#confirmedFunctionCallOutputIds.delete(callItemId);
+        return;
+      }
+    }
+  }
+
+  #getPendingHistoryReplay(itemId: string): PendingHistoryReplay {
+    let message: RealtimeMessageItem | undefined;
+    let call: RealtimeToolCallItem | undefined;
+    let output: RealtimeToolCallItem | undefined;
+    for (const pendingAck of this.#pendingHistoryReplayAcks.values()) {
+      if (pendingAck.kind !== 'create' || pendingAck.projected) {
+        continue;
+      }
+      if (
+        pendingAck.item.type === 'message' &&
+        pendingAck.item.itemId === itemId
+      ) {
+        message ??= pendingAck.item;
+      } else if (
+        pendingAck.item.type === 'function_call' &&
+        pendingAck.item.itemId === itemId
+      ) {
+        if (pendingAck.itemId === itemId && pendingAck.item.output === null) {
+          call ??= pendingAck.item;
+        } else if (
+          pendingAck.item.output !== null &&
+          pendingAck.item.outputItemId === pendingAck.itemId
+        ) {
+          output ??= pendingAck.item;
+        }
+      }
+    }
+    return { message, call, output };
+  }
+
+  #getOldestPendingFunctionCallOutputEventId(): string | undefined {
+    for (const [eventId, pendingAck] of this.#pendingHistoryReplayAcks) {
+      if (
+        pendingAck.kind === 'create' &&
+        pendingAck.item.type === 'function_call' &&
+        pendingAck.item.output !== null &&
+        pendingAck.item.outputItemId === pendingAck.itemId
+      ) {
+        return eventId;
+      }
+    }
+    return undefined;
+  }
+
+  #hasPendingFunctionCallDeletion(itemId: string): boolean {
+    const pendingEventId = this.#pendingHistoryReplayDeletes.get(itemId)?.[0];
+    if (pendingEventId === undefined) {
+      return false;
+    }
+    const pendingAck = this.#pendingHistoryReplayAcks.get(pendingEventId);
+    return (
+      pendingAck?.kind === 'delete' &&
+      pendingAck.projection.kind === 'call' &&
+      pendingAck.projection.deletion.itemWithoutOutput.itemId === itemId
+    );
+  }
+
+  #sendHistoryReplayEvent(
+    event: RealtimeClientMessage & { event_id: string },
+    pendingAck: PendingHistoryReplayAck,
+  ): void {
+    this.#registerPendingHistoryReplayAck(event.event_id, pendingAck);
+    try {
+      this.sendEvent(event);
+    } catch (error) {
+      this.#rejectPendingHistoryReplayAck(event.event_id);
+      throw error;
+    }
+  }
+
+  #registerPendingHistoryCallDelete(
+    deletion: PendingHistoryCallDeletion,
+  ): RealtimeClientMessage & { event_id: string } {
+    const eventId = createHistoryReplayEventId();
+    const itemId = deletion.itemWithoutOutput.itemId;
+    const event = {
+      type: 'conversation.item.delete' as const,
+      event_id: eventId,
+      item_id: itemId,
+    };
+    this.#registerPendingHistoryReplayAck(eventId, {
+      kind: 'delete',
+      itemId,
+      projection: { kind: 'call', deletion },
+    });
+    return event;
   }
 
   requestResponse(response?: Record<string, any>): void {
@@ -907,26 +1336,35 @@ export abstract class OpenAIRealtimeBase
     output: string,
     startResponse: boolean = true,
   ): void {
-    this.sendEvent({
+    const outputItemId = createFunctionCallOutputItemId();
+    const eventId = createHistoryReplayEventId();
+    const event = {
       type: 'conversation.item.create',
+      event_id: eventId,
+      ...(typeof toolCall.id === 'string'
+        ? { previous_item_id: toolCall.id }
+        : {}),
       item: {
+        id: outputItemId,
         type: 'function_call_output',
         output,
         call_id: toolCall.callId,
       },
-    });
+    } as const;
 
+    let item: RealtimeToolCallItem | undefined;
     try {
-      const item = realtimeToolCallItem.parse({
+      item = realtimeToolCallItem.parse({
         itemId: toolCall.id,
         previousItemId: toolCall.previousItemId,
+        callId: toolCall.callId,
+        outputItemId,
         type: 'function_call',
         status: 'completed',
         arguments: toolCall.arguments,
         name: toolCall.name,
         output,
       });
-      this.emit('item_update', item);
     } catch (error) {
       logToolActionError(
         logger,
@@ -934,6 +1372,42 @@ export abstract class OpenAIRealtimeBase
         error,
         toolCall,
       );
+    }
+
+    if (item === undefined) {
+      this.sendEvent(event);
+    } else {
+      if (
+        this.#hasOwnedFunctionCallOutput(item.itemId) ||
+        this.#hasPendingFunctionCallDeletion(item.itemId)
+      ) {
+        throw new UserError(
+          `Function call ${item.itemId} already has an output pending or confirmed by the Realtime API.`,
+        );
+      }
+      const pendingAck: PendingHistoryReplayCreate = {
+        kind: 'create',
+        itemId: outputItemId,
+        item,
+        projected: false,
+      };
+      this.#sendHistoryReplayEvent(event, pendingAck);
+      if (
+        !pendingAck.projected &&
+        this.#pendingHistoryReplayAcks.get(eventId) === pendingAck
+      ) {
+        pendingAck.projected = true;
+        try {
+          this.emit('item_update', item);
+        } catch (error) {
+          logToolActionError(
+            logger,
+            'Error parsing tool call item',
+            error,
+            toolCall,
+          );
+        }
+      }
     }
 
     if (startResponse) {
@@ -973,49 +1447,472 @@ export abstract class OpenAIRealtimeBase
    * @param newHistory - The new history of the conversation.
    */
   resetHistory(oldHistory: RealtimeItem[], newHistory: RealtimeItem[]): void {
-    const { removals, additions, updates } = diffRealtimeHistory(
-      oldHistory,
-      newHistory,
-    );
-
-    const removalIds = new Set(removals.map((item) => item.itemId));
-    // we don't have an update event for items so we will remove and re-add what's there
-    for (const update of updates) {
-      removalIds.add(update.itemId);
-    }
-
-    if (removalIds.size > 0) {
-      for (const itemId of removalIds) {
-        this.sendEvent({
-          type: 'conversation.item.delete',
-          item_id: itemId,
-        });
+    assertUniqueFunctionCallOutputItemIds(oldHistory, 'current');
+    const oldItemsById = new Map(oldHistory.map((item) => [item.itemId, item]));
+    const normalizedNewHistory = newHistory.map((item) => {
+      const oldItem = oldItemsById.get(item.itemId);
+      if (item.type === 'message') {
+        return cloneRealtimeEvent(item);
+      }
+      if (item.type !== 'function_call') {
+        return item;
+      }
+      const normalizedItem =
+        item.output === null ? withoutFunctionCallOutput(item) : item;
+      const pendingReplay = this.#getPendingHistoryReplay(
+        normalizedItem.itemId,
+      );
+      const identitySource =
+        oldItem?.type === 'function_call'
+          ? oldItem
+          : (pendingReplay.output ?? pendingReplay.call);
+      if (identitySource === undefined) {
+        return normalizedItem;
+      }
+      return realtimeToolCallItem.parse({
+        ...normalizedItem,
+        ...(normalizedItem.callId === undefined &&
+        identitySource.callId !== undefined
+          ? { callId: identitySource.callId }
+          : {}),
+        ...(normalizedItem.outputItemId === undefined &&
+        identitySource.outputItemId !== undefined
+          ? { outputItemId: identitySource.outputItemId }
+          : {}),
+      });
+    });
+    assertUniqueFunctionCallOutputItemIds(normalizedNewHistory, 'updated');
+    for (const item of normalizedNewHistory) {
+      if (
+        item.type === 'function_call' &&
+        item.output !== null &&
+        item.status !== 'completed'
+      ) {
+        throw new UserError(
+          `Function call history item ${item.itemId} must be completed when it has an output.`,
+        );
+      }
+      if (item.type === 'message' || item.type === 'function_call') {
+        const pendingReplay = this.#getPendingHistoryReplay(item.itemId);
+        const pendingVisibleItem = pendingReplay.message ?? pendingReplay.call;
+        if (
+          pendingVisibleItem !== undefined &&
+          pendingVisibleItem.type !== item.type
+        ) {
+          throw new UserError(
+            `History item ${item.itemId} cannot change type while its creation is awaiting acknowledgement.`,
+          );
+        }
       }
     }
 
-    const additionsAndUpdates = [...additions, ...updates];
+    const newHistoryIds = new Set<string>();
+    for (const item of normalizedNewHistory) {
+      if (newHistoryIds.has(item.itemId)) {
+        throw new UserError(
+          `History item ${item.itemId} appears more than once in the updated history.`,
+        );
+      }
+      newHistoryIds.add(item.itemId);
+    }
 
-    for (const addition of additionsAndUpdates) {
-      if (addition.type === 'message') {
-        const itemEntry: Record<string, any> = {
-          type: 'message',
-          role: addition.role,
-          content: addition.content,
-          id: addition.itemId,
-        };
-        if (addition.role !== 'system' && addition.status) {
-          itemEntry.status = addition.status;
-        }
-        this.sendEvent({
-          type: 'conversation.item.create',
-          item: itemEntry,
-        });
-      } else if (addition.type === 'function_call') {
-        logger.warn(
-          'Function calls cannot be manually added or updated at the moment. Ignoring.',
+    const { removals, additions, updates } = diffRealtimeHistory(
+      oldHistory,
+      normalizedNewHistory,
+    );
+    const functionCallOutputCompletionIds = new Set(
+      updates
+        .filter((update) =>
+          isFunctionCallOutputCompletion(
+            oldItemsById.get(update.itemId),
+            update,
+          ),
+        )
+        .map((update) => update.itemId),
+    );
+    const pendingFunctionCallDeletionCompletionIds = new Set(
+      [...functionCallOutputCompletionIds].filter((itemId) =>
+        this.#hasPendingFunctionCallDeletion(itemId),
+      ),
+    );
+
+    for (const update of updates) {
+      const oldItem = oldItemsById.get(update.itemId);
+      if (functionCallOutputCompletionIds.has(update.itemId)) {
+        continue;
+      }
+      if (
+        update.type === 'function_call' ||
+        oldItem?.type === 'function_call'
+      ) {
+        throw new UserError(
+          `Function call history item ${update.itemId} cannot be updated in place. Remove it in one updateHistory() call, then add the replacement in a later call.`,
         );
       }
     }
+
+    for (const item of removals) {
+      if (
+        item.type === 'function_call' &&
+        item.output !== null &&
+        item.outputItemId === undefined
+      ) {
+        throw new UserError(
+          `Function call history item ${item.itemId} cannot be removed because its output item ID is unavailable.`,
+        );
+      }
+    }
+
+    const preparedAdditions = additions.map((addition) => {
+      if (addition.type !== 'function_call') {
+        return addition;
+      }
+      const parsedAddition = realtimeToolCallItem.parse(addition);
+      const preparedAddition = realtimeToolCallItem.parse({
+        ...parsedAddition,
+        callId: parsedAddition.callId ?? parsedAddition.itemId,
+        outputItemId:
+          parsedAddition.output === null
+            ? undefined
+            : (parsedAddition.outputItemId ?? createFunctionCallOutputItemId()),
+      });
+      const pendingReplay = this.#getPendingHistoryReplay(
+        preparedAddition.itemId,
+      );
+      if (
+        pendingReplay.call !== undefined &&
+        JSON.stringify(pendingReplay.call) !==
+          JSON.stringify(withoutFunctionCallOutput(preparedAddition))
+      ) {
+        throw new UserError(
+          `Function call history item ${preparedAddition.itemId} cannot change while its call creation is awaiting acknowledgement.`,
+        );
+      }
+      if (
+        pendingReplay.output !== undefined &&
+        JSON.stringify(pendingReplay.output) !==
+          JSON.stringify(preparedAddition)
+      ) {
+        throw new UserError(
+          `Function call history item ${preparedAddition.itemId} cannot change its output while the previous output is awaiting acknowledgement.`,
+        );
+      }
+      return preparedAddition;
+    });
+    const preparedOutputCompletions = updates
+      .filter(
+        (update): update is RealtimeToolCallItem =>
+          update.type === 'function_call' &&
+          functionCallOutputCompletionIds.has(update.itemId) &&
+          !pendingFunctionCallDeletionCompletionIds.has(update.itemId),
+      )
+      .map((completion) => {
+        const confirmedOutputItemId = this.#confirmedFunctionCallOutputIds.get(
+          completion.itemId,
+        );
+        if (confirmedOutputItemId !== undefined) {
+          throw new UserError(
+            `Function call history item ${completion.itemId} cannot replay its output because output item ${confirmedOutputItemId} is already confirmed by the Realtime API.`,
+          );
+        }
+        const pendingOutput = this.#getPendingHistoryReplay(
+          completion.itemId,
+        ).output;
+        if (
+          pendingOutput !== undefined &&
+          (pendingOutput.output !== completion.output ||
+            (completion.outputItemId !== undefined &&
+              completion.outputItemId !== pendingOutput.outputItemId))
+        ) {
+          throw new UserError(
+            `Function call history item ${completion.itemId} cannot change its output while the previous output is awaiting acknowledgement.`,
+          );
+        }
+        return realtimeToolCallItem.parse({
+          ...completion,
+          outputItemId:
+            completion.outputItemId ??
+            pendingOutput?.outputItemId ??
+            createFunctionCallOutputItemId(),
+        });
+      });
+
+    const itemsToRemove = [
+      ...removals,
+      ...updates
+        .filter((update) => !functionCallOutputCompletionIds.has(update.itemId))
+        .map((update) => oldItemsById.get(update.itemId)!),
+    ].filter((item): item is RealtimeItem => Boolean(item));
+
+    const pendingFunctionCallOutputs = [
+      ...this.#pendingHistoryReplayAcks.values(),
+    ]
+      .filter(
+        (
+          pendingAck,
+        ): pendingAck is PendingHistoryReplayCreate & {
+          item: RealtimeToolCallItem;
+        } =>
+          pendingAck.kind === 'create' &&
+          pendingAck.item.type === 'function_call' &&
+          pendingAck.item.output !== null &&
+          pendingAck.item.outputItemId === pendingAck.itemId,
+      )
+      .map((pendingAck) => pendingAck.item);
+    assertUniqueFunctionCallOutputItemIds(normalizedNewHistory, 'updated', [
+      ...preparedAdditions.filter(
+        (item): item is RealtimeToolCallItem => item.type === 'function_call',
+      ),
+      ...preparedOutputCompletions,
+      ...pendingFunctionCallOutputs,
+      ...itemsToRemove.filter(
+        (item): item is RealtimeToolCallItem => item.type === 'function_call',
+      ),
+      ...[...this.#confirmedFunctionCallOutputIds].map(
+        ([itemId, outputItemId]) => ({ itemId, outputItemId }),
+      ),
+    ]);
+
+    const desiredItemsById = new Map(
+      normalizedNewHistory.map((item) => [item.itemId, item]),
+    );
+    const preparedFunctionCallReplayItemsById = new Map(
+      [...preparedAdditions, ...preparedOutputCompletions]
+        .filter(
+          (item): item is RealtimeToolCallItem => item.type === 'function_call',
+        )
+        .map((item) => [item.itemId, item]),
+    );
+    for (const item of [...preparedAdditions, ...preparedOutputCompletions]) {
+      desiredItemsById.set(item.itemId, item);
+    }
+
+    const replayItemIds = new Set(
+      [
+        ...additions,
+        ...updates.filter(
+          (update) =>
+            !pendingFunctionCallDeletionCompletionIds.has(update.itemId),
+        ),
+      ].map((item) => item.itemId),
+    );
+    const replayItems = normalizedNewHistory
+      .filter((item) => replayItemIds.has(item.itemId))
+      .map(
+        (item) => preparedFunctionCallReplayItemsById.get(item.itemId) ?? item,
+      );
+    const pendingMessageReplayIds = new Set<string>();
+    for (const item of replayItems) {
+      if (item.type !== 'message') {
+        continue;
+      }
+      const pendingMessage = this.#getPendingHistoryReplay(item.itemId).message;
+      if (pendingMessage === undefined) {
+        continue;
+      }
+      if (JSON.stringify(pendingMessage) !== JSON.stringify(item)) {
+        throw new UserError(
+          `History message ${item.itemId} cannot change while its creation is awaiting acknowledgement.`,
+        );
+      }
+      pendingMessageReplayIds.add(item.itemId);
+    }
+    const replayPreviousItemIds = new Map<string, string | undefined>();
+    for (const item of replayItems) {
+      if (item.type !== 'message' && item.type !== 'function_call') {
+        continue;
+      }
+      let previousItemId =
+        typeof item.previousItemId === 'string'
+          ? item.previousItemId
+          : undefined;
+      const previousItem =
+        previousItemId === undefined || previousItemId === 'root'
+          ? undefined
+          : desiredItemsById.get(previousItemId);
+      if (
+        previousItem?.type === 'function_call' &&
+        previousItem.output !== null
+      ) {
+        if (previousItem.outputItemId === undefined) {
+          const itemDescription =
+            item.type === 'function_call'
+              ? 'Function call history item'
+              : 'History item';
+          throw new UserError(
+            `${itemDescription} ${item.itemId} cannot follow function call ${previousItem.itemId} because its output item ID is unavailable.`,
+          );
+        }
+        previousItemId = previousItem.outputItemId;
+      }
+      replayPreviousItemIds.set(item.itemId, previousItemId);
+    }
+
+    const pendingDeletes = new Map<string, PendingHistoryReplayDelete>();
+    for (const item of itemsToRemove) {
+      let deletionItem = item;
+      if (item.type === 'function_call' && item.outputItemId === undefined) {
+        const pendingOutput = this.#getPendingHistoryReplay(item.itemId).output;
+        if (pendingOutput !== undefined) {
+          if (
+            JSON.stringify(withoutFunctionCallOutput(pendingOutput)) !==
+            JSON.stringify(item)
+          ) {
+            throw new UserError(
+              `Function call history item ${item.itemId} cannot be removed while a conflicting output is awaiting acknowledgement.`,
+            );
+          }
+          deletionItem = pendingOutput;
+        }
+      }
+      if (
+        deletionItem.type === 'function_call' &&
+        deletionItem.outputItemId !== undefined
+      ) {
+        const deletion: PendingHistoryCallDeletion = {
+          itemWithoutOutput: withoutFunctionCallOutput(deletionItem),
+        };
+        pendingDeletes.set(deletionItem.outputItemId, {
+          kind: 'delete',
+          itemId: deletionItem.outputItemId,
+          projection: { kind: 'call_output', deletion },
+        });
+      } else {
+        pendingDeletes.set(deletionItem.itemId, {
+          kind: 'delete',
+          itemId: deletionItem.itemId,
+          projection: { kind: 'item', itemId: deletionItem.itemId },
+        });
+      }
+    }
+
+    for (const pendingDelete of pendingDeletes.values()) {
+      if (this.#pendingHistoryReplayDeletes.has(pendingDelete.itemId)) {
+        continue;
+      }
+      const eventId = createHistoryReplayEventId();
+      this.#sendHistoryReplayEvent(
+        {
+          type: 'conversation.item.delete',
+          event_id: eventId,
+          item_id: pendingDelete.itemId,
+        },
+        pendingDelete,
+      );
+    }
+
+    for (const item of replayItems) {
+      if (item.type === 'message') {
+        if (pendingMessageReplayIds.has(item.itemId)) {
+          continue;
+        }
+        const itemEntry: Record<string, any> = {
+          type: 'message',
+          role: item.role,
+          content: item.content,
+          id: item.itemId,
+        };
+        if (item.role !== 'system' && item.status) {
+          itemEntry.status = item.status;
+        }
+        const previousItemId = replayPreviousItemIds.get(item.itemId);
+        const eventId = createHistoryReplayEventId();
+        this.#sendHistoryReplayEvent(
+          {
+            type: 'conversation.item.create',
+            event_id: eventId,
+            ...(previousItemId !== undefined
+              ? { previous_item_id: previousItemId }
+              : {}),
+            item: itemEntry,
+          },
+          {
+            kind: 'create',
+            itemId: item.itemId,
+            item,
+            projected: false,
+          },
+        );
+      } else if (item.type === 'function_call') {
+        if (functionCallOutputCompletionIds.has(item.itemId)) {
+          this.#replayFunctionCallOutputHistoryItem(item);
+        } else {
+          this.#replayFunctionCallHistoryItem(
+            item,
+            replayPreviousItemIds.get(item.itemId),
+          );
+        }
+      }
+    }
+  }
+
+  #replayFunctionCallHistoryItem(
+    item: RealtimeToolCallItem,
+    previousItemId: string | undefined,
+  ): void {
+    const callId = item.callId ?? item.itemId;
+    const outputItemId = item.outputItemId;
+    const pendingCall = this.#getPendingHistoryReplay(item.itemId).call;
+
+    if (pendingCall === undefined) {
+      const callEventId = createHistoryReplayEventId();
+      this.#sendHistoryReplayEvent(
+        {
+          type: 'conversation.item.create',
+          event_id: callEventId,
+          ...(previousItemId !== undefined
+            ? { previous_item_id: previousItemId }
+            : {}),
+          item: {
+            id: item.itemId,
+            type: 'function_call',
+            name: item.name,
+            arguments: item.arguments,
+            call_id: callId,
+          },
+        },
+        {
+          kind: 'create',
+          itemId: item.itemId,
+          item: item.output === null ? item : withoutFunctionCallOutput(item),
+          projected: false,
+        },
+      );
+    }
+
+    if (item.output !== null && outputItemId !== undefined) {
+      this.#replayFunctionCallOutputHistoryItem(item);
+    }
+  }
+
+  #replayFunctionCallOutputHistoryItem(item: RealtimeToolCallItem): void {
+    if (item.output === null || item.outputItemId === undefined) {
+      return;
+    }
+    const pendingOutput = this.#getPendingHistoryReplay(item.itemId).output;
+    if (pendingOutput?.outputItemId === item.outputItemId) {
+      return;
+    }
+    const outputEventId = createHistoryReplayEventId();
+    this.#sendHistoryReplayEvent(
+      {
+        type: 'conversation.item.create',
+        event_id: outputEventId,
+        previous_item_id: item.itemId,
+        item: {
+          id: item.outputItemId,
+          type: 'function_call_output',
+          call_id: item.callId ?? item.itemId,
+          output: item.output,
+        },
+      },
+      {
+        kind: 'create',
+        itemId: item.outputItemId,
+        item,
+        projected: false,
+      },
+    );
   }
 
   sendMcpResponse(

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -306,6 +306,8 @@ export function updateRealtimeHistory(
       }
       return item;
     });
+  } else if ((event as any).previousItemId === 'root') {
+    return [newEvent, ...history];
   } else if ((event as any).previousItemId) {
     // Insert after previousItemId if found, else at end
     const prevIndex = history.findIndex(

--- a/packages/agents-realtime/test/historyReplay.test.ts
+++ b/packages/agents-realtime/test/historyReplay.test.ts
@@ -86,6 +86,7 @@ describe('OpenAI realtime history replay', () => {
     expect(base.events).toEqual([
       {
         type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
         item_id: 'remove-me',
       },
     ]);

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -8,7 +8,11 @@ import {
   expectTypeOf,
 } from 'vitest';
 import type { MessageEvent as WebSocketMessageEvent } from 'ws';
-import type { RealtimeClientMessage, RealtimeSessionConfig } from '../src';
+import type {
+  RealtimeClientMessage,
+  RealtimeMessageItem,
+  RealtimeSessionConfig,
+} from '../src';
 import {
   DEFAULT_OPENAI_REALTIME_SESSION_CONFIG,
   OpenAIRealtimeBase,
@@ -37,6 +41,22 @@ class TestBase extends OpenAIRealtimeBase {
   }
 }
 
+class ThrowingTestBase extends TestBase {
+  sendCount = 0;
+
+  constructor(private readonly throwOnSend: number) {
+    super();
+  }
+
+  override sendEvent(event: RealtimeClientMessage) {
+    this.sendCount += 1;
+    if (this.sendCount === this.throwOnSend) {
+      throw new Error('send failed');
+    }
+    super.sendEvent(event);
+  }
+}
+
 class VoidMessageOverrideTransport extends TestBase {
   protected override _onMessage(
     event: MessageEvent | WebSocketMessageEvent,
@@ -54,6 +74,35 @@ function createToolCall() {
     arguments: '{}',
     responseId: 'response-1',
   };
+}
+
+function acknowledgeHistoryCreate(
+  base: TestBase,
+  eventIndex: number,
+  type:
+    | 'conversation.item.added'
+    | 'conversation.item.done' = 'conversation.item.added',
+): void {
+  const event = base.events[eventIndex] as any;
+  (base as any)._onMessage({
+    data: JSON.stringify({
+      type,
+      event_id: `server_${eventIndex}_${type}`,
+      previous_item_id: event.previous_item_id ?? null,
+      item: event.item,
+    }),
+  });
+}
+
+function acknowledgeHistoryDelete(base: TestBase, eventIndex: number): void {
+  const event = base.events[eventIndex] as any;
+  (base as any)._onMessage({
+    data: JSON.stringify({
+      type: 'conversation.item.deleted',
+      event_id: `server_${eventIndex}_deleted`,
+      item_id: event.item_id,
+    }),
+  });
 }
 
 describe('OpenAIRealtimeBase helpers', () => {
@@ -412,7 +461,7 @@ describe('OpenAIRealtimeBase helpers', () => {
     ]);
   });
 
-  it('sendFunctionCallOutput emits item_update and response.create', () => {
+  it('sendFunctionCallOutput anchors the output after its function call', () => {
     const base = new TestBase();
     const updates: any[] = [];
     base.on('item_update', (e) => updates.push(e));
@@ -420,10 +469,303 @@ describe('OpenAIRealtimeBase helpers', () => {
 
     expect(base.events[0]).toEqual({
       type: 'conversation.item.create',
-      item: { type: 'function_call_output', output: 'output', call_id: 'c1' },
+      event_id: expect.stringMatching(/^history_/),
+      previous_item_id: '1',
+      item: {
+        id: expect.stringMatching(/^fco_/),
+        type: 'function_call_output',
+        output: 'output',
+        call_id: 'c1',
+      },
     });
     expect(base.events[1]).toEqual({ type: 'response.create' });
-    expect(updates.length).toBe(1);
+    expect((base.events[0] as any).item.id).toHaveLength(32);
+    expect(updates).toEqual([
+      {
+        itemId: '1',
+        callId: 'c1',
+        outputItemId: (base.events[0] as any).item.id,
+        type: 'function_call',
+        status: 'completed',
+        arguments: '{}',
+        name: 'tool',
+        output: 'output',
+      },
+    ]);
+  });
+
+  it('continues the response when an output projection listener throws', () => {
+    const base = new TestBase();
+    let outputItemId: string | undefined;
+    base.on('item_update', () => {
+      outputItemId = (base.events[0] as any).item.id;
+      throw new Error('listener failed');
+    });
+
+    expect(() =>
+      base.sendFunctionCallOutput(createToolCall(), 'output', true),
+    ).not.toThrow();
+
+    expect(base.events.map((event) => event.type)).toEqual([
+      'conversation.item.create',
+      'response.create',
+    ]);
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error parsing tool call item',
+      'object',
+    );
+    expect(() =>
+      base.sendFunctionCallOutput(createToolCall(), 'retry', false),
+    ).toThrow(
+      'Function call 1 already has an output pending or confirmed by the Realtime API.',
+    );
+
+    acknowledgeHistoryCreate(base, 0, 'conversation.item.done');
+    expect(() =>
+      base.resetHistory(
+        [],
+        [
+          {
+            itemId: outputItemId!,
+            type: 'message',
+            role: 'user',
+            status: 'completed',
+            content: [{ type: 'input_text', text: 'reuse' }],
+          },
+        ],
+      ),
+    ).toThrow('conflicts with a visible item ID');
+
+    const inProgressCall = {
+      itemId: '1',
+      callId: 'c1',
+      type: 'function_call' as const,
+      status: 'in_progress' as const,
+      arguments: '{}',
+      name: 'tool',
+      output: null,
+    };
+    const completedCall = {
+      ...inProgressCall,
+      outputItemId,
+      status: 'completed' as const,
+      output: 'output',
+    };
+    expect(() => base.resetHistory([inProgressCall], [completedCall])).toThrow(
+      'is already confirmed by the Realtime API',
+    );
+    expect(() =>
+      base.resetHistory(
+        [inProgressCall],
+        [{ ...completedCall, outputItemId: undefined }],
+      ),
+    ).toThrow('is already confirmed by the Realtime API');
+    expect(base.events).toHaveLength(2);
+  });
+
+  it('omits the output predecessor when the function call ID is unavailable', () => {
+    const base = new TestBase();
+    base.sendFunctionCallOutput(
+      {
+        ...createToolCall(),
+        id: undefined,
+      },
+      'output',
+      false,
+    );
+
+    expect(base.events[0]).not.toHaveProperty('previous_item_id');
+  });
+
+  it('rolls back an ordinary function call output when its create is rejected', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    session.on('error', () => {});
+    await session.connect({ apiKey: 'test' });
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'response.output_item.done',
+        event_id: 'server_call',
+        response_id: 'response-1',
+        output_index: 0,
+        item: {
+          id: '1',
+          type: 'function_call',
+          status: 'completed',
+          arguments: '{}',
+          name: 'tool',
+          call_id: 'c1',
+        },
+      }),
+    });
+
+    transport.sendFunctionCallOutput(createToolCall(), 'output', false);
+    const outputCreate = transport.events.at(-1) as any;
+    expect(session.history[0]).toMatchObject({
+      itemId: '1',
+      status: 'completed',
+      output: 'output',
+      outputItemId: outputCreate.item.id,
+    });
+
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'server_output_error',
+        error: {
+          type: 'invalid_request_error',
+          code: 'invalid_tool_call_id',
+          message: 'The function call no longer exists.',
+        },
+      }),
+    });
+
+    expect(session.history[0]).toEqual({
+      itemId: '1',
+      callId: 'c1',
+      outputItemId: undefined,
+      type: 'function_call',
+      status: 'in_progress',
+      arguments: '{}',
+      name: 'tool',
+      output: null,
+    });
+
+    session.updateHistory([]);
+    expect(transport.events.at(-1)).toMatchObject({
+      type: 'conversation.item.delete',
+      item_id: '1',
+    });
+  });
+
+  it('matches uncorrelated output rejections in send order', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('error', () => {});
+    base.on('item_update', (item) => updates.push(item));
+    base.sendFunctionCallOutput(createToolCall(), 'first', false);
+    base.sendFunctionCallOutput(
+      {
+        ...createToolCall(),
+        id: '2',
+        callId: 'c2',
+      },
+      'second',
+      false,
+    );
+
+    const rejectOldestOutput = (eventId: string) =>
+      (base as any)._onMessage({
+        data: JSON.stringify({
+          type: 'error',
+          event_id: eventId,
+          error: {
+            type: 'invalid_request_error',
+            code: 'invalid_tool_call_id',
+            message: 'The function call no longer exists.',
+          },
+        }),
+      });
+    rejectOldestOutput('server_first_output_error');
+    rejectOldestOutput('server_second_output_error');
+
+    expect(updates.map((item) => [item.itemId, item.status])).toEqual([
+      ['1', 'completed'],
+      ['2', 'completed'],
+      ['1', 'in_progress'],
+      ['2', 'in_progress'],
+    ]);
+  });
+
+  it('rejects another output while one is awaiting acknowledgement', () => {
+    const base = new TestBase();
+    base.sendFunctionCallOutput(createToolCall(), 'first', false);
+
+    expect(() =>
+      base.sendFunctionCallOutput(createToolCall(), 'second', true),
+    ).toThrow(
+      'Function call 1 already has an output pending or confirmed by the Realtime API.',
+    );
+    expect(base.events).toHaveLength(1);
+  });
+
+  it('rejects another output after the first output is acknowledged', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    base.sendFunctionCallOutput(createToolCall(), 'first', false);
+    acknowledgeHistoryCreate(base, 0, 'conversation.item.done');
+
+    expect(() =>
+      base.sendFunctionCallOutput(createToolCall(), 'second', false),
+    ).toThrow(
+      'Function call 1 already has an output pending or confirmed by the Realtime API.',
+    );
+    expect(base.events).toHaveLength(1);
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      itemId: '1',
+      status: 'completed',
+      output: 'first',
+    });
+  });
+
+  it('allows retrying an output after its create is rejected', () => {
+    const base = new TestBase();
+    base.on('error', () => {});
+    base.sendFunctionCallOutput(createToolCall(), 'first', false);
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'server_first_output_error',
+        error: {
+          type: 'invalid_request_error',
+          code: 'invalid_tool_call_id',
+          message: 'The function call no longer exists.',
+        },
+      }),
+    });
+
+    expect(() =>
+      base.sendFunctionCallOutput(createToolCall(), 'retry', false),
+    ).not.toThrow();
+    expect(base.events).toHaveLength(2);
+    expect((base.events[1] as any).item.output).toBe('retry');
+  });
+
+  it('clears confirmed output ownership when the transport closes', () => {
+    const base = new TestBase();
+    base.sendFunctionCallOutput(createToolCall(), 'first', false);
+    acknowledgeHistoryCreate(base, 0, 'conversation.item.done');
+    (base as any)._onClose();
+
+    expect(() =>
+      base.sendFunctionCallOutput(createToolCall(), 'after reconnect', false),
+    ).not.toThrow();
+    expect(base.events).toHaveLength(2);
+  });
+
+  it('clears confirmed output ownership when the output is deleted', () => {
+    const base = new TestBase();
+    base.sendFunctionCallOutput(createToolCall(), 'first', false);
+    const outputItemId = (base.events[0] as any).item.id;
+    acknowledgeHistoryCreate(base, 0, 'conversation.item.done');
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.deleted',
+        event_id: 'server_output_deleted',
+        item_id: outputItemId,
+      }),
+    });
+
+    expect(() =>
+      base.sendFunctionCallOutput(createToolCall(), 'replacement', false),
+    ).not.toThrow();
+    expect(base.events).toHaveLength(2);
   });
 
   it('sendFunctionCallOutput logs errors when tool call parsing fails', () => {
@@ -551,10 +893,12 @@ describe('OpenAIRealtimeBase helpers', () => {
 
     expect(base.events[0]).toEqual({
       type: 'conversation.item.delete',
+      event_id: expect.stringMatching(/^history_/),
       item_id: '1',
     });
     expect(base.events[1]).toEqual({
       type: 'conversation.item.create',
+      event_id: expect.stringMatching(/^history_/),
       item: {
         id: '2',
         role: 'user',
@@ -565,13 +909,16 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
   });
 
-  it('resetHistory warns on function call additions', () => {
+  it('resetHistory restores a function call and updates local history', () => {
     const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
     const newHist = [
       {
         itemId: 'f1',
+        previousItemId: 'm1',
         type: 'function_call',
-        status: 'completed',
+        status: 'in_progress',
         arguments: '{}',
         name: 'calc',
         output: null,
@@ -580,10 +927,1657 @@ describe('OpenAIRealtimeBase helpers', () => {
 
     base.resetHistory([], newHist as any);
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      'Function calls cannot be manually added or updated at the moment. Ignoring.',
+    expect(updates).toEqual([]);
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        previous_item_id: 'm1',
+        item: {
+          id: 'f1',
+          type: 'function_call',
+          arguments: '{}',
+          name: 'calc',
+          call_id: 'f1',
+        },
+      },
+    ]);
+    acknowledgeHistoryCreate(base, 0);
+    expect(updates).toEqual([
+      {
+        ...newHist[0],
+        callId: 'f1',
+      },
+    ]);
+  });
+
+  it('resetHistory omits a null previous item ID for a function call', () => {
+    const base = new TestBase();
+    const item = {
+      itemId: 'f1',
+      previousItemId: null,
+      type: 'function_call' as const,
+      status: 'in_progress' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: null,
+    };
+
+    base.resetHistory([], [item]);
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        item: {
+          id: 'f1',
+          type: 'function_call',
+          arguments: '{}',
+          name: 'calc',
+          call_id: 'f1',
+        },
+      },
+    ]);
+  });
+
+  it('resetHistory preserves local order for mixed message and function call additions', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const addedItems: string[] = [];
+    session.on('history_added', (item) => addedItems.push(item.itemId));
+
+    session.updateHistory([
+      {
+        itemId: 'm1',
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text: 'use the tool' }],
+      },
+      {
+        itemId: 'f1',
+        previousItemId: 'm1',
+        type: 'function_call',
+        status: 'in_progress',
+        arguments: '{}',
+        name: 'calc',
+        output: null,
+      },
+    ]);
+
+    expect(session.history).toEqual([]);
+    expect(addedItems).toEqual([]);
+
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'server_m1',
+        previous_item_id: null,
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'use the tool' }],
+        },
+      }),
+    });
+
+    expect(session.history.map((item) => item.itemId)).toEqual(['m1']);
+    expect(addedItems).toEqual(['m1']);
+
+    acknowledgeHistoryCreate(transport, 1);
+
+    expect(session.history.map((item) => item.itemId)).toEqual(['m1', 'f1']);
+    expect(addedItems).toEqual(['m1', 'f1']);
+  });
+
+  it('resetHistory recreates an updated predecessor before a dependent function call', () => {
+    const base = new TestBase();
+    const oldMessage = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'old' }],
+    };
+    const updatedMessage = {
+      ...oldMessage,
+      content: [{ type: 'input_text' as const, text: 'updated' }],
+    };
+
+    base.resetHistory(
+      [oldMessage],
+      [
+        updatedMessage,
+        {
+          itemId: 'f1',
+          previousItemId: 'm1',
+          type: 'function_call',
+          status: 'in_progress',
+          arguments: '{}',
+          name: 'calc',
+          output: null,
+        },
+      ],
     );
-    expect(base.events).toHaveLength(0);
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
+        item_id: 'm1',
+      },
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'updated' }],
+        },
+      },
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        previous_item_id: 'm1',
+        item: {
+          id: 'f1',
+          type: 'function_call',
+          arguments: '{}',
+          name: 'calc',
+          call_id: 'f1',
+        },
+      },
+    ]);
+  });
+
+  it('resetHistory preserves recreated predecessor order after server echoes', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const receive = (event: Record<string, any>) => {
+      (transport as any)._onMessage({ data: JSON.stringify(event) });
+    };
+    const messageEvent = (text: string) => ({
+      type: 'conversation.item.added',
+      event_id: `message_${text}`,
+      previous_item_id: null,
+      item: {
+        id: 'm1',
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text }],
+      },
+    });
+    receive(messageEvent('old'));
+
+    session.updateHistory([
+      {
+        itemId: 'm1',
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text: 'updated' }],
+      },
+      {
+        itemId: 'f1',
+        previousItemId: 'm1',
+        type: 'function_call',
+        status: 'in_progress',
+        arguments: '{}',
+        name: 'calc',
+        output: null,
+      },
+    ]);
+    expect(session.history.map((item) => item.itemId)).toEqual(['m1']);
+
+    receive({
+      type: 'conversation.item.deleted',
+      event_id: 'delete_m1',
+      item_id: 'm1',
+    });
+    receive(messageEvent('updated'));
+    acknowledgeHistoryCreate(transport, 2);
+
+    expect(session.history.map((item) => item.itemId)).toEqual(['m1', 'f1']);
+  });
+
+  it('retires projected create ownership before recreating a deleted item ID', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const desiredCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      type: 'function_call' as const,
+      status: 'in_progress' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: null,
+    };
+    const addedItems: string[] = [];
+    session.on('history_added', (item) => addedItems.push(item.itemId));
+
+    session.updateHistory([desiredCall]);
+    acknowledgeHistoryCreate(transport, 0);
+    expect(session.history).toEqual([desiredCall]);
+
+    let restoreAfterDelete = true;
+    session.on('history_updated', (history) => {
+      if (restoreAfterDelete && history.length === 0) {
+        restoreAfterDelete = false;
+        session.updateHistory([desiredCall]);
+      }
+    });
+    session.updateHistory([]);
+    acknowledgeHistoryDelete(transport, 1);
+
+    expect(transport.events[2]).toMatchObject({
+      type: 'conversation.item.create',
+      item: { id: 'f1', type: 'function_call' },
+    });
+    acknowledgeHistoryCreate(transport, 2);
+    acknowledgeHistoryCreate(transport, 2, 'conversation.item.done');
+
+    expect(session.history).toEqual([desiredCall]);
+    expect(addedItems).toEqual(['f1', 'f1']);
+  });
+
+  it('coalesces a queued message replacement during deletion reentry', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const oldMessage = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'old' }],
+    };
+    const replacement = {
+      ...oldMessage,
+      content: [{ type: 'input_text' as const, text: 'replacement' }],
+    };
+    const addedItems: string[] = [];
+    session.on('history_added', (item) => addedItems.push(item.itemId));
+
+    session.updateHistory([oldMessage]);
+    acknowledgeHistoryCreate(transport, 0);
+
+    let reapplyAfterDelete = true;
+    session.on('history_updated', (history) => {
+      if (reapplyAfterDelete && history.length === 0) {
+        reapplyAfterDelete = false;
+        session.updateHistory([replacement]);
+      }
+    });
+    session.updateHistory([replacement]);
+    expect(transport.events).toHaveLength(3);
+
+    acknowledgeHistoryDelete(transport, 1);
+    expect(transport.events).toHaveLength(3);
+    acknowledgeHistoryCreate(transport, 2);
+    acknowledgeHistoryCreate(transport, 2, 'conversation.item.done');
+
+    expect(session.history).toEqual([replacement]);
+    expect(addedItems).toEqual(['m1', 'm1']);
+  });
+
+  it('rejects a conflicting message while its replacement is pending', () => {
+    const base = new TestBase();
+    const oldMessage = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'old' }],
+    };
+    const replacement = {
+      ...oldMessage,
+      content: [{ type: 'input_text' as const, text: 'replacement' }],
+    };
+
+    base.resetHistory([], [oldMessage]);
+    acknowledgeHistoryCreate(base, 0);
+    base.resetHistory([oldMessage], [replacement]);
+    acknowledgeHistoryDelete(base, 1);
+
+    expect(() =>
+      base.resetHistory(
+        [],
+        [
+          {
+            ...replacement,
+            content: [{ type: 'input_text', text: 'conflicting' }],
+          },
+        ],
+      ),
+    ).toThrow(
+      'History message m1 cannot change while its creation is awaiting acknowledgement.',
+    );
+    expect(base.events).toHaveLength(3);
+  });
+
+  it('keeps desired message state through a status-omitting added acknowledgement', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const desiredMessage = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'hello' }],
+    };
+    let reapplyOnce = true;
+    session.on('history_updated', () => {
+      if (reapplyOnce) {
+        reapplyOnce = false;
+        session.updateHistory([desiredMessage]);
+      }
+    });
+
+    session.updateHistory([desiredMessage]);
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'server_added',
+        previous_item_id: null,
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'hello' }],
+        },
+      }),
+    });
+
+    expect(session.history).toEqual([desiredMessage]);
+    expect(transport.events).toHaveLength(1);
+    acknowledgeHistoryCreate(transport, 0, 'conversation.item.done');
+    session.updateHistory([desiredMessage]);
+    expect(transport.events).toHaveLength(1);
+  });
+
+  it('snapshots desired messages before their acknowledgement', () => {
+    const base = new TestBase();
+    const desiredMessage: RealtimeMessageItem = {
+      itemId: 'm1',
+      type: 'message',
+      role: 'user',
+      status: 'completed',
+      content: [{ type: 'input_text', text: 'original' }],
+    };
+    const projectedItems: RealtimeMessageItem[] = [];
+    base.on('item_update', (item) => {
+      if (item.type === 'message') {
+        projectedItems.push(item);
+      }
+    });
+
+    base.resetHistory([], [desiredMessage]);
+    const sentEvent = structuredClone(base.events[0]);
+    desiredMessage.status = 'incomplete';
+    const retainedContent = desiredMessage.content[0];
+    if (retainedContent.type !== 'input_text') {
+      throw new Error('Expected input_text content');
+    }
+    retainedContent.text = 'mutated';
+    acknowledgeHistoryCreate(base, 0);
+
+    expect(base.events[0]).toEqual(sentEvent);
+    expect(projectedItems).toEqual([
+      {
+        itemId: 'm1',
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text: 'original' }],
+      },
+    ]);
+  });
+
+  it('resetHistory sends the projected insertion order to the server', () => {
+    const base = new TestBase();
+    const firstMessage = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'first' }],
+    };
+    const trailingMessage = {
+      itemId: 'm2',
+      previousItemId: 'm1',
+      type: 'message' as const,
+      role: 'assistant' as const,
+      status: 'completed' as const,
+      content: [{ type: 'output_text' as const, text: 'trailing' }],
+    };
+
+    base.resetHistory(
+      [firstMessage, trailingMessage],
+      [
+        firstMessage,
+        {
+          itemId: 'm-inserted',
+          previousItemId: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'inserted' }],
+        },
+        {
+          itemId: 'f1',
+          previousItemId: 'm-inserted',
+          type: 'function_call',
+          status: 'in_progress',
+          arguments: '{}',
+          name: 'calc',
+          output: null,
+        },
+        trailingMessage,
+      ],
+    );
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        previous_item_id: 'm1',
+        item: {
+          id: 'm-inserted',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'inserted' }],
+        },
+      },
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        previous_item_id: 'm-inserted',
+        item: {
+          id: 'f1',
+          type: 'function_call',
+          arguments: '{}',
+          name: 'calc',
+          call_id: 'f1',
+        },
+      },
+    ]);
+  });
+
+  it('resetHistory preserves a recreated message chain after server acknowledgements', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const receive = (event: Record<string, any>) => {
+      (transport as any)._onMessage({ data: JSON.stringify(event) });
+    };
+    const messageEvent = (
+      type: 'conversation.item.added' | 'conversation.item.done',
+      itemId: string,
+      previousItemId: string | null,
+      text: string,
+    ) => ({
+      type,
+      event_id: `${type}_${itemId}_${text}`,
+      previous_item_id: previousItemId,
+      item: {
+        id: itemId,
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text }],
+      },
+    });
+    receive(messageEvent('conversation.item.added', 'm0', null, 'old zero'));
+    receive(messageEvent('conversation.item.added', 'm1', 'm0', 'old one'));
+
+    session.updateHistory([
+      {
+        itemId: 'm0',
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text: 'new zero' }],
+      },
+      {
+        itemId: 'm1',
+        previousItemId: 'm0',
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text: 'new one' }],
+      },
+      {
+        itemId: 'f1',
+        previousItemId: 'm1',
+        type: 'function_call',
+        status: 'in_progress',
+        arguments: '{}',
+        name: 'calc',
+        output: null,
+      },
+    ]);
+    expect(session.history.map((item) => item.itemId)).toEqual(['m0', 'm1']);
+
+    receive({
+      type: 'conversation.item.deleted',
+      event_id: 'delete_m0',
+      item_id: 'm0',
+    });
+    receive({
+      type: 'conversation.item.deleted',
+      event_id: 'delete_m1',
+      item_id: 'm1',
+    });
+    receive(messageEvent('conversation.item.added', 'm0', null, 'new zero'));
+    receive(messageEvent('conversation.item.done', 'm0', null, 'new zero'));
+    receive(messageEvent('conversation.item.added', 'm1', 'm0', 'new one'));
+    receive(messageEvent('conversation.item.done', 'm1', 'm0', 'new one'));
+    acknowledgeHistoryCreate(transport, 4);
+
+    expect(session.history.map((item) => item.itemId)).toEqual([
+      'm0',
+      'm1',
+      'f1',
+    ]);
+  });
+
+  it('resetHistory keeps public predecessors when the wire uses a hidden output item', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const retainedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      outputItemId: 'fco_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: 'one',
+    };
+    session.updateHistory([retainedCall]);
+    acknowledgeHistoryCreate(transport, 0);
+    acknowledgeHistoryCreate(transport, 1);
+    const retainedHistory = [
+      retainedCall,
+      {
+        itemId: 'm1',
+        previousItemId: 'f1',
+        type: 'message' as const,
+        role: 'user' as const,
+        status: 'completed' as const,
+        content: [{ type: 'input_text' as const, text: 'next' }],
+      },
+    ];
+
+    session.updateHistory(retainedHistory);
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'message_m1_added',
+        previous_item_id: 'fco_1',
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      }),
+    });
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.done',
+        event_id: 'message_m1_done',
+        previous_item_id: 'fco_1',
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      }),
+    });
+
+    expect(session.history[1]).toMatchObject({
+      itemId: 'm1',
+      previousItemId: 'f1',
+    });
+    const sentEventCount = transport.events.length;
+    session.updateHistory([
+      ...retainedHistory,
+      {
+        itemId: 'm2',
+        previousItemId: 'm1',
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text: 'later' }],
+      },
+    ]);
+
+    expect(transport.events.slice(sentEventCount)).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        previous_item_id: 'm1',
+        item: {
+          id: 'm2',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'later' }],
+        },
+      },
+    ]);
+  });
+
+  it('resetHistory clears stale output identity from a call without output', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    const item = {
+      itemId: 'f1',
+      outputItemId: 'stale-output-id',
+      type: 'function_call' as const,
+      status: 'in_progress' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: null,
+    };
+
+    base.resetHistory([], [item]);
+
+    acknowledgeHistoryCreate(base, 0);
+
+    expect(updates).toEqual([
+      {
+        ...item,
+        callId: 'f1',
+        outputItemId: undefined,
+      },
+    ]);
+  });
+
+  it('resetHistory restores a completed function call and its output as a pair', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    const item = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{"x":1}',
+      name: 'calc',
+      callId: 'call_1',
+      output: '42',
+    };
+
+    base.resetHistory([], [item]);
+
+    const callEvent = base.events[0] as any;
+    const outputEvent = base.events[1] as any;
+    expect(callEvent).toMatchObject({
+      type: 'conversation.item.create',
+      item: {
+        id: 'f1',
+        type: 'function_call',
+        call_id: 'call_1',
+      },
+    });
+    expect(outputEvent).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: 'f1',
+      item: {
+        id: expect.stringMatching(/^fco_/),
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: '42',
+      },
+    });
+    expect(outputEvent.item.id).toHaveLength(32);
+
+    acknowledgeHistoryCreate(base, 0);
+    acknowledgeHistoryCreate(base, 1);
+
+    expect(updates).toEqual([
+      {
+        ...item,
+        status: 'in_progress',
+        output: null,
+      },
+      {
+        ...item,
+        outputItemId: outputEvent.item.id,
+      },
+    ]);
+  });
+
+  it('resetHistory anchors a later function call after the prior call output', () => {
+    const base = new TestBase();
+
+    base.resetHistory(
+      [],
+      [
+        {
+          itemId: 'f1',
+          type: 'function_call',
+          status: 'completed',
+          arguments: '{}',
+          name: 'first',
+          callId: 'call_1',
+          output: 'one',
+        },
+        {
+          itemId: 'f2',
+          previousItemId: 'f1',
+          type: 'function_call',
+          status: 'completed',
+          arguments: '{}',
+          name: 'second',
+          callId: 'call_2',
+          output: 'two',
+        },
+      ],
+    );
+
+    const firstOutputId = (base.events[1] as any).item.id;
+    expect(firstOutputId).toMatch(/^fco_/);
+    expect(base.events[2]).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: firstOutputId,
+      item: {
+        id: 'f2',
+        type: 'function_call',
+        call_id: 'call_2',
+      },
+    });
+    expect(base.events[3]).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: 'f2',
+      item: {
+        type: 'function_call_output',
+        call_id: 'call_2',
+        output: 'two',
+      },
+    });
+  });
+
+  it('resetHistory anchors a later message after the prior call output', () => {
+    const base = new TestBase();
+    const firstCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      outputItemId: 'fco_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'first',
+      output: 'one',
+    };
+
+    base.resetHistory(
+      [firstCall],
+      [
+        firstCall,
+        {
+          itemId: 'm1',
+          previousItemId: 'f1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      ],
+    );
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        previous_item_id: 'fco_1',
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      },
+    ]);
+  });
+
+  it('resetHistory rejects a hidden output predecessor without an item ID before sending', () => {
+    const base = new TestBase();
+    const firstCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'first',
+      output: 'one',
+    };
+
+    expect(() =>
+      base.resetHistory(
+        [firstCall],
+        [
+          firstCall,
+          {
+            itemId: 'f2',
+            previousItemId: 'f1',
+            type: 'function_call',
+            status: 'in_progress',
+            arguments: '{}',
+            name: 'second',
+            callId: 'call_2',
+            output: null,
+          },
+        ],
+      ),
+    ).toThrow(
+      'Function call history item f2 cannot follow function call f1 because its output item ID is unavailable.',
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('resetHistory preserves generated identities across repeated updates', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    const retainedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    base.resetHistory([], [retainedCall]);
+    acknowledgeHistoryCreate(base, 0);
+    acknowledgeHistoryCreate(base, 1);
+    base.events = [];
+    base.resetHistory(
+      [updates.at(-1)],
+      [
+        retainedCall,
+        {
+          itemId: 'm2',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      ],
+    );
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        item: {
+          id: 'm2',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      },
+    ]);
+  });
+
+  it('normalizes restored completed calls without outputs before later completion', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const restoredCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: null,
+    };
+
+    session.updateHistory([restoredCall]);
+    acknowledgeHistoryCreate(transport, 0, 'conversation.item.done');
+
+    expect(session.history).toMatchObject([
+      { itemId: 'f1', status: 'in_progress', output: null },
+    ]);
+
+    session.updateHistory([restoredCall]);
+    expect(transport.events).toHaveLength(1);
+
+    session.updateHistory([
+      { ...restoredCall, status: 'completed', output: '42' },
+    ]);
+    const outputItemId = (transport.events[1] as any).item.id;
+    expect(transport.events[1]).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: 'f1',
+      item: {
+        id: outputItemId,
+        type: 'function_call_output',
+        call_id: 'f1',
+        output: '42',
+      },
+    });
+    acknowledgeHistoryCreate(transport, 1, 'conversation.item.done');
+    expect(session.history).toEqual([
+      {
+        ...restoredCall,
+        callId: 'f1',
+        outputItemId,
+        output: '42',
+      },
+    ]);
+  });
+
+  it('coalesces a retained completion reapplied from history_updated', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const retainedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([retainedCall]);
+    const pendingOutputId = (transport.events[1] as any).item.id;
+    session.on('history_updated', (history) => {
+      if (
+        history.length === 1 &&
+        history[0]?.type === 'function_call' &&
+        history[0].output === null
+      ) {
+        session.updateHistory([retainedCall]);
+      }
+    });
+
+    acknowledgeHistoryCreate(transport, 0);
+
+    expect(transport.events).toHaveLength(2);
+    acknowledgeHistoryCreate(transport, 1);
+    expect(session.history).toEqual([
+      {
+        ...retainedCall,
+        callId: 'f1',
+        outputItemId: pendingOutputId,
+      },
+    ]);
+  });
+
+  it('coalesces repeated completed restores before the first acknowledgement', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const retainedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([retainedCall]);
+    const pendingOutputId = (transport.events[1] as any).item.id;
+    session.updateHistory([retainedCall]);
+
+    expect(transport.events).toHaveLength(2);
+    expect((transport.events[1] as any).item.id).toBe(pendingOutputId);
+    acknowledgeHistoryCreate(transport, 0);
+    acknowledgeHistoryCreate(transport, 1);
+    expect(session.history).toEqual([
+      {
+        ...retainedCall,
+        callId: 'f1',
+        outputItemId: pendingOutputId,
+      },
+    ]);
+  });
+
+  it('rejects a conflicting repeated restore before the first acknowledgement', () => {
+    const base = new TestBase();
+    const retainedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    base.resetHistory([], [retainedCall]);
+
+    expect(() =>
+      base.resetHistory([], [{ ...retainedCall, output: 'changed' }]),
+    ).toThrow(
+      'Function call history item f1 cannot change its output while the previous output is awaiting acknowledgement.',
+    );
+    expect(base.events).toHaveLength(2);
+  });
+
+  it('retries only the missing output after a synchronous partial send', () => {
+    const base = new ThrowingTestBase(2);
+    const retainedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    expect(() => base.resetHistory([], [retainedCall])).toThrow('send failed');
+    expect(base.events).toHaveLength(1);
+
+    base.resetHistory([], [retainedCall]);
+
+    expect(base.events).toHaveLength(2);
+    expect(base.events.map((event) => (event as any).item.type)).toEqual([
+      'function_call',
+      'function_call_output',
+    ]);
+  });
+
+  it('rejects a changed completion while its output is pending', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    const retainedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    base.resetHistory([], [retainedCall]);
+    acknowledgeHistoryCreate(base, 0);
+
+    expect(() =>
+      base.resetHistory(
+        [updates.at(-1)],
+        [{ ...retainedCall, output: 'changed' }],
+      ),
+    ).toThrow(
+      'Function call history item f1 cannot change its output while the previous output is awaiting acknowledgement.',
+    );
+    expect(base.events).toHaveLength(2);
+  });
+
+  it('resetHistory reuses a supplied output item ID across repeated updates', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    const retainedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      callId: 'call_1',
+      outputItemId: 'fco_persisted_output',
+      output: '42',
+    };
+
+    base.resetHistory([], [retainedCall]);
+    acknowledgeHistoryCreate(base, 0);
+    acknowledgeHistoryCreate(base, 1);
+
+    expect((base.events[1] as any).item.id).toBe('fco_persisted_output');
+    expect(updates.at(-1)).toEqual(retainedCall);
+
+    base.events = [];
+    base.resetHistory(
+      [updates.at(-1)],
+      [
+        retainedCall,
+        {
+          itemId: 'm2',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      ],
+    );
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.create',
+        event_id: expect.stringMatching(/^history_/),
+        item: {
+          id: 'm2',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'next' }],
+        },
+      },
+    ]);
+  });
+
+  it('resetHistory forwards an empty supplied output item ID', () => {
+    const base = new TestBase();
+    const item = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      callId: 'call_1',
+      outputItemId: '',
+      output: '42',
+    };
+
+    base.resetHistory([], [item]);
+
+    expect((base.events[1] as any).item.id).toBe('');
+
+    base.events = [];
+    base.resetHistory([item], []);
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
+        item_id: '',
+      },
+    ]);
+    acknowledgeHistoryDelete(base, 0);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
+        item_id: '',
+      },
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
+        item_id: 'f1',
+      },
+    ]);
+  });
+
+  it('resetHistory deletes a function call after its output acknowledgement', () => {
+    const base = new TestBase();
+    base.resetHistory(
+      [
+        {
+          itemId: 'f1',
+          outputItemId: 'fo1',
+          type: 'function_call',
+          status: 'completed',
+          arguments: '{}',
+          name: 'calc',
+          output: '42',
+        },
+      ] as any,
+      [],
+    );
+
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
+        item_id: 'fo1',
+      },
+    ]);
+    acknowledgeHistoryDelete(base, 0);
+    expect(base.events).toEqual([
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
+        item_id: 'fo1',
+      },
+      {
+        type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^history_/),
+        item_id: 'f1',
+      },
+    ]);
+  });
+
+  it('resetHistory rejects unsupported function call mutations before sending events', () => {
+    const original = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    const missingOutputId = new TestBase();
+    expect(() => missingOutputId.resetHistory([original], [])).toThrow(
+      'output item ID is unavailable',
+    );
+    expect(missingOutputId.events).toEqual([]);
+
+    const update = new TestBase();
+    expect(() =>
+      update.resetHistory(
+        [{ ...original, output: null }],
+        [{ ...original, output: '43' }],
+      ),
+    ).toThrow('cannot be updated in place');
+    expect(update.events).toEqual([]);
+
+    const incompleteOutput = new TestBase();
+    expect(() =>
+      incompleteOutput.resetHistory(
+        [],
+        [{ ...original, status: 'in_progress' }],
+      ),
+    ).toThrow('must be completed when it has an output');
+    expect(incompleteOutput.events).toEqual([]);
+
+    const retainedIncompleteOutput = new TestBase();
+    const retainedIncompleteCall = {
+      ...original,
+      outputItemId: 'fco_1',
+      status: 'in_progress' as const,
+    };
+    expect(() =>
+      retainedIncompleteOutput.resetHistory(
+        [retainedIncompleteCall],
+        [
+          retainedIncompleteCall,
+          {
+            itemId: 'm1',
+            type: 'message',
+            role: 'user',
+            status: 'completed',
+            content: [{ type: 'input_text', text: 'next' }],
+          },
+        ],
+      ),
+    ).toThrow('must be completed when it has an output');
+    expect(retainedIncompleteOutput.events).toEqual([]);
+
+    const duplicate = new TestBase();
+    expect(() =>
+      duplicate.resetHistory(
+        [],
+        [
+          { ...original, output: null },
+          { ...original, output: null },
+        ],
+      ),
+    ).toThrow('appears more than once');
+    expect(duplicate.events).toHaveLength(0);
+
+    const mixedDuplicate = new TestBase();
+    expect(() =>
+      mixedDuplicate.resetHistory([], [
+        { ...original, output: null },
+        {
+          itemId: 'f1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'same ID' }],
+        },
+      ] as any),
+    ).toThrow('appears more than once');
+    expect(mixedDuplicate.events).toHaveLength(0);
+
+    const unchangedDuplicate = new TestBase();
+    expect(() =>
+      unchangedDuplicate.resetHistory(
+        [{ ...original, output: null }],
+        [
+          { ...original, output: null },
+          { ...original, output: null },
+        ],
+      ),
+    ).toThrow('appears more than once');
+    expect(unchangedDuplicate.events).toHaveLength(0);
+
+    const duplicateMessages = new TestBase();
+    expect(() =>
+      duplicateMessages.resetHistory(
+        [],
+        [
+          {
+            itemId: 'm1',
+            type: 'message',
+            role: 'user',
+            status: 'completed',
+            content: [{ type: 'input_text', text: 'first' }],
+          },
+          {
+            itemId: 'm1',
+            type: 'message',
+            role: 'user',
+            status: 'completed',
+            content: [{ type: 'input_text', text: 'second' }],
+          },
+        ],
+      ),
+    ).toThrow('appears more than once');
+    expect(duplicateMessages.events).toHaveLength(0);
+  });
+
+  it('resetHistory rejects cross-kind reuse of a pending item ID', () => {
+    const message = {
+      itemId: 'same',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'message' }],
+    };
+    const functionCall = {
+      itemId: 'same',
+      type: 'function_call' as const,
+      status: 'in_progress' as const,
+      arguments: '{}',
+      name: 'tool',
+      output: null,
+    };
+
+    const messageThenCall = new TestBase();
+    messageThenCall.resetHistory([], [message]);
+    expect(() => messageThenCall.resetHistory([], [functionCall])).toThrow(
+      'cannot change type while its creation is awaiting acknowledgement',
+    );
+    expect(messageThenCall.events).toHaveLength(1);
+
+    const callThenMessage = new TestBase();
+    callThenMessage.resetHistory([], [functionCall]);
+    expect(() => callThenMessage.resetHistory([], [message])).toThrow(
+      'cannot change type while its creation is awaiting acknowledgement',
+    );
+    expect(callThenMessage.events).toHaveLength(1);
+  });
+
+  it('resetHistory rejects duplicate output item IDs before sending events', () => {
+    const base = new TestBase();
+    const completedCall = {
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      outputItemId: 'fco_shared',
+      output: '42',
+    };
+
+    expect(() =>
+      base.resetHistory(
+        [
+          { ...completedCall, itemId: 'f1', callId: 'call_1' },
+          { ...completedCall, itemId: 'f2', callId: 'call_2' },
+        ],
+        [],
+      ),
+    ).toThrow(
+      'Function call output item fco_shared appears more than once in the current history.',
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('resetHistory rejects output item IDs that collide with visible item IDs', () => {
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+    const message = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'visible' }],
+    };
+
+    const currentCollision = new TestBase();
+    expect(() =>
+      currentCollision.resetHistory(
+        [message, { ...completedCall, outputItemId: 'm1' }],
+        [],
+      ),
+    ).toThrow(
+      'Function call output item m1 conflicts with a visible item ID in the current history.',
+    );
+    expect(currentCollision.events).toEqual([]);
+
+    const updatedCollision = new TestBase();
+    expect(() =>
+      updatedCollision.resetHistory(
+        [],
+        [
+          { ...completedCall, outputItemId: 'f2' },
+          {
+            ...completedCall,
+            itemId: 'f2',
+            callId: 'call_2',
+            status: 'in_progress',
+            output: null,
+          },
+        ],
+      ),
+    ).toThrow(
+      'Function call output item f2 conflicts with a visible item ID in the updated history.',
+    );
+    expect(updatedCollision.events).toEqual([]);
+  });
+
+  it('resetHistory rejects reusing a removed call output ID for a visible item', () => {
+    const base = new TestBase();
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      outputItemId: 'fco_existing',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    expect(() =>
+      base.resetHistory(
+        [completedCall],
+        [
+          {
+            itemId: 'fco_existing',
+            type: 'message',
+            role: 'user',
+            status: 'completed',
+            content: [{ type: 'input_text', text: 'replacement' }],
+          },
+        ],
+      ),
+    ).toThrow(
+      'Function call output item fco_existing conflicts with a visible item ID in the updated history.',
+    );
+    expect(base.events).toEqual([]);
+  });
+
+  it('resetHistory rejects a visible ID owned by a pending completion output', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    const completedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    base.resetHistory([], [completedCall]);
+    const pendingOutputItemId = (base.events[1] as any).item.id;
+    acknowledgeHistoryCreate(base, 0, 'conversation.item.done');
+
+    expect(() =>
+      base.resetHistory(
+        [updates.at(-1)],
+        [
+          completedCall,
+          {
+            itemId: pendingOutputItemId,
+            type: 'message',
+            role: 'user',
+            status: 'completed',
+            content: [{ type: 'input_text', text: 'next' }],
+          },
+        ],
+      ),
+    ).toThrow(
+      `Function call output item ${pendingOutputItemId} conflicts with a visible item ID in the updated history.`,
+    );
+    expect(base.events).toHaveLength(2);
+  });
+
+  it('resetHistory rejects a replacement ID owned by a pending output', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    const completedCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    base.resetHistory([], [completedCall]);
+    const pendingOutputItemId = (base.events[1] as any).item.id;
+    acknowledgeHistoryCreate(base, 0, 'conversation.item.done');
+
+    expect(() =>
+      base.resetHistory(
+        [updates.at(-1)],
+        [
+          {
+            itemId: pendingOutputItemId,
+            type: 'message',
+            role: 'user',
+            status: 'completed',
+            content: [{ type: 'input_text', text: 'replacement' }],
+          },
+        ],
+      ),
+    ).toThrow(
+      `Function call output item ${pendingOutputItemId} conflicts with a visible item ID in the updated history.`,
+    );
+    expect(base.events).toHaveLength(2);
+  });
+
+  it('resetHistory does not project a mixed batch when a synchronous send fails', () => {
+    const base = new ThrowingTestBase(2);
+    const updates: any[] = [];
+    const deletions: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    base.on('item_deleted', (item) => deletions.push(item));
+    const oldMessage = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'old' }],
+    };
+
+    expect(() =>
+      base.resetHistory(
+        [oldMessage],
+        [
+          {
+            ...oldMessage,
+            content: [{ type: 'input_text', text: 'updated' }],
+          },
+          {
+            itemId: 'f1',
+            previousItemId: 'm1',
+            type: 'function_call',
+            status: 'in_progress',
+            arguments: '{}',
+            name: 'calc',
+            output: null,
+          },
+        ],
+      ),
+    ).toThrow('send failed');
+    expect(updates).toEqual([]);
+    expect(deletions).toEqual([]);
+
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.deleted',
+        event_id: 'delete_m1',
+        item_id: 'm1',
+      }),
+    });
+    expect(deletions).toEqual([{ itemId: 'm1' }]);
   });
 
   it('sendMcpResponse emits approval response items', () => {
@@ -863,6 +2857,7 @@ describe('OpenAIRealtimeBase helpers', () => {
 
     expect(funcs[0]?.name).toBe('calc');
     expect(funcs[0]?.responseId).toBe('r3');
+    expect(updates.find((u) => u.itemId === 'f1')?.callId).toBe('c1');
     expect(updates.find((u) => (u as any).itemId === 'mcp1')).toBeTruthy();
   });
 
@@ -1106,6 +3101,659 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
 
     expect(errors[0]?.error?.error?.message).toBe('nope');
+  });
+
+  it('stops suppressing a replay acknowledgement after its request errors', () => {
+    const base = new TestBase();
+    const errors: any[] = [];
+    const updates: any[] = [];
+    base.on('error', (error) => errors.push(error));
+    base.on('item_update', (item) => updates.push(item));
+    base.resetHistory(
+      [],
+      [
+        {
+          itemId: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'hello' }],
+        },
+        {
+          itemId: 'f1',
+          previousItemId: 'm1',
+          type: 'function_call',
+          status: 'in_progress',
+          arguments: '{}',
+          name: 'calc',
+          output: null,
+        },
+      ],
+    );
+    const messageCreate = base.events.find(
+      (event) =>
+        event.type === 'conversation.item.create' &&
+        event.item?.type === 'message',
+    );
+    expect(messageCreate?.event_id).toEqual(expect.stringMatching(/^history_/));
+
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'server_error',
+        error: {
+          event_id: messageCreate?.event_id,
+          message: 'create failed',
+        },
+      }),
+    });
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'message_added',
+        previous_item_id: null,
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'hello' }],
+        },
+      }),
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(updates.filter((item) => item.itemId === 'm1')).toHaveLength(1);
+  });
+
+  it('keeps rejected replay creates out of session history so they can be retried', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    session.on('error', () => {});
+    await session.connect({ apiKey: 'test' });
+    const desiredHistory = [
+      {
+        itemId: 'm1',
+        type: 'message' as const,
+        role: 'user' as const,
+        status: 'completed' as const,
+        content: [{ type: 'input_text' as const, text: 'hello' }],
+      },
+      {
+        itemId: 'f1',
+        previousItemId: 'm1',
+        type: 'function_call' as const,
+        status: 'in_progress' as const,
+        arguments: '{}',
+        name: 'calc',
+        output: null,
+      },
+    ];
+
+    session.updateHistory(desiredHistory);
+    expect(session.history).toEqual([]);
+
+    for (const event of transport.events) {
+      (transport as any)._onMessage({
+        data: JSON.stringify({
+          type: 'error',
+          event_id: `server_error_${event.event_id}`,
+          error: {
+            event_id: event.event_id,
+            message: 'create failed',
+          },
+        }),
+      });
+    }
+
+    expect(session.history).toEqual([]);
+    const firstAttemptCount = transport.events.length;
+    session.updateHistory(desiredHistory);
+
+    expect(transport.events).toHaveLength(firstAttemptCount + 2);
+    expect(
+      transport.events.slice(firstAttemptCount).map((event) => event.item?.id),
+    ).toEqual(['m1', 'f1']);
+  });
+
+  it('keeps a rejected replay deletion in session history so it can be retried', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    session.on('error', () => {});
+    await session.connect({ apiKey: 'test' });
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'server_existing_message',
+        previous_item_id: null,
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'keep me' }],
+        },
+      }),
+    });
+
+    session.updateHistory([]);
+    const firstDelete = transport.events[0];
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'server_delete_error',
+        error: {
+          event_id: firstDelete.event_id,
+          message: 'delete failed',
+        },
+      }),
+    });
+
+    expect(session.history.map((item) => item.itemId)).toEqual(['m1']);
+    session.updateHistory([]);
+    expect(transport.events).toHaveLength(2);
+    expect(transport.events[1]).toMatchObject({
+      type: 'conversation.item.delete',
+      item_id: 'm1',
+    });
+  });
+
+  it('projects a successful output deletion when the call deletion is rejected', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    session.on('error', () => {});
+    await session.connect({ apiKey: 'test' });
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      outputItemId: 'fco_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([completedCall]);
+    acknowledgeHistoryCreate(transport, 0, 'conversation.item.done');
+    acknowledgeHistoryCreate(transport, 1, 'conversation.item.done');
+    expect(session.history).toEqual([completedCall]);
+
+    session.updateHistory([]);
+    acknowledgeHistoryDelete(transport, 2);
+    expect(session.history).toEqual([
+      {
+        ...completedCall,
+        status: 'in_progress',
+        outputItemId: undefined,
+        output: null,
+      },
+    ]);
+
+    const callDelete = transport.events[3];
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'server_call_delete_error',
+        error: {
+          event_id: callDelete.event_id,
+          message: 'delete failed',
+        },
+      }),
+    });
+
+    expect(session.history).toEqual([
+      {
+        ...completedCall,
+        status: 'in_progress',
+        outputItemId: undefined,
+        output: null,
+      },
+    ]);
+
+    session.updateHistory([completedCall]);
+    expect(transport.events[4]).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: 'f1',
+      item: {
+        id: 'fco_1',
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: '42',
+      },
+    });
+  });
+
+  it('coalesces a reentrant call deletion after output deletion is acknowledged', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      outputItemId: 'fco_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([completedCall]);
+    acknowledgeHistoryCreate(transport, 0);
+    acknowledgeHistoryCreate(transport, 1);
+
+    let emptyHistoryUpdates = 0;
+    session.on('history_updated', (history) => {
+      if (history.length === 0) {
+        emptyHistoryUpdates += 1;
+      }
+      if (
+        history.length === 1 &&
+        history[0]?.type === 'function_call' &&
+        history[0].output === null
+      ) {
+        session.updateHistory([]);
+      }
+    });
+
+    session.updateHistory([]);
+    acknowledgeHistoryDelete(transport, 2);
+
+    const callDeletes = transport.events.filter(
+      (event) =>
+        event.type === 'conversation.item.delete' && event.item_id === 'f1',
+    );
+    expect(callDeletes).toHaveLength(1);
+    acknowledgeHistoryDelete(transport, 3);
+    expect(session.history).toEqual([]);
+    expect(emptyHistoryUpdates).toBe(1);
+  });
+
+  it('coalesces output replay while the paired call deletion is pending', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      outputItemId: 'fco_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([completedCall]);
+    acknowledgeHistoryCreate(transport, 0, 'conversation.item.done');
+    acknowledgeHistoryCreate(transport, 1, 'conversation.item.done');
+    session.on('history_updated', (history) => {
+      if (
+        history.length === 1 &&
+        history[0]?.type === 'function_call' &&
+        history[0].output === null
+      ) {
+        session.updateHistory([completedCall]);
+      }
+    });
+
+    session.updateHistory([]);
+    acknowledgeHistoryDelete(transport, 2);
+
+    const outputCreates = transport.events.filter(
+      (event) =>
+        event.type === 'conversation.item.create' &&
+        event.item.type === 'function_call_output',
+    );
+    expect(outputCreates).toHaveLength(1);
+    expect(transport.events[3]).toMatchObject({
+      type: 'conversation.item.delete',
+      item_id: 'f1',
+    });
+    acknowledgeHistoryDelete(transport, 3);
+    expect(session.history).toEqual([]);
+  });
+
+  it('pairs deletion with an output restore awaiting acknowledgement', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([completedCall]);
+    const pendingOutputId = (transport.events[1] as any).item.id;
+    session.on('history_updated', (history) => {
+      if (
+        history.length === 1 &&
+        history[0]?.type === 'function_call' &&
+        history[0].output === null
+      ) {
+        session.updateHistory([]);
+      }
+    });
+
+    acknowledgeHistoryCreate(transport, 0, 'conversation.item.done');
+
+    expect(transport.events[2]).toMatchObject({
+      type: 'conversation.item.delete',
+      item_id: pendingOutputId,
+    });
+    expect(
+      transport.events.filter(
+        (event) =>
+          event.type === 'conversation.item.delete' && event.item_id === 'f1',
+      ),
+    ).toHaveLength(0);
+
+    acknowledgeHistoryCreate(transport, 1, 'conversation.item.done');
+    acknowledgeHistoryDelete(transport, 2);
+    expect(transport.events[3]).toMatchObject({
+      type: 'conversation.item.delete',
+      item_id: 'f1',
+    });
+    acknowledgeHistoryDelete(transport, 3);
+    expect(session.history).toEqual([]);
+  });
+
+  it('retries call deletion after a pending output and its deletion are rejected', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    session.on('error', () => {});
+    await session.connect({ apiKey: 'test' });
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([completedCall]);
+    acknowledgeHistoryCreate(transport, 0, 'conversation.item.done');
+    session.updateHistory([]);
+    const outputCreate = transport.events[1];
+    const outputDelete = transport.events[2];
+
+    for (const event of [outputCreate, outputDelete]) {
+      (transport as any)._onMessage({
+        data: JSON.stringify({
+          type: 'error',
+          event_id: `server_error_${event.event_id}`,
+          error: {
+            event_id: event.event_id,
+            message: 'request rejected',
+          },
+        }),
+      });
+    }
+
+    expect(session.history).toMatchObject([
+      { itemId: 'f1', status: 'in_progress', output: null },
+    ]);
+    session.updateHistory([]);
+    expect(transport.events[3]).toMatchObject({
+      type: 'conversation.item.delete',
+      item_id: 'f1',
+    });
+    acknowledgeHistoryDelete(transport, 3);
+    expect(session.history).toEqual([]);
+  });
+
+  it('retries output deletion before sending the paired call deletion', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    session.on('error', () => {});
+    await session.connect({ apiKey: 'test' });
+    const completedCall = {
+      itemId: 'f1',
+      callId: 'call_1',
+      outputItemId: 'fco_1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([completedCall]);
+    acknowledgeHistoryCreate(transport, 0);
+    acknowledgeHistoryCreate(transport, 1);
+    session.updateHistory([]);
+    const rejectedOutputDelete = transport.events[2];
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'server_output_delete_error',
+        error: {
+          event_id: rejectedOutputDelete.event_id,
+          message: 'output delete rejected',
+        },
+      }),
+    });
+
+    expect(session.history).toEqual([completedCall]);
+    expect(transport.events).toHaveLength(3);
+
+    session.updateHistory([]);
+    expect(transport.events).toHaveLength(4);
+    expect(transport.events[3]).toMatchObject({
+      type: 'conversation.item.delete',
+      item_id: 'fco_1',
+    });
+  });
+
+  it('retries a rejected function call output without recreating the call', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    session.on('error', () => {});
+    await session.connect({ apiKey: 'test' });
+    const desiredCall = {
+      itemId: 'f1',
+      type: 'function_call' as const,
+      status: 'completed' as const,
+      arguments: '{}',
+      name: 'calc',
+      output: '42',
+    };
+
+    session.updateHistory([desiredCall]);
+    acknowledgeHistoryCreate(transport, 0);
+    const rejectedOutput = transport.events[1];
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'error',
+        event_id: 'server_output_error',
+        error: {
+          event_id: rejectedOutput.event_id,
+          message: 'output rejected',
+        },
+      }),
+    });
+    expect(session.history).toMatchObject([
+      {
+        itemId: 'f1',
+        callId: 'f1',
+        status: 'in_progress',
+        output: null,
+      },
+    ]);
+
+    session.updateHistory([desiredCall]);
+
+    expect(transport.events).toHaveLength(3);
+    expect(transport.events[2]).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: 'f1',
+      item: {
+        id: expect.stringMatching(/^fco_/),
+        type: 'function_call_output',
+        call_id: 'f1',
+        output: '42',
+      },
+    });
+    acknowledgeHistoryCreate(transport, 2);
+    expect(session.history).toMatchObject([
+      {
+        ...desiredCall,
+        callId: 'f1',
+        outputItemId: (transport.events[2] as any).item.id,
+      },
+    ]);
+  });
+
+  it('projects an acknowledged explicit-root function call at the beginning', async () => {
+    const { RealtimeSession } = await import('../src/realtimeSession');
+    const { RealtimeAgent } = await import('../src/realtimeAgent');
+    const transport = new TestBase();
+    const session = new RealtimeSession(new RealtimeAgent({ name: 'a' }), {
+      transport,
+    });
+    await session.connect({ apiKey: 'test' });
+    const trailingMessage = {
+      itemId: 'm1',
+      type: 'message' as const,
+      role: 'user' as const,
+      status: 'completed' as const,
+      content: [{ type: 'input_text' as const, text: 'existing' }],
+    };
+    (transport as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'server_existing_message',
+        previous_item_id: null,
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'existing' }],
+        },
+      }),
+    });
+
+    session.updateHistory([
+      {
+        itemId: 'f1',
+        previousItemId: 'root',
+        type: 'function_call',
+        status: 'in_progress',
+        arguments: '{}',
+        name: 'calc',
+        output: null,
+      },
+      trailingMessage,
+    ]);
+
+    const callCreateIndex = transport.events.findIndex(
+      (event) =>
+        event.type === 'conversation.item.create' &&
+        event.item?.type === 'function_call',
+    );
+    expect(transport.events[callCreateIndex]).toMatchObject({
+      type: 'conversation.item.create',
+      previous_item_id: 'root',
+      item: { id: 'f1', type: 'function_call' },
+    });
+    for (const [index, event] of transport.events.entries()) {
+      if (event.type === 'conversation.item.delete') {
+        acknowledgeHistoryDelete(transport, index);
+      } else {
+        acknowledgeHistoryCreate(transport, index);
+      }
+    }
+    expect(session.history.map((item) => item.itemId)).toEqual(['f1', 'm1']);
+  });
+
+  it('clears replay acknowledgement ownership when the transport closes', () => {
+    const base = new TestBase();
+    const updates: any[] = [];
+    base.on('item_update', (item) => updates.push(item));
+    base.resetHistory(
+      [],
+      [
+        {
+          itemId: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'hello' }],
+        },
+        {
+          itemId: 'f1',
+          previousItemId: 'm1',
+          type: 'function_call',
+          status: 'in_progress',
+          arguments: '{}',
+          name: 'calc',
+          output: null,
+        },
+      ],
+    );
+
+    (base as any)._onClose();
+    (base as any)._onMessage({
+      data: JSON.stringify({
+        type: 'conversation.item.added',
+        event_id: 'message_added',
+        previous_item_id: null,
+        item: {
+          id: 'm1',
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: 'hello' }],
+        },
+      }),
+    });
+
+    expect(updates.filter((item) => item.itemId === 'm1')).toHaveLength(1);
   });
 
   it('maps input_image content and merges provider data', () => {


### PR DESCRIPTION
## Description

This pull request resolves #645.

Previously, `RealtimeSession.updateHistory()` ignored manually added `function_call` items. This prevented applications from restoring conversation history that included tool calls and their recorded outputs.

This change:

- Allows `updateHistory()` to restore a function call without an output.
- Restores completed function calls and their outputs as an ordered `function_call` / `function_call_output` pair.
- Adds optional `callId` and `outputItemId` fields to `RealtimeToolCallItem` so the SDK can preserve API identities.
- Assigns client-generated output item IDs that satisfy the Realtime API's 32-character item ID limit.
- Deletes a restored output item before deleting its associated function call.
- Preserves the existing combined SDK representation of a function call and its output.
- Rejects unsupported in-place function-call edits, unsafe removals, contradictory status/output combinations, and duplicate identities before sending any conversation mutations.
- Keeps the existing optimistic local-history update behavior without introducing connection-scoped replay state.

Directly editing an existing function-call history item remains unsupported. Applications can remove the item in one `updateHistory()` call and add its replacement in a subsequent call.

The restored call/output flow was also verified against the live Realtime API: the model consumed the restored tool output successfully, and the output and call items were subsequently deleted without API errors.