### PR TITLE
fix(sandbox): validate dynamic compaction ratios

### DIFF
--- a/.changeset/safe-compaction-ratios.md
+++ b/.changeset/safe-compaction-ratios.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+validate dynamic sandbox compaction threshold ratios before use

--- a/.changeset/safe-compaction-ratios.md
+++ b/.changeset/safe-compaction-ratios.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-validate dynamic sandbox compaction threshold ratios before use
+fix: validate dynamic sandbox compaction threshold ratios before use

--- a/packages/agents-core/src/sandbox/capabilities/compaction.ts
+++ b/packages/agents-core/src/sandbox/capabilities/compaction.ts
@@ -1,4 +1,5 @@
 import type { AgentInputItem } from '../../types';
+import { UserError } from '../../errors';
 import { Capability } from './base';
 import { supportsResponsesCompactionTransport } from './transport';
 
@@ -28,6 +29,15 @@ export class DynamicCompactionPolicy extends CompactionPolicy {
     fallbackThreshold: number = 240000,
   ) {
     super();
+    if (
+      !Number.isFinite(thresholdRatio) ||
+      thresholdRatio < 0 ||
+      thresholdRatio > 1
+    ) {
+      throw new UserError(
+        'DynamicCompactionPolicy.thresholdRatio must be a finite number between 0 and 1.',
+      );
+    }
     this.thresholdRatio = thresholdRatio;
     this.fallbackThreshold = fallbackThreshold;
   }

--- a/packages/agents-core/test/sandboxCompactionPolicy.test.ts
+++ b/packages/agents-core/test/sandboxCompactionPolicy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { DynamicCompactionPolicy } from '../src/sandbox';
+
+describe('DynamicCompactionPolicy', () => {
+  it.each([-0.01, 1.01, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects an invalid threshold ratio %s',
+    (thresholdRatio) => {
+      expect(() => new DynamicCompactionPolicy(thresholdRatio)).toThrow(
+        'DynamicCompactionPolicy.thresholdRatio must be a finite number between 0 and 1.',
+      );
+    },
+  );
+
+  it.each([0, 1])('accepts boundary threshold ratio %s', (thresholdRatio) => {
+    const policy = new DynamicCompactionPolicy(thresholdRatio);
+
+    expect(policy.compactThreshold('gpt-5-mini')).toBe(
+      Math.floor(400000 * thresholdRatio),
+    );
+  });
+});


### PR DESCRIPTION
### Summary

Validate `DynamicCompactionPolicy.thresholdRatio` before it is used to derive sandbox compaction thresholds.

The JavaScript SDK currently accepts negative values, values above 1, `NaN`, and infinities. A ratio above 1 can place the compaction threshold beyond the model context window, while negative or non-finite values can produce invalid request parameters.

The equivalent Python sandbox policy constrains its dynamic threshold ratio to the inclusive 0–1 range. This change applies the same invariant in JavaScript and raises `UserError` at configuration time for non-finite or out-of-range values.

### Test plan

Added focused coverage for:

- negative and greater-than-one ratios
- `NaN` and positive/negative infinity
- valid boundary ratios of 0 and 1

A patch changeset for `@openai/agents-core` is included.

### Issue number

None. Found while comparing sandbox compaction assurance invariants across the Python and JavaScript SDKs.