### PR TITLE
fix(realtime): normalize unsupported PCM rates

### DIFF
--- a/.changeset/normalize-realtime-pcm-rate.md
+++ b/.changeset/normalize-realtime-pcm-rate.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix(realtime): normalize PCM audio to the supported 24 kHz rate

--- a/packages/agents-realtime/src/clientMessages.ts
+++ b/packages/agents-realtime/src/clientMessages.ts
@@ -286,11 +286,7 @@ export function normalizeAudioFormat(
 ): RealtimeAudioFormatDefinition | undefined {
   if (!format) return undefined;
   if (typeof format === 'object') {
-    if (
-      format.type === 'audio/pcm' &&
-      typeof format.rate === 'number' &&
-      !Number.isFinite(format.rate)
-    ) {
+    if (format.type === 'audio/pcm' && format.rate !== 24000) {
       return { type: 'audio/pcm', rate: 24000 };
     }
 

--- a/packages/agents-realtime/test/audioFormatRate.test.ts
+++ b/packages/agents-realtime/test/audioFormatRate.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAudioFormat } from '../src/clientMessages';
+
+describe('Realtime PCM audio format normalization', () => {
+  it.each([16000, 44100, 48000, Number.NaN, Number.POSITIVE_INFINITY])(
+    'normalizes unsupported PCM rate %s to 24000',
+    (rate) => {
+      expect(normalizeAudioFormat({ type: 'audio/pcm', rate })).toEqual({
+        type: 'audio/pcm',
+        rate: 24000,
+      });
+    },
+  );
+
+  it('preserves the supported 24000 Hz PCM format', () => {
+    expect(normalizeAudioFormat({ type: 'audio/pcm', rate: 24000 })).toEqual({
+      type: 'audio/pcm',
+      rate: 24000,
+    });
+  });
+
+  it('leaves G.711 formats unchanged', () => {
+    expect(normalizeAudioFormat({ type: 'audio/pcmu' })).toEqual({
+      type: 'audio/pcmu',
+    });
+    expect(normalizeAudioFormat({ type: 'audio/pcma' })).toEqual({
+      type: 'audio/pcma',
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Normalize Realtime PCM audio format objects to the only sample rate supported by the OpenAI Realtime API.

The current JavaScript converter only replaces non-finite PCM rates. Finite values such as 16000, 44100, or 48000 pass through unchanged even though the Realtime API's PCM format declares the rate as always 24000. This can allow an invalid session config to reach the API.

This change normalizes every PCM rate other than 24000 to 24000. The supported rate is preserved unchanged, and PCMU/PCMA formats are unaffected. This also matches the existing Python Agents SDK behavior for unsupported PCM rates.

### Test plan

Added focused coverage for:

- finite unsupported PCM rates including 16000, 44100, and 48000
- non-finite PCM rates
- the supported 24000 Hz rate
- unchanged PCMU and PCMA formats

A patch changeset for `@openai/agents-realtime` is included.

### Issue number

None. Found while comparing the Agents SDK Realtime format normalization against the OpenAI Realtime API contract and Python SDK behavior.