### PR TITLE
fix: validate model retry counts

### DIFF
--- a/.changeset/validate-model-retry-counts.md
+++ b/.changeset/validate-model-retry-counts.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: validate model retry counts before execution

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -163,6 +163,20 @@ export function validateModelTimeoutMs(
   return timeoutMs;
 }
 
+export function validateModelMaxRetries(modelSettings: ModelSettings): number {
+  const maxRetries = modelSettings.retry?.maxRetries ?? 0;
+  if (
+    !Number.isFinite(maxRetries) ||
+    maxRetries < 0 ||
+    !Number.isInteger(maxRetries)
+  ) {
+    throw new UserError(
+      'modelSettings.retry.maxRetries must be a non-negative finite integer when provided.',
+    );
+  }
+  return maxRetries;
+}
+
 function createModelTimeoutError(
   timeoutMs: number,
   cause?: unknown,
@@ -1063,7 +1077,7 @@ export async function getResponseWithRetry(
   request: ModelRequest,
   handlers: ModelRetryHandlers = {},
 ): Promise<ModelResponse> {
-  const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
+  const maxRetries = validateModelMaxRetries(request.modelSettings);
   const retryPolicy = request.modelSettings.retry?.policy;
   const retryBackoff = request.modelSettings.retry?.backoff;
   const timeoutMs = validateModelTimeoutMs(request.modelSettings);
@@ -1185,7 +1199,7 @@ export async function* getStreamedResponseWithRetry(
   request: ModelRequest,
   handlers: ModelRetryHandlers = {},
 ): AsyncIterable<StreamEvent> {
-  const maxRetries = request.modelSettings.retry?.maxRetries ?? 0;
+  const maxRetries = validateModelMaxRetries(request.modelSettings);
   const retryPolicy = request.modelSettings.retry?.policy;
   const retryBackoff = request.modelSettings.retry?.backoff;
   const timeoutMs = validateModelTimeoutMs(request.modelSettings);

--- a/packages/agents-core/test/modelRetryValidation.test.ts
+++ b/packages/agents-core/test/modelRetryValidation.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  Agent,
+  run,
+  setDefaultModelProvider,
+  setTracingDisabled,
+} from '../src';
+import { validateModelMaxRetries } from '../src/runner/modelRetry';
+import { ScriptedModel, modelResponse } from '../src/testing';
+import { Usage } from '../src/usage';
+import { fakeModelMessage, ScriptedModelProvider } from './stubs';
+
+beforeAll(() => {
+  setTracingDisabled(true);
+  setDefaultModelProvider(new ScriptedModelProvider());
+});
+
+describe('model retry count validation', () => {
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid maxRetries value %s',
+    (maxRetries) => {
+      expect(() =>
+        validateModelMaxRetries({ retry: { maxRetries } }),
+      ).toThrow(
+        'modelSettings.retry.maxRetries must be a non-negative finite integer when provided.',
+      );
+    },
+  );
+
+  it.each([0, 1, 3])('accepts bounded integer maxRetries %s', (maxRetries) => {
+    expect(validateModelMaxRetries({ retry: { maxRetries } })).toBe(maxRetries);
+  });
+
+  it('defaults maxRetries to zero', () => {
+    expect(validateModelMaxRetries({})).toBe(0);
+  });
+
+  it('fails before starting a model request for invalid retry counts', async () => {
+    const model = new ScriptedModel([
+      modelResponse({
+        output: [fakeModelMessage('should not run')],
+        usage: new Usage(),
+      }),
+    ]);
+    const agent = new Agent({
+      name: 'InvalidRetryCountAgent',
+      model,
+      modelSettings: {
+        retry: {
+          maxRetries: Number.NaN,
+          policy: () => true,
+        },
+      },
+    });
+
+    await expect(run(agent, 'hello')).rejects.toThrow(
+      'modelSettings.retry.maxRetries must be a non-negative finite integer when provided.',
+    );
+    expect(model.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Summary

Validate `modelSettings.retry.maxRetries` before runner-managed retries begin.

The retry loop currently uses the configured numeric value directly. `NaN` makes the retry exhaustion comparison permanently false, so a policy returning `true` can retry indefinitely; `Infinity` is likewise unbounded. Fractional and negative values also do not represent a valid bounded retry count.

This change requires `maxRetries` to be a non-negative finite integer when provided and fails before issuing a model request. The default remains zero and valid integer retry counts are unchanged. Validation is shared by streaming and non-streaming retry entrypoints.

### Test plan

Added focused coverage for:

- negative, fractional, `NaN`, and infinite retry counts
- valid zero and positive integer retry counts
- unchanged zero default
- user-facing run failure before any model request for invalid configuration

A patch changeset for `@openai/agents-core` is included.

### Issue number

None. Found while auditing the new runner-managed retry controls.