### PR TITLE
fix: keep Codex verification for development sandboxed

### DIFF
--- a/.agents/skills/code-change-verification/SKILL.md
+++ b/.agents/skills/code-change-verification/SKILL.md
@@ -13,10 +13,11 @@ Ensure work is only marked complete after installing dependencies, building, lin
 
 1. Keep this skill at `./.agents/skills/code-change-verification` so it loads automatically for the repository.
 2. Run the skill in the user's selected checkout without changing worktrees or branches.
-3. macOS/Linux: `bash .agents/skills/code-change-verification/scripts/run.sh`.
-4. Windows: `powershell -ExecutionPolicy Bypass -File .agents/skills/code-change-verification/scripts/run.ps1`.
-5. If any command fails, fix the issue, rerun the script, and report the failing output.
-6. Confirm completion only when all commands succeed with no remaining issues.
+3. Codex on macOS/Linux: `/usr/bin/env -u OPENAI_API_KEY bash .agents/skills/code-change-verification/scripts/run.sh`.
+4. Other macOS/Linux environments: `bash .agents/skills/code-change-verification/scripts/run.sh`.
+5. Windows: `powershell -ExecutionPolicy Bypass -File .agents/skills/code-change-verification/scripts/run.ps1`.
+6. If any command fails, fix the issue, rerun the script, and report the failing output.
+7. Confirm completion only when all commands succeed with no remaining issues.
 
 ## Start condition and host capacity
 
@@ -24,6 +25,12 @@ Ensure work is only marked complete after installing dependencies, building, lin
 - Immediately before starting the complete stack, use available read-only task or process evidence to check whether another repository-wide test, typecheck, build, examples runner, or integration command is already active on the same host.
 - When concrete contention is visible, continue useful non-heavy work such as review, remediation, evidence preparation, or focused checks, then check again later. Do not create or wait on a repository lock, host-wide mutex, or sentinel file.
 - Start automatically once review is clean, the diff is stable, and observable host capacity is available. Do not require a user-triggered `finalize` message. If host telemetry is unavailable, do not block solely because capacity cannot be measured.
+
+## Codex execution policy
+
+Repository verification and all child processes must remain in the normal Codex workspace sandbox. Never request elevated sandbox permissions for verification, and never retry with broader host access after a failure.
+
+On macOS/Linux, use the exact Codex command from Quick start so an inherited `OPENAI_API_KEY` is removed before the repository-controlled wrapper starts. Investigate failures inside the workspace sandbox and report any coverage that the sandbox cannot provide instead of weakening the sandbox boundary.
 
 ## Manual workflow
 

--- a/.agents/skills/code-change-verification/agents/openai.yaml
+++ b/.agents/skills/code-change-verification/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Code Change Verification"
   short_description: "Run the required local verification stack"
-  default_prompt: "Use $code-change-verification to run the required local verification stack and report any failures."
+  default_prompt: "Use $code-change-verification to run the required local verification stack inside the normal Codex workspace sandbox. On macOS/Linux, use the documented Codex command to remove the inherited OpenAI API key before the wrapper starts. Never request elevated sandbox permissions for verification, and never retry with broader host access after a failure. Report any failures."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,14 @@ jobs:
               '.husky/',
               'integration-tests/',
             ];
+            const CI_RELEVANT_PREFIXES = [
+              '.agents/skills/code-change-verification/',
+            ];
 
             const isIgnoredPath = (path) => {
+              if (CI_RELEVANT_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+                return false;
+              }
               if (IGNORED_PREFIXES.some((prefix) => path.startsWith(prefix))) {
                 return true;
               }
@@ -41,6 +47,10 @@ jobs:
               }
               return false;
             };
+            const changedPathsForFile = (file) =>
+              [file.filename, file.previous_filename].filter(
+                (path) => typeof path === 'string',
+              );
 
             let changedFiles = [];
 
@@ -51,7 +61,7 @@ jobs:
                 pull_number: context.payload.pull_request.number,
                 per_page: 100,
               });
-              changedFiles = files.map((file) => file.filename);
+              changedFiles = files.flatMap(changedPathsForFile);
             } else if (context.eventName === 'push') {
               const before = context.payload.before;
               const after = context.payload.after;
@@ -67,7 +77,7 @@ jobs:
                 repo: context.repo.repo,
                 basehead: `${before}...${after}`,
               });
