### PR TITLE
docs: show Docker sandbox network isolation

### DIFF
--- a/examples/docs/sandbox-agents/docker-client.ts
+++ b/examples/docs/sandbox-agents/docker-client.ts
@@ -10,7 +10,12 @@ const agent = new SandboxAgent({
 
 const result = await run(agent, 'Inspect the workspace.', {
   sandbox: {
-    client: new DockerSandboxClient({ image: 'node:22-bookworm-slim' }),
+    client: new DockerSandboxClient({
+      image: 'node:22-bookworm-slim',
+      // Uncomment to disable networking for the container.
+      // Do not combine networkMode: 'none' with exposedPorts.
+      // networkMode: 'none',
+    }),
   },
 });
 


### PR DESCRIPTION
### Summary

Document the Docker sandbox network-isolation option added in #1695 in the existing rendered Docker client example.

The snippet now shows `networkMode: 'none'` as an opt-in commented configuration and notes that it cannot be combined with `exposedPorts`. Keeping the option commented preserves the existing connected Docker example while making the new isolation control discoverable from the sandbox client guide.

This is intentionally a separate docs-only follow-up so its merge can be coordinated with the release that includes #1695.

### Test plan

- The changed TypeScript snippet remains syntactically valid with `networkMode` commented out.
- The documented option and incompatibility match `DockerSandboxClientOptions` and the runtime validation/tests added by #1695.
- No generated translations are edited.

### Issue number

Related to #1695.