### PR TITLE
docs: v01.6.1 release

### DIFF
--- a/docs/src/content/docs/guides/agents.mdx
+++ b/docs/src/content/docs/guides/agents.mdx
@@ -209,6 +209,8 @@ Need a slightly modified version of an existing agent? Use the `clone()` method,
 
 <Code lang="typescript" code={agentCloning} title="Cloning Agents" />
 
+`clone()` does not copy list properties such as `tools`, `handoffs`, `mcpServers`, `inputGuardrails`, or `outputGuardrails`. When the clone configuration omits one of these properties, the original agent and the clone share the same array, so mutating the array through either agent affects both agents. To give the clone its own array, pass a new array such as `tools: [...agent.tools, extraTool]`; the entries in that new array are still the same tool or handoff objects. Passing a list property as `undefined` counts as providing it and starts that list empty instead of inheriting the original array.
+
 ---
 
 ### Forcing tool use

--- a/docs/src/content/docs/guides/human-in-the-loop.mdx
+++ b/docs/src/content/docs/guides/human-in-the-loop.mdx
@@ -48,6 +48,8 @@ If you do not provide `message`, the SDK falls back to the configured `toolError
 
 You do not need to resolve every pending approval in the same pass. If you rerun after approving or rejecting only some items, those resolved calls can continue while unresolved ones remain in `interruptions` and pause the run again.
 
+Sticky decisions created with `alwaysApprove: true` or `alwaysReject: true` provide the default for later calls to the same tool. An exact decision for one call ID takes precedence over that sticky default: you can reject one call under sticky approval or approve one call under sticky rejection without changing the default for other calls. If you later replace that exact decision, the new exact decision applies to that call while the sticky default remains available for the rest.
+
 ### Add input before resuming
 
 Use `RunState.addInput()` when new user input arrives while a run is paused and should be admitted before the next resumed model call. Add the input before resolving approvals and passing the same state back to `Runner.run()`. The staged input is part of the serialized state, so it survives `toString()` / `fromString()` even if unresolved approvals or local tool work delay that model call.

--- a/docs/src/content/docs/guides/models.mdx
+++ b/docs/src/content/docs/guides/models.mdx
@@ -232,6 +232,7 @@ Do not combine this model with SDK handoffs, `reasoning.summary`, or `max_tool_c
 | `parallelToolCalls` | `boolean` | Allow parallel function calls where supported. |
 | `truncation` | `'auto' \| 'disabled'` | Token truncation strategy. |
 | `maxTokens` | `number` | Maximum tokens in the response. |
+| `timeoutMs` | `number` | Cooperative timeout in milliseconds for each model request attempt. Must be finite, greater than `0`, and no greater than `2147483647`. |
 | `store` | `boolean` | Persist the response for retrieval / RAG workflows. |
 | `promptCacheRetention` | `'in-memory' \| '24h' \| null` | Controls the legacy maximum prompt-cache retention policy when supported. This is independent of `promptCacheOptions.ttl`. |
 | `promptCacheOptions` | `{ mode?: 'implicit' \| 'explicit'; ttl?: '30m' }` | Controls implicit or explicit prompt-cache breakpoints for GPT-5.6 and later models. |
@@ -250,6 +251,8 @@ Attach settings at either level:
 <Code lang="typescript" code={modelSettingsExample} title="Model settings" />
 
 `Runner`‑level settings override conflicting per-agent settings. Nested fields in `reasoning`, `text`, `promptCacheOptions`, and `retry` are merged across runner and agent settings unless you explicitly clear an inherited value with `undefined`.
