### PR TITLE
feat(extensions): add Modal sandbox resource options

### DIFF
--- a/.changeset/calm-modal-resources.md
+++ b/.changeset/calm-modal-resources.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-extensions': patch
+'@openai/agents-core': patch
+---
+
+feat: add Modal sandbox CPU and memory options

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1477,6 +1477,7 @@ const sandboxSessionEntrySchema = z.object({
   sessionState: sandboxSessionStateEnvelopeSchema,
   preservedOwnedSession: z.boolean().optional(),
   reuseLiveSession: z.boolean().optional(),
+  requiresFreshCreation: z.boolean().optional(),
 });
 
 const sandboxStateSchema = z.object({

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -117,6 +117,20 @@ export interface SandboxClient<
    * reconnect safely, so only a same-process live session may be reused.
    */
   serializedSessionStateRequiresFreshCreation?: boolean;
+  /**
+   * Current trusted client options make serialized provider state unsafe to
+   * resume. The runtime may replace a same-process live session when it can
+   * authorize cleanup, but fails closed for untrusted cross-process state.
+   */
+  serializedSessionStateRequiresFreshCreationForOptions?(
+    state: TSessionState,
+    options?: SandboxClientResumeOptions<TOptions>,
+  ): Promise<boolean> | boolean;
+  /**
+   * A rejected same-process live session cannot be resumed from its serialized
+   * provider state and must be replaced through the normal create path.
+   */
+  preservedOwnedSessionReuseRejectionRequiresFreshCreation?: boolean;
   create?: SandboxClientCreate<TOptions, TSessionState>;
   delete?(state: TSessionState): Promise<void>;
   serializeSessionState?(
@@ -130,6 +144,14 @@ export interface SandboxClient<
     state: TSessionState,
     options?: SandboxPreservedSessionReuseOptions<TOptions>,
   ): Promise<boolean> | boolean;
+  /**
+   * Rebind trusted provider metadata after live reuse has been accepted and
+   * the runtime has verified that the session state did not change.
+   */
+  rebindPreservedOwnedSessionState?(
+    state: TSessionState,
+    options?: SandboxPreservedSessionReuseOptions<TOptions>,
+  ): void;
   deserializeSessionState?(
     state: Record<string, unknown>,
   ): Promise<TSessionState>;

--- a/packages/agents-core/src/sandbox/runtime/livePreservedSessions.ts
+++ b/packages/agents-core/src/sandbox/runtime/livePreservedSessions.ts
@@ -41,7 +41,9 @@ export function rememberLivePreservedOwnedSessions<TContext>(args: {
     if (!entry.preservedOwnedSession) {
       continue;
     }
-    if (entry.reuseLiveSession === false) {
+    const reuseRejected =
+      entry.reuseLiveSession === false && entry.requiresFreshCreation === true;
+    if (entry.reuseLiveSession === false && !reuseRejected) {
       continue;
     }
     const session = args.sessionsByAgentKey.get(agentKey);
@@ -61,7 +63,9 @@ export function rememberLivePreservedOwnedSessions<TContext>(args: {
       backendId: entry.backendId,
       currentAgentName: entry.currentAgentName,
       session,
-      ...(rejectedSessions.has(session) ? { reuseRejected: true } : {}),
+      ...(reuseRejected || rejectedSessions.has(session)
+        ? { reuseRejected: true }
+        : {}),
     });
   }
 

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -10,6 +10,7 @@ import { isMemoryCapability } from '../capabilities/memory';
 import type {
   SandboxClient,
   SandboxClientCreateArgs,
+  SandboxClientResumeOptions,
   SandboxRunConfig,
 } from '../client';
 import { SandboxLifecycleError, SandboxMountError } from '../errors';
@@ -109,6 +110,7 @@ type SandboxCleanupPlan = {
   afterOwnedSessionClose?: {
     clearSandboxState?: boolean;
     forgetLivePreservedSessions?: boolean;
+    removeFreshCreationSessionsFromSandboxState?: boolean;
     removeClosedSessionsFromSandboxState?: boolean;
   };
   deferredError?: unknown;
@@ -386,6 +388,9 @@ export class SandboxRuntimeManager<TContext> {
           preservedOwnedSessionAgentKeysWithoutLiveReuse(serializedState);
         if (serializedOnlySessionAgentKeys.size > 0) {
           cleanupPlan.ownedSessionCloseTarget = serializedOnlySessionAgentKeys;
+          cleanupPlan.afterOwnedSessionClose = {
+            removeFreshCreationSessionsFromSandboxState: true,
+          };
         }
       }
 
@@ -504,9 +509,12 @@ export class SandboxRuntimeManager<TContext> {
     },
   ): Promise<void> {
     if (plan.ownedSessionCloseTarget) {
-      let closedSessionAgentKeys: ReadonlySet<string>;
+      let closeResult: {
+        closedAgentKeys: ReadonlySet<string>;
+        closeErrors: unknown[];
+      };
       try {
-        closedSessionAgentKeys = await this.closeOwnedSessions(
+        closeResult = await this.closeOwnedSessions(
           plan.ownedSessionCloseTarget === 'all'
             ? undefined
             : plan.ownedSessionCloseTarget,
@@ -523,9 +531,26 @@ export class SandboxRuntimeManager<TContext> {
         options.onCloseError();
         throw error;
       }
+      const { closedAgentKeys: closedSessionAgentKeys, closeErrors } =
+        closeResult;
 
       if (plan.afterOwnedSessionClose?.forgetLivePreservedSessions) {
         forgetLivePreservedOwnedSessions(state);
+      }
+      if (
+        plan.afterOwnedSessionClose?.removeFreshCreationSessionsFromSandboxState
+      ) {
+        const sandboxState = getSerializedSandboxState(state);
+        const freshCreationAgentKeys = new Set(
+          [...closedSessionAgentKeys].filter(
+            (agentKey) =>
+              sandboxState?.sessionsByAgent[agentKey]?.requiresFreshCreation ===
+              true,
+          ),
+        );
+        if (freshCreationAgentKeys.size > 0) {
+          this.invalidateSerializedSessions(freshCreationAgentKeys);
+        }
       }
       if (plan.afterOwnedSessionClose?.removeClosedSessionsFromSandboxState) {
         const sandboxState = getSerializedSandboxState(state);
@@ -535,6 +560,13 @@ export class SandboxRuntimeManager<TContext> {
         ) {
           state._sandbox = undefined;
         }
+      }
+      if (closeErrors.length > 0) {
+        options.onCloseError();
+        throw lifecycleErrorForCloseErrors(
+          'Failed to close one or more owned sandbox sessions.',
+          closeErrors,
+        );
       }
       if (plan.afterOwnedSessionClose?.clearSandboxState) {
         state._sandbox = undefined;
@@ -739,6 +771,23 @@ export class SandboxRuntimeManager<TContext> {
         },
       );
       if (!serializedState) {
+        continue;
+      }
+      if (
+        await serializedSessionStateRequiresFreshCreationForOptions(
+          client,
+          serializedState,
+          {
+            archiveLimits: this.sandboxConfig?.archiveLimits,
+            clientOptions: this.sandboxConfig?.options,
+          },
+        )
+      ) {
+        if (liveDecision) {
+          await this.discardLiveSessionWithChangedMountAuthority(liveDecision);
+        } else {
+          throw serializedOwnedSessionReplacementError(client);
+        }
         continue;
       }
       const rejectedLiveEntry =
@@ -1053,6 +1102,7 @@ export class SandboxRuntimeManager<TContext> {
       agentKey,
     );
     const explicitSessionStateInput = this.sandboxConfig?.sessionState;
+    const hasExplicitSessionState = explicitSessionStateInput !== undefined;
     if (explicitSessionStateInput) {
       client.validateSessionStateForResume?.(
         { source: 'explicit', state: explicitSessionStateInput },
@@ -1062,7 +1112,7 @@ export class SandboxRuntimeManager<TContext> {
         },
       );
     }
-    const explicitSessionState = explicitSessionStateInput
+    const explicitSessionState = hasExplicitSessionState
       ? await this.prepareExplicitSessionStateForResume(client, trustedManifest)
       : undefined;
     if (explicitSessionState && !client.resume) {
@@ -1076,15 +1126,15 @@ export class SandboxRuntimeManager<TContext> {
       serializedEntry,
       trustedManifest,
     });
-    if (!explicitSessionState && liveDecision?.reusable) {
+    if (!hasExplicitSessionState && liveDecision?.reusable) {
       return liveDecision.entry.session;
     }
-    if (!explicitSessionState && liveDecision?.mountAuthorityChanged) {
+    if (!hasExplicitSessionState && liveDecision?.mountAuthorityChanged) {
       await this.discardLiveSessionWithChangedMountAuthority(liveDecision);
       return undefined;
     }
     if (
-      !explicitSessionState &&
+      !hasExplicitSessionState &&
       (client.serializedSessionStateRequiresFreshCreation ||
         manifestHasInContainerMounts(trustedManifest) ||
         manifestHasNonResumableMountAuthority(trustedManifest) ||
@@ -1137,6 +1187,24 @@ export class SandboxRuntimeManager<TContext> {
       },
     );
     if (!serializedState) {
+      return undefined;
+    }
+
+    if (
+      await serializedSessionStateRequiresFreshCreationForOptions(
+        client,
+        serializedState,
+        {
+          archiveLimits: this.sandboxConfig?.archiveLimits,
+          clientOptions: this.sandboxConfig?.options,
+        },
+      )
+    ) {
+      if (liveDecision) {
+        await this.discardLiveSessionWithChangedMountAuthority(liveDecision);
+      } else {
+        throw serializedOwnedSessionReplacementError(client);
+      }
       return undefined;
     }
 
@@ -1258,7 +1326,22 @@ export class SandboxRuntimeManager<TContext> {
     assertTrustedManifestForDockerRunState(args.client, args.trustedManifest);
 
     if (liveEntry.reuseRejected) {
-      return { entry: liveEntry, reusable: false };
+      await serializedSessionStateRequiresFreshCreationForOptions(
+        args.client,
+        liveEntry.session.state,
+        {
+          archiveLimits: this.sandboxConfig?.archiveLimits,
+          clientOptions: this.sandboxConfig?.options,
+        },
+      );
+      return {
+        entry: liveEntry,
+        reusable: false,
+        ...(args.client
+          .preservedOwnedSessionReuseRejectionRequiresFreshCreation === true
+          ? { mountAuthorityChanged: true }
+          : {}),
+      };
     }
 
     if (isSandboxSessionStateUnsafe(liveEntry.session.state)) {
@@ -1364,40 +1447,45 @@ export class SandboxRuntimeManager<TContext> {
         trustedManifest,
         trustedEnvironment,
       );
-      assertSandboxStateGenerationUnchanged(
-        liveEntry.session.state,
-        stateGeneration,
-      );
-      liveEntry.session.state.manifest = candidateState.manifest;
-      liveEntry.session.state.environment = candidateState.environment;
-      return { entry: liveEntry, reusable: true };
-    }
-    if (
-      !(await canReuse.call(args.client, candidateState, {
+    } else {
+      const reusable = await canReuse.call(args.client, candidateState, {
         clientOptions: this.sandboxConfig?.options,
         revalidateManifestEntries: true,
         trustedManifest,
-      }))
-    ) {
-      assertSandboxStateGenerationUnchanged(
-        liveEntry.session.state,
-        stateGeneration,
-      );
-      rejectLivePreservedOwnedSessionHandle({
-        state: this.runState,
-        session: liveEntry.session,
       });
-      return { entry: liveEntry, reusable: false };
-    }
+      if (!reusable) {
+        const requiresFreshCreation =
+          args.client
+            .preservedOwnedSessionReuseRejectionRequiresFreshCreation === true;
+        assertSandboxStateGenerationUnchanged(
+          liveEntry.session.state,
+          stateGeneration,
+        );
+        rejectLivePreservedOwnedSessionHandle({
+          state: this.runState,
+          session: liveEntry.session,
+        });
+        return {
+          entry: liveEntry,
+          reusable: false,
+          ...(requiresFreshCreation ? { mountAuthorityChanged: true } : {}),
+        };
+      }
 
-    if (args.client.backendId !== 'docker') {
-      await refreshLiveEnvironmentReferences(candidateState, trustedManifest);
+      if (args.client.backendId !== 'docker') {
+        await refreshLiveEnvironmentReferences(candidateState, trustedManifest);
+      }
     }
 
     assertSandboxStateGenerationUnchanged(
       liveEntry.session.state,
       stateGeneration,
     );
+    args.client.rebindPreservedOwnedSessionState?.(liveEntry.session.state, {
+      clientOptions: this.sandboxConfig?.options,
+      revalidateManifestEntries: true,
+      trustedManifest,
+    });
 
     // Rebind only after the backend has verified that its live authority still
     // matches the current trusted manifest.
@@ -1439,7 +1527,7 @@ export class SandboxRuntimeManager<TContext> {
       }
     }
 
-    this.invalidateSerializedSessions(agentKeys);
+    this.markSerializedSessionsRequireFreshCreation(agentKeys);
     for (const agentKey of agentKeys) {
       this.sessionsByAgentKey.delete(agentKey);
       this.sessionAgentNamesByKey.delete(agentKey);
@@ -1467,6 +1555,7 @@ export class SandboxRuntimeManager<TContext> {
     }
 
     await cleanupSandboxSession(decision.entry.session);
+    this.invalidateSerializedSessions(agentKeys);
     forgetLivePreservedOwnedSessionHandle({
       state: this.runState,
       session,
@@ -1475,6 +1564,24 @@ export class SandboxRuntimeManager<TContext> {
 
   private invalidateSerializedSession(agentKey: string): void {
     this.invalidateSerializedSessions(new Set([agentKey]));
+  }
+
+  private markSerializedSessionsRequireFreshCreation(
+    agentKeys: ReadonlySet<string>,
+  ): void {
+    const sandboxState = getSerializedSandboxState(this.runState);
+    if (!sandboxState) {
+      return;
+    }
+    for (const agentKey of agentKeys) {
+      const entry = sandboxState.sessionsByAgent[agentKey];
+      if (!entry) {
+        continue;
+      }
+      entry.preservedOwnedSession = true;
+      entry.reuseLiveSession = false;
+      entry.requiresFreshCreation = true;
+    }
   }
 
   private invalidateSerializedSessions(agentKeys: ReadonlySet<string>): void {
@@ -1671,7 +1778,10 @@ export class SandboxRuntimeManager<TContext> {
       removeClosedSessionsFromSandboxState?: boolean;
       tracingParent?: Span<any> | Trace;
     } = {},
-  ): Promise<ReadonlySet<string>> {
+  ): Promise<{
+    closedAgentKeys: ReadonlySet<string>;
+    closeErrors: unknown[];
+  }> {
     const keysToClose = [...(agentKeys ?? this.ownedSessionAgentKeys)].filter(
       (agentKey) => this.ownedSessionAgentKeys.has(agentKey),
     );
@@ -1698,7 +1808,7 @@ export class SandboxRuntimeManager<TContext> {
       }
     }
     if (sessionsToClose.size === 0) {
-      return new Set();
+      return { closedAgentKeys: new Set(), closeErrors: [] };
     }
 
     const closedAgentKeys = new Set<string>();
@@ -1770,16 +1880,7 @@ export class SandboxRuntimeManager<TContext> {
       },
       options.tracingParent,
     );
-    if (closeErrors.length === 1) {
-      throw closeErrors[0];
-    }
-    if (closeErrors.length > 1) {
-      throw new SandboxLifecycleError(
-        'Failed to close one or more owned sandbox sessions.',
-        { errors: closeErrors },
-      );
-    }
-    return closedAgentKeys;
+    return { closedAgentKeys, closeErrors };
   }
 
   private releaseAgents(): void {
@@ -1915,6 +2016,27 @@ function removeClosedPreservedOwnedSessions(
   return removeClosedSerializedSessions(sandboxState, agentKeys, {
     requirePreservedSession: true,
   });
+}
+
+async function serializedSessionStateRequiresFreshCreationForOptions(
+  client: SandboxClient,
+  state: SandboxSessionState,
+  options: SandboxClientResumeOptions = {},
+): Promise<boolean> {
+  return (
+    (await client.serializedSessionStateRequiresFreshCreationForOptions?.(
+      state,
+      options,
+    )) ?? false
+  );
+}
+
+function serializedOwnedSessionReplacementError(
+  client: SandboxClient,
+): UserError {
+  return new UserError(
+    `Sandbox client "${client.backendId}" cannot safely replace an owned sandbox from untrusted serialized state because remote ownership cannot be verified. Reconnect through a caller-managed sandbox selection, or explicitly clean up the old sandbox before starting a new run.`,
+  );
 }
 
 function lifecycleErrorForCloseErrors(

--- a/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionSerialization.ts
@@ -83,6 +83,12 @@ export async function serializeSandboxRuntimeState(args: {
                     trustedManifestForAgentKey?.(currentAgentKey),
                 })
               : true;
+          const requiresFreshCreation =
+            isOwnedSession &&
+            includeOwnedSessions &&
+            !reuseLiveSession &&
+            client.preservedOwnedSessionReuseRejectionRequiresFreshCreation ===
+              true;
           const providerState = await serializeSessionState.call(
             client,
             session.state,
@@ -106,6 +112,9 @@ export async function serializeSandboxRuntimeState(args: {
               ? {
                   preservedOwnedSession: true,
                   ...(reuseLiveSession ? {} : { reuseLiveSession: false }),
+                  ...(requiresFreshCreation
+                    ? { requiresFreshCreation: true }
+                    : {}),
                 }
               : {}),
           };
@@ -118,6 +127,12 @@ export async function serializeSandboxRuntimeState(args: {
     // keep their sandbox sessions in the RunState.
     sessionsByAgent[currentAgentKey] = serializedEntry;
   }
+
+  normalizeSharedOwnedSessionFreshCreation({
+    sessionsByAgent,
+    sessionsByAgentKey,
+    ownedSessionAgentKeys,
+  });
 
   const currentAgentKey =
     preferredCurrentAgentKey && sessionsByAgent[preferredCurrentAgentKey]
@@ -138,6 +153,53 @@ export async function serializeSandboxRuntimeState(args: {
     sessionState: currentEntry.sessionState,
     sessionsByAgent,
   };
+}
+
+function normalizeSharedOwnedSessionFreshCreation(args: {
+  sessionsByAgent: Record<string, SerializedSandboxSessionEntry>;
+  sessionsByAgentKey: ReadonlyMap<
+    string,
+    SandboxSessionLike<SandboxSessionState>
+  >;
+  ownedSessionAgentKeys: ReadonlySet<string>;
+}): void {
+  const agentKeysBySession = new Map<
+    SandboxSessionLike<SandboxSessionState>,
+    string[]
+  >();
+  for (const [agentKey, session] of args.sessionsByAgentKey) {
+    if (
+      !args.ownedSessionAgentKeys.has(agentKey) ||
+      !args.sessionsByAgent[agentKey]?.preservedOwnedSession
+    ) {
+      continue;
+    }
+    const agentKeys = agentKeysBySession.get(session);
+    if (agentKeys) {
+      agentKeys.push(agentKey);
+    } else {
+      agentKeysBySession.set(session, [agentKey]);
+    }
+  }
+
+  for (const agentKeys of agentKeysBySession.values()) {
+    if (
+      !agentKeys.some(
+        (agentKey) =>
+          args.sessionsByAgent[agentKey]?.requiresFreshCreation === true,
+      )
+    ) {
+      continue;
+    }
+    for (const agentKey of agentKeys) {
+      const entry = args.sessionsByAgent[agentKey];
+      if (!entry) {
+        continue;
+      }
+      entry.reuseLiveSession = false;
+      entry.requiresFreshCreation = true;
+    }
+  }
 }
 
 function dropLegacySessionEntries(

--- a/packages/agents-core/src/sandbox/runtime/sessionState.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionState.ts
@@ -52,6 +52,7 @@ export type SerializedSandboxSessionEntry = {
   sessionState: SandboxSessionStateEnvelope;
   preservedOwnedSession?: boolean;
   reuseLiveSession?: boolean;
+  requiresFreshCreation?: boolean;
 };
 
 export type SerializedSandboxState = {

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from 'vitest';
 import { z } from 'zod';
 import { Agent, type AgentOutputType } from '../src/agent';
 import { handoff } from '../src/handoff';
@@ -98,6 +106,8 @@ import type {
   SandboxClient,
   SandboxClientCreateArgs,
   SandboxClientOptions,
+  SandboxPreservedSessionReuseOptions,
+  SandboxClientResumeOptions,
   SandboxSessionLike,
   SandboxSessionSerializationOptions,
   SandboxSessionState,
@@ -371,6 +381,7 @@ class ReservedFunctionNameCapability extends Capability {
 
 type FakeSandboxSessionState = SandboxSessionState & {
   sessionId: string;
+  resourcePolicy?: string;
 };
 
 function createManifestApplyingSpy(state: FakeSandboxSessionState) {
@@ -665,6 +676,38 @@ class SerializedResumeFakeSandboxClient extends FakeSandboxClient {
   }
 }
 
+class OptionFreshCreatingSerializedResumeFakeSandboxClient extends SerializedResumeFakeSandboxClient {
+  readonly freshCreationChecks: Array<
+    SandboxClientResumeOptions<SandboxClientOptions>
+  > = [];
+
+  serializedSessionStateRequiresFreshCreationForOptions(
+    state: FakeSandboxSessionState,
+    options: SandboxClientResumeOptions<SandboxClientOptions> = {},
+  ): boolean {
+    this.freshCreationChecks.push(options);
+    if (options.clientOptions?.resourcePolicy === 'invalid') {
+      throw new UserError('Invalid current resource policy.');
+    }
+    return (
+      state.resourcePolicy !== 'selected' &&
+      options.clientOptions?.resourcePolicy === 'new'
+    );
+  }
+
+  override async deserializeSessionState(
+    state: Record<string, unknown>,
+  ): Promise<FakeSandboxSessionState> {
+    return {
+      ...(await super.deserializeSessionState(state)),
+      resourcePolicy:
+        typeof state.resourcePolicy === 'string'
+          ? state.resourcePolicy
+          : undefined,
+    };
+  }
+}
+
 class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
   readonly reuseChecks: Manifest[] = [];
   readonly reuseEnvironments: Array<Record<string, string> | undefined> = [];
@@ -722,6 +765,75 @@ class RevalidatingLiveProcessFakeSandboxClient extends FakeSandboxClient {
         await close?.();
       },
     };
+  }
+}
+
+class RebindingLiveStateFakeSandboxClient extends RevalidatingLiveProcessFakeSandboxClient {
+  readonly rebindClientOptions: Array<SandboxClientOptions | undefined> = [];
+
+  rebindPreservedOwnedSessionState(
+    state: FakeSandboxSessionState,
+    options: { clientOptions?: SandboxClientOptions } = {},
+  ): void {
+    this.rebindClientOptions.push(options.clientOptions);
+    state.resourcePolicy = String(
+      options.clientOptions?.resourcePolicy ?? 'default',
+    );
+  }
+}
+
+class FreshCreatingLiveStateFakeSandboxClient extends FakeSandboxClient {
+  readonly preservedOwnedSessionReuseRejectionRequiresFreshCreation = true;
+  readonly closeAttempts: string[] = [];
+  readonly failingSessionIds = new Set<string>();
+
+  protected override lifecycleHandlers(
+    state: FakeSandboxSessionState,
+  ): Partial<SandboxSessionLike<FakeSandboxSessionState>> {
+    return {
+      close: async () => {
+        this.closeAttempts.push(state.sessionId);
+        if (this.failingSessionIds.has(state.sessionId)) {
+          throw new Error(`Failed to close ${state.sessionId}`);
+        }
+        this.closeCalls.push(state.sessionId);
+      },
+    };
+  }
+
+  canReusePreservedOwnedSession(
+    state: FakeSandboxSessionState,
+    options: {
+      clientOptions?: SandboxClientOptions;
+      revalidateManifestEntries?: boolean;
+    } = {},
+  ): boolean {
+    const resourcePolicy = String(
+      options.clientOptions?.resourcePolicy ?? 'default',
+    );
+    return state.resourcePolicy === resourcePolicy;
+  }
+
+  serializedSessionStateRequiresFreshCreationForOptions(
+    state: FakeSandboxSessionState,
+    options: SandboxClientResumeOptions<SandboxClientOptions> = {},
+  ): boolean {
+    if (options.clientOptions?.resourcePolicy === 'invalid') {
+      throw new UserError('Invalid current resource policy.');
+    }
+    return (
+      state.resourcePolicy !==
+      String(options.clientOptions?.resourcePolicy ?? 'default')
+    );
+  }
+}
+
+class ManifestSelectiveFreshCreatingFakeSandboxClient extends FreshCreatingLiveStateFakeSandboxClient {
+  override canReusePreservedOwnedSession(
+    _state: FakeSandboxSessionState,
+    options: SandboxPreservedSessionReuseOptions = {},
+  ): boolean {
+    return options.trustedManifest?.root === '/accepted';
   }
 }
 
@@ -1071,6 +1183,12 @@ function fakeSandboxSessionStateEnvelope(
 }
 
 describe('sandbox runner integration', () => {
+  it('preserves the boolean live-session reuse hook contract', () => {
+    expectTypeOf<
+      ReturnType<NonNullable<SandboxClient['canReusePreservedOwnedSession']>>
+    >().toEqualTypeOf<boolean | Promise<boolean>>();
+  });
+
   it.each([
     { label: 'local non-streaming', stream: false, serverManaged: false },
     { label: 'server-managed streaming', stream: true, serverManaged: true },
@@ -5795,6 +5913,55 @@ describe('sandbox runner integration', () => {
     ]);
   });
 
+  it('rejects serialized preserved replacement without trusted ownership', async () => {
+    const client = new OptionFreshCreatingSerializedResumeFakeSandboxClient();
+    const clientOptions = { resourcePolicy: 'new' };
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const sessionState = fakeSandboxSessionStateEnvelope({
+      sessionId: 'preserved-with-old-resources',
+    });
+    state._sandbox = {
+      backendId: 'fake-sandbox',
+      currentAgentKey: 'SandboxWorker',
+      currentAgentName: 'SandboxWorker',
+      sessionState,
+      sessionsByAgent: {
+        SandboxWorker: {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          preservedOwnedSession: true,
+          sessionState,
+        },
+      },
+    };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: { client, options: clientOptions },
+      runState: state,
+    });
+
+    await expect(manager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      'Sandbox client "fake-sandbox" cannot safely replace an owned sandbox from untrusted serialized state because remote ownership cannot be verified. Reconnect through a caller-managed sandbox selection, or explicitly clean up the old sandbox before starting a new run.',
+    );
+
+    expect(client.freshCreationChecks).toEqual([
+      { archiveLimits: undefined, clientOptions },
+    ]);
+    expect(client.resumeCalls).toHaveLength(0);
+    expect(client.createCalls).toHaveLength(0);
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toBeDefined();
+  });
+
   it('does not restart provided sandbox sessions that report running', async () => {
     const client = new StartableFakeSandboxClient();
     const providedSession = client.makeSession({
@@ -6874,6 +7041,75 @@ describe('sandbox runner integration', () => {
     ]);
     expect(client.closeCalls).toEqual(['session-2', 'session-1']);
     expect(state._sandbox).toBeUndefined();
+  });
+
+  it('retains failed serialized cleanup entries when a sibling close succeeds', async () => {
+    const failingSessionIds = new Set(['session-1']);
+    const client = new SelectiveCloseFailureFakeSandboxClient(
+      failingSessionIds,
+    );
+    const firstAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'FirstSandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: new Manifest({ root: '/workspace' }),
+    });
+    const secondAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SecondSandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: new Manifest({ root: '/workspace' }),
+    });
+    const state = new RunState<unknown, Agent<unknown, AgentOutputType>>(
+      new RunContext(),
+      'Hello',
+      firstAgent,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent,
+      sandboxConfig: { client },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: firstAgent,
+      turnInput: [],
+    });
+    await firstManager.prepareAgent({
+      currentAgent: secondAgent,
+      turnInput: [],
+    });
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const restoredState = await RunState.fromString(
+      firstAgent,
+      state.toString(),
+    );
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent,
+      sandboxConfig: { client },
+      runState: restoredState,
+    });
+    await expect(secondManager.cleanup(restoredState)).rejects.toThrow(
+      'Failed to close session-1',
+    );
+
+    expect(client.closeCalls).toEqual(['session-2']);
+    expect(
+      restoredState._sandbox?.sessionsByAgent.FirstSandboxWorker,
+    ).toBeDefined();
+    expect(
+      restoredState._sandbox?.sessionsByAgent.SecondSandboxWorker,
+    ).toBeUndefined();
+
+    failingSessionIds.clear();
+    const thirdManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent,
+      sandboxConfig: { client },
+      runState: restoredState,
+    });
+    await thirdManager.cleanup(restoredState);
+
+    expect(client.closeCalls).toEqual(['session-2', 'session-1']);
+    expect(restoredState._sandbox).toBeUndefined();
   });
 
   it('closes mixed live and restorable preserved sessions on non-sandbox interruption cleanup', async () => {
@@ -8329,6 +8565,519 @@ describe('sandbox runner integration', () => {
     expect(client.closeCalls).toEqual([liveSession?.state.sessionId]);
   });
 
+  it('commits provider metadata after accepting live reuse', async () => {
+    const client = new RebindingLiveStateFakeSandboxClient();
+    const manifest = new Manifest();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'initial' },
+      },
+      runState: state,
+    });
+
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0]!;
+    liveSession.state.resourcePolicy = 'initial';
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'updated' },
+      },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+
+    expect(liveSession.state.resourcePolicy).toBe('updated');
+    expect(client.rebindClientOptions).toEqual([{ resourcePolicy: 'updated' }]);
+    await secondManager.cleanup(state);
+  });
+
+  it('fails closed when changed resources require unverifiable serialized cleanup', async () => {
+    const client = new FreshCreatingLiveStateFakeSandboxClient();
+    const manifest = new Manifest();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const secondAgent = new SandboxAgent({
+      name: 'SandboxReviewer',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'initial' },
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0]!;
+    liveSession.state.resourcePolicy = 'initial';
+    const firstManagerInternals = firstManager as unknown as {
+      agentsByKey: Map<string, Agent<unknown, any>>;
+      sessionsByAgentKey: Map<string, SandboxSessionLike>;
+      sessionAgentNamesByKey: Map<string, string>;
+      ownedSessionAgentKeys: Set<string>;
+    };
+    firstManagerInternals.agentsByKey.set(
+      secondAgent.name,
+      secondAgent as Agent<unknown, any>,
+    );
+    firstManagerInternals.sessionsByAgentKey.set(secondAgent.name, liveSession);
+    firstManagerInternals.sessionAgentNamesByKey.set(
+      secondAgent.name,
+      secondAgent.name,
+    );
+    firstManagerInternals.ownedSessionAgentKeys.add(secondAgent.name);
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'updated' },
+      },
+      runState: state,
+    });
+    client.failingSessionIds.add(liveSession.state.sessionId);
+    await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      `Failed to close ${liveSession.state.sessionId}`,
+    );
+    expect(client.createdSessions).toHaveLength(1);
+    expect(client.resumeCalls).toEqual([]);
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toMatchObject({
+      preservedOwnedSession: true,
+      reuseLiveSession: false,
+      requiresFreshCreation: true,
+    });
+    expect(state._sandbox?.sessionsByAgent.SandboxReviewer).toMatchObject({
+      preservedOwnedSession: true,
+      reuseLiveSession: false,
+      requiresFreshCreation: true,
+    });
+
+    const restoredAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const restoredState = await RunState.fromString(
+      restoredAgent as Agent<unknown, any>,
+      state.toString(),
+    );
+    const thirdManager = new SandboxRuntimeManager({
+      startingAgent: restoredAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'updated' },
+      },
+      runState: restoredState,
+    });
+    await expect(thirdManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      'cannot safely replace an owned sandbox from untrusted serialized state',
+    );
+    expect(client.createdSessions).toHaveLength(1);
+    expect(restoredState._sandbox?.sessionsByAgent.SandboxWorker).toBeDefined();
+    expect(
+      restoredState._sandbox?.sessionsByAgent.SandboxReviewer,
+    ).toBeDefined();
+
+    expect(liveSession.state.resourcePolicy).toBe('initial');
+    expect(client.closeCalls).toEqual([]);
+    expect(client.closeAttempts).toEqual([liveSession.state.sessionId]);
+    expect(client.resumeCalls).toEqual([]);
+    expect(client.createdSessions).toHaveLength(1);
+  });
+
+  it('fresh-creates after retrying a rejected live cleanup without resource options', async () => {
+    const client = new FreshCreatingLiveStateFakeSandboxClient();
+    const manifest = new Manifest();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'initial' },
+      },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0]!;
+    liveSession.state.resourcePolicy = 'initial';
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'updated' },
+      },
+      runState: state,
+    });
+    client.failingSessionIds.add(liveSession.state.sessionId);
+    await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
+      `Failed to close ${liveSession.state.sessionId}`,
+    );
+
+    const invalidRetryManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        manifest,
+        options: { resourcePolicy: 'invalid' },
+      },
+      runState: state,
+    });
+    await expect(
+      invalidRetryManager.adoptPreservedOwnedSessions(),
+    ).rejects.toThrow('Invalid current resource policy.');
+    expect(client.closeAttempts).toEqual([liveSession.state.sessionId]);
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toBeDefined();
+
+    client.failingSessionIds.clear();
+    const retryManager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest },
+      runState: state,
+    });
+    await retryManager.adoptPreservedOwnedSessions();
+    await retryManager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    expect(client.closeAttempts).toEqual([
+      liveSession.state.sessionId,
+      liveSession.state.sessionId,
+    ]);
+    expect(client.closeCalls).toEqual([liveSession.state.sessionId]);
+    expect(client.resumeCalls).toEqual([]);
+    expect(client.createdSessions).toHaveLength(2);
+  });
+
+  it('fresh-creates after successful serialization-time rejection cleanup', async () => {
+    const client = new FreshCreatingLiveStateFakeSandboxClient();
+    const options: SandboxClientOptions = { resourcePolicy: 'initial' };
+    const manifest = new Manifest();
+    const firstAgent = new SandboxAgent({
+      name: 'FirstSandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const secondAgent = new SandboxAgent({
+      name: 'SecondSandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      firstAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest, options },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await firstManager.prepareAgent({
+      currentAgent: secondAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    client.createdSessions[0]!.state.resourcePolicy = 'initial';
+    client.createdSessions[1]!.state.resourcePolicy = 'updated';
+    options.resourcePolicy = 'updated';
+
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    expect(client.closeCalls).toEqual(['session-1']);
+    expect(state._sandbox?.sessionsByAgent.FirstSandboxWorker).toBeUndefined();
+    expect(state._sandbox?.sessionsByAgent.SecondSandboxWorker).toBeDefined();
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest, options },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+    await secondManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await secondManager.prepareAgent({
+      currentAgent: secondAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    expect(client.resumeCalls).toEqual([]);
+    expect(client.createdSessions).toHaveLength(3);
+    await secondManager.cleanup(state);
+  });
+
+  it('invalidates every alias when a shared live session requires fresh creation', async () => {
+    const client = new ManifestSelectiveFreshCreatingFakeSandboxClient();
+    const firstAgent = new SandboxAgent({
+      name: 'FirstSandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: new Manifest({ root: '/rejected' }),
+    });
+    const secondAgent = new SandboxAgent({
+      name: 'SecondSandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: new Manifest({ root: '/accepted' }),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      firstAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    const liveSession = client.createdSessions[0]!;
+    const firstManagerInternals = firstManager as unknown as {
+      agentsByKey: Map<string, Agent<unknown, any>>;
+      sessionsByAgentKey: Map<string, SandboxSessionLike>;
+      sessionAgentNamesByKey: Map<string, string>;
+      ownedSessionAgentKeys: Set<string>;
+    };
+    firstManagerInternals.agentsByKey.set(
+      secondAgent.name,
+      secondAgent as Agent<unknown, any>,
+    );
+    firstManagerInternals.sessionsByAgentKey.set(secondAgent.name, liveSession);
+    firstManagerInternals.sessionAgentNamesByKey.set(
+      secondAgent.name,
+      secondAgent.name,
+    );
+    firstManagerInternals.ownedSessionAgentKeys.add(secondAgent.name);
+
+    await firstManager.cleanup(state, { preserveOwnedSessions: true });
+
+    expect(client.closeAttempts).toEqual([liveSession.state.sessionId]);
+    expect(client.closeCalls).toEqual([liveSession.state.sessionId]);
+    expect(state._sandbox).toBeUndefined();
+
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+    await secondManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await secondManager.prepareAgent({
+      currentAgent: secondAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    expect(client.resumeCalls).toEqual([]);
+    expect(client.createdSessions).toHaveLength(3);
+    await secondManager.cleanup(state);
+  });
+
+  it('invalidates successful serialization-time closes before reporting sibling failures', async () => {
+    const client = new FreshCreatingLiveStateFakeSandboxClient();
+    const options: SandboxClientOptions = { resourcePolicy: 'initial' };
+    const manifest = new Manifest();
+    const firstAgent = new SandboxAgent({
+      name: 'FirstSandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const secondAgent = new SandboxAgent({
+      name: 'SecondSandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      firstAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest, options },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await firstManager.prepareAgent({
+      currentAgent: secondAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    client.createdSessions[0]!.state.resourcePolicy = 'initial';
+    client.createdSessions[1]!.state.resourcePolicy = 'initial';
+    options.resourcePolicy = 'updated';
+    client.failingSessionIds.add('session-1');
+
+    await expect(
+      firstManager.cleanup(state, { preserveOwnedSessions: true }),
+    ).rejects.toThrow('Failed to close session-1');
+
+    expect(client.closeCalls).toEqual(['session-2']);
+    expect(state._sandbox?.sessionsByAgent.FirstSandboxWorker).toBeDefined();
+    expect(state._sandbox?.sessionsByAgent.SecondSandboxWorker).toBeUndefined();
+
+    client.failingSessionIds.clear();
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest, options },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+    await secondManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await secondManager.prepareAgent({
+      currentAgent: secondAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    expect(client.closeCalls).toEqual(['session-2', 'session-1']);
+    expect(client.resumeCalls).toEqual([]);
+    expect(client.createdSessions).toHaveLength(4);
+    await secondManager.cleanup(state);
+  });
+
+  it('persists fresh creation without discarding unrelated live sessions', async () => {
+    const client = new FreshCreatingLiveStateFakeSandboxClient();
+    const options: SandboxClientOptions = { resourcePolicy: 'initial' };
+    const manifest = new Manifest();
+    const firstAgent = new SandboxAgent({
+      name: 'FirstSandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const secondAgent = new SandboxAgent({
+      name: 'SecondSandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      firstAgent as Agent<unknown, any>,
+      1,
+    );
+    const firstManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest, options },
+      runState: state,
+    });
+    await firstManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await firstManager.prepareAgent({
+      currentAgent: secondAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    client.createdSessions[0]!.state.resourcePolicy = 'initial';
+    client.createdSessions[1]!.state.resourcePolicy = 'updated';
+    options.resourcePolicy = 'updated';
+
+    client.failingSessionIds.add('session-1');
+    await expect(
+      firstManager.cleanup(state, { preserveOwnedSessions: true }),
+    ).rejects.toThrow('Failed to close session-1');
+
+    expect(state._sandbox?.sessionsByAgent.FirstSandboxWorker).toMatchObject({
+      preservedOwnedSession: true,
+      reuseLiveSession: false,
+      requiresFreshCreation: true,
+    });
+    expect(state._sandbox?.sessionsByAgent.SecondSandboxWorker).toMatchObject({
+      preservedOwnedSession: true,
+    });
+    expect(
+      state._sandbox?.sessionsByAgent.SecondSandboxWorker,
+    ).not.toHaveProperty('requiresFreshCreation');
+    expect(client.closeAttempts).toEqual(['session-1']);
+    expect(client.closeCalls).toEqual([]);
+
+    client.failingSessionIds.clear();
+    const secondManager = new SandboxRuntimeManager({
+      startingAgent: firstAgent as Agent<unknown, any>,
+      sandboxConfig: { client, manifest, options },
+      runState: state,
+    });
+    await secondManager.adoptPreservedOwnedSessions();
+    expect(client.closeAttempts).toEqual(['session-1', 'session-1']);
+    expect(client.closeCalls).toEqual(['session-1']);
+    await secondManager.prepareAgent({
+      currentAgent: firstAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+    await secondManager.prepareAgent({
+      currentAgent: secondAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    expect(client.resumeCalls).toEqual([]);
+    expect(client.createdSessions).toHaveLength(3);
+    expect(state._sandbox?.sessionsByAgent.FirstSandboxWorker).toBeUndefined();
+
+    await secondManager.cleanup(state);
+  });
+
   it('rejects live reuse inspection while a manifest transition is pending', async () => {
     const client = new RevalidatingLiveProcessFakeSandboxClient();
     const manifest = new Manifest();
@@ -8446,7 +9195,7 @@ describe('sandbox runner integration', () => {
   });
 
   it('invalidates stale mount resume state before live cleanup can fail', async () => {
-    const client = new FailingBeforeLiveCleanupFakeSandboxClient(2);
+    const client = new FailingBeforeLiveCleanupFakeSandboxClient(1);
     const manifest = new Manifest({
       entries: {
         remote: s3Mount({
@@ -8489,7 +9238,11 @@ describe('sandbox runner integration', () => {
     await expect(secondManager.adoptPreservedOwnedSessions()).rejects.toThrow(
       'live cleanup failed before termination',
     );
-    expect(state._sandbox).toBeUndefined();
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toMatchObject({
+      preservedOwnedSession: true,
+      reuseLiveSession: false,
+      requiresFreshCreation: true,
+    });
 
     const thirdManager = new SandboxRuntimeManager({
       startingAgent: sandboxAgent as Agent<unknown, any>,
@@ -8504,9 +9257,7 @@ describe('sandbox runner integration', () => {
 
     expect(client.resumeCalls).toHaveLength(0);
     expect(client.createdSessions).toHaveLength(2);
-    await expect(
-      thirdManager.cleanup(state, { preserveOwnedSessions: true }),
-    ).rejects.toThrow('live cleanup failed before termination');
+    await thirdManager.cleanup(state, { preserveOwnedSessions: true });
 
     const fourthManager = new SandboxRuntimeManager({
       startingAgent: sandboxAgent as Agent<unknown, any>,
@@ -8604,7 +9355,16 @@ describe('sandbox runner integration', () => {
         sessionsByAgentKey: Map<string, SandboxSessionLike>;
         ownedSessionAgentKeys: Set<string>;
       };
-      expect(state._sandbox).toBeUndefined();
+      expect(state._sandbox?.sessionsByAgent.SandboxWorker).toMatchObject({
+        preservedOwnedSession: true,
+        reuseLiveSession: false,
+        requiresFreshCreation: true,
+      });
+      expect(state._sandbox?.sessionsByAgent.SandboxReviewer).toMatchObject({
+        preservedOwnedSession: true,
+        reuseLiveSession: false,
+        requiresFreshCreation: true,
+      });
       expect(secondManagerInternals.sessionsByAgent.size).toBe(0);
       expect(secondManagerInternals.sessionsByAgentKey.size).toBe(0);
       expect(secondManagerInternals.ownedSessionAgentKeys.size).toBe(0);
@@ -10251,6 +11011,203 @@ describe('sandbox runner integration', () => {
 
     expect(client.resumeCalls).toHaveLength(0);
     expect(client.createCalls).toHaveLength(1);
+    await manager.cleanup(state);
+  });
+
+  it('rejects serialized replacement without trusted ownership', async () => {
+    const client = new OptionFreshCreatingSerializedResumeFakeSandboxClient();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const sessionState = fakeSandboxSessionStateEnvelope({
+      sessionId: 'persisted-with-old-resources',
+    });
+    state._sandbox = {
+      backendId: 'fake-sandbox',
+      currentAgentKey: 'SandboxWorker',
+      currentAgentName: 'SandboxWorker',
+      sessionState,
+      sessionsByAgent: {
+        SandboxWorker: {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          sessionState,
+        },
+      },
+    };
+    const clientOptions = { resourcePolicy: 'new' };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: { client, options: clientOptions },
+      runState: state,
+    });
+
+    await expect(
+      manager.prepareAgent({
+        currentAgent: sandboxAgent as Agent<unknown, any>,
+        turnInput: [],
+      }),
+    ).rejects.toThrow(
+      'cannot safely replace an owned sandbox from untrusted serialized state',
+    );
+
+    expect(client.freshCreationChecks).toEqual([
+      { archiveLimits: undefined, clientOptions },
+    ]);
+    expect(client.resumeCalls).toHaveLength(0);
+    expect(client.createCalls).toHaveLength(0);
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toBeDefined();
+  });
+
+  it('resumes serialized state when the provider exempts a selected sandbox', async () => {
+    const client = new OptionFreshCreatingSerializedResumeFakeSandboxClient();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const sessionState = fakeSandboxSessionStateEnvelope({
+      sessionId: 'persisted-selected-sandbox',
+      resourcePolicy: 'selected',
+    });
+    state._sandbox = {
+      backendId: 'fake-sandbox',
+      currentAgentKey: 'SandboxWorker',
+      currentAgentName: 'SandboxWorker',
+      sessionState,
+      sessionsByAgent: {
+        SandboxWorker: {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          requiresFreshCreation: true,
+          sessionState,
+        },
+      },
+    };
+    const clientOptions = { resourcePolicy: 'new' };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: { client, options: clientOptions },
+      runState: state,
+    });
+
+    await manager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(client.resumeCalls[0]?.state.sessionId).toBe(
+      'persisted-selected-sandbox',
+    );
+    expect(client.createCalls).toHaveLength(0);
+    await manager.cleanup(state);
+  });
+
+  it('retains selected serialized state when current options are invalid', async () => {
+    const client = new OptionFreshCreatingSerializedResumeFakeSandboxClient();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const sessionState = fakeSandboxSessionStateEnvelope({
+      sessionId: 'persisted-invalid-selected-sandbox',
+      resourcePolicy: 'selected',
+    });
+    state._sandbox = {
+      backendId: 'fake-sandbox',
+      currentAgentKey: 'SandboxWorker',
+      currentAgentName: 'SandboxWorker',
+      sessionState,
+      sessionsByAgent: {
+        SandboxWorker: {
+          backendId: 'fake-sandbox',
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          requiresFreshCreation: true,
+          sessionState,
+        },
+      },
+    };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        options: { resourcePolicy: 'invalid' },
+      },
+      runState: state,
+    });
+
+    await expect(
+      manager.prepareAgent({
+        currentAgent: sandboxAgent as Agent<unknown, any>,
+        turnInput: [],
+      }),
+    ).rejects.toThrow('Invalid current resource policy.');
+
+    expect(state._sandbox?.sessionsByAgent.SandboxWorker).toBeDefined();
+    expect(client.resumeCalls).toHaveLength(0);
+    expect(client.createCalls).toHaveLength(0);
+  });
+
+  it('passes explicit session state to the provider before option-aware resume decisions', async () => {
+    const client = new OptionFreshCreatingSerializedResumeFakeSandboxClient();
+    const sandboxAgent = new SandboxAgent({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+    });
+    const state = new RunState<unknown, Agent<unknown, any>>(
+      new RunContext(),
+      'Hello',
+      sandboxAgent as Agent<unknown, any>,
+      1,
+    );
+    const explicitSessionState: FakeSandboxSessionState = {
+      manifest: new Manifest(),
+      sessionId: 'explicit-selected-sandbox',
+      resourcePolicy: 'selected',
+    };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent as Agent<unknown, any>,
+      sandboxConfig: {
+        client,
+        options: { resourcePolicy: 'new' },
+        sessionState: explicitSessionState,
+      },
+      runState: state,
+    });
+
+    await manager.prepareAgent({
+      currentAgent: sandboxAgent as Agent<unknown, any>,
+      turnInput: [],
+    });
+
+    expect(client.freshCreationChecks).toHaveLength(0);
+    expect(client.resumeCalls).toHaveLength(1);
+    expect(client.resumeCalls[0]?.state.sessionId).toBe(
+      'explicit-selected-sandbox',
+    );
+    expect(client.createCalls).toHaveLength(0);
     await manager.cleanup(state);
   });
 

--- a/packages/agents-extensions/src/sandbox/modal/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/modal/sandbox.ts
@@ -8,6 +8,8 @@ import {
   type SandboxClient,
   type SandboxClientCreateArgs,
   type SandboxClientOptions,
+  type SandboxClientResumeOptions,
+  type SandboxPreservedSessionReuseOptions,
   type SandboxArchiveLimits,
   type SandboxConcurrencyLimits,
   type ExposedPortEndpoint,
@@ -27,6 +29,7 @@ import {
   validateSandboxArchiveLimits,
 } from '@openai/agents-core/sandbox';
 import {
+  liveMountEnvironmentAuthorityMatches,
   normalizePosixPath,
   relativePosixPathWithinRoot,
   shellQuote,
@@ -287,6 +290,10 @@ export interface ModalSandboxClientOptions extends SandboxClientOptions {
   env?: Record<string, string>;
   timeoutMs?: number;
   idleTimeoutMs?: number;
+  cpu?: number;
+  cpuLimit?: number;
+  memoryMiB?: number;
+  memoryLimitMiB?: number;
   gpu?: string;
   exposedPorts?: number[];
   environment?: string;
@@ -312,6 +319,10 @@ export interface ModalSandboxSessionState extends SandboxSessionState {
   environment: Record<string, string>;
   timeoutMs?: number;
   idleTimeoutMs?: number;
+  cpu?: number;
+  cpuLimit?: number;
+  memoryMiB?: number;
+  memoryLimitMiB?: number;
   gpu?: string;
   configuredExposedPorts?: number[];
   modalEnvironment?: string;
@@ -1015,6 +1026,7 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
   }
 
   private async sandboxCreateParams(): Promise<Record<string, unknown>> {
+    validateModalResourceOptions(this.state);
     const cloudBucketMounts = await this.resolveCloudBucketMounts();
     return {
       workdir: this.state.manifest.root,
@@ -1025,6 +1037,16 @@ export class ModalSandboxSession implements SandboxSession<ModalSandboxSessionSt
         : {}),
       ...(typeof this.state.idleTimeoutMs === 'number'
         ? { idleTimeoutMs: this.state.idleTimeoutMs }
+        : {}),
+      ...(typeof this.state.cpu === 'number' ? { cpu: this.state.cpu } : {}),
+      ...(typeof this.state.cpuLimit === 'number'
+        ? { cpuLimit: this.state.cpuLimit }
+        : {}),
+      ...(typeof this.state.memoryMiB === 'number'
+        ? { memoryMiB: this.state.memoryMiB }
+        : {}),
+      ...(typeof this.state.memoryLimitMiB === 'number'
+        ? { memoryLimitMiB: this.state.memoryLimitMiB }
         : {}),
       ...(this.state.gpu ? { gpu: this.state.gpu } : {}),
       ...(this.state.configuredExposedPorts
@@ -1320,6 +1342,7 @@ export class ModalSandboxClient implements SandboxClient<
   ModalSandboxSessionState
 > {
   readonly backendId = 'modal';
+  readonly preservedOwnedSessionReuseRejectionRequiresFreshCreation = true;
   private readonly options: Partial<ModalSandboxClientOptions>;
 
   constructor(options: Partial<ModalSandboxClientOptions> = {}) {
@@ -1418,6 +1441,18 @@ export class ModalSandboxClient implements SandboxClient<
             ...(typeof resolvedOptions.idleTimeoutMs === 'number'
               ? { idleTimeoutMs: resolvedOptions.idleTimeoutMs }
               : {}),
+            ...(typeof resolvedOptions.cpu === 'number'
+              ? { cpu: resolvedOptions.cpu }
+              : {}),
+            ...(typeof resolvedOptions.cpuLimit === 'number'
+              ? { cpuLimit: resolvedOptions.cpuLimit }
+              : {}),
+            ...(typeof resolvedOptions.memoryMiB === 'number'
+              ? { memoryMiB: resolvedOptions.memoryMiB }
+              : {}),
+            ...(typeof resolvedOptions.memoryLimitMiB === 'number'
+              ? { memoryLimitMiB: resolvedOptions.memoryLimitMiB }
+              : {}),
             ...(resolvedOptions.gpu ? { gpu: resolvedOptions.gpu } : {}),
             ...(resolvedOptions.exposedPorts
               ? { encryptedPorts: resolvedOptions.exposedPorts }
@@ -1455,6 +1490,10 @@ export class ModalSandboxClient implements SandboxClient<
           environment,
           timeoutMs: resolvedOptions.timeoutMs,
           idleTimeoutMs: resolvedOptions.idleTimeoutMs,
+          cpu: resolvedOptions.cpu,
+          cpuLimit: resolvedOptions.cpuLimit,
+          memoryMiB: resolvedOptions.memoryMiB,
+          memoryLimitMiB: resolvedOptions.memoryLimitMiB,
           gpu: resolvedOptions.gpu,
           configuredExposedPorts: resolvedOptions.exposedPorts,
           modalEnvironment: resolvedOptions.environment,
@@ -1506,14 +1545,74 @@ export class ModalSandboxClient implements SandboxClient<
     return false;
   }
 
+  serializedSessionStateRequiresFreshCreationForOptions(
+    state: ModalSandboxSessionState,
+    options: SandboxClientResumeOptions<ModalSandboxClientOptions> = {},
+  ): boolean {
+    const trustedResourceOptions = modalResourceOptionsFrom(
+      resolveOptions(this.options, options.clientOptions),
+    );
+    validateModalResourceOptions(trustedResourceOptions);
+    return state.ownsSandbox !== false;
+  }
+
+  async canReusePreservedOwnedSession(
+    state: ModalSandboxSessionState,
+    options: SandboxPreservedSessionReuseOptions<ModalSandboxClientOptions> = {},
+  ): Promise<boolean> {
+    if (!options.trustedManifest) {
+      return false;
+    }
+    const resolvedOptions = resolveOptions(this.options, options.clientOptions);
+    const trustedResourceOptions = modalResourceOptionsFrom(resolvedOptions);
+    validateModalResourceOptions(trustedResourceOptions);
+    const trustedEnvironment = await materializeEnvironment(
+      options.trustedManifest,
+      resolvedOptions.env,
+    );
+    if (
+      !liveMountEnvironmentAuthorityMatches(
+        state.manifest,
+        options.trustedManifest,
+        trustedEnvironment,
+      )
+    ) {
+      return false;
+    }
+    if (state.ownsSandbox === false) {
+      return true;
+    }
+    return (
+      state.cpu === trustedResourceOptions.cpu &&
+      state.cpuLimit === trustedResourceOptions.cpuLimit &&
+      state.memoryMiB === trustedResourceOptions.memoryMiB &&
+      state.memoryLimitMiB === trustedResourceOptions.memoryLimitMiB
+    );
+  }
+
+  rebindPreservedOwnedSessionState(
+    state: ModalSandboxSessionState,
+    options: SandboxPreservedSessionReuseOptions<ModalSandboxClientOptions> = {},
+  ): void {
+    if (state.ownsSandbox !== false) {
+      return;
+    }
+    const trustedResourceOptions = modalResourceOptionsFrom(
+      resolveOptions(this.options, options.clientOptions),
+    );
+    validateModalResourceOptions(trustedResourceOptions);
+    Object.assign(state, trustedResourceOptions);
+  }
+
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<ModalSandboxSessionState> {
+    const trustedResourceOptions = modalResourceOptionsFrom(this.options);
     const baseState = await rehydrateRemoteSandboxSessionStateValues(
       state,
       this.options.env,
     );
-    return {
+    const restoredState: ModalSandboxSessionState = {
       ...state,
       ...baseState,
       ownsSandbox: state.ownsSandbox === false ? false : true,
@@ -1533,6 +1632,7 @@ export class ModalSandboxClient implements SandboxClient<
       ),
       timeoutMs: readOptionalNumber(state, 'timeoutMs'),
       idleTimeoutMs: readOptionalNumber(state, 'idleTimeoutMs'),
+      ...trustedResourceOptions,
       gpu: readOptionalString(state, 'gpu'),
       configuredExposedPorts: readOptionalNumberArray(
         state.configuredExposedPorts,
@@ -1547,10 +1647,27 @@ export class ModalSandboxClient implements SandboxClient<
       useSleepCmd:
         typeof state.useSleepCmd === 'boolean' ? state.useSleepCmd : true,
     };
+    return restoredState;
   }
 
-  async resume(state: ModalSandboxSessionState): Promise<ModalSandboxSession> {
+  async resume(
+    state: ModalSandboxSessionState,
+    options: SandboxClientResumeOptions<ModalSandboxClientOptions> = {},
+  ): Promise<ModalSandboxSession> {
     assertRemoteSandboxSessionStateCanResume(state);
+    const trustedResourceOptions = modalResourceOptionsFrom(
+      resolveOptions(this.options, options.clientOptions),
+    );
+    validateModalResourceOptions(trustedResourceOptions);
+    if (state.ownsSandbox !== false) {
+      throw new UserError(
+        'Modal sandbox resume cannot verify the existing CPU or memory allocation. Create a fresh sandbox from current trusted configuration.',
+      );
+    }
+    const trustedState = {
+      ...state,
+      ...trustedResourceOptions,
+    };
     if (!state.sandboxId) {
       throw new UserError(
         'Modal sandbox resume requires a persisted sandboxId.',
@@ -1559,28 +1676,10 @@ export class ModalSandboxClient implements SandboxClient<
     const sandboxId = state.sandboxId;
 
     const modalModule = await loadModalModule();
-    const modal = createModalClientFromModule(modalModule, {
-      ...this.options,
-      appName: state.appName,
-      image: state.imageId
-        ? ModalImageSelector.fromId(state.imageId)
-        : undefined,
-      imageTag: state.imageTag,
-      sandboxCreateTimeoutS: state.sandboxCreateTimeoutS,
-      workspacePersistence: state.workspacePersistence,
-      snapshotFilesystemTimeoutMs: state.snapshotFilesystemTimeoutMs,
-      snapshotFilesystemRestoreTimeoutMs:
-        state.snapshotFilesystemRestoreTimeoutMs,
-      timeoutMs: state.timeoutMs,
-      idleTimeoutMs: state.idleTimeoutMs,
-      gpu: state.gpu,
-      exposedPorts: state.configuredExposedPorts,
-      environment: state.modalEnvironment ?? this.options.environment,
-      endpoint: state.endpoint ?? this.options.endpoint,
-      imageBuilderVersion:
-        state.imageBuilderVersion ?? this.options.imageBuilderVersion,
-      useSleepCmd: state.useSleepCmd,
-    });
+    const modal = createModalClientFromModule(
+      modalModule,
+      modalClientOptionsForPersistedState(this.options, state),
+    );
     const sandbox = await withProviderError(
       'ModalSandboxClient',
       'modal',
@@ -1614,7 +1713,7 @@ export class ModalSandboxClient implements SandboxClient<
     }
 
     return new ModalSandboxSession({
-      state,
+      state: trustedState,
       modal,
       app,
       sandbox,
@@ -1693,6 +1792,32 @@ function createModalClientFromModule(
       originalImageBuilderVersion(version ?? options.imageBuilderVersion);
   }
   return client;
+}
+
+function modalClientOptionsForPersistedState(
+  options: Partial<ModalSandboxClientOptions>,
+  state: ModalSandboxSessionState,
+): Partial<ModalSandboxClientOptions> {
+  return {
+    ...options,
+    appName: state.appName,
+    image: state.imageId ? ModalImageSelector.fromId(state.imageId) : undefined,
+    imageTag: state.imageTag,
+    sandboxCreateTimeoutS: state.sandboxCreateTimeoutS,
+    workspacePersistence: state.workspacePersistence,
+    snapshotFilesystemTimeoutMs: state.snapshotFilesystemTimeoutMs,
+    snapshotFilesystemRestoreTimeoutMs:
+      state.snapshotFilesystemRestoreTimeoutMs,
+    timeoutMs: state.timeoutMs,
+    idleTimeoutMs: state.idleTimeoutMs,
+    gpu: state.gpu,
+    exposedPorts: state.configuredExposedPorts,
+    environment: state.modalEnvironment ?? options.environment,
+    endpoint: state.endpoint ?? options.endpoint,
+    imageBuilderVersion:
+      state.imageBuilderVersion ?? options.imageBuilderVersion,
+    useSleepCmd: state.useSleepCmd,
+  };
 }
 
 async function resolveModalImage(
@@ -2154,6 +2279,10 @@ function resolveOptions(
     },
     timeoutMs: overrides?.timeoutMs ?? defaults.timeoutMs,
     idleTimeoutMs: overrides?.idleTimeoutMs ?? defaults.idleTimeoutMs,
+    cpu: overrides?.cpu ?? defaults.cpu,
+    cpuLimit: overrides?.cpuLimit ?? defaults.cpuLimit,
+    memoryMiB: overrides?.memoryMiB ?? defaults.memoryMiB,
+    memoryLimitMiB: overrides?.memoryLimitMiB ?? defaults.memoryLimitMiB,
     gpu: overrides?.gpu ?? defaults.gpu,
     exposedPorts: overrides?.exposedPorts ?? defaults.exposedPorts,
     environment: overrides?.environment ?? defaults.environment,
@@ -2227,6 +2356,72 @@ function validateOptions(options: ModalSandboxClientOptions): void {
       );
     }
   }
+  validateModalResourceOptions(options);
+}
+
+function validateModalResourceOptions(
+  options: Pick<
+    ModalSandboxClientOptions,
+    'cpu' | 'cpuLimit' | 'memoryMiB' | 'memoryLimitMiB'
+  >,
+): void {
+  for (const [name, value] of [
+    ['cpu', options.cpu],
+    ['cpuLimit', options.cpuLimit],
+    ['memoryMiB', options.memoryMiB],
+    ['memoryLimitMiB', options.memoryLimitMiB],
+  ] as const) {
+    if (
+      value !== undefined &&
+      (typeof value !== 'number' || !Number.isFinite(value) || value <= 0)
+    ) {
+      throw new UserError(
+        `ModalSandboxClient ${name} must be a positive number.`,
+      );
+    }
+  }
+  if (options.cpu === undefined && options.cpuLimit !== undefined) {
+    throw new UserError(
+      'ModalSandboxClient cpu must be specified when cpuLimit is specified.',
+    );
+  }
+  if (
+    options.cpu !== undefined &&
+    options.cpuLimit !== undefined &&
+    options.cpuLimit < options.cpu
+  ) {
+    throw new UserError(
+      'ModalSandboxClient cpuLimit must be greater than or equal to cpu.',
+    );
+  }
+  if (options.memoryMiB === undefined && options.memoryLimitMiB !== undefined) {
+    throw new UserError(
+      'ModalSandboxClient memoryMiB must be specified when memoryLimitMiB is specified.',
+    );
+  }
+  if (
+    options.memoryMiB !== undefined &&
+    options.memoryLimitMiB !== undefined &&
+    options.memoryLimitMiB < options.memoryMiB
+  ) {
+    throw new UserError(
+      'ModalSandboxClient memoryLimitMiB must be greater than or equal to memoryMiB.',
+    );
+  }
+}
+
+function modalResourceOptionsFrom(
+  options: Partial<ModalSandboxClientOptions>,
+): Pick<
+  ModalSandboxClientOptions,
+  'cpu' | 'cpuLimit' | 'memoryMiB' | 'memoryLimitMiB'
+> {
+  return {
+    cpu: options.cpu,
+    cpuLimit: options.cpuLimit,
+    memoryMiB: options.memoryMiB,
+    memoryLimitMiB: options.memoryLimitMiB,
+  };
 }
 
 function validateModalImageSelector(selector: ModalImageSelector): void {

--- a/packages/agents-extensions/test/sandbox/modal.test.ts
+++ b/packages/agents-extensions/test/sandbox/modal.test.ts
@@ -3,6 +3,7 @@ import {
   SandboxProviderError,
   SandboxUnsupportedFeatureError,
 } from '@openai/agents-core/sandbox';
+import { captureLiveMountCredentialAuthorityIfAbsent } from '@openai/agents-core/sandbox/internal';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -485,6 +486,397 @@ describe('ModalSandboxClient', () => {
     expect(session.state.idleTimeoutMs).toBe(60_000);
   });
 
+  test.each([
+    {
+      name: 'requests',
+      options: { cpu: 1, memoryMiB: 2_048 },
+    },
+    {
+      name: 'requests and limits',
+      options: {
+        cpu: 1,
+        cpuLimit: 4,
+        memoryMiB: 2_048,
+        memoryLimitMiB: 8_192,
+      },
+    },
+  ])('passes Modal resource $name through sandbox creation', async (entry) => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      ...entry.options,
+    } satisfies ModalSandboxClientOptions);
+
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test' },
+      expect.objectContaining(entry.options),
+    );
+    expect(session.state).toMatchObject(entry.options);
+  });
+
+  test('merges Modal resource defaults with per-create overrides', async () => {
+    const client = new ModalSandboxClient({
+      cpu: 1,
+      cpuLimit: 4,
+      memoryMiB: 2_048,
+      memoryLimitMiB: 8_192,
+    });
+
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      cpu: 2,
+      memoryLimitMiB: 4_096,
+    } satisfies ModalSandboxClientOptions);
+
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_test' },
+      expect.objectContaining({
+        cpu: 2,
+        cpuLimit: 4,
+        memoryMiB: 2_048,
+        memoryLimitMiB: 4_096,
+      }),
+    );
+    expect(session.state).toMatchObject({
+      cpu: 2,
+      cpuLimit: 4,
+      memoryMiB: 2_048,
+      memoryLimitMiB: 4_096,
+    });
+  });
+
+  test('serializes and deserializes Modal resource settings', async () => {
+    const client = new ModalSandboxClient();
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      cpu: 1,
+      cpuLimit: 4,
+      memoryMiB: 2_048,
+      memoryLimitMiB: 8_192,
+    } satisfies ModalSandboxClientOptions);
+
+    const serialized = await client.serializeSessionState(session.state);
+    const restored = await new ModalSandboxClient({
+      cpu: 0.5,
+      cpuLimit: 2,
+      memoryMiB: 1_024,
+      memoryLimitMiB: 4_096,
+    }).deserializeSessionState({
+      ...serialized,
+      cpu: 1_000_000,
+      cpuLimit: 2_000_000,
+      memoryMiB: 1_000_000_000,
+      memoryLimitMiB: 2_000_000_000,
+    });
+
+    expect(restored).toMatchObject({
+      cpu: 0.5,
+      cpuLimit: 2,
+      memoryMiB: 1_024,
+      memoryLimitMiB: 4_096,
+    });
+
+    const unconfiguredRestored = await client.deserializeSessionState({
+      ...serialized,
+      cpu: [1, 4],
+      cpuLimit: '4',
+      memoryMiB: null,
+      memoryLimitMiB: [2_048, 8_192],
+    });
+    expect(unconfiguredRestored.cpu).toBeUndefined();
+    expect(unconfiguredRestored.cpuLimit).toBeUndefined();
+    expect(unconfiguredRestored.memoryMiB).toBeUndefined();
+    expect(unconfiguredRestored.memoryLimitMiB).toBeUndefined();
+
+    const legacyPayload = { ...serialized };
+    delete legacyPayload.cpu;
+    delete legacyPayload.cpuLimit;
+    delete legacyPayload.memoryMiB;
+    delete legacyPayload.memoryLimitMiB;
+    const legacyRestored = await client.deserializeSessionState(legacyPayload);
+
+    expect(legacyRestored.cpu).toBeUndefined();
+    expect(legacyRestored.cpuLimit).toBeUndefined();
+    expect(legacyRestored.memoryMiB).toBeUndefined();
+    expect(legacyRestored.memoryLimitMiB).toBeUndefined();
+  });
+
+  test.each([
+    [{ cpu: 0 }, 'ModalSandboxClient cpu must be a positive number.'],
+    [
+      { cpu: Number.POSITIVE_INFINITY },
+      'ModalSandboxClient cpu must be a positive number.',
+    ],
+    [
+      { cpuLimit: 2 },
+      'ModalSandboxClient cpu must be specified when cpuLimit is specified.',
+    ],
+    [
+      { cpu: 2, cpuLimit: 1 },
+      'ModalSandboxClient cpuLimit must be greater than or equal to cpu.',
+    ],
+    [
+      { memoryMiB: 0 },
+      'ModalSandboxClient memoryMiB must be a positive number.',
+    ],
+    [
+      { memoryMiB: Number.NaN },
+      'ModalSandboxClient memoryMiB must be a positive number.',
+    ],
+    [
+      { memoryLimitMiB: 2_048 },
+      'ModalSandboxClient memoryMiB must be specified when memoryLimitMiB is specified.',
+    ],
+    [
+      { memoryMiB: 2_048, memoryLimitMiB: 1_024 },
+      'ModalSandboxClient memoryLimitMiB must be greater than or equal to memoryMiB.',
+    ],
+  ])('rejects invalid Modal resource options %#', async (options, message) => {
+    const client = new ModalSandboxClient();
+
+    await expect(
+      client.create(new Manifest(), {
+        appName: 'sandbox-tests',
+        ...options,
+      } satisfies ModalSandboxClientOptions),
+    ).rejects.toThrow(message);
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('requires fresh creation before resuming with trusted resources', async () => {
+    const client = new ModalSandboxClient();
+    const state: ModalSandboxSessionState = {
+      sandboxId: 'sbx_test',
+      appName: 'sandbox-tests',
+      imageTag: 'debian:bookworm-slim',
+      manifest: new Manifest(),
+      workspacePersistence: 'tar',
+      environment: {},
+      useSleepCmd: true,
+      cpu: 1_000_000,
+      cpuLimit: 2_000_000,
+      memoryMiB: 1_000_000_000,
+      memoryLimitMiB: 2_000_000_000,
+    };
+
+    const resumeOptions = {
+      clientOptions: {
+        appName: 'sandbox-tests',
+        cpu: 1,
+        cpuLimit: 2,
+        memoryMiB: 1_024,
+        memoryLimitMiB: 2_048,
+      },
+    };
+
+    expect(
+      client.serializedSessionStateRequiresFreshCreationForOptions(
+        state,
+        resumeOptions,
+      ),
+    ).toBe(true);
+    await expect(client.resume(state, resumeOptions)).rejects.toThrow(
+      'Modal sandbox resume cannot verify the existing CPU or memory allocation.',
+    );
+    expect(sandboxesFromIdMock).not.toHaveBeenCalled();
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('merges constructor and run-level Modal resources before resume', async () => {
+    const client = new ModalSandboxClient({
+      cpuLimit: 4,
+      memoryLimitMiB: 4_096,
+    });
+    const state: ModalSandboxSessionState = {
+      sandboxId: 'sbx_test',
+      appName: 'sandbox-tests',
+      imageTag: 'debian:bookworm-slim',
+      manifest: new Manifest(),
+      workspacePersistence: 'tar',
+      environment: {},
+      useSleepCmd: true,
+      cpu: 1_000_000,
+      cpuLimit: 2_000_000,
+      memoryMiB: 1_000_000_000,
+      memoryLimitMiB: 2_000_000_000,
+    };
+
+    const restored = await client.deserializeSessionState(
+      state as unknown as Record<string, unknown>,
+    );
+    const resumeOptions = {
+      clientOptions: {
+        appName: 'sandbox-tests',
+        cpu: 2,
+        memoryMiB: 1_024,
+        memoryLimitMiB: 2_048,
+      },
+    };
+
+    expect(
+      client.serializedSessionStateRequiresFreshCreationForOptions(
+        restored,
+        resumeOptions,
+      ),
+    ).toBe(true);
+    await expect(client.resume(restored, resumeOptions)).rejects.toThrow(
+      'Modal sandbox resume cannot verify the existing CPU or memory allocation.',
+    );
+    expect(sandboxesFromIdMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects an owned sandbox when trusted resources are omitted', async () => {
+    const client = new ModalSandboxClient();
+    const state: ModalSandboxSessionState = {
+      sandboxId: 'sbx_test',
+      appName: 'sandbox-tests',
+      imageTag: 'debian:bookworm-slim',
+      manifest: new Manifest(),
+      workspacePersistence: 'tar',
+      environment: {},
+      useSleepCmd: true,
+      cpu: 1_000_000,
+      memoryMiB: 1_000_000_000,
+    };
+
+    expect(
+      client.serializedSessionStateRequiresFreshCreationForOptions(state),
+    ).toBe(true);
+    await expect(client.resume(state)).rejects.toThrow(
+      'Modal sandbox resume cannot verify the existing CPU or memory allocation.',
+    );
+    expect(sandboxesFromIdMock).not.toHaveBeenCalled();
+    expect(sandboxesCreateMock).not.toHaveBeenCalled();
+    expect(sandboxTerminateMock).not.toHaveBeenCalled();
+  });
+
+  test('requires fresh creation when trusted Modal resources change', async () => {
+    const client = new ModalSandboxClient({
+      cpu: 1,
+      cpuLimit: 4,
+      memoryMiB: 1_024,
+      memoryLimitMiB: 4_096,
+    });
+    const session = await client.create(new Manifest(), {
+      appName: 'sandbox-tests',
+      cpu: 2,
+    } satisfies ModalSandboxClientOptions);
+
+    expect(
+      await client.canReusePreservedOwnedSession(session.state, {
+        clientOptions: {
+          appName: 'sandbox-tests',
+          cpu: 2,
+        },
+        trustedManifest: session.state.manifest,
+      }),
+    ).toBe(true);
+
+    expect(
+      await client.canReusePreservedOwnedSession(session.state, {
+        clientOptions: {
+          appName: 'sandbox-tests',
+          cpu: 3,
+        },
+        trustedManifest: session.state.manifest,
+      }),
+    ).toBe(false);
+    expect(session.state).toMatchObject({
+      cpu: 2,
+      cpuLimit: 4,
+      memoryMiB: 1_024,
+      memoryLimitMiB: 4_096,
+    });
+  });
+
+  test('rebinds resources when reusing a selected sandbox', async () => {
+    const manifest = new Manifest();
+    const state: ModalSandboxSessionState = {
+      sandboxId: 'sbx_selected',
+      appName: 'sandbox-tests',
+      imageTag: 'debian:bookworm-slim',
+      manifest,
+      workspacePersistence: 'tar',
+      environment: {},
+      useSleepCmd: true,
+      ownsSandbox: false,
+      cpu: 1,
+      cpuLimit: 2,
+      memoryMiB: 1_024,
+      memoryLimitMiB: 2_048,
+    };
+    captureLiveMountCredentialAuthorityIfAbsent(
+      state.manifest,
+      state.environment,
+    );
+    const client = new ModalSandboxClient();
+
+    const reuseOptions = {
+      trustedManifest: manifest,
+      clientOptions: {
+        appName: 'sandbox-tests',
+        cpu: 2,
+        memoryMiB: 2_048,
+      },
+    };
+    await expect(
+      client.canReusePreservedOwnedSession(state, reuseOptions),
+    ).resolves.toBe(true);
+    client.rebindPreservedOwnedSessionState(state, reuseOptions);
+    expect(state).toMatchObject({
+      cpu: 2,
+      memoryMiB: 2_048,
+    });
+    expect(state.cpuLimit).toBeUndefined();
+    expect(state.memoryLimitMiB).toBeUndefined();
+  });
+
+  test('requires fresh creation when mount credential environment changes', async () => {
+    const manifest = new Manifest({
+      entries: {
+        data: {
+          type: 's3_mount',
+          bucket: 'logs',
+          mountStrategy: { type: 'in_container' },
+        },
+      },
+    }).withInContainerMountBroadCredentialExposureAcknowledged('data');
+    const state: ModalSandboxSessionState = {
+      sandboxId: 'sbx_test',
+      appName: 'sandbox-tests',
+      imageTag: 'debian:bookworm-slim',
+      manifest,
+      workspacePersistence: 'tar',
+      environment: {
+        AWS_ACCESS_KEY_ID: 'original-access',
+        AWS_SECRET_ACCESS_KEY: 'original-secret',
+      },
+      useSleepCmd: true,
+      cpu: 2,
+    };
+    captureLiveMountCredentialAuthorityIfAbsent(
+      state.manifest,
+      state.environment,
+    );
+    const client = new ModalSandboxClient({ cpu: 2 });
+
+    await expect(
+      client.canReusePreservedOwnedSession(state, {
+        trustedManifest: manifest,
+        clientOptions: {
+          appName: 'sandbox-tests',
+          cpu: 2,
+          env: {
+            AWS_ACCESS_KEY_ID: 'rotated-access',
+            AWS_SECRET_ACCESS_KEY: 'rotated-secret',
+          },
+        },
+      }),
+    ).resolves.toBe(false);
+  });
+
   test('materializes git_repo file subpaths as files', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
@@ -500,7 +892,12 @@ describe('ModalSandboxClient', () => {
         return processFailure('unexpected command');
       },
     );
-    const client = new ModalSandboxClient();
+    const client = new ModalSandboxClient({
+      cpu: 1,
+      cpuLimit: 2,
+      memoryMiB: 1_024,
+      memoryLimitMiB: 2_048,
+    });
 
     await client.create(
       new Manifest({
@@ -955,6 +1352,8 @@ describe('ModalSandboxClient', () => {
     sandboxesFromIdMock.mockResolvedValueOnce(existingSandbox);
     const client = new ModalSandboxClient({
       sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+      cpu: 2,
+      memoryMiB: 2_048,
     });
 
     const session = await client.create(new Manifest(), {
@@ -981,11 +1380,25 @@ describe('ModalSandboxClient', () => {
     sandboxesFromIdMock.mockResolvedValueOnce(existingSandbox);
     const client = new ModalSandboxClient({
       sandbox: ModalSandboxSelector.fromId('sbx_existing'),
+      cpu: 2,
+      memoryMiB: 2_048,
     });
 
     const session = await client.create(new Manifest(), {
       appName: 'sandbox-tests',
     });
+    expect(
+      client.serializedSessionStateRequiresFreshCreationForOptions(
+        session.state,
+        {
+          clientOptions: {
+            appName: 'sandbox-tests',
+            cpu: 2,
+            memoryMiB: 2_048,
+          },
+        },
+      ),
+    ).toBe(false);
     sandboxesFromIdMock.mockResolvedValueOnce(existingSandbox);
     const resumed = await client.resume(
       session.state as ModalSandboxSessionState,
@@ -1027,7 +1440,7 @@ describe('ModalSandboxClient', () => {
     expect(sandboxTerminateMock).not.toHaveBeenCalled();
   });
 
-  test('supports editor operations and live resume', async () => {
+  test('supports editor operations and selected live resume', async () => {
     const client = new ModalSandboxClient();
     const session = await client.create(
       new Manifest({
@@ -1061,9 +1474,10 @@ describe('ModalSandboxClient', () => {
       },
     });
 
-    const resumed = await client.resume?.(
-      session.state as ModalSandboxSessionState,
-    );
+    const resumed = await client.resume?.({
+      ...session.state,
+      ownsSandbox: false,
+    } as ModalSandboxSessionState);
     await editor.deleteFile({
       type: 'delete_file',
       path: 'notes.txt',
@@ -1121,7 +1535,7 @@ describe('ModalSandboxClient', () => {
     expect(session.state.manifest.entries).toHaveProperty('second.txt');
   });
 
-  test('wraps Modal resume SDK failures as provider errors', async () => {
+  test('wraps selected Modal resume SDK failures as provider errors', async () => {
     const client = new ModalSandboxClient();
     const session = await client.create(new Manifest(), {
       appName: 'sandbox-tests',
@@ -1129,7 +1543,10 @@ describe('ModalSandboxClient', () => {
     sandboxesFromIdMock.mockRejectedValueOnce(new Error('resume failed'));
 
     await expect(
-      client.resume(session.state as ModalSandboxSessionState),
+      client.resume({
+        ...session.state,
+        ownsSandbox: false,
+      } as ModalSandboxSessionState),
     ).rejects.toMatchObject({
       details: {
         provider: 'modal',
@@ -1178,7 +1595,7 @@ describe('ModalSandboxClient', () => {
     ).rejects.toThrow(/escapes the workspace root/);
   });
 
-  test('preserves configured credentials when resuming', async () => {
+  test('preserves configured credentials when resuming selected sandboxes', async () => {
     const client = new ModalSandboxClient({
       appName: 'sandbox-tests',
       tokenId: 'token-id',
@@ -1186,7 +1603,10 @@ describe('ModalSandboxClient', () => {
     });
     const session = await client.create(new Manifest());
 
-    await client.resume(session.state as ModalSandboxSessionState);
+    await client.resume({
+      ...session.state,
+      ownsSandbox: false,
+    } as ModalSandboxSessionState);
 
     expect(modalClientParams.at(-1)).toMatchObject({
       tokenId: 'token-id',
@@ -1214,6 +1634,11 @@ describe('ModalSandboxClient', () => {
       workspacePersistence: 'snapshot_filesystem',
       environment: {},
       useSleepCmd: true,
+      ownsSandbox: false,
+      cpu: 1_000_000,
+      cpuLimit: 2_000_000,
+      memoryMiB: 1_000_000_000,
+      memoryLimitMiB: 2_000_000_000,
     };
 
     const session = await client.resume(state);
@@ -1414,6 +1839,10 @@ describe('ModalSandboxClient', () => {
       snapshotFilesystemTimeoutMs: 12_345,
       snapshotFilesystemRestoreTimeoutMs: 23_456,
       idleTimeoutMs: 60_000,
+      cpu: 1,
+      cpuLimit: 4,
+      memoryMiB: 2_048,
+      memoryLimitMiB: 8_192,
       exposedPorts: [3000],
     } satisfies ModalSandboxClientOptions);
 
@@ -1438,12 +1867,20 @@ describe('ModalSandboxClient', () => {
         workdir: '/workspace',
         env: {},
         idleTimeoutMs: 60_000,
+        cpu: 1,
+        cpuLimit: 4,
+        memoryMiB: 2_048,
+        memoryLimitMiB: 8_192,
         encryptedPorts: [3000],
       }),
     );
     expect(sandboxTerminateMock).toHaveBeenCalledOnce();
     expect(session.state.snapshotFilesystemRestoreTimeoutMs).toBe(23_456);
     expect(session.state.idleTimeoutMs).toBe(60_000);
+    expect(session.state.cpu).toBe(1);
+    expect(session.state.cpuLimit).toBe(4);
+    expect(session.state.memoryMiB).toBe(2_048);
+    expect(session.state.memoryLimitMiB).toBe(8_192);
   });
 
   test('persists an empty tar when the workspace root is ephemeral', async () => {
@@ -1541,7 +1978,24 @@ describe('ModalSandboxClient', () => {
     const session = await client.create(new Manifest(), {
       appName: 'sandbox-tests',
       workspacePersistence: 'snapshot_filesystem',
+      cpu: 1,
+      cpuLimit: 2,
+      memoryMiB: 1_024,
+      memoryLimitMiB: 2_048,
     } satisfies ModalSandboxClientOptions);
+
+    const reuseOptions = {
+      trustedManifest: session.state.manifest,
+      clientOptions: {
+        appName: 'sandbox-tests',
+        cpu: 3,
+        memoryMiB: 3_072,
+      },
+    };
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, reuseOptions),
+    ).resolves.toBe(true);
+    client.rebindPreservedOwnedSessionState(session.state, reuseOptions);
 
     await session.hydrateWorkspace(
       encodeNativeSnapshotRef({
@@ -1553,10 +2007,25 @@ describe('ModalSandboxClient', () => {
     await session.close();
 
     expect(previousTerminateMock).not.toHaveBeenCalled();
+    expect(sandboxesCreateMock).toHaveBeenCalledWith(
+      { appId: 'ap_test' },
+      { imageId: 'im_snapshot_fs' },
+      expect.objectContaining({
+        cpu: 3,
+        memoryMiB: 3_072,
+      }),
+    );
+    const replacementParams = sandboxesCreateMock.mock.calls.at(-1)?.[2];
+    expect(replacementParams).not.toHaveProperty('cpuLimit');
+    expect(replacementParams).not.toHaveProperty('memoryLimitMiB');
     expect(session.state).toMatchObject({
       sandboxId: 'sbx_restored',
       ownsSandbox: true,
+      cpu: 3,
+      memoryMiB: 3_072,
     });
+    expect(session.state.cpuLimit).toBeUndefined();
+    expect(session.state.memoryLimitMiB).toBeUndefined();
     expect(replacementTerminateMock).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
This pull request adds optional CPU and memory requests and limits to the Modal sandbox client.

The resource settings are merged across client and per-create options, validated before provider side effects, persisted in session state, and forwarded during initial creation and snapshot-based recreation. Existing serialized states without these fields remain compatible, while malformed persisted resource values are rejected before resume.