### PR TITLE
fix: preserve sandbox failures during error serialization

### DIFF
--- a/.changeset/safe-sandbox-error-serialization.md
+++ b/.changeset/safe-sandbox-error-serialization.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve sandbox failures when error serialization fails

--- a/packages/agents-core/src/sandbox/events.ts
+++ b/packages/agents-core/src/sandbox/events.ts
@@ -133,20 +133,26 @@ export function createChainedSandboxEventSink(
 }
 
 export function serializeSandboxEventError(error: unknown): SandboxEventError {
-  if (error instanceof Error) {
-    const code = readErrorCode(error);
-    const retryable = readErrorRetryability(error);
+  try {
+    if (error instanceof Error) {
+      const code = readErrorCode(error);
+      const retryable = readErrorRetryability(error);
+      return {
+        name: error.name,
+        message: error.message,
+        ...(code ? { code } : {}),
+        ...(retryable !== undefined ? { retryable } : {}),
+      };
+    }
+
     return {
-      name: error.name,
-      message: error.message,
-      ...(code ? { code } : {}),
-      ...(retryable !== undefined ? { retryable } : {}),
+      message: String(error),
+    };
+  } catch {
+    return {
+      message: 'Sandbox operation failed with an unserializable error.',
     };
   }
-
-  return {
-    message: String(error),
-  };
 }
 
 function readErrorCode(error: Error): string | undefined {

--- a/packages/agents-core/src/sandbox/events.ts
+++ b/packages/agents-core/src/sandbox/events.ts
@@ -48,6 +48,8 @@ export type SandboxHttpEventSinkOptions = {
 };
 
 const sandboxEventSinks = new Set<SandboxEventSink>();
+const UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE =
+  'Sandbox operation failed with an unserializable error.';
 
 export function addSandboxEventSink(sink: SandboxEventSink): () => void {
   sandboxEventSinks.add(sink);
@@ -133,38 +135,64 @@ export function createChainedSandboxEventSink(
 }
 
 export function serializeSandboxEventError(error: unknown): SandboxEventError {
-  try {
-    if (error instanceof Error) {
-      const code = readErrorCode(error);
-      const retryable = readErrorRetryability(error);
-      return {
-        name: error.name,
-        message: error.message,
-        ...(code ? { code } : {}),
-        ...(retryable !== undefined ? { retryable } : {}),
-      };
-    }
+  if (error instanceof Error) {
+    const name = readStringErrorProperty(error, 'name');
+    const message =
+      readStringErrorProperty(error, 'message') ??
+      UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE;
+    const code = readErrorCode(error);
+    const retryable = readErrorRetryability(error);
+    return {
+      ...(name !== undefined ? { name } : {}),
+      message,
+      ...(code ? { code } : {}),
+      ...(retryable !== undefined ? { retryable } : {}),
+    };
+  }
 
-    return {
-      message: String(error),
-    };
+  return {
+    message: stringifyThrownValue(error),
+  };
+}
+
+function readStringErrorProperty(
+  error: Error,
+  property: 'name' | 'message',
+): string | undefined {
+  try {
+    const value = error[property];
+    return typeof value === 'string' ? value : undefined;
   } catch {
-    return {
-      message: 'Sandbox operation failed with an unserializable error.',
-    };
+    return undefined;
   }
 }
 
 function readErrorCode(error: Error): string | undefined {
-  const code = (error as { code?: unknown }).code;
-  return typeof code === 'string' ? code : undefined;
+  try {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function readErrorRetryability(error: Error): boolean | null | undefined {
-  const retryable = (error as { retryable?: unknown }).retryable;
-  return typeof retryable === 'boolean' || retryable === null
-    ? retryable
-    : undefined;
+  try {
+    const retryable = (error as { retryable?: unknown }).retryable;
+    return typeof retryable === 'boolean' || retryable === null
+      ? retryable
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function stringifyThrownValue(error: unknown): string {
+  try {
+    return String(error);
+  } catch {
+    return UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE;
+  }
 }
 
 function readGlobalFetch(): SandboxHttpEventFetch | undefined {

--- a/packages/agents-core/src/sandbox/events.ts
+++ b/packages/agents-core/src/sandbox/events.ts
@@ -135,13 +135,23 @@ export function createChainedSandboxEventSink(
 }
 
 export function serializeSandboxEventError(error: unknown): SandboxEventError {
-  if (error instanceof Error) {
-    const name = readStringErrorProperty(error, 'name');
+  let isError = false;
+  try {
+    isError = error instanceof Error;
+  } catch {
+    return {
+      message: UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE,
+    };
+  }
+
+  if (isError) {
+    const errorValue = error as Error;
+    const name = readStringErrorProperty(errorValue, 'name');
     const message =
-      readStringErrorProperty(error, 'message') ??
+      readStringErrorProperty(errorValue, 'message') ??
       UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE;
-    const code = readErrorCode(error);
-    const retryable = readErrorRetryability(error);
+    const code = readErrorCode(errorValue);
+    const retryable = readErrorRetryability(errorValue);
     return {
       ...(name !== undefined ? { name } : {}),
       message,

--- a/packages/agents-core/test/sandboxErrorSerialization.test.ts
+++ b/packages/agents-core/test/sandboxErrorSerialization.test.ts
@@ -62,4 +62,29 @@ describe('sandbox error serialization', () => {
       message: 'provider failed',
     });
   });
+
+  it('preserves the original failure when Error classification throws', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+    const operationError = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error('classification failed');
+        },
+      },
+    );
+
+    await expect(
+      withSandboxSpan('sandbox.exec', { cmd: 'false' }, async () => {
+        throw operationError;
+      }),
+    ).rejects.toBe(operationError);
+
+    expect(events[1]?.error).toEqual({
+      message: 'Sandbox operation failed with an unserializable error.',
+    });
+  });
 });

--- a/packages/agents-core/test/sandboxErrorSerialization.test.ts
+++ b/packages/agents-core/test/sandboxErrorSerialization.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  addSandboxEventSink,
+  clearSandboxEventSinks,
+  type SandboxEvent,
+  withSandboxSpan,
+} from '../src/sandbox';
+
+describe('sandbox error serialization', () => {
+  afterEach(() => {
+    clearSandboxEventSinks();
+  });
+
+  it('preserves the original failure when a thrown value cannot be stringified', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+    const operationError = {
+      toString() {
+        throw new Error('serialization failed');
+      },
+    };
+
+    await expect(
+      withSandboxSpan('sandbox.exec', { cmd: 'false' }, async () => {
+        throw operationError;
+      }),
+    ).rejects.toBe(operationError);
+
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({
+      type: 'sandbox_operation',
+      name: 'sandbox.exec',
+      phase: 'error',
+      error: {
+        message: 'Sandbox operation failed with an unserializable error.',
+      },
+    });
+  });
+
+  it('preserves Error failures when optional metadata access throws', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+    const operationError = new Error('provider failed');
+    Object.defineProperty(operationError, 'code', {
+      get() {
+        throw new Error('metadata access failed');
+      },
+    });
+
+    await expect(
+      withSandboxSpan('sandbox.start', {}, async () => {
+        throw operationError;
+      }),
+    ).rejects.toBe(operationError);
+
+    expect(events[1]?.error).toEqual({
+      message: 'Sandbox operation failed with an unserializable error.',
+    });
+  });
+});

--- a/packages/agents-core/test/sandboxErrorSerialization.test.ts
+++ b/packages/agents-core/test/sandboxErrorSerialization.test.ts
@@ -39,7 +39,7 @@ describe('sandbox error serialization', () => {
     });
   });
 
