### PR TITLE
fix(core): honor exact call approval decisions

### DIFF
--- a/.changeset/exact-call-approval-decisions.md
+++ b/.changeset/exact-call-approval-decisions.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: honor exact call approval decisions before sticky defaults

--- a/packages/agents-core/src/runContext.ts
+++ b/packages/agents-core/src/runContext.ts
@@ -489,34 +489,18 @@ export class RunContext<TContext = UnknownContext> {
       rawItem,
     );
     if (rawItem.type === 'function_call') {
-      const scopedEntries = this.#getFunctionApprovalEntries(
-        toolName,
-        false,
+      return this.#resolveFunctionApprovalEntryGroups(
         agent,
-      );
-      const stickyDecision = this.#resolveStickyApprovalEntries(scopedEntries);
-      if (stickyDecision !== undefined) {
-        return stickyDecision;
-      }
-      const legacyEntries = this.#getLegacyFunctionApprovalEntries(toolName);
-      const legacyStickyDecision =
-        this.#resolveStickyApprovalEntries(legacyEntries);
-      if (legacyStickyDecision !== undefined) {
-        return legacyStickyDecision;
-      }
-      if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
-        return (
-          this.#resolveApprovalEntries(scopedEntries, callId) ??
-          this.#resolveApprovalEntries(legacyEntries, callId)
-        );
-      }
-      return undefined;
+        toolName,
+        callId,
+        this.#approvalInvocations.get(agent)?.get(callId) === fingerprint,
+      )?.decision;
     }
     const entries = this.#getToolApprovalEntries(toolName, agent);
     if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
-      const scopedDecision = this.#resolveApprovalEntries(entries, callId);
-      if (scopedDecision !== undefined) {
-        return scopedDecision;
+      const exactDecision = this.#resolveExactApprovalEntries(entries, callId);
+      if (exactDecision !== undefined) {
+        return exactDecision;
       }
     }
     const stickyEntries = getHostedMcpApprovalRequestIdentity(rawItem)
@@ -535,53 +519,43 @@ export class RunContext<TContext = UnknownContext> {
     toolName: string,
     rawItem: ApprovalCapableToolCall,
   ): string | undefined {
-    const { callId, fingerprint } = this._validateToolInvocation(
+    if (rawItem.type === 'function_call') {
+      const { callId, fingerprint } = this._validateToolInvocation(
+        agent,
+        toolName,
+        rawItem,
+      );
+      const resolution = this.#resolveFunctionApprovalEntryGroups(
+        agent,
+        toolName,
+        callId,
+        this.#approvalInvocations.get(agent)?.get(callId) === fingerprint,
+      );
+      if (resolution?.decision !== false) {
+        return undefined;
+      }
+      return this.#getRejectionMessageForRejectedCall(
+        resolution.entries,
+        callId,
+      );
+    }
+    const decision = this._resolveToolInvocationApproval(
       agent,
       toolName,
       rawItem,
     );
-    if (rawItem.type === 'function_call') {
-      const scopedEntries = this.#getFunctionApprovalEntries(
-        toolName,
-        false,
-        agent,
-      );
-      const stickyMessage = scopedEntries.find(
-        (entry) => entry.rejected === true,
-      )?.stickyRejectMessage;
-      if (stickyMessage !== undefined) {
-        return stickyMessage;
-      }
-      const legacyEntries = this.#getLegacyFunctionApprovalEntries(toolName);
-      const legacyStickyMessage = legacyEntries.find(
-        (entry) => entry.rejected === true,
-      )?.stickyRejectMessage;
-      if (legacyStickyMessage !== undefined) {
-        return legacyStickyMessage;
-      }
-      if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
-        return (
-          this.#getRejectionMessageFromEntries(scopedEntries, callId) ??
-          this.#getRejectionMessageFromEntries(legacyEntries, callId)
-        );
-      }
+    if (decision !== false) {
       return undefined;
     }
+    const callId = getToolInvocationCallId(rawItem)!;
     const entries = this.#getToolApprovalEntries(toolName, agent);
-    if (this.#approvalInvocations.get(agent)?.get(callId) === fingerprint) {
-      const scopedMessage = this.#getRejectionMessageFromEntries(
-        entries,
-        callId,
-      );
-      if (scopedMessage !== undefined) {
-        return scopedMessage;
-      }
-    }
     const stickyEntries = getHostedMcpApprovalRequestIdentity(rawItem)
       ? this.#getHostedMcpApprovalEntries(toolName)
       : this.#getApprovalEntries(toolName, false);
