### PR TITLE
fix(realtime): preserve omitted noise reduction

### DIFF
--- a/.changeset/preserve-realtime-noise-reduction.md
+++ b/.changeset/preserve-realtime-noise-reduction.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix(realtime): preserve omitted input noise reduction

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -217,7 +217,7 @@ export function toNewSessionConfig(
     const inputConfig = audioInput
       ? {
           format: normalizeAudioFormat(audioInput?.format),
-          noiseReduction: audioInput?.noiseReduction ?? null,
+          noiseReduction: audioInput.noiseReduction,
           transcription: audioInput?.transcription,
           turnDetection: audioInput?.turnDetection,
         }

--- a/packages/agents-realtime/test/clientMessagesNoiseReduction.test.ts
+++ b/packages/agents-realtime/test/clientMessagesNoiseReduction.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { toNewSessionConfig } from '../src/clientMessages';
+
+describe('Realtime GA audio config conversion', () => {
+  it('does not disable noise reduction when the caller only sets input format', () => {
+    const config = toNewSessionConfig({
+      audio: {
+        input: {
+          format: { type: 'audio/pcm', rate: 24000 },
+        },
+      },
+    });
+
+    expect(config.audio?.input?.noiseReduction).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(config.audio?.input))).not.toHaveProperty(
+      'noiseReduction',
+    );
+  });
+
+  it('preserves explicit noise reduction disable and configuration values', () => {
+    const disabled = toNewSessionConfig({
+      audio: { input: { noiseReduction: null } },
+    });
+    const enabled = toNewSessionConfig({
+      audio: { input: { noiseReduction: { type: 'near_field' } } },
+    });
+
+    expect(disabled.audio?.input?.noiseReduction).toBeNull();
+    expect(enabled.audio?.input?.noiseReduction).toEqual({
+      type: 'near_field',
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Preserve omission of `audio.input.noiseReduction` when converting the GA Realtime session config.

`toNewSessionConfig` currently maps an omitted `noiseReduction` field to `null` whenever an input audio object exists. This means a caller that only sets `audio.input.format` silently sends an explicit noise-reduction disable instead of leaving that setting unspecified.

The new-config path is documented as a shallow normalization of the supplied GA config. This change keeps omitted noise reduction omitted while continuing to preserve explicit `null` and explicit noise-reduction configurations. The deprecated config conversion remains unchanged.

### Test plan

Added focused coverage showing that:

- setting only `audio.input.format` leaves `noiseReduction` undefined and absent after JSON serialization
- explicit `noiseReduction: null` remains `null`
- an explicit `{ type: 'near_field' }` configuration is preserved

A patch changeset for `@openai/agents-realtime` is included.

### Issue number

None. Found while auditing GA Realtime session config normalization.