### PR TITLE
fix(sandbox): make provider error inspection fail-safe

### DIFF
--- a/.changeset/failsafe-provider-errors.md
+++ b/.changeset/failsafe-provider-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix(sandbox): make provider error inspection fail-safe

--- a/packages/agents-extensions/src/sandbox/shared/session.ts
+++ b/packages/agents-extensions/src/sandbox/shared/session.ts
@@ -10,6 +10,9 @@ import { isRecord } from './typeGuards';
 
 export { withSandboxSpan };
 
+const UNINSPECTABLE_PROVIDER_ERROR =
+  'Provider error could not be inspected safely.';
+
 export async function closeRemoteSessionOnManifestError(
   providerName: string,
   session: { close(): Promise<void> },
@@ -95,7 +98,7 @@ export async function withProviderError<T>(
         },
       );
     }
-    if (error instanceof UserError) {
+    if (safelyIsUserError(error)) {
       throw error;
     }
     const cause = providerErrorMessage(error);
@@ -115,11 +118,15 @@ export async function withProviderError<T>(
 }
 
 export function isProviderSandboxNotFoundError(error: unknown): boolean {
-  if (isNotFoundErrorRecord(error, new Set())) {
-    return true;
+  try {
+    if (isNotFoundErrorRecord(error, new Set())) {
+      return true;
+    }
+  } catch {
+    // Fall through to the fail-safe text path below.
   }
 
-  const text = errorMessage(error).trim();
+  const text = providerErrorMessage(error).trim();
   return isNotFoundErrorMessage(text);
 }
 
@@ -133,7 +140,7 @@ export function assertResumeRecreateAllowed(
   error: unknown,
   context: ResumeRecreateErrorContext,
 ): void {
-  if (error instanceof UserError) {
+  if (safelyIsUserError(error)) {
     throw error;
   }
 
@@ -155,7 +162,12 @@ export function assertResumeRecreateAllowed(
 }
 
 export function providerErrorMessage(error: unknown): string {
-  const message = errorMessage(error);
+  let message = UNINSPECTABLE_PROVIDER_ERROR;
+  try {
+    message = errorMessage(error);
+  } catch {
+    // Keep the generic fail-safe message.
+  }
   const details = providerErrorDetails(error);
   const detailText = formatProviderErrorDetailSummary(details);
   if (!detailText) {
@@ -165,18 +177,30 @@ export function providerErrorMessage(error: unknown): string {
 }
 
 export function providerErrorDetails(error: unknown): Record<string, unknown> {
-  return collectProviderErrorDetails(error, new Set<object>(), 0);
+  try {
+    return collectProviderErrorDetails(error, new Set<object>(), 0);
+  } catch {
+    return {};
+  }
 }
 
 export function providerErrorRetryability(error: unknown): boolean | null {
-  return readProviderErrorRetryability(error, new Set<object>(), 0);
+  try {
+    return readProviderErrorRetryability(error, new Set<object>(), 0);
+  } catch {
+    return null;
+  }
 }
 
 function safelyReadProviderErrorRetryability(error: unknown): boolean | null {
+  return providerErrorRetryability(error);
+}
+
+function safelyIsUserError(error: unknown): error is UserError {
   try {
-    return providerErrorRetryability(error);
+    return error instanceof UserError;
   } catch {
-    return null;
+    return false;
   }
 }
 

--- a/packages/agents-extensions/test/sandbox/providerErrorFailsafe.test.ts
+++ b/packages/agents-extensions/test/sandbox/providerErrorFailsafe.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { SandboxProviderError } from '@openai/agents-core/sandbox';
+import {
+  assertResumeRecreateAllowed,
+  providerErrorDetails,
+  providerErrorMessage,
+  providerErrorRetryability,
+  withProviderError,
+} from '../../src/sandbox/shared';
+
+function hostileProviderError(): object {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('provider metadata trap');
+      },
+      getPrototypeOf() {
+        throw new Error('provider prototype trap');
+      },
+    },
+  );
+}
+
+describe('sandbox provider error inspection', () => {
+  it('keeps diagnostic helpers fail-safe for hostile provider errors', () => {
+    const error = hostileProviderError();
+
+    expect(providerErrorMessage(error)).toBe(
+      'Provider error could not be inspected safely.',
+    );
+    expect(providerErrorDetails(error)).toEqual({});
+    expect(providerErrorRetryability(error)).toBeNull();
+  });
+
+  it('wraps hostile provider failures as SandboxProviderError', async () => {
+    const providerFailure = hostileProviderError();
+    let thrown: unknown;
+
+    try {
+      await withProviderError(
+        'ProviderSandboxClient',
+        'provider',
+        'create sandbox',
+        async () => {
+          throw providerFailure;
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as Error).message).toContain(
+      'Provider error could not be inspected safely.',
+    );
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'provider',
+      operation: 'create sandbox',
+      retryable: null,
+      cause: 'Provider error could not be inspected safely.',
+    });
+  });
+
+  it('keeps hostile resume failures inside the provider error boundary', () => {
+    expect(() =>
+      assertResumeRecreateAllowed(hostileProviderError(), {
+        providerName: 'ProviderSandboxClient',
+        provider: 'provider',
+      }),
+    ).toThrow(SandboxProviderError);
+  });
+});


### PR DESCRIPTION
### Summary

Keep remote sandbox provider failures inside the SDK's provider-error boundary even when the thrown value cannot be safely inspected.

The shared provider helpers inspect arbitrary SDK/provider failures for message, status, retryability, response payload, and nested cause data. JavaScript permits proxies and property accessors that can themselves throw. In those cases, `instanceof`, property reads, or string conversion could replace the original provider failure with a JavaScript inspection error before `withProviderError` produced its intended `SandboxProviderError`.

This change makes the exported provider diagnostic helpers fail-safe. Normal provider errors retain their existing rich metadata. Uninspectable failures use a generic message, empty structured details, and unknown retryability. UserError passthrough is preserved when classification is safe, and resume error handling uses the same guarded boundary.

### Test plan

Added regression coverage showing that a hostile provider proxy whose property and prototype access throw:

- produces a safe generic provider message
- produces empty structured details and unknown retryability
- is wrapped by `withProviderError` as `SandboxProviderError`
- remains inside the provider error boundary during resume handling

A patch changeset for `@openai/agents-extensions` is included.

### Issue number

None. Found while auditing remote sandbox provider failure integrity.