-    return stickyEntries.find((entry) => entry.rejected === true)
-      ?.stickyRejectMessage;
+    return this.#getRejectionMessageForRejectedCall(
+      [...entries, ...stickyEntries],
+      callId,
+    );
   }
 
   /**
@@ -952,29 +926,15 @@ export class RunContext<TContext = UnknownContext> {
     callId: string,
     agent: Agent<any, any>,
   ): string | undefined {
-    const scopedEntries = this.#getFunctionApprovalEntries(
-      toolName,
-      false,
+    const resolution = this.#resolveFunctionApprovalEntryGroups(
       agent,
-    );
-    const scopedDecision = this.#resolveApprovalEntries(scopedEntries, callId);
-    const scopedMessage = this.#getRejectionMessageFromEntries(
-      scopedEntries,
+      toolName,
       callId,
     );
-    if (scopedMessage !== undefined) {
-      return scopedMessage;
+    if (resolution?.decision !== false) {
+      return undefined;
     }
-    if (
-      scopedDecision === undefined &&
-      this.#functionApprovalState.legacyApprovals.size > 0
-    ) {
-      return this.#getRejectionMessageFromEntries(
-        this.#getLegacyFunctionApprovalEntries(toolName),
-        callId,
-      );
-    }
-    return undefined;
+    return this.#getRejectionMessageForRejectedCall(resolution.entries, callId);
   }
 
   /**
@@ -1122,20 +1082,13 @@ export class RunContext<TContext = UnknownContext> {
   }) {
     const { toolName, callId, functionTool = true, agent } = approval;
     if (agent) {
-      const scopedDecision = this.#resolveApprovalEntries(
-        this.#getFunctionApprovalEntries(toolName, functionTool, agent),
+      return this.#resolveFunctionApprovalEntryGroups(
+        agent,
+        toolName,
         callId,
-      );
-      if (scopedDecision !== undefined) {
-        return scopedDecision;
-      }
-      if (this.#functionApprovalState.legacyApprovals.size === 0) {
-        return undefined;
-      }
-      return this.#resolveApprovalEntries(
-        this.#getLegacyFunctionApprovalEntries(toolName),
-        callId,
-      );
+        true,
+        functionTool,
+      )?.decision;
     }
 
     const includeFunctionState =
@@ -1193,11 +1146,16 @@ export class RunContext<TContext = UnknownContext> {
     approvalEntries: readonly ApprovalRecord[],
     callId: string,
   ): boolean | undefined {
-    const stickyDecision = this.#resolveStickyApprovalEntries(approvalEntries);
-    if (stickyDecision !== undefined) {
-      return stickyDecision;
-    }
+    return (
+      this.#resolveExactApprovalEntries(approvalEntries, callId) ??
+      this.#resolveStickyApprovalEntries(approvalEntries)
+    );
+  }
 
+  #resolveExactApprovalEntries(
+    approvalEntries: readonly ApprovalRecord[],
+    callId: string,
+  ): boolean | undefined {
     const individualCallApproval = approvalEntries.some((approvalEntry) =>
       Array.isArray(approvalEntry.approved)
         ? approvalEntry.approved.includes(callId)
@@ -1225,6 +1183,49 @@ export class RunContext<TContext = UnknownContext> {
     }
 
     return undefined;
+  }
+
+  #resolveApprovalEntryGroups(
+    approvalEntryGroups: readonly (readonly ApprovalRecord[])[],
+    callId: string,
+    includeExactDecisions = true,
+  ): { decision: boolean; entries: readonly ApprovalRecord[] } | undefined {
+    if (includeExactDecisions) {
+      for (const entries of approvalEntryGroups) {
+        const decision = this.#resolveExactApprovalEntries(entries, callId);
+        if (decision !== undefined) {
+          return { decision, entries };
+        }
+      }
+    }
+    for (const entries of approvalEntryGroups) {
+      const decision = this.#resolveStickyApprovalEntries(entries);
+      if (decision !== undefined) {
+        return { decision, entries };
+      }
+    }
+    return undefined;
+  }
+
+  #resolveFunctionApprovalEntryGroups(
+    agent: Agent<any, any>,
+    toolName: string,
+    callId: string,
+    includeExactDecisions = true,
+    includeFunctionAliases = false,
+  ) {
+    return this.#resolveApprovalEntryGroups(
+      [
+        this.#getFunctionApprovalEntries(
+          toolName,
+          includeFunctionAliases,
+          agent,
+        ),
+        this.#getLegacyFunctionApprovalEntries(toolName),
+      ],
+      callId,
+      includeExactDecisions,
+    );
   }
 
   #resolveStickyApprovalEntries(
@@ -1255,6 +1256,16 @@ export class RunContext<TContext = UnknownContext> {
   }
 
   #getRejectionMessageFromEntries(
+    approvalEntries: readonly ApprovalRecord[],
+    callId: string,
+  ): string | undefined {
+    if (this.#resolveExactApprovalEntries(approvalEntries, callId) === true) {
+      return undefined;
+    }
+    return this.#getRejectionMessageForRejectedCall(approvalEntries, callId);
+  }
+
+  #getRejectionMessageForRejectedCall(
     approvalEntries: readonly ApprovalRecord[],
     callId: string,
   ): string | undefined {
@@ -1390,13 +1401,35 @@ export class RunContext<TContext = UnknownContext> {
       approved: [] as string[],
       rejected: [] as string[],
     };
-    const decisions = approved
-      ? approvalEntry.approved
-      : approvalEntry.rejected;
-    if (Array.isArray(decisions) && !decisions.includes(callId)) {
-      decisions.push(callId);
+    const opposite = approved ? approvalEntry.rejected : approvalEntry.approved;
+    if (Array.isArray(opposite)) {
+      const oppositeIndex = opposite.indexOf(callId);
+      if (oppositeIndex !== -1) {
+        opposite.splice(oppositeIndex, 1);
+      }
     }
-    if (!approved && message !== undefined) {
+    let decisions = approved ? approvalEntry.approved : approvalEntry.rejected;
+    if (decisions !== true) {
+      if (!Array.isArray(decisions)) {
+        decisions = [];
+        if (approved) {
+          approvalEntry.approved = decisions;
+        } else {
+          approvalEntry.rejected = decisions;
+        }
+      }
+      if (!decisions.includes(callId)) {
+        decisions.push(callId);
+      }
+    }
+    if (approved) {
+      if (approvalEntry.messages) {
+        delete approvalEntry.messages[callId];
+        if (Object.keys(approvalEntry.messages).length === 0) {
+          delete approvalEntry.messages;
+        }
+      }
+    } else if (message !== undefined) {
       approvalEntry.messages = approvalEntry.messages ?? {};
       approvalEntry.messages[callId] = message;
     }

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -157,8 +157,10 @@ import {
  *   scopes persistent hosted MCP approvals by server label and tool name, preserves
  *   JSON-compatible tool outputs as structured data, and adds durable pending input
  *   and accepted-response resume state.
+ * - 1.19: Lets an exact call approval decision override a sticky decision for the
+ *   same canonical approval identity.
  */