-              changedFiles = (comparison.data.files ?? []).map((file) => file.filename);
+              changedFiles = (comparison.data.files ?? []).flatMap(changedPathsForFile);
             } else {
               core.info(`Unsupported event "${context.eventName}". Running CI by default.`);
               core.setOutput('run_ci', 'true');

--- a/helpers/vitest/codeChangeVerificationPolicy.test.ts
+++ b/helpers/vitest/codeChangeVerificationPolicy.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+const rootDir = resolve(import.meta.dirname, '../..');
+const skillPath = resolve(
+  rootDir,
+  '.agents/skills/code-change-verification/SKILL.md',
+);
+const promptPath = resolve(
+  rootDir,
+  '.agents/skills/code-change-verification/agents/openai.yaml',
+);
+const workflowPath = resolve(rootDir, '.github/workflows/test.yml');
+
+describe('code-change verification policy', () => {
+  it('keeps Codex execution inside the workspace sandbox', () => {
+    const skill = readFileSync(skillPath, 'utf8');
+    const prompt = readFileSync(promptPath, 'utf8');
+    const sandboxPolicy =
+      'Never request elevated sandbox permissions for verification, and never retry with broader host access after a failure.';
+
+    expect(skill).toContain(sandboxPolicy);
+    expect(prompt).toContain(sandboxPolicy);
+    expect(skill).not.toContain('sandbox_permissions=require_escalated');
+    expect(prompt).not.toContain('sandbox_permissions=require_escalated');
+    expect(skill).not.toContain('outside the Codex sandbox');
+    expect(prompt).not.toContain('outside the Codex sandbox');
+    expect(skill).toContain(
+      '/usr/bin/env -u OPENAI_API_KEY bash .agents/skills/code-change-verification/scripts/run.sh',
+    );
+  });
+
+  it('runs CI for code-change verification policy updates', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const relevantBranch = [
+      'if (CI_RELEVANT_PREFIXES.some((prefix) => path.startsWith(prefix))) {',
+      '                return false;',
+      '              }',
+    ].join('\n');
+    const ignoredBranch =
+      'if (IGNORED_PREFIXES.some((prefix) => path.startsWith(prefix))) {';
+
+    expect(workflow).toContain(
+      "const CI_RELEVANT_PREFIXES = [\n              '.agents/skills/code-change-verification/',\n            ];",
+    );
+    expect(workflow).toContain(relevantBranch);
+    expect(workflow.indexOf(relevantBranch)).toBeLessThan(
+      workflow.indexOf(ignoredBranch),
+    );
+    expect(workflow).toContain(
+      'changedFiles = files.flatMap(changedPathsForFile);',
+    );
+    expect(workflow).toContain(
+      'changedFiles = (comparison.data.files ?? []).flatMap(changedPathsForFile);',
+    );
+
+    const scriptStart = workflow.indexOf('            const IGNORED_PREFIXES');
+    const scriptEnd = workflow.indexOf('\n\n            let changedFiles');
+    expect(scriptStart).toBeGreaterThanOrEqual(0);
+    expect(scriptEnd).toBeGreaterThan(scriptStart);
+    const policyScript = `${workflow
+      .slice(scriptStart, scriptEnd)
+      .replace(/^ {12}/gm, '')}
+this.isIgnoredPath = isIgnoredPath;
+this.changedPathsForFile = changedPathsForFile;`;
+    const context: {
+      isIgnoredPath?: (path: string) => boolean;
+      changedPathsForFile?: (file: {
+        filename: string;
+        previous_filename?: string;
+      }) => string[];
+    } = {};
+
+    runInNewContext(policyScript, context);
+    expect(context.isIgnoredPath).toBeTypeOf('function');
+    expect(context.changedPathsForFile).toBeTypeOf('function');
+
+    const changedPaths = context.changedPathsForFile!({
+      filename: '.agents/disabled-code-change-verification/SKILL.md',
+      previous_filename: '.agents/skills/code-change-verification/SKILL.md',
+    });
+
+    expect(changedPaths).toEqual([
+      '.agents/disabled-code-change-verification/SKILL.md',
+      '.agents/skills/code-change-verification/SKILL.md',
+    ]);
+    expect(changedPaths.some((path) => !context.isIgnoredPath!(path))).toBe(
+      true,
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
           maxConcurrency: 4,
           include: [
             'helpers/tests/consoleGuard.test.ts',
+            'helpers/vitest/codeChangeVerificationPolicy.test.ts',
             'helpers/vitest/reviewTestProfile.test.ts',
             'helpers/vitest/testConcurrency.test.ts',
             'helpers/vitest/workspacePackageAliases.test.ts',


### PR DESCRIPTION
This pull request fixes repository-controlled Codex verification so it remains inside the normal workspace sandbox.

It also keeps verification-policy changes CI-relevant, including renames reported through `previous_filename`, and adds focused regression coverage. This aligns the JS maintainer workflow with openai/openai-agents-python#4508 without adding native macOS sandbox test handling that does not exist in this repository.