### PR TITLE
fix: validate raster view_image output content

### DIFF
--- a/.changeset/quiet-image-boundary.md
+++ b/.changeset/quiet-image-boundary.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: validate raster image bytes at the view_image output boundary

--- a/packages/agents-core/src/sandbox/shared/media.ts
+++ b/packages/agents-core/src/sandbox/shared/media.ts
@@ -14,7 +14,10 @@ export function imageOutputFromBytes(
   bytes: Uint8Array,
 ): ToolOutputImage {
   assertViewImageByteLength(path, bytes.byteLength);
-  const mediaType = sniffImageMediaType(bytes, path);
+  const inferredMediaType = mediaTypeFromPath(path);
+  const mediaType =
+    sniffImageMediaType(bytes) ??
+    (inferredMediaType === 'image/svg+xml' ? inferredMediaType : null);
   if (!mediaType) {
     throw new UserError(`Unsupported image format for view_image: ${path}`);
   }
@@ -35,7 +38,11 @@ export function sniffImageMediaType(
     bytes[0] === 0x89 &&
     bytes[1] === 0x50 &&
     bytes[2] === 0x4e &&
-    bytes[3] === 0x47
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
   ) {
     return 'image/png';
   }
@@ -46,7 +53,9 @@ export function sniffImageMediaType(
     bytes[0] === 0x47 &&
     bytes[1] === 0x49 &&
     bytes[2] === 0x46 &&
-    bytes[3] === 0x38
+    bytes[3] === 0x38 &&
+    (bytes[4] === 0x37 || bytes[4] === 0x39) &&
+    bytes[5] === 0x61
   ) {
     return 'image/gif';
   }
@@ -65,7 +74,7 @@ export function sniffImageMediaType(
   if (bytes[0] === 0x42 && bytes[1] === 0x4d) {
     return 'image/bmp';
   }
-  if (
+  const isClassicTiff =
     (bytes[0] === 0x49 &&
       bytes[1] === 0x49 &&
       bytes[2] === 0x2a &&
@@ -73,8 +82,25 @@ export function sniffImageMediaType(
     (bytes[0] === 0x4d &&
       bytes[1] === 0x4d &&
       bytes[2] === 0x00 &&
-      bytes[3] === 0x2a)
-  ) {
+      bytes[3] === 0x2a);
+  const isBigTiff =
+    (bytes[0] === 0x49 &&
+      bytes[1] === 0x49 &&
+      bytes[2] === 0x2b &&
+      bytes[3] === 0x00 &&
+      bytes[4] === 0x08 &&
+      bytes[5] === 0x00 &&
+      bytes[6] === 0x00 &&
+      bytes[7] === 0x00) ||
+    (bytes[0] === 0x4d &&
+      bytes[1] === 0x4d &&
+      bytes[2] === 0x00 &&
+      bytes[3] === 0x2b &&
+      bytes[4] === 0x00 &&
+      bytes[5] === 0x08 &&
+      bytes[6] === 0x00 &&
+      bytes[7] === 0x00);
+  if (isClassicTiff || isBigTiff) {
     return 'image/tiff';
   }
   if (looksLikeSvg(bytes)) {

--- a/packages/agents-core/test/sandboxImageBoundary.test.ts
+++ b/packages/agents-core/test/sandboxImageBoundary.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { imageOutputFromBytes } from '../src/sandbox/internal';
+
+const SVG_BODY = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+
+function encodeUtf16(source: string): Uint8Array {
+  const bytes = new Uint8Array(2 + source.length * 2);
+  bytes[0] = 0xff;
+  bytes[1] = 0xfe;
+  for (let index = 0; index < source.length; index += 1) {
+    const codeUnit = source.charCodeAt(index);
+    const offset = 2 + index * 2;
+    bytes[offset] = codeUnit & 0xff;
+    bytes[offset + 1] = codeUnit >> 8;
+  }
+  return bytes;
+}
+
+describe('sandbox image output boundary', () => {
+  it('rejects non-image bytes with a raster image extension', () => {
+    expect(() =>
+      imageOutputFromBytes(
+        'images/fake.png',
+        new TextEncoder().encode('not an image'),
+      ),
+    ).toThrow('Unsupported image format for view_image: images/fake.png');
+  });
+
+  it('accepts complete PNG signature bytes with an unrelated extension', () => {
+    const bytes = Uint8Array.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    ]);
+
+    expect(imageOutputFromBytes('images/payload.bin', bytes)).toEqual({
+      type: 'image',
+      image: {
+        data: bytes,
+        mediaType: 'image/png',
+      },
+    });
+  });
+
+  it.each([
+    ['GIF87a', [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]],
+    ['GIF89a', [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]],
+  ])('accepts complete %s signature bytes', (_name, header) => {
+    const bytes = Uint8Array.from(header);
+    const output = imageOutputFromBytes('images/payload.bin', bytes);
+
+    expect(output.type).toBe('image');
+    expect(output.image).toMatchObject({ mediaType: 'image/gif' });
+  });
+
+  it.each([
+    ['truncated PNG signature', [0x89, 0x50, 0x4e, 0x47]],
+    [
+      'invalid PNG signature',
+      [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x00],
+    ],
+    ['truncated GIF signature', [0x47, 0x49, 0x46, 0x38]],
+    ['invalid GIF version', [0x47, 0x49, 0x46, 0x38, 0x38, 0x61]],
+  ])('rejects %s', (_name, header) => {
+    expect(() =>
+      imageOutputFromBytes('images/payload.bin', Uint8Array.from(header)),
+    ).toThrow('Unsupported image format for view_image: images/payload.bin');
+  });
+
+  it.each([
+    [
+      'little-endian BigTIFF',
+      [0x49, 0x49, 0x2b, 0x00, 0x08, 0x00, 0x00, 0x00],
+    ],
+    [
+      'big-endian BigTIFF',
+      [0x4d, 0x4d, 0x00, 0x2b, 0x00, 0x08, 0x00, 0x00],
+    ],
+  ])('accepts %s bytes without relying on the filename', (_name, header) => {
+    const bytes = Uint8Array.from(header);
+    const output = imageOutputFromBytes('images/payload.bin', bytes);
+
+    expect(output.type).toBe('image');
+    expect(output.image).toMatchObject({ mediaType: 'image/tiff' });
+  });
+
+  it.each([
+    ['truncated little-endian header', [0x49, 0x49, 0x2b, 0x00]],
+    ['truncated big-endian header', [0x4d, 0x4d, 0x00, 0x2b]],
+    [
+      'invalid little-endian offset size',
+      [0x49, 0x49, 0x2b, 0x00, 0x04, 0x00, 0x00, 0x00],
+    ],
+    [
+      'invalid big-endian reserved field',
+      [0x4d, 0x4d, 0x00, 0x2b, 0x00, 0x08, 0x00, 0x01],
+    ],
+  ])('rejects %s as BigTIFF', (_name, header) => {
+    expect(() =>
+      imageOutputFromBytes('images/payload.bin', Uint8Array.from(header)),
+    ).toThrow('Unsupported image format for view_image: images/payload.bin');
+  });
+
+  it.each([
+    [
+      'comment',
+      new TextEncoder().encode(`<!-- generated -->\n${SVG_BODY}`),
+    ],
+    [
+      'doctype',
+      new TextEncoder().encode(
+        `<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "svg11.dtd">\n${SVG_BODY}`,
+      ),
+    ],
+    [
+      'long comment',
+      new TextEncoder().encode(`<!--${'x'.repeat(4096)}-->\n${SVG_BODY}`),
+    ],
+    ['utf16', encodeUtf16(SVG_BODY)],
+  ])('preserves SVG filename compatibility for %s content', (_name, bytes) => {
+    const output = imageOutputFromBytes('images/vector.svg', bytes);
+
+    expect(output.type).toBe('image');
+    expect(output.image).toMatchObject({ mediaType: 'image/svg+xml' });
+  });
+
+  it('preserves compressed SVGZ filename compatibility', () => {
+    const gzipBytes = Uint8Array.from([0x1f, 0x8b, 0x08, 0x00]);
+
+    const output = imageOutputFromBytes('images/vector.svgz', gzipBytes);
+
+    expect(output.type).toBe('image');
+    expect(output.image).toMatchObject({ mediaType: 'image/svg+xml' });
+  });
+});


### PR DESCRIPTION
### Summary

Require the sandbox `view_image` output boundary to identify signature-bearing raster image formats from bytes instead of trusting a raster-looking filename.

`sniffImageMediaType` intentionally supports optional filename inference, and `imageOutputFromBytes` previously passed the sandbox path into that fallback. As a result, arbitrary bytes stored under a filename such as `fake.png` could be returned as structured PNG image data.

This change keeps the public sniff helper compatible while narrowing filename inference at the actual `view_image` output boundary. PNG requires its full eight-byte signature, GIF requires `GIF87a` or `GIF89a`, and the existing JPEG, WebP, BMP, and TIFF invariant signatures remain byte-validated. BigTIFF additionally requires the version-43 header, offset-size field `8`, and zero reserved field. SVG and SVGZ retain filename inference because SVG has no single binary magic value and SVGZ is compressed, preserving the SDK's existing support for valid prolog, alternate-encoding, and compressed SVG inputs.

### Test plan

Added regression coverage showing that:

- non-image bytes named `fake.png` are rejected
- a complete PNG signature named `payload.bin` is accepted as PNG, while truncated or malformed PNG signatures are rejected
- complete `GIF87a` and `GIF89a` signatures are accepted, while truncated or invalid GIF signatures are rejected
- valid little- and big-endian BigTIFF headers are recognized without filename inference
- truncated BigTIFF headers, invalid offset sizes, and nonzero reserved fields are rejected
- SVG inputs beginning with comments, `DOCTYPE`, long prologs, and UTF-16 content remain accepted
- SVGZ filename compatibility remains intact

A patch changeset for `@openai/agents-core` is included.

### Issue number

None. Found during a sandbox content-validation audit.