-export const CURRENT_SCHEMA_VERSION = '1.18' as const;
+export const CURRENT_SCHEMA_VERSION = '1.19' as const;
 export const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -178,6 +180,7 @@ export const SUPPORTED_SCHEMA_VERSIONS = [
   '1.15',
   '1.16',
   '1.17',
+  '1.18',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -186,7 +189,7 @@ const $schemaVersion = z.enum(SUPPORTED_SCHEMA_VERSIONS);
 function schemaVersionSupportsV118State(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
-  return schemaVersion === CURRENT_SCHEMA_VERSION;
+  return schemaVersion === '1.18' || schemaVersion === CURRENT_SCHEMA_VERSION;
 }
 
 function schemaVersionSupportsV116State(
@@ -5350,7 +5353,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       stateJson.ambiguousToolInvocationCallIds === undefined)
   ) {
     throw new UserError(
-      'RunState schema 1.18 requires explicit approval, completed, completion-evidence, and ambiguous invocation records.',
+      `RunState schema ${schemaVersion} requires explicit approval, completed, completion-evidence, and ambiguous invocation records.`,
     );
   }
   if (schemaVersionSupportsV118State(schemaVersion)) {
@@ -5653,7 +5656,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       schemaVersion,
     );
     if (
-      schemaVersion !== CURRENT_SCHEMA_VERSION &&
+      !schemaVersionSupportsV118State(schemaVersion) &&
       shouldRestoreSerializedContext
     ) {
       restoreLegacyHostedMcpApprovalsForPendingRequests(

--- a/packages/agents-core/test/agentScenarios.test.ts
+++ b/packages/agents-core/test/agentScenarios.test.ts
@@ -2912,6 +2912,83 @@ describe('Agent scenarios (examples and docs patterns)', () => {
     },
   );
 
+  it.each([
+    { name: 'run with sticky approval', stream: false, sticky: 'approve' },
+    { name: 'stream with sticky approval', stream: true, sticky: 'approve' },
+    { name: 'run with sticky rejection', stream: false, sticky: 'reject' },
+    { name: 'stream with sticky rejection', stream: true, sticky: 'reject' },
+  ] as const)(
+    'honors exact call decisions after a serialized $name resume',
+    async ({ stream, sticky }) => {
+      const executions: string[] = [];
+      const approvalTool = tool({
+        name: 'exact_decision_tool',
+        description: 'Executes only approved calls.',
+        parameters: z.object({ value: z.string() }),
+        needsApproval: true,
+        execute: async ({ value }) => {
+          executions.push(value);
+          return value;
+        },
+      });
+      const model = new RecordingModel();
+      model.addMultipleTurnOutputs([
+        [
+          functionToolCall(
+            approvalTool.name,
+            JSON.stringify({ value: 'sticky' }),
+            'sticky-call',
+          ),
+          functionToolCall(
+            approvalTool.name,
+            JSON.stringify({ value: 'exception' }),
+            'exception-call',
+          ),
+        ],
+        [textMessage('done')],
+      ]);
+      const agent = new Agent({
+        name: 'ExactDecisionResumeAgent',
+        model,
+        tools: [approvalTool],
+      });
+      const runWithMode = async (
+        input: string | RunState<unknown, Agent<unknown, 'text'>>,
+      ) => {
+        if (stream) {
+          const result = await run(agent, input, { stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input);
+      };
+
+      const first = await runWithMode('start');
+      expect(first.interruptions).toHaveLength(2);
+      if (sticky === 'approve') {
+        first.state.approve(first.interruptions[0], { alwaysApprove: true });
+        first.state.reject(first.interruptions[1], {
+          message: 'Denied exactly.',
+        });
+      } else {
+        first.state.reject(first.interruptions[0], {
+          alwaysReject: true,
+          message: 'Denied by default.',
+        });
+        first.state.approve(first.interruptions[1]);
+      }
+
+      const restored = await RunState.fromString(agent, first.state.toString());
+      const resumed = await runWithMode(restored);
+
+      expect(resumed.interruptions).toHaveLength(0);
+      expect(resumed.finalOutput).toBe('done');
+      expect(executions).toEqual([
+        sticky === 'approve' ? 'sticky' : 'exception',
+      ]);
+    },
+  );
+
   it('restores a pending schema 1.17 sticky MCP approval as exact-call approval', async () => {
     const model = new RecordingModel();
     model.addMultipleTurnOutputs([

--- a/packages/agents-core/test/fixtures/run-state/README.md
+++ b/packages/agents-core/test/fixtures/run-state/README.md
@@ -10,7 +10,7 @@ This directory is immutable compatibility evidence for released `RunState` write
 
 Each historical fixture records its package version, release tag, full source commit, npm integrity, scenario, path, and SHA-256 in `sources.json`. The published package and npm integrity identify the primary writer artifact; the tag and commit are supplementary source provenance. Minimal fixtures prove the writer format for every published schema. Feature and resume fixtures are intentionally limited to durable boundaries that need more than an empty state to exercise compatibility.
 
-The released `1.17` sandbox format predates the mount-credential redaction boundary added by unreleased schema `1.18`, so this corpus intentionally does not fabricate a released credential-redaction fixture. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
+The released `1.17` sandbox format predates the mount-credential redaction boundary added by schema `1.18`. The `v0.16.0` writer fixtures establish the released `1.18` boundary, including canonical per-call approval identity. Schema `1.19` changes mixed sticky and exact approval decisions to resolve the exact call first. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
 
 ## Regeneration
 

--- a/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
+++ b/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
@@ -670,6 +670,33 @@ if (schemaVersion === '1.17') {
   outputs['side-effect-committed'] = JSON.parse(sideEffectState.toString());
 }
 
+if (schemaVersion === '1.18') {
+  const approvalAgent = new sdk.Agent({ name: 'ApprovalOverrideAgent' });
+  const approvalState = new sdk.RunState(
+    new sdk.RunContext({ fixture: 'per-call-approval-override' }),
+    'approve selectively',
+    approvalAgent,
+    3,
+  );
+  approvalState.approve(
+    new sdk.RunToolApprovalItem(
+      functionCall('sensitive_tool', 'sticky-call'),
+      approvalAgent,
+    ),
+    { alwaysApprove: true },
+  );
+  approvalState.reject(
+    new sdk.RunToolApprovalItem(
+      functionCall('sensitive_tool', 'exception-call'),
+      approvalAgent,
+    ),
+    { message: 'Denied exactly.' },
+  );
+  outputs['per-call-approval-override'] = JSON.parse(
+    approvalState.toString(),
+  );
+}
+
 process.stdout.write(JSON.stringify(outputs));
 `;
 }

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.18-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.18-minimal.json
@@ -1,5 +1,5 @@
 {
-  "$schemaVersion": "1.19",
+  "$schemaVersion": "1.18",
   "currentTurn": 0,
   "currentAgent": {
     "name": "HistoricalAgent"

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.18-per-call-approval-override.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.18-per-call-approval-override.json
@@ -1,0 +1,63 @@
+{
+  "$schemaVersion": "1.18",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "ApprovalOverrideAgent"
+  },
+  "originalInput": "approve selectively",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "functionApprovals": [
+      {
+        "agentIdentity": "ApprovalOverrideAgent",
+        "approvals": {
+          "[\"bare\",\"sensitive_tool\"]": {
+            "approved": true,
+            "rejected": ["exception-call"],
+            "messages": {
+              "exception-call": "Denied exactly."
+            }
+          }
+        }
+      }
+    ],
+    "approvalInvocations": [
+      {
+        "agentIdentity": "ApprovalOverrideAgent",
+        "invocations": {
+          "sticky-call": "{\"caller\":{\"type\":\"direct\"},\"payload\":{\"format\":\"json\",\"value\":{}},\"toolName\":\"[\\\"bare\\\",\\\"sensitive_tool\\\"]\",\"type\":\"function_call\"}",
+          "exception-call": "{\"caller\":{\"type\":\"direct\"},\"payload\":{\"format\":\"json\",\"value\":{}},\"toolName\":\"[\\\"bare\\\",\\\"sensitive_tool\\\"]\",\"type\":\"function_call\"}"
+        },
+        "approvals": {}
+      }
+    ],
+    "context": {
+      "fixture": "per-call-approval-override"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "completedToolInvocations": [],
+  "completedToolInvocationEvidence": [],
+  "ambiguousToolInvocationCallIds": [],
+  "trace": null
+}

--- a/packages/agents-core/test/fixtures/run-state/sources.json
+++ b/packages/agents-core/test/fixtures/run-state/sources.json
@@ -1,6 +1,6 @@
 {
   "formatVersion": 1,
-  "currentSchemaAtCreation": "1.18",
+  "currentSchemaAtCreation": "1.19",
   "schemas": [
     {
       "schemaVersion": "1.0",
@@ -294,16 +294,37 @@
     },
     {
       "schemaVersion": "1.18",
+      "status": "published_writer",
+      "packageVersion": "0.16.0",
+      "tag": "v0.16.0",
+      "commit": "d988dc5b7f9115442623466e0aab2fbf8eb73013",
+      "npmIntegrity": "sha512-k0ioc6IM36Yli/Wwe/6uFdU85EPj45RVaj+0oSSqrmZEtgwrPCYA2Ohe8LVol//IaM25QjqE09mhiRD74tE8IQ==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.18-minimal.json",
+          "sha256": "114f59b4c2a6a52fa1597a61c9cbfed52f003e8d57e7c55dfa5a31586416515f"
+        },
+        {
+          "scenario": "per-call-approval-override",
+          "kind": "resume",
+          "path": "historical/v1.18-per-call-approval-override.json",
+          "sha256": "a1ae0631fe1aa2d6866bad3f6aee6af7fd22b1c11f814b9cbea86ffd0d8a2ef9"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.19",
       "status": "current_unreleased",
-      "commit": "49fe593b603410e713f67cf853a578e61d480b48",
-      "reason": "Supported on main but not emitted by the latest released package v0.14.3."
+      "reason": "Supported on main but not emitted by the latest released package v0.16.0."
     }
   ],
   "expectedNormalizedFixtures": [
     {
       "sourceSchemaVersion": "1.0",
       "path": "expected/v1.0-normalized-current.json",
-      "sha256": "114f59b4c2a6a52fa1597a61c9cbfed52f003e8d57e7c55dfa5a31586416515f"
+      "sha256": "e2ac4f6f2ba1631eb8c95c35c7d1895a30d40a5077dbd5476107e57a01de1edb"
     }
   ],
   "negativeFixtures": [

--- a/packages/agents-core/test/runContext.test.ts
+++ b/packages/agents-core/test/runContext.test.ts
@@ -7,6 +7,7 @@ import {
   getFunctionToolLookupKey,
   getFunctionToolStateKeyForCall,
 } from '../src/toolIdentity';
+import { getToolInvocationFingerprint } from '../src/toolInvocation';
 import { z } from 'zod';
 
 const agent = new Agent({ name: 'A' });
@@ -224,6 +225,70 @@ describe('RunContext', () => {
     );
   });
 
+  it('lets an exact rejection override and then restore sticky approval', () => {
+    const ctx = new RunContext();
+    const stickyCall = createApproval('sticky-call');
+    const exceptionCall = createApproval('exception-call');
+
+    ctx.approveTool(stickyCall, { alwaysApprove: true });
+    ctx.rejectTool(exceptionCall, { message: 'Denied exactly.' });
+
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'exception-call' }),
+    ).toBe(false);
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'other-call' }),
+    ).toBe(true);
+    expect(ctx.getRejectionMessage('toolX', 'exception-call')).toBe(
+      'Denied exactly.',
+    );
+
+    ctx.approveTool(exceptionCall);
+
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'exception-call' }),
+    ).toBe(true);
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'other-call' }),
+    ).toBe(true);
+    expect(ctx.getRejectionMessage('toolX', 'exception-call')).toBeUndefined();
+  });
+
+  it('lets an exact approval override and then restore sticky rejection', () => {
+    const ctx = new RunContext();
+    const stickyCall = createApproval('sticky-call');
+    const exceptionCall = createApproval('exception-call');
+
+    ctx.rejectTool(stickyCall, {
+      alwaysReject: true,
+      message: 'Denied by default.',
+    });
+    ctx.approveTool(exceptionCall);
+
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'exception-call' }),
+    ).toBe(true);
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'other-call' }),
+    ).toBe(false);
+    expect(ctx.getRejectionMessage('toolX', 'exception-call')).toBeUndefined();
+    expect(ctx.getRejectionMessage('toolX', 'other-call')).toBe(
+      'Denied by default.',
+    );
+
+    ctx.rejectTool(exceptionCall);
+
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'exception-call' }),
+    ).toBe(false);
+    expect(
+      ctx.isToolApproved({ toolName: 'toolX', callId: 'other-call' }),
+    ).toBe(false);
+    expect(ctx.getRejectionMessage('toolX', 'exception-call')).toBe(
+      'Denied by default.',
+    );
+  });
+
   it('scopes function approval decisions to the owning agent', () => {
     const otherAgent = new Agent({ name: 'B' });
     const first = createApproval('shared-call');
@@ -269,6 +334,163 @@ describe('RunContext', () => {
     expect(
       ctx._getFunctionRejectionMessage(toolName, 'shared-call', otherAgent),
     ).toBe('Rejected for B.');
+  });
+
+  it('preserves an exact legacy rejection message over scoped sticky approval', () => {
+    const ctx = new RunContext();
+    const toolName = getFunctionToolStateKeyForCall(rawItem)!;
+    const exceptionCall = createApproval('exception-call');
+    const agentsByIdentity = new Map([[agent.name, agent]]);
+    ctx._rebuildFunctionApprovals(
+      [
+        {
+          agentIdentity: agent.name,
+          approvals: {
+            [toolName]: { approved: true, rejected: [] },
+          },
+        },
+      ],
+      agentsByIdentity,
+    );
+    ctx._rebuildLegacyFunctionApprovals({
+      toolX: {
+        approved: [],
+        rejected: ['exception-call'],
+        messages: { 'exception-call': 'Rejected by legacy decision.' },
+      },
+    });
+    ctx._rebuildApprovalInvocations(
+      [
+        {
+          agentIdentity: agent.name,
+          invocations: {
+            'exception-call': getToolInvocationFingerprint(
+              toolName,
+              exceptionCall.rawItem,
+            ),
+          },
+          approvals: {},
+        },
+      ],
+      agentsByIdentity,
+    );
+
+    expect(
+      ctx._resolveToolInvocationApproval(
+        agent,
+        toolName,
+        exceptionCall.rawItem,
+      ),
+    ).toBe(false);
+    expect(
+      ctx.isToolApproved({
+        toolName,
+        callId: 'exception-call',
+        functionTool: false,
+        agent,
+      }),
+    ).toBe(false);
+    expect(
+      ctx.isToolApproved({
+        toolName,
+        callId: 'other-call',
+        functionTool: false,
+        agent,
+      }),
+    ).toBe(true);
+    expect(
+      ctx._getFunctionRejectionMessage(toolName, 'exception-call', agent),
+    ).toBe('Rejected by legacy decision.');
+    expect(
+      ctx._getToolInvocationRejectionMessage(
+        agent,
+        toolName,
+        exceptionCall.rawItem,
+      ),
+    ).toBe('Rejected by legacy decision.');
+    expect(
+      ctx._getFunctionRejectionMessage(toolName, 'other-call', agent),
+    ).toBeUndefined();
+  });
+
+  it('does not borrow function rejection messages from lower-priority groups', () => {
+    const toolName = getFunctionToolStateKeyForCall(rawItem)!;
+    const exceptionCall = createApproval('exception-call');
+    const agentsByIdentity = new Map([[agent.name, agent]]);
+    const bindExceptionCall = (ctx: RunContext) =>
+      ctx._rebuildApprovalInvocations(
+        [
+          {
+            agentIdentity: agent.name,
+            invocations: {
+              'exception-call': getToolInvocationFingerprint(
+                toolName,
+                exceptionCall.rawItem,
+              ),
+            },
+            approvals: {},
+          },
+        ],
+        agentsByIdentity,
+      );
+
+    const scopedExact = new RunContext();
+    scopedExact._rebuildFunctionApprovals(
+      [
+        {
+          agentIdentity: agent.name,
+          approvals: {
+            [toolName]: { approved: [], rejected: ['exception-call'] },
+          },
+        },
+      ],
+      agentsByIdentity,
+    );
+    scopedExact._rebuildLegacyFunctionApprovals({
+      toolX: {
+        approved: [],
+        rejected: true,
+        stickyRejectMessage: 'Losing legacy message.',
+      },
+    });
+    bindExceptionCall(scopedExact);
+
+    expect(
+      scopedExact._getToolInvocationRejectionMessage(
+        agent,
+        toolName,
+        exceptionCall.rawItem,
+      ),
+    ).toBeUndefined();
+
+    const legacyExact = new RunContext();
+    legacyExact._rebuildFunctionApprovals(
+      [
+        {
+          agentIdentity: agent.name,
+          approvals: {
+            [toolName]: {
+              approved: [],
+              rejected: true,
+              stickyRejectMessage: 'Losing scoped message.',
+            },
+          },
+        },
+      ],
+      agentsByIdentity,
+    );
+    legacyExact._rebuildLegacyFunctionApprovals({
+      toolX: { approved: [], rejected: ['exception-call'] },
+    });
+    bindExceptionCall(legacyExact);
+
+    expect(
+      legacyExact._getToolInvocationRejectionMessage(
+        agent,
+        toolName,
+        exceptionCall.rawItem,
+      ),
+    ).toBeUndefined();
   });
 
   it('reuses alwaysReject messages for future call ids', () => {

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -10753,7 +10753,7 @@ export function registerRunStateApprovalTests(): void {
       });
     });
 
-    it('preserves schema 1.17 sticky rejection precedence over an exact approval', async () => {
+    it('preserves fail-closed sticky rejection precedence during schema 1.17 hosted MCP migration', async () => {
       const agent = new Agent({ name: 'LegacyHostedMcpPrecedenceAgent' });
       const pendingApproval = new ToolApprovalItem(
         {

--- a/packages/agents-core/test/runState.compatibility.test.ts
+++ b/packages/agents-core/test/runState.compatibility.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../src/runState';
 import { setDefaultModelProvider } from '../src/providers';
 import { tool } from '../src/tool';
+import { getFunctionToolStateKey } from '../src/toolIdentity';
 import { Usage } from '../src/usage';
 import { ScriptedModel, modelResponse } from '../src/testing';
 
@@ -117,6 +118,7 @@ describe('historical RunState compatibility corpus', () => {
       '1.14',
       '1.15',
       '1.17',
+      '1.18',
     ]);
     expect(
       manifest.schemas
@@ -127,7 +129,7 @@ describe('historical RunState compatibility corpus', () => {
       manifest.schemas
         .filter((entry) => entry.status === 'current_unreleased')
         .map((entry) => entry.schemaVersion),
-    ).toEqual(['1.18']);
+    ).toEqual(['1.19']);
   });
 
   it('pins every fixture to immutable bytes and complete writer provenance', () => {
@@ -289,6 +291,58 @@ describe('historical RunState compatibility corpus', () => {
           item.output === 'side effect completed',
       ),
     ).toHaveLength(1);
+  });
+
+  it('honors an exact rejection from the released schema 1.18 writer', async () => {
+    const approvalTool = tool({
+      name: 'sensitive_tool',
+      description: 'Requires an exact approval decision.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute: async () => 'unused',
+    });
+    const agent = new Agent({
+      name: 'ApprovalOverrideAgent',
+      tools: [approvalTool],
+    });
+    const buildCall = (callId: string) => ({
+      id: `fc_${callId}`,
+      type: 'function_call' as const,
+      name: approvalTool.name,
+      callId,
+      status: 'completed' as const,
+      arguments: '{}',
+      providerData: {},
+    });
+    const restored = await RunState.fromString(
+      agent,
+      readFixture('historical/v1.18-per-call-approval-override.json'),
+    );
+    const toolName = getFunctionToolStateKey(approvalTool)!;
+    const exceptionCall = buildCall('exception-call');
+
+    expect(
+      restored._context._resolveToolInvocationApproval(
+        agent,
+        toolName,
+        exceptionCall,
+      ),
+    ).toBe(false);
+    expect(
+      restored._context._getToolInvocationRejectionMessage(
+        agent,
+        toolName,
+        exceptionCall,
+      ),
+    ).toBe('Denied exactly.');
+    expect(
+      restored._context._resolveToolInvocationApproval(
+        agent,
+        toolName,
+        buildCall('other-call'),
+      ),
+    ).toBe(true);
+    expect(restored.toJSON().$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
   });
 
   it.each(manifest.negativeFixtures.filter((fixture) => fixture.expectedError))(

--- a/packages/agents-core/test/toolInvocationReplay.test.ts
+++ b/packages/agents-core/test/toolInvocationReplay.test.ts
@@ -11,7 +11,7 @@ import {
 import type { ModelResponse } from '../src/model';
 import { Runner } from '../src/run';
 import { RunContext } from '../src/runContext';
-import { RunState } from '../src/runState';
+import { CURRENT_SCHEMA_VERSION, RunState } from '../src/runState';
 import {
   applyPatchTool,
   attachClientToolSearchExecutor,
@@ -171,7 +171,7 @@ describe('tool invocation replay binding', () => {
       1,
     ).toJSON() as any;
 
-    expect(serialized.$schemaVersion).toBe('1.18');
+    expect(serialized.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(serialized.context.approvalInvocations).toEqual([]);
     expect(serialized.completedToolInvocations).toEqual([]);
     expect(serialized.completedToolInvocationEvidence).toEqual([]);
@@ -205,7 +205,9 @@ describe('tool invocation replay binding', () => {
 
       await expect(
         RunState.fromString(agent, JSON.stringify(serialized)),
-      ).rejects.toThrow(UserError);
+      ).rejects.toThrow(
+        `RunState schema ${CURRENT_SCHEMA_VERSION} requires explicit approval, completed, completion-evidence, and ambiguous invocation records.`,
+      );
     },
   );
 
@@ -838,7 +840,7 @@ describe('tool invocation replay binding', () => {
       expect(calls).toEqual(['first']);
 
       const serialized = secondInterruption.state.toJSON() as any;
-      expect(serialized.$schemaVersion).toBe('1.18');
+      expect(serialized.$schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
       expect(
         serialized.context.approvalInvocations[0].invocations[firstCallId],
       ).toBeTypeOf('string');


### PR DESCRIPTION
This pull request fixes approval resolution so an exact per-call approval or rejection takes precedence over a sticky default for the same canonical approval identity.

It also advances RunState to schema 1.19 while retaining compatibility with the released schema 1.18 format. The existing schema 1.17 hosted MCP migration remains fail closed and continues to preserve its legacy sticky-decision precedence for ambiguous identity migration.