+
+When `timeoutMs` expires, the SDK aborts the current model request attempt. If retry processing neither starts another attempt nor surfaces a different failure, the SDK raises [`ModelTimeoutError`](/openai-agents-js/openai/agents-core/classes/modeltimeouterror). A run-level abort signal still cancels the whole run. If model retries are enabled, the retry policy evaluates the timeout like another failed attempt; the SDK retries only when that policy opts in and the request is safe to replay or the application explicitly approves an unsafe replay.
 
 Set `preserveRawUsage: true` when you need provider-specific usage fields or need to distinguish an omitted field from a normalized zero. OpenAI Responses, OpenAI Chat Completions, and AI SDK-backed models support it for streaming and non-streaming runs. Preservation is best-effort: if a provider does not return usage or returns a value that cannot be safely copied as plain JSON-compatible data, `rawUsage` remains `undefined`. See [Raw responses](/openai-agents-js/guides/results#raw-responses) for how to access the preserved payload.
 

--- a/docs/src/content/docs/guides/running-agents.mdx
+++ b/docs/src/content/docs/guides/running-agents.mdx
@@ -272,6 +272,7 @@ The SDK throws a small set of errors you can catch:
 - [`MaxTurnsExceededError`](/openai-agents-js/openai/agents-core/classes/maxturnsexceedederror) – `maxTurns` reached.
 - [`ModelBehaviorError`](/openai-agents-js/openai/agents-core/classes/modelbehaviorerror) – model produced invalid output (e.g. malformed JSON, unknown tool).
 - [`ModelRefusalError`](/openai-agents-js/openai/agents-core/classes/modelrefusalerror) – model refused to produce the requested output.
+- [`ModelTimeoutError`](/openai-agents-js/openai/agents-core/classes/modeltimeouterror) – a timed-out model request attempt remained the final failure after retry processing.
 - [`InputGuardrailTripwireTriggered`](/openai-agents-js/openai/agents-core/classes/inputguardrailtripwiretriggered) / [`OutputGuardrailTripwireTriggered`](/openai-agents-js/openai/agents-core/classes/outputguardrailtripwiretriggered) – guardrail violations.
 - [`ToolInputGuardrailTripwireTriggered`](/openai-agents-js/openai/agents-core/classes/toolinputguardrailtripwiretriggered) / [`ToolOutputGuardrailTripwireTriggered`](/openai-agents-js/openai/agents-core/classes/tooloutputguardrailtripwiretriggered) – tool guardrail violations.
 - [`GuardrailExecutionError`](/openai-agents-js/openai/agents-core/classes/guardrailexecutionerror) – guardrails failed to complete.

--- a/docs/src/content/docs/guides/sandbox-agents/clients.mdx
+++ b/docs/src/content/docs/guides/sandbox-agents/clients.mdx
@@ -50,6 +50,8 @@ The same agent can usually run with either local client:
   title="Switch between local clients"
 />
 
+`DockerSandboxClient` uses Docker's default networking unless you set `networkMode: 'none'` in the client constructor or the per-run `sandbox.options`. The `'none'` mode starts the container with networking disabled. It cannot be combined with `exposedPorts`; the SDK rejects that configuration before creating or resuming a container. No other explicit `networkMode` value is currently supported.
+
 ### Session ownership
 
 There are two lifecycle styles.
@@ -153,6 +155,8 @@ Install `@openai/agents-extensions` and satisfy its package-level peers. Each pr
 | `ModalSandboxClient` | `@openai/agents-extensions/sandbox/modal` | npm peer: `modal` |
 | `RunloopSandboxClient` | `@openai/agents-extensions/sandbox/runloop` | npm peer: `@runloop/api-client` |
 | `VercelSandboxClient` | `@openai/agents-extensions/sandbox/vercel` | npm peer: `@vercel/sandbox` |
+
+When `ModalSandboxClient` creates a sandbox, use `cpu` and `memoryMiB` to request CPU and memory reservations. Use `cpuLimit` and `memoryLimitMiB` to set upper limits. You can set these options on the client constructor or in per-run `sandbox.options`; per-run values override constructor defaults. Every value must be a positive finite number. `cpuLimit` requires `cpu` and cannot be lower than it, while `memoryLimitMiB` requires `memoryMiB` and cannot be lower than it.
 
 `CloudflareSandboxClient` does not import a Cloudflare npm SDK. It talks to a deployed Cloudflare Sandbox bridge Worker over HTTP instead.
 

--- a/docs/src/content/docs/guides/sandbox-agents/concepts.mdx
+++ b/docs/src/content/docs/guides/sandbox-agents/concepts.mdx
@@ -181,12 +181,18 @@ Built-in capabilities include:
 | Capability | Add it when | Notes |
 | --- | --- | --- |
 | `shell()` | The agent needs shell access. | Adds `exec_command`, plus `write_stdin` when the sandbox client supports PTY interaction. |
-| `filesystem()` | The agent needs to edit files or inspect local images. | Adds `apply_patch` and `view_image`; patch paths are workspace-root-relative. |
+| `filesystem()` | The agent needs to edit files or inspect local images. | Adds `apply_patch` and `view_image`; relative paths start at the workspace root by default or at `sandbox.cwd` when configured. |
 | `skills()` | You want skill discovery and materialization in the sandbox. | Prefer this over mounting `.agents` or `.agents/skills` manually for sandbox-local `SKILL.md` skills. |
 | `memory()` | Follow-on runs should read or generate memory artifacts. | Requires `shell()`; live updates also require `filesystem()`. |
 | `compaction()` | Long-running flows need context trimming after compaction items. | Adjusts model sampling and input handling. |
 
 By default, `SandboxAgent.capabilities` uses `Capabilities.default()`, which includes `filesystem()`, `shell()`, and `compaction()`. If you pass `capabilities: [...]`, that list replaces the default, so include any default capabilities you still want.
+
+`view_image` accepts PNG, JPEG, GIF, WebP, BMP, TIFF, and SVG images up to 10 MB. The SDK detects raster formats from file signatures instead of trusting raster filename extensions, so a raster extension alone does not make unsupported bytes valid. The SDK recognizes SVG from its contents or an `.svg` or `.svgz` filename.
+
+`compaction()` uses `DynamicCompactionPolicy` by default. For a recognized model, the policy asks the Responses API to compact when the rendered context reaches 90% of that model's context window. If the model is missing or unknown, the policy uses a fallback threshold of 240,000 tokens. Pass a different ratio and fallback threshold to `new DynamicCompactionPolicy(thresholdRatio, fallbackThreshold)`, or use `new StaticCompactionPolicy(threshold)` when every supported model should use one fixed token threshold. A dynamic ratio must be a finite number from `0` through `1`.
+
+When server-side compaction produces a compaction item, the capability keeps that item and later input while dropping older replayed items. The compaction item is opaque model state rather than a human-readable summary, so pass it forward without editing it. These controls apply only to model transports that support Responses compaction.
 
 ## Concepts
 
@@ -332,6 +338,16 @@ Use developer-owned lifecycle when you want to eagerly create a sandbox, reuse o
   title="Manage the sandbox session yourself"
 />
 
+### Observe sandbox operations
+
+Sandbox operation events provide process-wide observability for runner-managed sandbox work. Register a `SandboxEventSink` with `addSandboxEventSink()` to receive `sandbox_operation` events. Each operation emits a `start` phase followed by either `end` or `error`; terminal events include the duration, and error events include normalized error details such as a code or retryability when the provider exposes them.
+
+When a run configures `sandbox.cwd`, `sandbox.exec` event data reports the effective cwd-anchored `workdir`, and `sandbox.view_image` event data reports the effective cwd-anchored `path`. These values match the paths sent to the sandbox session.
+
+Use `createSandboxJsonlEventSink()` to write one event per JSONL line, `createSandboxHttpEventSink()` to send each event as an HTTP `POST`, or `createChainedSandboxEventSink()` to fan out to several sinks. `addSandboxEventSink()` returns a removal function; call it when the application no longer needs that sink, or use `clearSandboxEventSinks()` to remove all registered sinks.
+
+Event sinks are observational. The SDK waits for the registered sinks to settle, but a sink failure does not replace the sandbox operation's result or error. Handle delivery retries, buffering, and sink-specific failures inside the sink when your application requires stronger delivery guarantees.
+
 ## `sandbox` run options
 
 The `sandbox` run option holds the per-run options that decide where the sandbox session comes from and how a fresh session should be initialized.
@@ -345,6 +361,12 @@ These options decide whether the runner should reuse, resume, or create the sand
 | `client` | You want the runner to create, resume, and clean up sandbox sessions for you. | Required unless you provide a live sandbox `session`. |
 | `session` | You already created a live sandbox session yourself. | The caller owns lifecycle; the runner reuses that live sandbox session. |
 | `sessionState` | You have serialized sandbox session state but not a live sandbox session object. | Requires `client`; the runner resumes from that explicit state as an owning session. |
+
+### Working directory
+
+Set `cwd` on the `sandbox` run config to make a workspace-relative directory the working directory for that run. The built-in `exec_command`, `view_image`, and `apply_patch` tools resolve relative paths from this directory; other sandbox tools keep their own path contracts. The setting changes path resolution but does not isolate the run from the rest of the session workspace.
+
+The value must be a non-empty, workspace-relative POSIX path. Absolute paths, backslashes, and parent (`..`) segments are rejected. Before every model turn, the runner checks that the directory exists and is accessible for the sandbox agent's `runAs` identity. A custom or injected session used with `cwd` must implement `directoryExists()`.
 
 ### Fresh-session inputs
 


### PR DESCRIPTION
This pull request updates the v0.16.1 documentation for sandbox agents. It explains the available compaction policies and their defaults, including dynamic threshold validation and compaction-item replay behavior, and documents process-wide sandbox operation event sinks, lifecycle phases, helper sinks, and failure isolation.