### PR TITLE
fix(core): validate the remaining sandbox compaction thresholds

### DIFF
--- a/.changeset/validate-compaction-thresholds.md
+++ b/.changeset/validate-compaction-thresholds.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: validate the remaining sandbox compaction thresholds

--- a/packages/agents-core/src/sandbox/capabilities/compaction.ts
+++ b/packages/agents-core/src/sandbox/capabilities/compaction.ts
@@ -7,11 +7,20 @@ export abstract class CompactionPolicy {
   abstract compactThreshold(model?: string): number;
 }
 
+function assertCompactionThreshold(value: number, label: string): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new UserError(
+      `${label} must be a finite number greater than or equal to 0.`,
+    );
+  }
+}
+
 export class StaticCompactionPolicy extends CompactionPolicy {
   readonly threshold: number;
 
   constructor(threshold: number = 240000) {
     super();
+    assertCompactionThreshold(threshold, 'StaticCompactionPolicy.threshold');
     this.threshold = threshold;
   }
 
@@ -38,6 +47,10 @@ export class DynamicCompactionPolicy extends CompactionPolicy {
         'DynamicCompactionPolicy.thresholdRatio must be a finite number between 0 and 1.',
       );
     }
+    assertCompactionThreshold(
+      fallbackThreshold,
+      'DynamicCompactionPolicy.fallbackThreshold',
+    );
     this.thresholdRatio = thresholdRatio;
     this.fallbackThreshold = fallbackThreshold;
   }

--- a/packages/agents-core/test/sandboxCompactionPolicy.test.ts
+++ b/packages/agents-core/test/sandboxCompactionPolicy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { DynamicCompactionPolicy } from '../src/sandbox';
+import {
+  compaction,
+  DynamicCompactionPolicy,
+  StaticCompactionPolicy,
+} from '../src/sandbox';
 
 describe('DynamicCompactionPolicy', () => {
   it.each([-0.01, 1.01, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
@@ -17,5 +21,51 @@ describe('DynamicCompactionPolicy', () => {
     expect(policy.compactThreshold('gpt-5-mini')).toBe(
       Math.floor(400000 * thresholdRatio),
     );
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
+    'rejects an invalid fallback threshold %s',
+    (fallbackThreshold) => {
+      expect(() => new DynamicCompactionPolicy(0.9, fallbackThreshold)).toThrow(
+        'DynamicCompactionPolicy.fallbackThreshold must be a finite number greater than or equal to 0.',
+      );
+    },
+  );
+
+  it('keeps a valid fallback threshold for unrecognised models', () => {
+    const policy = new DynamicCompactionPolicy(0.9, 1000);
+
+    expect(policy.compactThreshold('not-a-known-model')).toBe(1000);
+    expect(policy.compactThreshold()).toBe(1000);
+  });
+});
+
+describe('StaticCompactionPolicy', () => {
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -1])(
+    'rejects an invalid threshold %s',
+    (threshold) => {
+      expect(() => new StaticCompactionPolicy(threshold)).toThrow(
+        'StaticCompactionPolicy.threshold must be a finite number greater than or equal to 0.',
+      );
+    },
+  );
+
+  it.each([0, 240000])('accepts a valid threshold %s', (threshold) => {
+    expect(new StaticCompactionPolicy(threshold).compactThreshold()).toBe(
+      threshold,
+    );
+  });
+});
+
+describe('compaction sampling params', () => {
+  it('never serialises a non-numeric compact_threshold', () => {
+    // NaN serialises to null on the wire, which is not a valid threshold.
+    const params = compaction({
+      policy: new StaticCompactionPolicy(240000),
+    }).samplingParams({ model: 'gpt-4o' });
+
+    const threshold = (params as any).context_management[0].compact_threshold;
+    expect(Number.isFinite(threshold)).toBe(true);
+    expect(JSON.parse(JSON.stringify(params))).toEqual(params);
   });
 });


### PR DESCRIPTION
### Summary

#1691 added a finite check for `DynamicCompactionPolicy.thresholdRatio`. The same constructor's second argument and the sibling `StaticCompactionPolicy` were left unchecked, so the same invalid values still get through:

```ts
new StaticCompactionPolicy(Number.NaN).compactThreshold();            // NaN
new StaticCompactionPolicy(-240000).compactThreshold();               // -240000
new DynamicCompactionPolicy(0.9, Number.NaN).compactThreshold('x');   // NaN
new DynamicCompactionPolicy(0.9, -1).compactThreshold();              // -1
```

`fallbackThreshold` is not a rare path: `compactThreshold()` returns it for every model the SDK does not recognise, and for any call with no model at all.

Both classes are public API through `@openai/agents-core/sandbox`, and the value flows straight into the request that `CompactionCapability.samplingParams` builds. `NaN` does not survive JSON, so the capability emits a null threshold:

```
samplingParams: {"context_management":[{"type":"compaction","compact_threshold":null}]}
```

A negative or `Infinity` threshold is worse in a way, since it serialises fine and silently changes when compaction triggers.

### Fix

The same finite check #1691 introduced, applied to both absolute thresholds through one shared helper:

```ts
function assertCompactionThreshold(value: number, label: string): void {
  if (!Number.isFinite(value) || value < 0) {
    throw new UserError(
      `${label} must be a finite number greater than or equal to 0.`,
    );
  }
}
```

`0` stays valid, matching the existing boundary test that accepts a `thresholdRatio` of `0`.

### Test plan

Seven cases added to `packages/agents-core/test/sandboxCompactionPolicy.test.ts`, all failing on `main`:

- `StaticCompactionPolicy` rejects `NaN`, `Infinity`, `-Infinity` and `-1`
- `DynamicCompactionPolicy` rejects a `NaN`, `Infinity` or negative `fallbackThreshold`

Plus three that pass in both states, pinning what must not change: valid thresholds of `0` and `240000` still round-trip, a valid `fallbackThreshold` is still returned for unrecognised models and for no model, and `samplingParams` still serialises to a finite `compact_threshold`.

Verified locally on Windows:

- `pnpm test packages/agents-core/test/sandboxCompactionPolicy.test.ts`: 18 passing, 7 of them failing on `main`
- `tsc --noEmit -p packages/agents-core/tsconfig.json`: 0 errors
- `pnpm lint`
- Wider `agents-core` run shows no new failures. The pre-existing ones on this platform are the sandbox suites that need POSIX path separators and symlink support, and the RunState fixture hash that trips on a CRLF checkout.

### Issue number

Follow-up to #1691

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
