### PR TITLE
feat: allow Docker sandboxes to disable networking

### DIFF
--- a/.changeset/calm-dockers-rest.md
+++ b/.changeset/calm-dockers-rest.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: allow Docker sandboxes to disable networking

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -158,7 +158,9 @@ import {
  *   JSON-compatible tool outputs as structured data, and adds durable pending input
  *   and accepted-response resume state.
  * - 1.19: Lets an exact call approval decision override a sticky decision for the
- *   same canonical approval identity.
+ *   same canonical approval identity, and adds sandbox session-state envelope version 4
+ *   so Docker network-isolation state cannot be consumed by older SDKs that would drop it
+ *   during container replacement.
  */
 export const CURRENT_SCHEMA_VERSION = '1.19' as const;
 export const SUPPORTED_SCHEMA_VERSIONS = [
@@ -189,7 +191,15 @@ const $schemaVersion = z.enum(SUPPORTED_SCHEMA_VERSIONS);
 function schemaVersionSupportsV118State(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
-  return schemaVersion === '1.18' || schemaVersion === CURRENT_SCHEMA_VERSION;
+  return (
+    schemaVersion === '1.18' || schemaVersionSupportsV119State(schemaVersion)
+  );
+}
+
+function schemaVersionSupportsV119State(
+  schemaVersion: SupportedSchemaVersion,
+): boolean {
+  return schemaVersion === CURRENT_SCHEMA_VERSION;
 }
 
 function schemaVersionSupportsV116State(
@@ -1446,6 +1456,7 @@ const sandboxSessionStateEnvelopeSchema = z.object({
     ) as [
       z.ZodLiteral<1>,
       z.ZodLiteral<2>,
+      z.ZodLiteral<3>,
       z.ZodLiteral<typeof SANDBOX_SESSION_STATE_VERSION>,
     ],
   ),
@@ -3175,13 +3186,15 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
     schemaVersion === '1.16' ||
     schemaVersion === '1.17' ||
     schemaVersionSupportsV118State(schemaVersion);
+  const supportsVersion3 = schemaVersionSupportsV118State(schemaVersion);
   if (
     envelopes.every(
       (envelope) =>
         envelope.version === 1 ||
         (envelope.version === 2 && supportsVersion2) ||
+        (envelope.version === 3 && supportsVersion3) ||
         (envelope.version === SANDBOX_SESSION_STATE_VERSION &&
-          schemaVersionSupportsV118State(schemaVersion)),
+          schemaVersionSupportsV119State(schemaVersion)),
     )
   ) {
     return;
@@ -3191,9 +3204,10 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
     (envelope) =>
       envelope.version !== 1 &&
       !(envelope.version === 2 && supportsVersion2) &&
+      !(envelope.version === 3 && supportsVersion3) &&
       !(
         envelope.version === SANDBOX_SESSION_STATE_VERSION &&
-        schemaVersionSupportsV118State(schemaVersion)
+        schemaVersionSupportsV119State(schemaVersion)
       ),
   )?.version;
   throw new UserError(

--- a/packages/agents-core/src/sandbox/client.ts
+++ b/packages/agents-core/src/sandbox/client.ts
@@ -60,6 +60,18 @@ export type SandboxClientResumeOptions<
   clientOptions?: TOptions;
 };
 
+export type SandboxSessionResumeValidationInput<
+  TSessionState extends SandboxSessionState = SandboxSessionState,
+> =
+  | {
+      source: 'explicit';
+      state: TSessionState;
+    }
+  | {
+      source: 'runState';
+      state: Record<string, unknown>;
+    };
+
 export type SandboxClientCreate<
   TOptions extends SandboxClientOptions = SandboxClientOptions,
   TSessionState extends SandboxSessionState = SandboxSessionState,
@@ -129,6 +141,11 @@ export interface SandboxClient<
     manifest: Manifest,
     options?: TOptions,
   ): Manifest;
+  /** Synchronously validates resume policy before environment materialization. */
+  validateSessionStateForResume?(
+    input: SandboxSessionResumeValidationInput<TSessionState>,
+    options?: SandboxClientResumeOptions<TOptions>,
+  ): void;
   resume?(
     state: TSessionState,
     options?: SandboxClientResumeOptions<TOptions>,

--- a/packages/agents-core/src/sandbox/runtime/manager.ts
+++ b/packages/agents-core/src/sandbox/runtime/manager.ts
@@ -1052,7 +1052,17 @@ export class SandboxRuntimeManager<TContext> {
       getSerializedSandboxState(this.runState),
       agentKey,
     );
-    const explicitSessionState = this.sandboxConfig?.sessionState
+    const explicitSessionStateInput = this.sandboxConfig?.sessionState;
+    if (explicitSessionStateInput) {
+      client.validateSessionStateForResume?.(
+        { source: 'explicit', state: explicitSessionStateInput },
+        {
+          archiveLimits: this.sandboxConfig?.archiveLimits,
+          clientOptions: this.sandboxConfig?.options,
+        },
+      );
+    }
+    const explicitSessionState = explicitSessionStateInput
       ? await this.prepareExplicitSessionStateForResume(client, trustedManifest)
       : undefined;
     if (explicitSessionState && !client.resume) {

--- a/packages/agents-core/src/sandbox/runtime/sessionState.ts
+++ b/packages/agents-core/src/sandbox/runtime/sessionState.ts
@@ -265,6 +265,17 @@ export async function deserializeSandboxSessionStateEntry(
     resolvedTrustedManifest,
   );
   assertMountCredentialsRebound(prevalidatedPersistedState);
+  client.validateSessionStateForResume?.(
+    {
+      source: 'runState',
+      state: providerStateWithSdkEnvelopeFields(
+        envelope,
+        prevalidatedPersistedState.manifest,
+        resolvedTrustedManifest,
+      ),
+    },
+    { clientOptions: trustedConfig.clientOptions },
+  );
   const materializedTrustedManifest = resolvedTrustedManifest
     ? await resolveAndValidateMountEnvironment(resolvedTrustedManifest)
     : undefined;

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -53,6 +53,7 @@ import type {
   SandboxConcurrencyLimits,
   SandboxPreservedSessionReuseOptions,
   SandboxSessionSerializationOptions,
+  SandboxSessionResumeValidationInput,
 } from '../client';
 import { normalizeSandboxClientCreateArgs } from '../client';
 import {
@@ -144,6 +145,7 @@ import {
   normalizeExposedPorts,
 } from './shared/sessionStateValues';
 import {
+  readOptionalNumberArray,
   readOptionalString,
   readString,
   readStringArray,
@@ -167,9 +169,12 @@ const DOCKER_SESSION_IDENTITY_LABEL = 'openai-agents-sandbox.session-identity';
 const DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL =
   'openai-agents-sandbox.mount-authority-fingerprint';
 
+type DockerNetworkMode = 'none';
+
 export interface DockerSandboxClientOptions extends SandboxClientOptions {
   image?: string;
   exposedPorts?: number[];
+  networkMode?: DockerNetworkMode;
   workspaceBaseDir?: string;
   snapshot?: LocalSandboxSnapshotSpec;
   concurrencyLimits?: SandboxConcurrencyLimits;
@@ -188,6 +193,7 @@ export interface DockerSandboxSessionState extends UnixLocalSandboxSessionState 
   image: string;
   defaultUser?: string;
   configuredExposedPorts?: number[];
+  networkMode?: DockerNetworkMode;
   dockerVolumeNames?: string[];
   snapshotExcludedPaths?: string[];
 }
@@ -1028,6 +1034,8 @@ export class DockerSandboxClient implements SandboxClient<
         ? { archiveLimits: createArgs.archiveLimits }
         : {}),
     };
+    const { configuredExposedPorts, networkMode } =
+      resolveDockerNetworkConfiguration(this.options, createArgs.options);
     const environment = await manifest.resolveEnvironment();
     validateMountEnvironmentCredentialBoundaries(manifest, environment);
     await ensureDockerAvailable();
@@ -1056,9 +1064,6 @@ export class DockerSandboxClient implements SandboxClient<
     await prepareDockerWorkspaceRoot(workspaceRootPath, manifest);
     const image = resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE;
     const defaultUser = getHostDockerUser();
-    const configuredExposedPorts = normalizeExposedPorts(
-      resolvedOptions.exposedPorts,
-    );
     const sessionIdentity = randomUUID();
     const container = await startDockerContainer({
       image,
@@ -1069,6 +1074,7 @@ export class DockerSandboxClient implements SandboxClient<
       environment,
       defaultUser,
       exposedPorts: configuredExposedPorts,
+      networkMode,
     });
     const session = new DockerSandboxSession({
       state: {
@@ -1085,6 +1091,7 @@ export class DockerSandboxClient implements SandboxClient<
         containerId: container.containerId,
         defaultUser,
         configuredExposedPorts,
+        networkMode,
         dockerVolumeNames: container.volumeNames,
       },
       archiveLimits: resolvedOptions.archiveLimits,
@@ -1118,14 +1125,51 @@ export class DockerSandboxClient implements SandboxClient<
 
   async resume(
     state: DockerSandboxSessionState,
-    options: SandboxClientResumeOptions = {},
+    options: SandboxClientResumeOptions<DockerSandboxClientOptions> = {},
   ): Promise<DockerSandboxSession> {
-    assertMountCredentialsRebound(state);
-    assertHostPathGrantsRebound(state);
-    assertDockerManifestSupported(state.manifest);
+    const trustedConfig = getRunStateSessionTrustedConfig(state);
+    this.validateSessionStateForResume(
+      {
+        source: trustedConfig ? 'runState' : 'explicit',
+        state,
+      },
+      trustedConfig
+        ? {
+            ...options,
+            clientOptions: trustedConfig.clientOptions as
+              DockerSandboxClientOptions | undefined,
+          }
+        : options,
+    );
+    let resumeState = state;
+    if (!isRunStateSessionState(state)) {
+      const { configuredExposedPorts, networkMode } =
+        resolveDockerNetworkConfiguration(
+          this.options,
+          options.clientOptions,
+          state,
+        );
+      if (
+        state.networkMode !== networkMode ||
+        !dockerExposedPortSetsEqual(
+          state.configuredExposedPorts ?? [],
+          configuredExposedPorts,
+        )
+      ) {
+        resumeState = {
+          ...state,
+          configuredExposedPorts,
+          networkMode,
+          exposedPorts: undefined,
+        };
+      }
+    }
+    assertMountCredentialsRebound(resumeState);
+    assertHostPathGrantsRebound(resumeState);
+    assertDockerManifestSupported(resumeState.manifest);
     validateMountEnvironmentCredentialBoundaries(
-      state.manifest,
-      state.environment,
+      resumeState.manifest,
+      resumeState.environment,
     );
     await ensureDockerAvailable();
     await this.retryFailedCreateCleanups();
@@ -1133,7 +1177,10 @@ export class DockerSandboxClient implements SandboxClient<
       options.archiveLimits === undefined
         ? this.options.archiveLimits
         : options.archiveLimits;
-    const restoredState = await this.restoreIfNeeded(state, archiveLimits);
+    const restoredState = await this.restoreIfNeeded(
+      resumeState,
+      archiveLimits,
+    );
 
     return new DockerSandboxSession({
       state: restoredState,
@@ -1141,10 +1188,37 @@ export class DockerSandboxClient implements SandboxClient<
     });
   }
 
+  validateSessionStateForResume(
+    input: SandboxSessionResumeValidationInput<DockerSandboxSessionState>,
+    options: SandboxClientResumeOptions<DockerSandboxClientOptions> = {},
+  ): void {
+    const configuredExposedPorts =
+      input.source === 'explicit'
+        ? normalizeExposedPorts(input.state.configuredExposedPorts)
+        : normalizeExposedPorts(
+            readOptionalNumberArray(input.state.configuredExposedPorts),
+          );
+    const networkMode = validateDockerNetworkConfiguration(
+      input.state.networkMode,
+      configuredExposedPorts,
+    );
+    resolveDockerNetworkConfiguration(
+      this.options,
+      options.clientOptions,
+      input.source === 'explicit'
+        ? { configuredExposedPorts, networkMode }
+        : undefined,
+    );
+  }
+
   async canReusePreservedOwnedSession(
     state: DockerSandboxSessionState,
     options: SandboxPreservedSessionReuseOptions<DockerSandboxClientOptions> = {},
   ): Promise<boolean> {
+    validateDockerNetworkConfiguration(
+      state.networkMode,
+      state.configuredExposedPorts,
+    );
     if (isSandboxSessionStateUnsafe(state)) {
       return false;
     }
@@ -1164,12 +1238,15 @@ export class DockerSandboxClient implements SandboxClient<
       ...this.options,
       ...options.clientOptions,
     };
+    const { configuredExposedPorts, networkMode } =
+      resolveDockerNetworkConfiguration(this.options, options.clientOptions);
     if (
       state.image !== (resolvedOptions.image ?? DEFAULT_DOCKER_IMAGE) ||
       !dockerExposedPortSetsEqual(
         state.configuredExposedPorts ?? [],
-        normalizeExposedPorts(resolvedOptions.exposedPorts),
-      )
+        configuredExposedPorts,
+      ) ||
+      state.networkMode !== networkMode
     ) {
       return false;
     }
@@ -1245,6 +1322,9 @@ export class DockerSandboxClient implements SandboxClient<
       containerId: state.containerId,
       defaultUser: state.defaultUser,
       configuredExposedPorts: state.configuredExposedPorts ?? [],
+      ...(state.networkMode !== undefined
+        ? { networkMode: state.networkMode }
+        : {}),
       dockerVolumeNames: state.dockerVolumeNames ?? [],
       exposedPorts: state.exposedPorts ?? null,
     };
@@ -1255,6 +1335,13 @@ export class DockerSandboxClient implements SandboxClient<
   async deserializeSessionState(
     state: Record<string, unknown>,
   ): Promise<DockerSandboxSessionState> {
+    const configuredExposedPorts = normalizeExposedPorts(
+      readOptionalNumberArray(state.configuredExposedPorts),
+    );
+    const networkMode = validateDockerNetworkConfiguration(
+      state.networkMode,
+      configuredExposedPorts,
+    );
     const baseState = await deserializeLocalSandboxSessionStateValues(
       state,
       this.options.snapshot,
@@ -1266,6 +1353,7 @@ export class DockerSandboxClient implements SandboxClient<
       containerId: readString(state, 'containerId'),
       defaultUser:
         readOptionalString(state, 'defaultUser') ?? getHostDockerUser(),
+      networkMode,
       dockerVolumeNames: readStringArray(state.dockerVolumeNames),
     };
   }
@@ -1282,6 +1370,12 @@ export class DockerSandboxClient implements SandboxClient<
         ...(trustedConfig?.clientOptions as
           DockerSandboxClientOptions | undefined),
       };
+      const { configuredExposedPorts, networkMode } =
+        resolveDockerNetworkConfiguration(
+          this.options,
+          trustedConfig?.clientOptions as
+            DockerSandboxClientOptions | undefined,
+        );
       const trustedState: DockerSandboxSessionState = {
         ...state,
         sessionIdentity: undefined,
@@ -1293,9 +1387,8 @@ export class DockerSandboxClient implements SandboxClient<
           resolvedOptions.snapshot ??
           null,
         defaultUser: getHostDockerUser(),
-        configuredExposedPorts: normalizeExposedPorts(
-          resolvedOptions.exposedPorts,
-        ),
+        configuredExposedPorts,
+        networkMode,
         dockerVolumeNames: [],
         exposedPorts: undefined,
       };
@@ -1447,6 +1540,7 @@ export class DockerSandboxClient implements SandboxClient<
       environment: state.environment,
       defaultUser: state.defaultUser,
       exposedPorts: state.configuredExposedPorts,
+      networkMode: state.networkMode,
     });
     const nextState = {
       ...state,
@@ -1610,6 +1704,9 @@ async function inspectRunningDockerContainerForReuse(
   if (!ownershipVerified) {
     return { ownershipVerified: false, reusable: false };
   }
+  if (!(await dockerNetworkConfigurationMatches(state))) {
+    return { ownershipVerified: true, reusable: false };
+  }
 
   const expectedBindMounts = dockerBindMountsFromAuthority([
     workspaceMountAfterInspect,
@@ -1680,10 +1777,12 @@ async function inspectLegacyDockerContainerForReuse(
   const ownershipVerified = actualBindMounts.some((mount) =>
     dockerBindMountsEqual(mount, expectedWorkspaceMount),
   );
+  const networkConfigurationMatches =
+    ownershipVerified && (await dockerNetworkConfigurationMatches(state));
   return {
     ownershipVerified,
     reusable:
-      ownershipVerified &&
+      networkConfigurationMatches &&
       dockerMountAuthoritiesEqual(
         workspaceMountBeforeInspect,
         workspaceMountAfterInspect,
@@ -1698,6 +1797,52 @@ async function inspectLegacyDockerContainerForReuse(
         ...dockerBindMountsFromAuthority(manifestBindMountsAfterInspect),
       ]),
   };
+}
+
+async function dockerNetworkConfigurationMatches(
+  state: DockerSandboxSessionState,
+): Promise<boolean> {
+  if (state.networkMode === undefined) {
+    return true;
+  }
+  const inspectionResult = await runSandboxProcess(
+    'docker',
+    [
+      'inspect',
+      '--type',
+      'container',
+      '--format',
+      '{{json .HostConfig.NetworkMode}}\n{{json .NetworkSettings.Networks}}',
+      state.containerId,
+    ],
+    { timeoutMs: DOCKER_FAST_COMMAND_TIMEOUT_MS },
+  );
+  if (inspectionResult.status !== 0) {
+    return false;
+  }
+  try {
+    const [modeJson, networksJson, ...unexpectedLines] = inspectionResult.stdout
+      .trim()
+      .split('\n');
+    if (
+      modeJson === undefined ||
+      networksJson === undefined ||
+      unexpectedLines.length > 0
+    ) {
+      return false;
+    }
+    const mode: unknown = JSON.parse(modeJson);
+    const networks: unknown = JSON.parse(networksJson);
+    return (
+      mode === 'none' &&
+      typeof networks === 'object' &&
+      networks !== null &&
+      !Array.isArray(networks) &&
+      Object.keys(networks).every((network) => network === 'none')
+    );
+  } catch {
+    return false;
+  }
 }
 
 function dockerContainerIdentityMatches(
@@ -2037,6 +2182,63 @@ function dockerExposedPortSetsEqual(left: number[], right: number[]): boolean {
   );
 }
 
+function validateDockerNetworkConfiguration(
+  networkMode: unknown,
+  exposedPorts: number[] | undefined,
+): DockerNetworkMode | undefined {
+  if (networkMode !== undefined && networkMode !== 'none') {
+    throw new UserError(
+      'DockerSandboxClient networkMode must be "none" when provided.',
+    );
+  }
+  if (networkMode === 'none' && (exposedPorts?.length ?? 0) > 0) {
+    throw new UserError(
+      'DockerSandboxClient exposedPorts cannot be used when networkMode is "none".',
+    );
+  }
+  return networkMode;
+}
+
+function resolveDockerNetworkConfiguration(
+  clientOptions: DockerSandboxClientOptions,
+  perRunOptions?: DockerSandboxClientOptions,
+  explicitStateFallback?: Pick<
+    DockerSandboxSessionState,
+    'configuredExposedPorts' | 'networkMode'
+  >,
+): {
+  configuredExposedPorts: number[];
+  networkMode?: DockerNetworkMode;
+} {
+  const trustedExposedPorts =
+    perRunOptions?.exposedPorts !== undefined
+      ? normalizeExposedPorts(perRunOptions.exposedPorts)
+      : clientOptions.exposedPorts !== undefined
+        ? normalizeExposedPorts(clientOptions.exposedPorts)
+        : undefined;
+  const exposedPorts = explicitStateFallback
+    ? normalizeExposedPorts(explicitStateFallback.configuredExposedPorts)
+    : (trustedExposedPorts ?? []);
+  if (
+    explicitStateFallback &&
+    trustedExposedPorts !== undefined &&
+    !dockerExposedPortSetsEqual(trustedExposedPorts, exposedPorts)
+  ) {
+    throw new UserError(
+      'DockerSandboxClient exposedPorts cannot be changed when resuming explicit session state. Start a fresh sandbox session instead.',
+    );
+  }
+  const networkMode = validateDockerNetworkConfiguration(
+    perRunOptions?.networkMode !== undefined
+      ? perRunOptions.networkMode
+      : clientOptions.networkMode !== undefined
+        ? clientOptions.networkMode
+        : explicitStateFallback?.networkMode,
+    exposedPorts,
+  );
+  return { configuredExposedPorts: exposedPorts, networkMode };
+}
+
 function assertDockerManifestDeltaSupported(
   currentManifest: Manifest,
   deltaManifest: Manifest,
@@ -2294,7 +2496,9 @@ async function startDockerContainer(args: {
   environment: Record<string, string>;
   defaultUser?: string;
   exposedPorts?: number[];
+  networkMode?: DockerNetworkMode;
 }): Promise<{ containerId: string; volumeNames: string[] }> {
+  validateDockerNetworkConfiguration(args.networkMode, args.exposedPorts);
   const envArgs = Object.entries(args.environment).flatMap(([key, value]) => [
     '-e',
     `${key}=${value}`,
@@ -2304,6 +2508,7 @@ async function startDockerContainer(args: {
     '-p',
     `127.0.0.1::${port}`,
   ]);
+  const networkArgs = args.networkMode ? ['--network', args.networkMode] : [];
   const containerName = `openai-agents-sandbox-${randomUUID().slice(0, 8)}`;
   const workspaceMount = await resolveDockerWorkspaceMount(
     args.workspaceRootPath,
@@ -2339,6 +2544,7 @@ async function startDockerContainer(args: {
       ...privilegeArgs,
       '-w',
       args.manifestRoot,
+      ...networkArgs,
       ...portArgs,
       ...userArgs,
       ...envArgs,

--- a/packages/agents-core/src/sandbox/session.ts
+++ b/packages/agents-core/src/sandbox/session.ts
@@ -6,10 +6,11 @@ import type { Entry } from './entries';
 import type { Manifest } from './manifest';
 import type { Snapshot } from './snapshot';
 
-export const SANDBOX_SESSION_STATE_VERSION = 3 as const;
+export const SANDBOX_SESSION_STATE_VERSION = 4 as const;
 export const SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS = [
   1,
   2,
+  3,
   SANDBOX_SESSION_STATE_VERSION,
 ] as const;
 export type SandboxSessionStateVersion =

--- a/packages/agents-core/test/fixtures/run-state/README.md
+++ b/packages/agents-core/test/fixtures/run-state/README.md
@@ -10,7 +10,7 @@ This directory is immutable compatibility evidence for released `RunState` write
 
 Each historical fixture records its package version, release tag, full source commit, npm integrity, scenario, path, and SHA-256 in `sources.json`. The published package and npm integrity identify the primary writer artifact; the tag and commit are supplementary source provenance. Minimal fixtures prove the writer format for every published schema. Feature and resume fixtures are intentionally limited to durable boundaries that need more than an empty state to exercise compatibility.
 
-The released `1.17` sandbox format predates the mount-credential redaction boundary added by schema `1.18`. The `v0.16.0` writer fixtures establish the released `1.18` boundary, including canonical per-call approval identity. Schema `1.19` changes mixed sticky and exact approval decisions to resolve the exact call first. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
+The released `1.17` sandbox format predates the mount-credential redaction boundary added by schema `1.18`. The `v0.16.0` writer fixtures establish the released `1.18` boundary, including canonical per-call approval identity. Current schema `1.19` changes mixed sticky and exact approval decisions to resolve the exact call first and adds the next sandbox envelope version for Docker network-isolation state. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
 
 ## Regeneration
 

--- a/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
+++ b/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
@@ -439,6 +439,8 @@ function generateNegativeFixtures(outputRoot: string) {
   sandboxV2.sandbox = sandbox(2);
   const sandboxV3 = readHistorical('1.17');
   sandboxV3.sandbox = sandbox(3);
+  const sandboxV4 = readHistorical('1.18');
+  sandboxV4.sandbox = sandbox(4);
   const protoKey = readHistorical('1.0');
   const protoContext = JSON.parse(
     '{"__proto__":{"polluted":"sentinel-not-a-secret"}}',
@@ -464,6 +466,11 @@ function generateNegativeFixtures(outputRoot: string) {
       'v1.17-sandbox-v3',
       sandboxV3,
       'does not support sandbox session state version 3',
+    ],
+    [
+      'v1.18-sandbox-v4',
+      sandboxV4,
+      'does not support sandbox session state version 4',
     ],
   ] as const;
   const records = fixtures.map(([scenario, payload, expectedError]) => {

--- a/packages/agents-core/test/fixtures/run-state/negative/v1.18-sandbox-v4.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/v1.18-sandbox-v4.json
@@ -1,0 +1,53 @@
+{
+  "$schemaVersion": "1.18",
+  "currentTurn": 0,
+  "currentAgent": {
+    "name": "HistoricalAgent"
+  },
+  "originalInput": "hello",
+  "modelResponses": [],
+  "context": {
+    "usage": {
+      "requests": 0,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "inputTokensDetails": [],
+      "outputTokensDetails": []
+    },
+    "approvals": {},
+    "approvalInvocations": [],
+    "context": {
+      "fixture": "minimal"
+    }
+  },
+  "toolUseTracker": {},
+  "maxTurns": 3,
+  "noActiveAgentRun": true,
+  "inputGuardrailResults": [],
+  "outputGuardrailResults": [],
+  "toolInputGuardrailResults": [],
+  "toolOutputGuardrailResults": [],
+  "currentTurnInProgress": false,
+  "generatedItems": [],
+  "pendingAgentToolRuns": {},
+  "pendingAgentToolRunAliases": {},
+  "currentTurnPersistedItemCount": 0,
+  "completedToolInvocations": [],
+  "completedToolInvocationEvidence": [],
+  "ambiguousToolInvocationCallIds": [],
+  "trace": null,
+  "sandbox": {
+    "backendId": "fixture-sandbox",
+    "currentAgentKey": "HistoricalAgent",
+    "currentAgentName": "HistoricalAgent",
+    "sessionState": {
+      "version": 4,
+      "backendId": "fixture-sandbox",
+      "manifest": {},
+      "workspaceReady": true,
+      "providerState": {}
+    },
+    "sessionsByAgent": {}
+  }
+}

--- a/packages/agents-core/test/fixtures/run-state/sources.json
+++ b/packages/agents-core/test/fixtures/run-state/sources.json
@@ -317,7 +317,7 @@
     {
       "schemaVersion": "1.19",
       "status": "current_unreleased",
-      "reason": "Supported on main but not emitted by the latest released package v0.16.0."
+      "reason": "Supported on main but not emitted by the latest released package v0.16.0; includes exact-call approval precedence and sandbox envelope version 4."
     }
   ],
   "expectedNormalizedFixtures": [
@@ -363,6 +363,12 @@
       "path": "negative/v1.17-sandbox-v3.json",
       "sha256": "686c6b8e7deafce9afcb306acbeebef180e74fa9921e9cebcac74186981dce0c",
       "expectedError": "does not support sandbox session state version 3"
+    },
+    {
+      "scenario": "v1.18-sandbox-v4",
+      "path": "negative/v1.18-sandbox-v4.json",
+      "sha256": "7792da13fda1bd76b59499ea13051cef593d59f391a125920d299cf9e6c24869",
+      "expectedError": "does not support sandbox session state version 4"
     },
     {
       "scenario": "prototype-key",

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -634,11 +634,61 @@ export function registerRunStateCoreTests(): void {
       };
       const serialized = state.toJSON();
       serialized.$schemaVersion = '1.17';
+      serialized.sandbox!.sessionState.version = 3;
 
       await expect(
         RunState.fromString(agent, JSON.stringify(serialized)),
       ).rejects.toThrow(
         'Run state schema version 1.17 does not support sandbox session state version 3.',
+      );
+    });
+
+    it('keeps reading schema 1.18 payloads with sandbox session state version 3', async () => {
+      const agent = new Agent({ name: 'VersionThreeSandboxEnvelopeAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._sandbox = {
+        backendId: 'unix-local',
+        currentAgentKey: 'VersionThreeSandboxEnvelopeAgent',
+        currentAgentName: 'VersionThreeSandboxEnvelopeAgent',
+        sessionState: sandboxSessionStateEnvelope({
+          workspaceId: 'ws_version_three',
+        }),
+        sessionsByAgent: {},
+      };
+      const serialized = state.toJSON();
+      serialized.$schemaVersion = '1.18';
+      serialized.sandbox!.sessionState.version = 3;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._sandbox?.sessionState.version).toBe(3);
+      expect(() => restored.toString()).toThrow(
+        /must be resumed through the Runner/u,
+      );
+    });
+
+    it('rejects sandbox session state version 4 under released schema 1.18', async () => {
+      const agent = new Agent({ name: 'VersionFourSandboxEnvelopeAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._sandbox = {
+        backendId: 'unix-local',
+        currentAgentKey: 'VersionFourSandboxEnvelopeAgent',
+        currentAgentName: 'VersionFourSandboxEnvelopeAgent',
+        sessionState: sandboxSessionStateEnvelope({
+          workspaceId: 'ws_version_four',
+        }),
+        sessionsByAgent: {},
+      };
+      const serialized = state.toJSON();
+      serialized.$schemaVersion = '1.18';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Run state schema version 1.18 does not support sandbox session state version 4.',
       );
     });
 

--- a/packages/agents-core/test/sandboxRunner.test.ts
+++ b/packages/agents-core/test/sandboxRunner.test.ts
@@ -88,6 +88,10 @@ import {
   normalizeSandboxClientCreateArgs,
   s3Mount,
 } from '../src/sandbox';
+import {
+  DockerSandboxClient,
+  type DockerSandboxSessionState,
+} from '../src/sandbox/sandboxes/docker';
 import type { Tool } from '../src/tool';
 import { shellTool } from '../src/tool';
 import type {
@@ -3045,6 +3049,136 @@ describe('sandbox runner integration', () => {
     expect(client.resumeCalls).toHaveLength(0);
   });
 
+  it('validates explicit Docker network policy before resolving trusted environment', async () => {
+    let resolveCalls = 0;
+    const client = new DockerSandboxClient({ networkMode: 'none' });
+    const resume = vi
+      .spyOn(client, 'resume')
+      .mockRejectedValue(new Error('resume should not be called'));
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: new Manifest({
+        environment: {
+          TOKEN: {
+            value: '',
+            resolve: async () => {
+              resolveCalls += 1;
+              return 'TRUSTED_SECRET_SENTINEL';
+            },
+            ephemeral: true,
+          },
+        },
+      }),
+    });
+    const sessionState: DockerSandboxSessionState = {
+      manifest: new Manifest(),
+      workspaceRootPath: '/tmp/docker-sandbox',
+      workspaceRootOwned: false,
+      environment: {},
+      snapshotSpec: null,
+      snapshot: null,
+      containerId: 'container-1',
+      image: 'python:3.14-slim',
+      configuredExposedPorts: [8080],
+    };
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: { client, sessionState },
+      runState,
+    });
+
+    await expect(
+      manager.prepareAgent({ currentAgent: sandboxAgent, turnInput: [] }),
+    ).rejects.toThrow(
+      'DockerSandboxClient exposedPorts cannot be used when networkMode is "none".',
+    );
+    expect(resolveCalls).toBe(0);
+    expect(resume).not.toHaveBeenCalled();
+  });
+
+  it('validates RunState Docker network policy before resolving trusted environment', async () => {
+    let resolveCalls = 0;
+    const client = new DockerSandboxClient({ networkMode: 'none' });
+    const resume = vi
+      .spyOn(client, 'resume')
+      .mockRejectedValue(new Error('resume should not be called'));
+    const trustedManifest = new Manifest({
+      environment: {
+        TOKEN: {
+          value: '',
+          resolve: async () => {
+            resolveCalls += 1;
+            return 'TRUSTED_SECRET_SENTINEL';
+          },
+          ephemeral: true,
+        },
+      },
+    });
+    const sandboxAgent = new SandboxAgent<unknown, AgentOutputType>({
+      name: 'SandboxWorker',
+      model: new RecordingModel([]),
+      defaultManifest: trustedManifest,
+    });
+    const sessionState: DockerSandboxSessionState = {
+      manifest: new Manifest(),
+      workspaceRootPath: '/tmp/docker-sandbox',
+      workspaceRootOwned: false,
+      environment: {},
+      snapshotSpec: null,
+      snapshot: null,
+      containerId: 'container-1',
+      image: 'python:3.14-slim',
+      configuredExposedPorts: [],
+    };
+    const envelope = toSessionStateEnvelope(client.backendId, sessionState, {
+      workspaceRootPath: sessionState.workspaceRootPath,
+      workspaceRootOwned: sessionState.workspaceRootOwned,
+      environment: {},
+      snapshotSpec: null,
+      snapshot: null,
+      image: sessionState.image,
+      containerId: sessionState.containerId,
+      configuredExposedPorts: [],
+      dockerVolumeNames: [],
+    });
+    const runState = new RunState<
+      unknown,
+      SandboxAgent<unknown, AgentOutputType>
+    >(new RunContext(), 'Hello', sandboxAgent, 1);
+    runState._sandbox = {
+      backendId: client.backendId,
+      currentAgentKey: 'SandboxWorker',
+      currentAgentName: 'SandboxWorker',
+      sessionState: envelope,
+      sessionsByAgent: {
+        SandboxWorker: {
+          backendId: client.backendId,
+          currentAgentKey: 'SandboxWorker',
+          currentAgentName: 'SandboxWorker',
+          sessionState: envelope,
+        },
+      },
+    };
+    const manager = new SandboxRuntimeManager({
+      startingAgent: sandboxAgent,
+      sandboxConfig: { client, options: { exposedPorts: [8080] } },
+      runState,
+    });
+
+    await expect(
+      manager.prepareAgent({ currentAgent: sandboxAgent, turnInput: [] }),
+    ).rejects.toThrow(
+      'DockerSandboxClient exposedPorts cannot be used when networkMode is "none".',
+    );
+    expect(resolveCalls).toBe(0);
+    expect(resume).not.toHaveBeenCalled();
+  });
+
   it('serializes sandbox session state and resumes it on the next run', async () => {
     const client = new ManifestSerializingFakeSandboxClient();
     const sandboxModel = new RecordingModel([
@@ -4194,7 +4328,7 @@ describe('sandbox runner integration', () => {
     expect(client.deserializeSessionState).not.toHaveBeenCalled();
   });
 
-  it.each([2, SANDBOX_SESSION_STATE_VERSION])(
+  it.each([2, 3, SANDBOX_SESSION_STATE_VERSION])(
     'rejects persisted in-container mount credentials before provider deserialization for session state v%s',
     async (version) => {
       const client = new FakeSandboxClient();

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -113,6 +113,8 @@ function dockerWorkspaceMount(source: string, target = '/workspace') {
 type DockerContainerInspection = {
   labels: Record<string, string>;
   mounts: ReturnType<typeof dockerWorkspaceMount>;
+  networkMode: string;
+  networks: unknown;
 };
 
 function dockerRunInspection(args: string[]): DockerContainerInspection {
@@ -148,9 +150,14 @@ function dockerRunInspection(args: string[]): DockerContainerInspection {
       RW: options.readonly !== true,
     });
   }
+  const networkArgIndex = args.indexOf('--network');
+  const networkMode =
+    networkArgIndex === -1 ? 'bridge' : (args[networkArgIndex + 1] ?? '');
   return {
     labels: dockerRunLabels(args),
     mounts,
+    networkMode,
+    networks: networkMode === 'none' ? {} : { [networkMode]: {} },
   };
 }
 
@@ -164,6 +171,14 @@ function dockerInspectionResult(
   }
   if (args[4] === '{{json .Mounts}}') {
     return success(JSON.stringify(inspection?.mounts ?? []));
+  }
+  if (
+    args[4] ===
+    '{{json .HostConfig.NetworkMode}}\n{{json .NetworkSettings.Networks}}'
+  ) {
+    return success(
+      `${JSON.stringify(inspection?.networkMode ?? '')}\n${JSON.stringify(inspection?.networks ?? null)}\n`,
+    );
   }
   return undefined;
 }
@@ -332,6 +347,7 @@ describe('DockerSandboxClient unit behavior', () => {
         'custom:image',
       ]),
     );
+    expect(runCall?.[1]).not.toContain('--network');
     const imageArgIndex = runCall?.[1].indexOf('custom:image') ?? -1;
     expect(runCall?.[1].slice(imageArgIndex + 1, imageArgIndex + 3)).toEqual([
       '/bin/sh',
@@ -369,6 +385,105 @@ describe('DockerSandboxClient unit behavior', () => {
       { timeoutMs: 30_000 },
     );
     await expect(stat(session.state.workspaceRootPath)).rejects.toThrow();
+  });
+
+  it.each(['bridge', 'host', null, 42])(
+    'rejects unsupported network mode %j before Docker or filesystem effects',
+    async (networkMode) => {
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        networkMode: networkMode as never,
+      });
+
+      await expect(client.create(new Manifest())).rejects.toThrow(
+        'networkMode must be "none"',
+      );
+
+      expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+      await expect(readdir(rootDir)).resolves.toEqual([]);
+    },
+  );
+
+  it('rejects exposed ports with network isolation before Docker or filesystem effects', async () => {
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      networkMode: 'none',
+      exposedPorts: [3000],
+    });
+
+    await expect(client.create(new Manifest())).rejects.toThrow(
+      'exposedPorts cannot be used when networkMode is "none"',
+    );
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    await expect(readdir(rootDir)).resolves.toEqual([]);
+  });
+
+  it('creates and persists a network-isolated container', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-isolated\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      networkMode: 'none',
+      snapshot: new NoopSnapshotSpec(),
+    });
+
+    const session = await client.create(new Manifest(), {
+      networkMode: undefined,
+    });
+    const runArgs = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    )?.[1];
+
+    expect(session.state.networkMode).toBe('none');
+    expect(runArgs).toEqual(expect.arrayContaining(['--network', 'none']));
+    expect(runArgs?.indexOf('--network')).toBe(
+      (runArgs?.indexOf('none') ?? 0) - 1,
+    );
+    expect(runArgs).not.toContain('-p');
+
+    const serialized = await client.serializeSessionState(session.state);
+    expect(serialized.networkMode).toBe('none');
+    await expect(
+      client.deserializeSessionState(serialized),
+    ).resolves.toMatchObject({ networkMode: 'none' });
+
+    const legacy = { ...serialized };
+    delete legacy.networkMode;
+    await expect(client.deserializeSessionState(legacy)).resolves.toMatchObject(
+      { networkMode: undefined },
+    );
+
+    const providerCallCount = processMocks.runSandboxProcess.mock.calls.length;
+    await expect(
+      client.deserializeSessionState({
+        ...serialized,
+        networkMode: 'bridge',
+      }),
+    ).rejects.toThrow('networkMode must be "none"');
+    await expect(
+      client.deserializeSessionState({
+        ...serialized,
+        configuredExposedPorts: [3000],
+      }),
+    ).rejects.toThrow('exposedPorts cannot be used when networkMode is "none"');
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledTimes(
+      providerCallCount,
+    );
+
+    await session.close();
   });
 
   it('passes bind and Docker volume mounts to container creation', async () => {
@@ -3036,6 +3151,11 @@ describe('DockerSandboxClient unit behavior', () => {
         clientOptions: { exposedPorts: [8080] },
       }),
     ).resolves.toBe(false);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        clientOptions: { networkMode: 'none' },
+      }),
+    ).resolves.toBe(false);
     expect(activeChild.kill).not.toHaveBeenCalled();
     expect(runCount).toBe(1);
     expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
@@ -3046,6 +3166,284 @@ describe('DockerSandboxClient unit behavior', () => {
 
     await session.close();
   });
+
+  it('verifies actual Docker network isolation before live reuse', async () => {
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          inspections.set('container-isolated', dockerRunInspection(args));
+          return success('container-isolated\n');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      networkMode: 'none',
+    });
+    const session = await client.create(new Manifest());
+    const inspection = inspections.get('container-isolated')!;
+
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(true);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        clientOptions: { networkMode: undefined },
+      }),
+    ).resolves.toBe(true);
+
+    inspection.networks = { bridge: {} };
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(false);
+
+    inspection.networks = { none: {} };
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(true);
+
+    inspection.networkMode = 'bridge';
+    inspection.networks = {};
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(false);
+
+    inspection.networkMode = 'none';
+    inspection.networks = null;
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(false);
+
+    await session.close();
+  });
+
+  it('replaces an owned container whose network isolation no longer matches', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      networkMode: 'none',
+    });
+    const session = await client.create(new Manifest());
+    const firstInspection = inspections.get('container-1')!;
+    firstInspection.networkMode = 'bridge';
+    firstInspection.networks = { bridge: {} };
+
+    const resumed = await client.resume(session.state);
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(resumed.state.networkMode).toBe('none');
+    expect(inspections.get('container-2')).toMatchObject({
+      networkMode: 'none',
+      networks: {},
+    });
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-1'],
+      { timeoutMs: 30_000 },
+    );
+
+    await resumed.close();
+  });
+
+  it('applies trusted network isolation when resuming explicit session state', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest());
+
+    const resumed = await client.resume(session.state, {
+      clientOptions: { networkMode: 'none' },
+    });
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(resumed.state.networkMode).toBe('none');
+    expect(inspections.get('container-1')).toMatchObject({
+      networkMode: 'bridge',
+    });
+    expect(inspections.get('container-2')).toMatchObject({
+      networkMode: 'none',
+      networks: {},
+    });
+    expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-1'],
+      { timeoutMs: 30_000 },
+    );
+
+    await resumed.close();
+  });
+
+  it('keeps constructor network isolation when per-run resume mode is undefined', async () => {
+    let runCount = 0;
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          const containerId = `container-${runCount}`;
+          inspections.set(containerId, dockerRunInspection(args));
+          return success(`${containerId}\n`);
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const sourceClient = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const sourceSession = await sourceClient.create(new Manifest());
+    const isolatedClient = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      networkMode: 'none',
+    });
+
+    const resumed = await isolatedClient.resume(sourceSession.state, {
+      clientOptions: { networkMode: undefined },
+    });
+
+    expect(resumed.state.containerId).toBe('container-2');
+    expect(resumed.state.networkMode).toBe('none');
+    expect(inspections.get('container-2')).toMatchObject({
+      networkMode: 'none',
+      networks: {},
+    });
+
+    await resumed.close();
+  });
+
+  it('rejects trusted network isolation conflicts before explicit resume side effects', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-1\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest(), {
+      exposedPorts: [8080],
+    });
+    processMocks.runSandboxProcess.mockClear();
+
+    await expect(
+      client.resume(session.state, {
+        clientOptions: { networkMode: 'none' },
+      }),
+    ).rejects.toThrow('exposedPorts cannot be used when networkMode is "none"');
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+
+    await session.close();
+  });
+
+  it.each([{ exposedPorts: [] }, { exposedPorts: [9090] }])(
+    'rejects explicit resume port changes before side effects: $exposedPorts',
+    async ({ exposedPorts }) => {
+      processMocks.runSandboxProcess.mockImplementation(
+        async (_command: string, args: string[]) => {
+          if (args[0] === 'version') {
+            return success('Docker version test');
+          }
+          if (args[0] === 'run') {
+            return success('container-1\n');
+          }
+          if (args[0] === 'rm') {
+            return success();
+          }
+          return failure('unexpected docker command');
+        },
+      );
+      const client = new DockerSandboxClient({
+        workspaceBaseDir: rootDir,
+        snapshot: new NoopSnapshotSpec(),
+      });
+      const session = await client.create(new Manifest(), {
+        exposedPorts: [8080],
+      });
+      const deserialized = await client.deserializeSessionState(
+        await client.serializeSessionState(session.state),
+      );
+      expect(deserialized.configuredExposedPorts).toEqual([8080]);
+      processMocks.runSandboxProcess.mockClear();
+
+      await expect(
+        client.resume(deserialized, {
+          clientOptions: { exposedPorts },
+        }),
+      ).rejects.toThrow(
+        'exposedPorts cannot be changed when resuming explicit session state',
+      );
+      expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+
+      await session.close();
+    },
+  );
 
   it('preserves live reuse after runtime files are materialized', async () => {
     let runCount = 0;
@@ -4902,6 +5300,88 @@ describe('DockerSandboxClient unit behavior', () => {
     await expect(
       readFile(join(restored.state.workspaceRootPath, 'notes.txt'), 'utf8'),
     ).resolves.toBe('snapshot\n');
+
+    await restored.close();
+    await session.close();
+  });
+
+  it('recreates Docker RunState with trusted network isolation', async () => {
+    let runCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-${runCount}\n`);
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      snapshot: {
+        type: 'local',
+        baseDir: rootDir,
+      },
+    });
+    const manifest = new Manifest({
+      entries: {
+        'notes.txt': {
+          type: 'file',
+          content: 'snapshot\n',
+        },
+      },
+    });
+    const session = await client.create(manifest);
+    const serialized = await client.serializeSessionState(session.state);
+    delete serialized.networkMode;
+
+    const persistedState = (await deserializeSandboxSessionStateEntry(
+      client,
+      {
+        backendId: client.backendId,
+        currentAgentKey: 'SandboxWorker',
+        currentAgentName: 'SandboxWorker',
+        sessionState: toSessionStateEnvelope(
+          client.backendId,
+          session.state,
+          serialized,
+        ),
+      },
+      manifest,
+      {
+        clientOptions: {
+          networkMode: 'none',
+          workspaceBaseDir: rootDir,
+        },
+        snapshot: {
+          type: 'local',
+          baseDir: rootDir,
+        },
+      },
+    )) as DockerSandboxSessionState;
+
+    expect(persistedState.networkMode).toBeUndefined();
+    const restored = await client.resume(persistedState);
+    const runCalls = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    );
+
+    expect(restored.state.networkMode).toBe('none');
+    expect(runCalls[0]?.[1]).not.toContain('--network');
+    expect(runCalls[1]?.[1]).toEqual(
+      expect.arrayContaining(['--network', 'none']),
+    );
+    expect(
+      processMocks.runSandboxProcess.mock.calls.some(
+        ([, args]) => args[0] === 'inspect',
+      ),
+    ).toBe(false);
 
     await restored.close();
     await session.close();


### PR DESCRIPTION
This pull request adds opt-in network isolation for Docker sandboxes through `networkMode: "none"`.

It rejects incompatible exposed-port configuration before side effects, preserves the setting across session serialization and replacement, and rebuilds RunState sessions from trusted current configuration. Preserved containers are reused only after Docker inspection confirms that they remain isolated.

The RunState schema and sandbox-state envelope are advanced to prevent older SDK versions from silently dropping the isolation requirement during replacement.