### PR TITLE
fix(sandbox): trace effective sandbox exec workdirs

### DIFF
--- a/.changeset/calm-traces-workdir.md
+++ b/.changeset/calm-traces-workdir.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix sandbox exec traces to record the effective run-scoped working directory

--- a/.changeset/calm-traces-workdir.md
+++ b/.changeset/calm-traces-workdir.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix sandbox exec traces to record the effective run-scoped working directory
+fix: record the effective workdir in sandbox exec traces

--- a/packages/agents-core/src/sandbox/capabilities/shell.ts
+++ b/packages/agents-core/src/sandbox/capabilities/shell.ts
@@ -108,12 +108,14 @@ class ShellCapability extends Capability {
           },
           _context,
           details?: ToolCallDetails,
-        ): Promise<string> =>
-          await withSandboxSpan(
+        ): Promise<string> => {
+          const effectiveWorkdir =
+            this._workspaceScope?.anchor(workdir) ?? workdir;
+          return await withSandboxSpan(
             'sandbox.exec',
             {
               cmd,
-              workdir,
+              workdir: effectiveWorkdir,
               shell,
               login,
               tty,
@@ -122,7 +124,7 @@ class ShellCapability extends Capability {
             async () =>
               await session.execCommand!({
                 cmd,
-                workdir: this._workspaceScope?.anchor(workdir) ?? workdir,
+                workdir: effectiveWorkdir,
                 shell,
                 login,
                 tty,
@@ -131,7 +133,8 @@ class ShellCapability extends Capability {
                 runAs: this._runAs,
               } satisfies ExecCommandArgs),
             this.tracingParent(details),
-          ),
+          );
+        },
       }),
     ];
 

--- a/packages/agents-core/test/sandboxTracePaths.test.ts
+++ b/packages/agents-core/test/sandboxTracePaths.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { RunContext } from '../src';
+import {
+  addSandboxEventSink,
+  clearSandboxEventSinks,
+  SandboxWorkspaceScope,
+  shell,
+  type SandboxEvent,
+} from '../src/sandbox';
+import { scriptedSandboxSession } from '../src/testing';
+
+describe('sandbox trace paths', () => {
+  afterEach(() => {
+    clearSandboxEventSinks();
+  });
+
+  it('records the effective run-scoped exec workdir', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+
+    const session = scriptedSandboxSession([
+      { method: 'execCommand', result: 'default cwd' },
+      { method: 'execCommand', result: 'nested cwd' },
+    ]);
+    const capability = shell();
+    capability
+      .bind(session)
+      .bindWorkspaceScope(SandboxWorkspaceScope.fromCwd('tasks/a'));
+    const execCommand = capability.tools()[0] as any;
+
+    await execCommand.invoke(new RunContext(), JSON.stringify({ cmd: 'pwd' }));
+    await execCommand.invoke(
+      new RunContext(),
+      JSON.stringify({ cmd: 'pwd', workdir: 'reports' }),
+    );
+
+    const starts = events.filter(
+      (event) =>
+        event.type === 'sandbox_operation' &&
+        event.name === 'sandbox.exec' &&
+        event.phase === 'start',
+    );
+    expect(starts.map((event) => event.data.workdir)).toEqual([
+      'tasks/a',
+      'tasks/a/reports',
+    ]);
+    expect(session.calls.map((call) => (call.args[0] as any).workdir)).toEqual([
+      'tasks/a',
+      'tasks/a/reports',
+    ]);
+    session.assertComplete();
+  });
+});


### PR DESCRIPTION
### Summary

Record the effective sandbox working directory in `sandbox.exec` trace and event data.

With a run-scoped sandbox cwd, `exec_command` already anchors an omitted or relative `workdir` before calling the sandbox session. The span data was still populated from the raw model argument, so an execution under `tasks/a` could be traced with `workdir` missing, and `reports` could be traced even though the session executed in `tasks/a/reports`.

This change computes the effective workdir once and uses that same value for both the trace payload and `session.execCommand`.

### Test plan

Added event-level regression coverage for an omitted workdir and an explicit relative workdir under `SandboxWorkspaceScope.fromCwd('tasks/a')`. The test verifies that emitted audit events and sandbox execution receive identical effective paths.

A patch changeset for `@openai/agents-core` is included.

### Issue number

None. Found while auditing run-scoped sandbox trace provenance.