### PR TITLE
fix(sandbox): trace effective run-scoped sandbox paths

### DIFF
--- a/.changeset/effective-view-image-traces.md
+++ b/.changeset/effective-view-image-traces.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix(sandbox): trace the effective view_image path
+fix(sandbox): trace effective run-scoped sandbox paths

--- a/.changeset/effective-view-image-traces.md
+++ b/.changeset/effective-view-image-traces.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(sandbox): trace the effective view_image path

--- a/packages/agents-core/src/sandbox/capabilities/filesystem.ts
+++ b/packages/agents-core/src/sandbox/capabilities/filesystem.ts
@@ -548,16 +548,17 @@ class FilesystemCapability extends Capability {
           'Filesystem sandbox sessions must provide viewImage().',
         );
       }
+      const effectivePath = this._workspaceScope?.anchor(path) ?? path;
       try {
         return await withSandboxSpan(
           'sandbox.view_image',
           {
-            path,
+            path: effectivePath,
             run_as: this._runAs,
           },
           async () =>
             await session.viewImage!({
-              path: this._workspaceScope?.anchor(path) ?? path,
+              path: effectivePath,
               runAs: this._runAs,
             } satisfies ViewImageArgs),
           this.tracingParent(details),

--- a/packages/agents-core/src/sandbox/capabilities/shell.ts
+++ b/packages/agents-core/src/sandbox/capabilities/shell.ts
@@ -108,12 +108,14 @@ class ShellCapability extends Capability {
           },
           _context,
           details?: ToolCallDetails,
-        ): Promise<string> =>
-          await withSandboxSpan(
+        ): Promise<string> => {
+          const effectiveWorkdir =
+            this._workspaceScope?.anchor(workdir) ?? workdir;
+          return await withSandboxSpan(
             'sandbox.exec',
             {
               cmd,
-              workdir,
+              workdir: effectiveWorkdir,
               shell,
               login,
               tty,
@@ -122,7 +124,7 @@ class ShellCapability extends Capability {
             async () =>
               await session.execCommand!({
                 cmd,
-                workdir: this._workspaceScope?.anchor(workdir) ?? workdir,
+                workdir: effectiveWorkdir,
                 shell,
                 login,
                 tty,
@@ -131,7 +133,8 @@ class ShellCapability extends Capability {
                 runAs: this._runAs,
               } satisfies ExecCommandArgs),
             this.tracingParent(details),
-          ),
+          );
+        },
       }),
     ];
 

--- a/packages/agents-core/test/sandboxTracePaths.test.ts
+++ b/packages/agents-core/test/sandboxTracePaths.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { RunContext } from '../src';
+import {
+  addSandboxEventSink,
+  clearSandboxEventSinks,
+  SandboxWorkspaceScope,
+  shell,
+  type SandboxEvent,
+} from '../src/sandbox';
+import { scriptedSandboxSession } from '../src/testing';
+
+describe('sandbox trace paths', () => {
+  afterEach(() => {
+    clearSandboxEventSinks();
+  });
+
+  it('records the effective run-scoped exec workdir', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+
+    const session = scriptedSandboxSession([
+      { method: 'execCommand', result: 'default cwd' },
+      { method: 'execCommand', result: 'nested cwd' },
+    ]);
+    const capability = shell();
+    capability
+      .bind(session)
+      .bindWorkspaceScope(SandboxWorkspaceScope.fromCwd('tasks/a'));
+    const execCommand = capability.tools()[0] as any;
+
+    await execCommand.invoke(new RunContext(), JSON.stringify({ cmd: 'pwd' }));
+    await execCommand.invoke(
+      new RunContext(),
+      JSON.stringify({ cmd: 'pwd', workdir: 'reports' }),
+    );
+
+    const starts = events.filter(
+      (event) =>
+        event.type === 'sandbox_operation' &&
+        event.name === 'sandbox.exec' &&
+        event.phase === 'start',
+    );
+    expect(starts.map((event) => event.data.workdir)).toEqual([
+      'tasks/a',
+      'tasks/a/reports',
+    ]);
+    expect(session.calls.map((call) => (call.args[0] as any).workdir)).toEqual([
+      'tasks/a',
+      'tasks/a/reports',
+    ]);
+    session.assertComplete();
+  });
+});

--- a/packages/agents-core/test/sandboxTracePaths.test.ts
+++ b/packages/agents-core/test/sandboxTracePaths.test.ts
@@ -42,7 +42,7 @@ describe('sandbox trace paths', () => {
         event.name === 'sandbox.exec' &&
         event.phase === 'start',
     );
-    expect(starts.map((event) => event.data.workdir)).toEqual([
+    expect(starts.map((event) => event.data?.workdir)).toEqual([
       'tasks/a',
       'tasks/a/reports',
     ]);

--- a/packages/agents-core/test/sandboxViewImageTrace.test.ts
+++ b/packages/agents-core/test/sandboxViewImageTrace.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { RunContext } from '../src';
+import {
+  addSandboxEventSink,
+  clearSandboxEventSinks,
+  filesystem,
+  Manifest,
+  SandboxWorkspaceScope,
+  type SandboxEvent,
+} from '../src/sandbox';
+
+describe('sandbox view_image tracing', () => {
+  afterEach(() => {
+    clearSandboxEventSinks();
+  });
+
+  it('records the same run-scoped path that view_image reads', async () => {
+    const events: SandboxEvent[] = [];
+    const readPaths: string[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+
+    const session = {
+      state: { manifest: new Manifest() },
+      createEditor: () => ({
+        createFile: async () => undefined,
+        updateFile: async () => undefined,
+        deleteFile: async () => undefined,
+      }),
+      viewImage: async ({ path }: { path: string }) => {
+        readPaths.push(path);
+        return { type: 'image', image: 'image-ref' };
+      },
+    } as any;
+
+    const capability = filesystem();
+    capability
+      .bind(session)
+      .bindWorkspaceScope(SandboxWorkspaceScope.fromCwd('tasks/a'));
+    const [viewImage] = capability.tools();
+
+    await (viewImage as any).invoke(
+      new RunContext(),
+      JSON.stringify({ path: 'plot.png' }),
+    );
+
+    expect(readPaths).toEqual(['tasks/a/plot.png']);
+    expect(
+      events
+        .filter((event) => event.name === 'sandbox.view_image')
+        .map((event) => event.data?.path),
+    ).toEqual(['tasks/a/plot.png', 'tasks/a/plot.png']);
+  });
+});


### PR DESCRIPTION
### Summary

Record the effective run-scoped sandbox paths in tracing and audit event data for both `view_image` and `exec_command`.

With a run-scoped sandbox cwd, the model-provided path/workdir can differ from the value actually passed to the sandbox session. Previously, tracing could record the raw relative value even though execution used the anchored path.

This change computes each effective path once and uses that same value for both the trace payload and sandbox call:

- `view_image` records and reads the same anchored path
- `exec_command` records and executes in the same effective workdir, including omitted and relative workdirs

User-facing `view_image` error messages continue to use the model-provided path.

This incorporates the related `exec_command` fix and regression coverage from #1689 into this PR as requested in review.

### Test plan

Added event-level regression coverage under `SandboxWorkspaceScope.fromCwd('tasks/a')` verifying:

- `view_image` reads `tasks/a/plot.png` and both start/end events record that path
- omitted `exec_command` workdir resolves to `tasks/a`
- relative `exec_command` workdir `reports` resolves to `tasks/a/reports`
- sandbox execution and emitted audit events receive identical effective paths

A single patch changeset for `@openai/agents-core` is included.

### Issue number

None. Found while auditing run-scoped sandbox trace provenance.