-  it('preserves Error failures when optional metadata access throws', async () => {
+  it('preserves safe Error fields when optional metadata access throws', async () => {
     const events: SandboxEvent[] = [];
     addSandboxEventSink((event) => {
       events.push(event);
@@ -58,7 +58,8 @@ describe('sandbox error serialization', () => {
     ).rejects.toBe(operationError);
 
     expect(events[1]?.error).toEqual({
-      message: 'Sandbox operation failed with an unserializable error.',
+      name: 'Error',
+      message: 'provider failed',
     });
   });
 });


### PR DESCRIPTION
### Summary

Preserve the original sandbox operation failure when telemetry error serialization encounters an unserializable thrown value, hostile optional metadata accessor, or hostile error-classification proxy.

`withSandboxSpan` serializes failures before recording the error event and then rethrows the original value. JavaScript permits arbitrary thrown values, proxies, and property getters that can themselves throw, so telemetry serialization could replace the original sandbox failure and prevent the intended error event from being emitted.

This change makes error serialization fail-safe. Non-`Error` values that cannot be stringified or classified receive a generic event message. For `Error` objects, safe fields such as `name` and `message` are preserved independently, while optional `code` or `retryable` metadata that cannot be read is omitted. `withSandboxSpan` continues to rethrow the exact original operation failure.

### Test plan

Added regression coverage for:

- a non-`Error` thrown value whose `toString()` throws
- an `Error` whose optional `code` getter throws
- a proxy whose prototype lookup makes `instanceof Error` throw
- preservation of the exact original thrown value in all cases
- preservation of safe `Error` name/message fields when optional metadata access fails

A patch changeset for `@openai/agents-core` is included.

### Issue number

None. Found while auditing sandbox error and trace integrity.