### PR TITLE
fix(core): redact blocked tool outputs and aliases from replay state

### DIFF
--- a/.changeset/redact-blocked-tool-outputs.md
+++ b/.changeset/redact-blocked-tool-outputs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': minor
+---
+
+fix: redact blocked tool outputs and aliases from replay state

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -4,7 +4,6 @@ import {
   AgentsError,
   ModelBehaviorError,
   ModelTimeoutError,
-  OutputGuardrailTripwireTriggered,
   UserError,
 } from './errors';
 import {
@@ -46,7 +45,6 @@ import type { TracingConfig } from './tracing';
 import { includeTaskAndTurnSpans, mergeTracingConfig } from './tracing/config';
 import { Usage } from './usage';
 import { convertAgentOutputTypeToSerializable } from './utils/tools';
-import { isDataRedactedError } from './utils/finalOutputError';
 import { snapshotRawUsage } from './utils/rawUsage';
 import { DEFAULT_MAX_TURNS } from './runner/constants';
 import { StreamEventResponseCompleted } from './types/protocol';
@@ -62,7 +60,7 @@ import {
 } from './runner/conversation';
 import {
   createGuardrailTracker,
-  runOutputGuardrails,
+  finalizeOutputGuardrails,
 } from './runner/guardrails';
 import {
   adjustModelSettingsForNonGPT5RunnerModel,
@@ -100,7 +98,15 @@ import {
   preflightToolInvocations,
   resolveTurnAfterModelResponse,
 } from './runner/turnResolution';
-import { hasBlockedOutputExecutionEffect } from './runner/blockedOutputPersistence';
+import {
+  assertResumedSessionOutputGuardrailSafety,
+  captureCurrentResponseToolOutputGuardrailResultStart,
+  hasBlockedOutputExecutionEffect,
+  hasTerminalToolOutputSource,
+  OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+  sanitizeBlockedTerminalToolOutput,
+  shouldDeferInterruptedSessionItems,
+} from './runner/blockedOutputPersistence';
 import { prepareTurn } from './runner/turnPreparation';
 import type { NextStep } from './runner/steps';
 import {
@@ -790,6 +796,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         undefined;
       const portableInputItems =
         resumedState._currentTurnSessionHistoryTransactionInputItems;
+      assertResumedSessionOutputGuardrailSafety(
+        resumedState,
+        session,
+        this.#agentHasOutputGuardrail(resumedState._currentAgent),
+      );
       resumedState.setReasoningItemIdPolicy(reasoningItemIdPolicy);
       await prepareSessionHistoryTransactionsForRun(session, resumedState, {
         serverManagesConversation,
@@ -998,6 +1009,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     OutputGuardrailMetadata,
     AgentOutputType<unknown>
   >[];
+
+  #agentHasOutputGuardrail(agent: Agent<any, any>): boolean {
+    return Boolean(
+      this.outputGuardrailDefs.length > 0 || agent.outputGuardrails.length > 0,
+    );
+  }
+
+  #shouldDeferInterruptedSessionItems(state: RunState<any, any>): boolean {
+    return shouldDeferInterruptedSessionItems(
+      state,
+      this.#agentHasOutputGuardrail(state._currentAgent),
+    );
+  }
 
   /**
    * @internal
@@ -1266,6 +1290,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         result: RunResult<TContext, TAgent>,
         overrideOptions?: SessionPersistenceOptions,
       ) => {
+        if (this.#shouldDeferInterruptedSessionItems(result.state)) {
+          return;
+        }
         const hasUnpersistedItems =
           result.newItems.length > state._currentTurnPersistedItemCount ||
           (overrideOptions?.additionalRunItems?.length ?? 0) > 0;
@@ -1320,42 +1347,29 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           );
         }
         markAcceptedResponseFinalizationStarted(state);
-        try {
-          await runOutputGuardrails(
-            state,
-            this.outputGuardrailDefs,
-            currentStep.output,
-          );
-        } catch (error) {
-          if (
-            error instanceof OutputGuardrailTripwireTriggered &&
-            persistResult
-          ) {
-            try {
-              await persistResult(new RunResult<TContext, TAgent>(state), {
-                outputBlocked: true,
-              });
-            } catch (persistenceError) {
-              error.state ??= state;
-              (error as Error & { cause?: unknown }).cause = persistenceError;
-            }
-            releaseUnusedSessionHistoryTransactionBinding(state);
-          } else if (error instanceof OutputGuardrailTripwireTriggered) {
-            releaseUnusedSessionHistoryTransactionBinding(state);
-          } else {
-            try {
-              await persistNonStreamingResult(
-                new RunResult<TContext, TAgent>(state),
-              );
-              completedResultPersisted = true;
-            } catch (persistenceError) {
-              if (!isDataRedactedError(error)) {
-                (error as Error & { cause?: unknown }).cause = persistenceError;
-              }
-            }
-          }
-          throw error;
-        }
+        await finalizeOutputGuardrails({
+          state,
+          runnerOutputGuardrails: this.outputGuardrailDefs,
+          output: currentStep.output,
+          redactedOutput: OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+          guardedTerminalToolOutput: hasTerminalToolOutputSource(state),
+          signal: options.signal,
+          sanitizeRejectedOutput: sanitizeBlockedTerminalToolOutput,
+          persistBlockedOutput: persistResult
+            ? async () =>
+                persistResult(new RunResult<TContext, TAgent>(state), {
+                  outputBlocked: true,
+                })
+            : undefined,
+          persistUnblockedFailure: async () => {
+            await persistNonStreamingResult(
+              new RunResult<TContext, TAgent>(state),
+            );
+            completedResultPersisted = true;
+          },
+          releaseBlockedOutputPersistence:
+            releaseUnusedSessionHistoryTransactionBinding,
+        });
         if (
           state._serializedCurrentStep === currentStep &&
           hasRetainableBlockedOutputEffect(state)
@@ -1414,14 +1428,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
           };
 
           if (isAcceptedResponseCheckpoint(state)) {
+            captureCurrentResponseToolOutputGuardrailResultStart(state, false);
             await resumeAcceptedModelResponse({
               state,
               runner: this,
               toolErrorFormatter,
               agentToolParentRunConfig,
               signal: options.signal,
-              validateHandoffAgent: (handoffAgent) =>
-                this.#validateModelTimeoutForAgent(handoffAgent),
+              validateHandoffAgent: (handoffAgent) => {
+                this.#validateModelTimeoutForAgent(handoffAgent);
+              },
             });
           }
 
@@ -1448,26 +1464,38 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               setRunStateTurnSpanParent(state, currentTurnSpan.span);
             }
 
+            captureCurrentResponseToolOutputGuardrailResultStart(state, false);
             const interruptedOutcome = await resumeInterruptedTurn({
               state,
               runner: this,
               toolErrorFormatter,
               agentToolParentRunConfig,
               signal: options.signal,
-              validateHandoffAgent: (handoffAgent) =>
-                this.#validateModelTimeoutForAgent(handoffAgent),
+              validateHandoffAgent: (handoffAgent) => {
+                this.#validateModelTimeoutForAgent(handoffAgent);
+              },
             });
-            if (interruptedOutcome.approvedToolResumed && persistResult) {
+            const approvedToolCheckpointDeferred =
+              interruptedOutcome.approvedToolResumed &&
+              interruptedOutcome.nextStep.type === 'next_step_final_output' &&
+              this.#agentHasOutputGuardrail(state._currentAgent);
+            if (interruptedOutcome.approvedToolResumed) {
               const approvedToolResult = new RunResult<TContext, TAgent>(state);
               approvedToolCheckpointRequiresLocalInputCompaction = true;
-              await persistResult(approvedToolResult, {
-                compactionMode: 'input',
-              });
-              approvedToolCheckpointCompacted = true;
-              approvedToolCheckpointModelResponseCount =
-                approvedToolResult.rawResponses.length;
+              if (
+                persistResult &&
+                interruptedOutcome.nextStep.type !== 'next_step_final_output' &&
+                !this.#shouldDeferInterruptedSessionItems(state)
+              ) {
+                await persistResult(approvedToolResult, {
+                  compactionMode: 'input',
+                });
+                approvedToolCheckpointCompacted = true;
+                approvedToolCheckpointModelResponseCount =
+                  approvedToolResult.rawResponses.length;
+              }
             }
-            if (options.signal?.aborted) {
+            if (options.signal?.aborted && !approvedToolCheckpointDeferred) {
               persistenceCheckpoint = new RunResult<TContext, TAgent>(state);
             }
             options.signal?.throwIfAborted();
@@ -1788,11 +1816,12 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
             markAcceptedResponseProcessingStarted(state);
 
+            captureCurrentResponseToolOutputGuardrailResultStart(state, true);
             const turnResult = await resolveTurnAfterModelResponse(
               state._currentAgent,
               state._originalInput,
               state._generatedItems,
-              state._lastTurnResponse,
+              state._lastTurnResponse!,
               state._lastProcessedResponse!,
               this,
               state,
@@ -2054,7 +2083,6 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const agentToolParentRunConfig = this.#getAgentToolParentRunConfig(options);
     const useTaskAndTurnSpans =
       !this.config.tracingDisabled && includeTaskAndTurnSpans(options.tracing);
-
     // Tracks when we resume an approval interruption so the next run-again step stays in the same turn.
     let continuingInterruptedTurn = false;
     let runError: unknown;
@@ -2077,6 +2105,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const saveStreamResultWithCompactionOwnership = async (
       overrideOptions?: SessionPersistenceOptions,
     ) => {
+      if (this.#shouldDeferInterruptedSessionItems(result.state)) {
+        return;
+      }
       const hasUnpersistedItems =
         result.newItems.length > result.state._currentTurnPersistedItemCount ||
         (overrideOptions?.additionalRunItems?.length ?? 0) > 0;
@@ -2143,39 +2174,26 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       }
       markAcceptedResponseFinalizationStarted(result.state);
       result._hideFinalOutput();
-      try {
-        await runOutputGuardrails(
-          result.state,
-          this.outputGuardrailDefs,
-          currentStep.output,
-        );
-      } catch (error) {
-        if (
-          error instanceof OutputGuardrailTripwireTriggered &&
-          !serverManagesConversation
-        ) {
-          try {
-            await saveStreamResultWithCompactionOwnership({
-              outputBlocked: true,
-            });
-          } catch (persistenceError) {
-            error.state ??= result.state;
-            (error as Error & { cause?: unknown }).cause = persistenceError;
-          }
-          releaseUnusedSessionHistoryTransactionBinding(result.state);
-        } else if (error instanceof OutputGuardrailTripwireTriggered) {
-          releaseUnusedSessionHistoryTransactionBinding(result.state);
-        } else if (!serverManagesConversation) {
-          try {
-            await saveStreamResultWithCompactionOwnership();
-          } catch (persistenceError) {
-            if (!isDataRedactedError(error)) {
-              (error as Error & { cause?: unknown }).cause = persistenceError;
-            }
-          }
-        }
-        throw error;
-      }
+      await finalizeOutputGuardrails({
+        state: result.state,
+        runnerOutputGuardrails: this.outputGuardrailDefs,
+        output: currentStep.output,
+        redactedOutput: OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+        guardedTerminalToolOutput: hasTerminalToolOutputSource(result.state),
+        signal: options.signal,
+        sanitizeRejectedOutput: sanitizeBlockedTerminalToolOutput,
+        persistBlockedOutput: !serverManagesConversation
+          ? async () =>
+              saveStreamResultWithCompactionOwnership({
+                outputBlocked: true,
+              })
+          : undefined,
+        persistUnblockedFailure: !serverManagesConversation
+          ? async () => saveStreamResultWithCompactionOwnership()
+          : undefined,
+        releaseBlockedOutputPersistence:
+          releaseUnusedSessionHistoryTransactionBinding,
+      });
       if (
         result.state._serializedCurrentStep === currentStep &&
         hasRetainableBlockedOutputEffect(result.state)
@@ -2266,14 +2284,19 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
         };
 
         if (isAcceptedResponseCheckpoint(result.state)) {
+          captureCurrentResponseToolOutputGuardrailResultStart(
+            result.state,
+            false,
+          );
           await resumeAcceptedModelResponse({
             state: result.state,
             runner: this,
             toolErrorFormatter,
             agentToolParentRunConfig,
             signal: options.signal,
-            validateHandoffAgent: (handoffAgent) =>
-              this.#validateModelTimeoutForAgent(handoffAgent),
+            validateHandoffAgent: (handoffAgent) => {
+              this.#validateModelTimeoutForAgent(handoffAgent);
+            },
             onStepItems: (turnResult) => {
               addStepToRunResult(result, turnResult);
             },
@@ -2304,30 +2327,38 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             setRunStateTurnSpanParent(result.state, currentTurnSpan.span);
           }
 
+          captureCurrentResponseToolOutputGuardrailResultStart(
+            result.state,
+            false,
+          );
           const interruptedOutcome = await resumeInterruptedTurn({
             state: result.state,
             runner: this,
             toolErrorFormatter,
             agentToolParentRunConfig,
             signal: options.signal,
-            validateHandoffAgent: (handoffAgent) =>
-              this.#validateModelTimeoutForAgent(handoffAgent),
+            validateHandoffAgent: (handoffAgent) => {
+              this.#validateModelTimeoutForAgent(handoffAgent);
+            },
             onStepItems: (turnResult) => {
               addStepToRunResult(result, turnResult);
             },
           });
-          if (
-            interruptedOutcome.approvedToolResumed &&
-            !serverManagesConversation &&
-            options.session
-          ) {
+          if (interruptedOutcome.approvedToolResumed) {
             approvedToolCheckpointRequiresLocalInputCompaction = true;
-            await saveStreamResultToSession(options.session, result, {
-              compactionMode: 'input',
-            });
-            approvedToolCheckpointCompacted = true;
-            approvedToolCheckpointModelResponseCount =
-              result.rawResponses.length;
+            if (
+              interruptedOutcome.nextStep.type !== 'next_step_final_output' &&
+              !serverManagesConversation &&
+              options.session &&
+              !this.#shouldDeferInterruptedSessionItems(result.state)
+            ) {
+              await saveStreamResultToSession(options.session, result, {
+                compactionMode: 'input',
+              });
+              approvedToolCheckpointCompacted = true;
+              approvedToolCheckpointModelResponseCount =
+                result.rawResponses.length;
+            }
           }
 
           // Don't reset counter here - resolveInterruptedTurn already adjusted it via rewind logic
@@ -2822,11 +2853,15 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
 
           markAcceptedResponseProcessingStarted(result.state);
 
+          captureCurrentResponseToolOutputGuardrailResultStart(
+            result.state,
+            true,
+          );
           const turnResult = await resolveTurnAfterModelResponse(
             currentAgent,
             result.state._originalInput,
             result.state._generatedItems,
-            result.state._lastTurnResponse,
+            result.state._lastTurnResponse!,
             result.state._lastProcessedResponse!,
             this,
             result.state,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1752,7 +1752,8 @@ export const SerializedRunState = z.object({
   sandbox: sandboxStateSchema.optional(),
 });
 
-export type FinalOutputSource = 'error_handler' | 'turn_resolution';
+export type FinalOutputSource =
+  'error_handler' | 'turn_resolution' | 'tool_result';
 
 type ToolSearchRuntimeToolEntry<TContext = UnknownContext> = {
   order: number;

--- a/packages/agents-core/src/runner/blockedOutputPersistence.ts
+++ b/packages/agents-core/src/runner/blockedOutputPersistence.ts
@@ -1,7 +1,9 @@
-import { UserError } from '../errors';
+import { OutputGuardrailTripwireTriggered, UserError } from '../errors';
+import type { OutputGuardrailResult } from '../guardrail';
 import {
   RunHandoffOutputItem,
   RunItem,
+  RunToolCallItem,
   RunToolCallOutputItem,
   RunToolSearchCallItem,
   RunToolSearchOutputItem,
@@ -10,6 +12,8 @@ import {
   getToolCallName,
   getToolCallNamespace,
   getToolCallQualifiedName,
+  getFunctionToolLookupKeyForCall,
+  matchesFunctionToolName,
 } from '../toolIdentity';
 import {
   getToolSearchExecution,
@@ -18,7 +22,21 @@ import {
   getToolSearchProviderCallId,
 } from '../tooling';
 import { AgentInputItem } from '../types';
-import type { ToolSearchOutputItem } from '../types/protocol';
+import {
+  FunctionCallItem as FunctionCallItemSchema,
+  FunctionCallResultItem as FunctionCallResultItemSchema,
+  type FunctionCallItem,
+  type FunctionCallResultItem,
+  type ToolSearchOutputItem,
+} from '../types/protocol';
+import type { RunState } from '../runState';
+import type { Session } from '../memory/session';
+import { Usage } from '../usage';
+import {
+  sanitizeBlockedOutputGuardrailResults,
+  sanitizeBlockedToolOutputGuardrailResults,
+} from './guardrails';
+import { invalidateOutputItemNormalization } from './items';
 import {
   getToolResultCorrelationForCall,
   getToolResultCorrelationForResult,
@@ -27,6 +45,207 @@ import {
 import { addLoadedToolNamesFromToolSearchOutput } from './toolSearch';
 
 type BlockedPairKind = 'tool' | 'handoff';
+
+export const OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT =
+  'Output withheld by an output guardrail.';
+
+const currentResponseToolOutputGuardrailResultStarts = new WeakMap<
+  RunState<any, any>,
+  number
+>();
+
+export function captureCurrentResponseToolOutputGuardrailResultStart(
+  state: RunState<any, any>,
+  overwrite: boolean,
+): void {
+  if (overwrite || !currentResponseToolOutputGuardrailResultStarts.has(state)) {
+    currentResponseToolOutputGuardrailResultStarts.set(
+      state,
+      state._toolOutputGuardrailResults.length,
+    );
+  }
+}
+
+function currentCompletedToolRuns(state: RunState<any, any>) {
+  const responseCalls = getResponseOutput(currentResponse(state))?.filter(
+    (item): item is FunctionCallItem => item.type === 'function_call',
+  );
+  const processedRuns = state._lastProcessedResponse?.functions ?? [];
+  if (!responseCalls?.length || processedRuns.length < responseCalls.length) {
+    return [];
+  }
+  return processedRuns.slice(-responseCalls.length).filter((run, index) => {
+    try {
+      return (
+        JSON.stringify(buildCanonicalFunctionCall(run.toolCall)) ===
+          JSON.stringify(buildCanonicalFunctionCall(responseCalls[index]!)) &&
+        state._completedToolInvocationEvidence
+          .get(state._currentAgent)
+          ?.has(run.toolCall.callId)
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+
+function currentTerminalToolRuns(state: RunState<any, any>) {
+  if (state._currentStep?.type !== 'next_step_final_output') {
+    return [];
+  }
+  const behavior = state._currentAgent.toolUseBehavior;
+  if (behavior === 'run_llm_again') {
+    return [];
+  }
+  const completedRuns = currentCompletedToolRuns(state);
+  if (
+    typeof behavior === 'object' &&
+    !completedRuns.some((run) =>
+      behavior.stopAtToolNames.some((toolName: string) =>
+        matchesFunctionToolName(run.tool, toolName),
+      ),
+    )
+  ) {
+    return [];
+  }
+  return completedRuns;
+}
+
+export function hasTerminalToolOutputSource(
+  state: RunState<any, any>,
+): boolean {
+  return (
+    state._finalOutputSource === 'tool_result' ||
+    (state._finalOutputSource === undefined &&
+      state._serializedCurrentStep === state._currentStep &&
+      currentTerminalToolRuns(state).length > 0)
+  );
+}
+
+export function sanitizeBlockedTerminalToolOutput(
+  state: RunState<any, any>,
+  outputGuardrailResultStart: number,
+  completedOutputGuardrailTripwireResult:
+    OutputGuardrailResult<any, any> | undefined,
+  observedOutputGuardrailResults: ReadonlyMap<
+    OutputGuardrailResult<any, any>,
+    boolean
+  >,
+  tripwire?: OutputGuardrailTripwireTriggered<any, any>,
+  ownedOutputGuardrailResults?: ReadonlySet<OutputGuardrailResult<any, any>>,
+): boolean {
+  if (
+    !hasTerminalToolOutputSource(state) ||
+    !completedOutputGuardrailTripwireResult
+  ) {
+    return false;
+  }
+  redactBlockedResponseToolOutputs(state);
+  sanitizeBlockedOutputGuardrailResults(
+    state,
+    outputGuardrailResultStart,
+    OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+    observedOutputGuardrailResults,
+    tripwire,
+    ownedOutputGuardrailResults,
+  );
+  sanitizeBlockedToolOutputGuardrailResults(
+    state,
+    currentResponseToolOutputGuardrailResultStarts.get(state) ?? 0,
+    OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+  );
+  return true;
+}
+
+export function shouldDeferInterruptedSessionItems(
+  state: RunState<any, any>,
+  hasOutputGuardrail: boolean,
+): boolean {
+  return (
+    state._currentStep?.type === 'next_step_interruption' &&
+    hasOutputGuardrail &&
+    state._currentAgent.toolUseBehavior !== 'run_llm_again' &&
+    hasOutputBearingApprovalCheckpoint(state)
+  );
+}
+
+export function assertResumedSessionOutputGuardrailSafety(
+  state: RunState<any, any>,
+  session: Session | undefined,
+  hasOutputGuardrail: boolean,
+): void {
+  if (
+    hasOutputGuardrail &&
+    state._serializedCurrentStep === state._currentStep &&
+    state._currentStep?.type === 'next_step_final_output' &&
+    state._finalOutputSource === undefined &&
+    currentCompletedToolRuns(state).length > 0 &&
+    !hasTerminalToolOutputSource(state)
+  ) {
+    throw new UserError(
+      'Cannot resume this serialized terminal output because terminal tool output provenance could not be verified after the tool behavior changed. Continue the live RunState or start a new run from safe input.',
+    );
+  }
+  const shouldDefer = shouldDeferInterruptedSessionItems(
+    state,
+    hasOutputGuardrail,
+  );
+  if (state._serializedCurrentStep !== undefined && shouldDefer) {
+    const responseOutput = getResponseOutput(currentResponse(state));
+    if (
+      session !== undefined ||
+      state._toolOutputGuardrailResults.length > 0 ||
+      !responseOutput ||
+      responseOutput.some((item) => item.type !== 'function_call') ||
+      !currentRunItemSelection(state, responseOutput).proven
+    ) {
+      throw new UserError(
+        'Cannot resume this serialized output-bearing approval checkpoint because current-response provenance was not preserved. Start a new run from safe input.',
+      );
+    }
+  }
+  if (session === undefined) {
+    if (shouldDefer && state._currentTurnPersistedItemCount > 0) {
+      state.resetTurnPersistence();
+    }
+    return;
+  }
+  if (!shouldDefer || state._currentTurnPersistedItemCount <= 0) {
+    return;
+  }
+  const currentCallIds = new Set(
+    (state._lastProcessedResponse?.functions ?? []).map(
+      (run) => run.toolCall.callId,
+    ),
+  );
+  const currentStart = state._generatedItems.findIndex(
+    (item) =>
+      item instanceof RunToolCallItem &&
+      item.rawItem.type === 'function_call' &&
+      currentCallIds.has(item.rawItem.callId),
+  );
+  const firstOutputIndex = state._generatedItems.findIndex(
+    (item, index) =>
+      index >= currentStart && item instanceof RunToolCallOutputItem,
+  );
+  if (
+    currentStart >= 0 &&
+    firstOutputIndex === state._currentTurnPersistedItemCount &&
+    state._generatedItems
+      .slice(currentStart, firstOutputIndex)
+      .every(
+        (item) =>
+          'rawItem' in item &&
+          item.rawItem.type === 'function_call' &&
+          currentCallIds.has(item.rawItem.callId),
+      )
+  ) {
+    return;
+  }
+  throw new UserError(
+    'Cannot resume an output-bearing approval checkpoint with a Session while output guardrails are enabled because the persisted response ownership cannot be proven. Start a new run from safe input.',
+  );
+}
 
 type BlockedToolRecord = Readonly<{
   key: string;
@@ -625,6 +844,11 @@ export function buildRunItemPersistencePlan(options: {
   currentDeferredIndexes: Iterable<number>;
   outputBlocked: boolean;
   canUseHistoryTransactions: boolean;
+  blockedSnapshot?: Readonly<{
+    items: RunItem[];
+    startIndex: number;
+    alreadyPersistedCount: number;
+  }>;
 }): RunItemPersistencePlan {
   const {
     items,
@@ -632,6 +856,7 @@ export function buildRunItemPersistencePlan(options: {
     currentDeferredIndexes,
     outputBlocked,
     canUseHistoryTransactions,
+    blockedSnapshot,
   } = options;
   const newRunItemIndexes = Array.from(
     { length: Math.max(0, items.length - alreadyPersistedCount) },
@@ -639,6 +864,24 @@ export function buildRunItemPersistencePlan(options: {
   );
 
   if (outputBlocked) {
+    if (blockedSnapshot) {
+      const snapshotPersistedCount = canUseHistoryTransactions
+        ? alreadyPersistedCount
+        : blockedSnapshot.alreadyPersistedCount;
+      const persistedSnapshotItems = Math.max(
+        0,
+        snapshotPersistedCount - blockedSnapshot.startIndex,
+      );
+      return {
+        alreadyPersistedCount: snapshotPersistedCount,
+        runItemsToPersist: blockedSnapshot.items.slice(persistedSnapshotItems),
+        runItemsToReplace: [],
+        processedRunItemCount: newRunItemIndexes.length,
+        deferredRunItemIndexes: [],
+        useHistoryTransaction: canUseHistoryTransactions,
+        transactionKind: 'blocked_append',
+      };
+    }
     if (!canUseHistoryTransactions) {
       return {
         alreadyPersistedCount,
@@ -731,4 +974,731 @@ export function buildRunItemPersistencePlan(options: {
     useHistoryTransaction: true,
     transactionKind: 'accepted_replace',
   };
+}
+
+type BlockedModelResponse = NonNullable<
+  RunState<any, any>['_lastTurnResponse']
+>;
+
+function optionalField<K extends PropertyKey, V>(
+  key: K,
+  value: V | undefined,
+): Partial<Record<K, V>> {
+  return value === undefined ? {} : ({ [key]: value } as Record<K, V>);
+}
+
+function buildCanonicalFunctionCall(rawItem: AgentInputItem): FunctionCallItem {
+  const parsed = FunctionCallItemSchema.parse(rawItem);
+  return FunctionCallItemSchema.parse({
+    type: 'function_call',
+    name: parsed.name,
+    ...optionalField('namespace', parsed.namespace),
+    callId: parsed.callId,
+    arguments: parsed.arguments,
+    ...optionalField('id', parsed.id),
+    ...optionalField('status', parsed.status),
+    ...optionalField('caller', parsed.caller),
+  });
+}
+
+export function buildBlockedToolOutputRawItem(
+  rawItem: AgentInputItem,
+): FunctionCallResultItem {
+  const parsed = FunctionCallResultItemSchema.parse(rawItem);
+  return FunctionCallResultItemSchema.parse({
+    type: 'function_call_result',
+    name: parsed.name,
+    ...optionalField('namespace', parsed.namespace),
+    callId: parsed.callId,
+    output: OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+    ...optionalField('id', parsed.id),
+    ...optionalField('status', parsed.status),
+  });
+}
+
+function getResponseOutput(
+  response: BlockedModelResponse | undefined,
+): AgentInputItem[] | undefined {
+  if (!response) return [];
+  try {
+    return Array.isArray(response.output)
+      ? (response.output.slice() as AgentInputItem[])
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function copyResponseString(
+  response: BlockedModelResponse,
+  key: 'responseId' | 'requestId',
+): string | undefined {
+  try {
+    const value = response[key];
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function cloneBlockedResponse(
+  response: BlockedModelResponse,
+  output: AgentInputItem[],
+): BlockedModelResponse {
+  let usage = new Usage();
+  try {
+    usage = new Usage(response.usage);
+  } catch {
+    // Usage is not replay authority. Keep the replacement data-free.
+  }
+  return {
+    usage,
+    output,
+    ...optionalField('responseId', copyResponseString(response, 'responseId')),
+    ...optionalField('requestId', copyResponseString(response, 'requestId')),
+  };
+}
+
+function currentResponse(
+  state: RunState<any, any>,
+): BlockedModelResponse | undefined {
+  return state._lastTurnResponse;
+}
+
+function functionCallKey(item: AgentInputItem): string | undefined {
+  if (item?.type !== 'function_call') return undefined;
+  try {
+    const parsed = FunctionCallItemSchema.parse(item);
+    const toolKey = getFunctionToolLookupKeyForCall(parsed);
+    return toolKey ? JSON.stringify([toolKey, parsed.callId]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function functionResultKey(item: AgentInputItem): string | undefined {
+  if (item?.type !== 'function_call_result') return undefined;
+  try {
+    const parsed = FunctionCallResultItemSchema.parse(item);
+    const toolKey = getFunctionToolLookupKeyForCall(parsed);
+    return toolKey ? JSON.stringify([toolKey, parsed.callId]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+type CurrentRunItemSelection = Readonly<{
+  primary: RunItem[];
+  aliases: RunItem[];
+  proven: boolean;
+}>;
+
+function functionRunItemSignature(item: RunItem): string | undefined {
+  try {
+    if (
+      item instanceof RunToolCallItem &&
+      item.rawItem.type === 'function_call'
+    ) {
+      return JSON.stringify(buildCanonicalFunctionCall(item.rawItem));
+    }
+    if (
+      item instanceof RunToolCallOutputItem &&
+      item.rawItem.type === 'function_call_result'
+    ) {
+      const parsed = FunctionCallResultItemSchema.parse(item.rawItem);
+      return JSON.stringify({
+        type: parsed.type,
+        name: parsed.name,
+        ...optionalField('namespace', parsed.namespace),
+        callId: parsed.callId,
+        output: parsed.output,
+        ...optionalField('id', parsed.id),
+        ...optionalField('status', parsed.status),
+      });
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function functionRunItemSequenceIsPrefix(
+  items: readonly RunItem[],
+  prefix: readonly RunItem[],
+): boolean {
+  return (
+    prefix.length <= items.length &&
+    prefix.every((item, index) => {
+      const signature = functionRunItemSignature(item);
+      return (
+        signature !== undefined &&
+        signature === functionRunItemSignature(items[index]!)
+      );
+    })
+  );
+}
+
+function boundedCurrentFunctionResponseStart(
+  generated: readonly RunItem[],
+  responseOutput: readonly AgentInputItem[],
+): number | undefined {
+  const responseKeys = responseOutput.map(functionCallKey);
+  if (
+    responseKeys.length === 0 ||
+    responseKeys.some((key) => key === undefined)
+  ) {
+    return undefined;
+  }
+  const start = generated.length - responseKeys.length * 2;
+  if (start < 0) return undefined;
+  const suffix = generated.slice(start);
+  const calls = suffix.filter(
+    (item): item is RunToolCallItem =>
+      item instanceof RunToolCallItem && item.rawItem.type === 'function_call',
+  );
+  const results = suffix.filter(
+    (item): item is RunToolCallOutputItem =>
+      item instanceof RunToolCallOutputItem &&
+      item.rawItem.type === 'function_call_result',
+  );
+  if (
+    calls.length !== responseKeys.length ||
+    results.length !== responseKeys.length ||
+    calls.some(
+      (item, index) => functionCallKey(item.rawItem) !== responseKeys[index],
+    ) ||
+    results.some(
+      (item, index) => functionResultKey(item.rawItem) !== responseKeys[index],
+    )
+  ) {
+    return undefined;
+  }
+  return start;
+}
+
+function currentRunItemSelection(
+  state: RunState<any, any>,
+  responseOutput: AgentInputItem[],
+): CurrentRunItemSelection {
+  const generated = state._generatedItems.slice();
+  const responseObjects = new Set(responseOutput);
+  const processed = state._lastProcessedResponse?.newItems ?? [];
+  const ownsResponseItem = (item: RunItem): boolean => {
+    try {
+      return (
+        'rawItem' in item && responseObjects.has(item.rawItem as AgentInputItem)
+      );
+    } catch {
+      return false;
+    }
+  };
+  const processedOwnsResponse = processed.some(ownsResponseItem);
+  const processedItems = new Set(processed);
+  const processedOwnerStart = generated.findIndex((item) =>
+    processedItems.has(item),
+  );
+  const completedInvocationOwners = new Set(
+    (state._lastProcessedResponse?.functions ?? []).flatMap(
+      (run) =>
+        state._completedToolInvocationEvidence
+          .get(state._currentAgent)
+          ?.get(run.toolCall.callId)?.items ?? [],
+    ),
+  );
+  const completedInvocationOwnerStart = generated.findIndex((item) =>
+    completedInvocationOwners.has(item),
+  );
+  const boundedCurrentStart = boundedCurrentFunctionResponseStart(
+    generated,
+    responseOutput,
+  );
+  let start = generated.findIndex(ownsResponseItem);
+  if (
+    start < 0 &&
+    boundedCurrentStart !== undefined &&
+    (processedOwnerStart >= boundedCurrentStart ||
+      completedInvocationOwnerStart >= boundedCurrentStart)
+  ) {
+    start = boundedCurrentStart;
+  }
+  if (start >= 0) {
+    const primary = generated.slice(start);
+    const aliases = [...primary];
+    const currentProcessedCalls = new Set(
+      (state._lastProcessedResponse?.functions ?? []).map(
+        (run) => run.toolCall,
+      ),
+    );
+    let currentProcessedStart = processed.findIndex(ownsResponseItem);
+    if (currentProcessedStart < 0) {
+      currentProcessedStart = processed.findIndex((item) =>
+        primary.includes(item),
+      );
+    }
+    if (currentProcessedStart < 0) {
+      currentProcessedStart = processed.findIndex(
+        (item) =>
+          item instanceof RunToolCallItem &&
+          item.rawItem.type === 'function_call' &&
+          currentProcessedCalls.has(item.rawItem),
+      );
+    }
+    if (
+      currentProcessedStart >= 0 &&
+      (processedOwnsResponse ||
+        processedOwnerStart >= start ||
+        completedInvocationOwnerStart >= start)
+    ) {
+      for (const item of processed.slice(currentProcessedStart)) {
+        if (!aliases.includes(item)) aliases.push(item);
+      }
+    }
+    return { primary, aliases, proven: true };
+  }
+
+  if (
+    state._currentStep?.type === 'next_step_interruption' &&
+    processed.length > 0 &&
+    processed.length === responseOutput.length &&
+    processed.length * 2 <= generated.length &&
+    processed.every(
+      (item, index) =>
+        item instanceof RunToolCallItem &&
+        item.rawItem.type === 'function_call' &&
+        functionCallKey(item.rawItem) ===
+          functionCallKey(responseOutput[index]!),
+    )
+  ) {
+    const interruptionCount = state._currentStep.data.interruptions.length;
+    const currentSuffix = generated.slice(-processed.length * 2);
+    const callItems = currentSuffix.slice(0, processed.length);
+    const outcomeItems = currentSuffix.slice(processed.length);
+    const responseKeys = new Set(responseOutput.map(functionCallKey));
+    const outcomeKeys = new Set<string>();
+    let approvalCount = 0;
+    const outcomesAreBounded = outcomeItems.every((item) => {
+      if (item.type === 'tool_approval_item') {
+        if (!('rawItem' in item) || item.rawItem.type !== 'function_call') {
+          return false;
+        }
+        approvalCount += 1;
+        const key = functionCallKey(item.rawItem);
+        if (!key || !responseKeys.has(key) || outcomeKeys.has(key))
+          return false;
+        outcomeKeys.add(key);
+        return true;
+      }
+      if (
+        !(item instanceof RunToolCallOutputItem) ||
+        item.rawItem.type !== 'function_call_result'
+      ) {
+        return false;
+      }
+      const key = functionResultKey(item.rawItem);
+      if (!key || !responseKeys.has(key) || outcomeKeys.has(key)) return false;
+      outcomeKeys.add(key);
+      return true;
+    });
+    if (
+      responseKeys.size === responseOutput.length &&
+      outcomeKeys.size === responseOutput.length &&
+      approvalCount === interruptionCount &&
+      outcomesAreBounded &&
+      functionRunItemSequenceIsPrefix(callItems, processed)
+    ) {
+      return {
+        primary: currentSuffix,
+        aliases: [...currentSuffix, ...processed],
+        proven: true,
+      };
+    }
+  }
+
+  if (state._currentTurnBlockedSessionStartIndex !== undefined) {
+    const blockedStart = Math.min(
+      state._currentTurnBlockedSessionStartIndex,
+      generated.length,
+    );
+    return {
+      primary: generated.slice(blockedStart),
+      aliases: generated.slice(blockedStart),
+      proven: true,
+    };
+  }
+
+  const fallbackStart = Math.min(
+    state._currentTurnPersistedItemCount,
+    generated.length,
+  );
+  const fallback = generated.slice(fallbackStart);
+  return { primary: fallback, aliases: fallback, proven: false };
+}
+
+type CurrentFunctionPairPlan = Readonly<{
+  responseOutput: FunctionCallItem[];
+  replacements: ReadonlyMap<RunItem, RunItem>;
+  sanitizedItems: RunItem[];
+}>;
+
+function buildCurrentFunctionPairPlan(
+  state: RunState<any, any>,
+  responseOutput: AgentInputItem[],
+  selection: CurrentRunItemSelection,
+): CurrentFunctionPairPlan | undefined {
+  if (!selection.proven) return undefined;
+
+  try {
+    const canonicalResponse = responseOutput.map(buildCanonicalFunctionCall);
+    const responseKeys = canonicalResponse.map((item) => {
+      const key = functionCallKey(item);
+      if (!key) throw new Error();
+      return key;
+    });
+    if (
+      responseKeys.length === 0 ||
+      new Set(responseKeys).size !== responseKeys.length
+    ) {
+      return undefined;
+    }
+
+    const callKeys: string[] = [];
+    const resultKeys: string[] = [];
+    const callIndexes = new Map<string, number>();
+    const resultIndexes = new Map<string, number>();
+    const sanitizedItems: RunItem[] = [];
+    for (const [index, item] of selection.primary.entries()) {
+      if (
+        item instanceof RunToolCallItem &&
+        item.rawItem.type === 'function_call'
+      ) {
+        const key = functionCallKey(item.rawItem);
+        if (!key || callIndexes.has(key)) return undefined;
+        callKeys.push(key);
+        callIndexes.set(key, index);
+        sanitizedItems.push(
+          new RunToolCallItem(
+            buildCanonicalFunctionCall(item.rawItem),
+            item.agent,
+          ),
+        );
+        continue;
+      }
+      if (
+        item instanceof RunToolCallOutputItem &&
+        item.rawItem.type === 'function_call_result'
+      ) {
+        const key = functionResultKey(item.rawItem);
+        if (!key || resultIndexes.has(key)) return undefined;
+        resultKeys.push(key);
+        resultIndexes.set(key, index);
+        sanitizedItems.push(
+          new RunToolCallOutputItem(
+            buildBlockedToolOutputRawItem(item.rawItem),
+            item.agent,
+            OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+            undefined,
+            item.executionStatus,
+          ),
+        );
+        continue;
+      }
+      return undefined;
+    }
+
+    if (
+      callKeys.length !== responseKeys.length ||
+      resultKeys.length !== responseKeys.length ||
+      callKeys.some((key, index) => key !== responseKeys[index]) ||
+      resultKeys.some((key, index) => key !== responseKeys[index]) ||
+      responseKeys.some(
+        (key) =>
+          callIndexes.get(key) === undefined ||
+          resultIndexes.get(key) === undefined ||
+          callIndexes.get(key)! >= resultIndexes.get(key)!,
+      )
+    ) {
+      return undefined;
+    }
+
+    const replacements = new Map<RunItem, RunItem>();
+    for (const [index, item] of selection.primary.entries()) {
+      replacements.set(item, sanitizedItems[index]!);
+    }
+    const processed = state._lastProcessedResponse?.newItems ?? [];
+    const aliases = new Set(selection.aliases);
+    let currentProcessedStart = processed.findIndex((item) =>
+      aliases.has(item),
+    );
+    if (
+      currentProcessedStart < 0 &&
+      state._serializedCurrentStep !== undefined &&
+      state._serializedCurrentStep === state._currentStep &&
+      functionRunItemSequenceIsPrefix(selection.primary, processed)
+    ) {
+      currentProcessedStart = 0;
+      for (const item of processed) aliases.add(item);
+    }
+    if (currentProcessedStart >= 0) {
+      const currentProcessed = processed.slice(currentProcessedStart);
+      if (
+        currentProcessed.some((item) => !aliases.has(item)) ||
+        !functionRunItemSequenceIsPrefix(selection.primary, currentProcessed)
+      ) {
+        return undefined;
+      }
+      for (const [index, item] of currentProcessed.entries()) {
+        if (replacements.has(item)) continue;
+        const replacement = sanitizedItems[index]!;
+        if (
+          replacement instanceof RunToolCallItem &&
+          item instanceof RunToolCallItem
+        ) {
+          replacements.set(
+            item,
+            new RunToolCallItem(replacement.rawItem, item.agent),
+          );
+        } else if (
+          replacement instanceof RunToolCallOutputItem &&
+          item instanceof RunToolCallOutputItem
+        ) {
+          replacements.set(
+            item,
+            new RunToolCallOutputItem(
+              replacement.rawItem,
+              item.agent,
+              OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT,
+              undefined,
+              replacement.executionStatus,
+            ),
+          );
+        } else {
+          return undefined;
+        }
+      }
+    }
+    return {
+      responseOutput: sanitizedItems.flatMap((item): FunctionCallItem[] =>
+        item instanceof RunToolCallItem && item.rawItem.type === 'function_call'
+          ? [item.rawItem]
+          : [],
+      ),
+      replacements,
+      sanitizedItems,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function replaceRunItems(
+  state: RunState<any, any>,
+  replacements: ReadonlyMap<RunItem, RunItem | undefined>,
+  responseOutput: AgentInputItem[] | undefined,
+  canonicalResponseOutput: FunctionCallItem[],
+): void {
+  const rawReplacements = new Map<AgentInputItem, AgentInputItem | undefined>();
+  for (const [item, replacement] of replacements) {
+    if ('rawItem' in item) {
+      rawReplacements.set(
+        item.rawItem as AgentInputItem,
+        replacement && 'rawItem' in replacement
+          ? (replacement.rawItem as AgentInputItem)
+          : undefined,
+      );
+    }
+  }
+  for (const [index, item] of (responseOutput ?? []).entries()) {
+    rawReplacements.set(item, canonicalResponseOutput[index]);
+  }
+  const replace = (items: RunItem[]): RunItem[] =>
+    items.flatMap((item) => {
+      if (!replacements.has(item)) return [item];
+      const replacement = replacements.get(item);
+      return replacement ? [replacement] : [];
+    });
+  state._generatedItems = replace(state._generatedItems);
+  if (state._lastProcessedResponse) {
+    const processed = state._lastProcessedResponse;
+    processed.newItems = replace(processed.newItems);
+    const replaceToolActions = <T extends { toolCall: AgentInputItem }>(
+      actions: T[] | undefined,
+      allowRestoredCurrentPosition = false,
+    ): T[] | undefined =>
+      actions?.flatMap((action, index) => {
+        const currentIndex =
+          index - (actions.length - canonicalResponseOutput.length);
+        if (
+          !rawReplacements.has(action.toolCall) &&
+          allowRestoredCurrentPosition &&
+          state._serializedCurrentStep !== undefined &&
+          state._serializedCurrentStep === state._currentStep &&
+          action.toolCall.type === 'function_call' &&
+          currentIndex >= 0 &&
+          canonicalResponseOutput[currentIndex] &&
+          JSON.stringify(buildCanonicalFunctionCall(action.toolCall)) ===
+            JSON.stringify(canonicalResponseOutput[currentIndex])
+        ) {
+          rawReplacements.set(
+            action.toolCall,
+            canonicalResponseOutput[currentIndex],
+          );
+        }
+        if (!rawReplacements.has(action.toolCall)) return [action];
+        const replacement = rawReplacements.get(action.toolCall);
+        if (!replacement || replacement.type !== action.toolCall.type)
+          return [];
+        action.toolCall = replacement;
+        return [action];
+      });
+    if (processed.functions) {
+      processed.functions = replaceToolActions(processed.functions, true)!;
+    }
+    if (processed.handoffs) {
+      processed.handoffs = replaceToolActions(processed.handoffs)!;
+    }
+    if (processed.functionToolsNotFound) {
+      processed.functionToolsNotFound = replaceToolActions(
+        processed.functionToolsNotFound,
+      );
+    }
+    if (processed.computerActions) {
+      processed.computerActions = replaceToolActions(
+        processed.computerActions,
+      )!;
+    }
+    if (processed.shellActions) {
+      processed.shellActions = replaceToolActions(processed.shellActions)!;
+    }
+    if (processed.applyPatchActions) {
+      processed.applyPatchActions = replaceToolActions(
+        processed.applyPatchActions,
+      )!;
+    }
+  }
+  for (const [agent, invocations] of state._completedToolInvocationEvidence) {
+    for (const [callId, evidence] of invocations) {
+      const items = replace(evidence.items);
+      if (items.length !== 2) {
+        invocations.delete(callId);
+        state._completedToolInvocations.get(agent)?.delete(callId);
+      } else {
+        evidence.items = items as [RunItem, RunItem];
+      }
+    }
+  }
+}
+
+function replaceCurrentResponse(
+  state: RunState<any, any>,
+  response: BlockedModelResponse,
+  output: AgentInputItem[],
+): void {
+  const replacement = cloneBlockedResponse(response, output);
+  let replacedResponse = false;
+  state._modelResponses = state._modelResponses.map((candidate) => {
+    if (candidate !== response) return candidate;
+    replacedResponse = true;
+    return replacement;
+  });
+  if (
+    !replacedResponse &&
+    state._serializedCurrentStep !== undefined &&
+    state._serializedCurrentStep === state._currentStep &&
+    state._modelResponses.length > 0
+  ) {
+    const archivedResponse = state._modelResponses.at(-1);
+    try {
+      if (
+        archivedResponse &&
+        JSON.stringify(getResponseOutput(archivedResponse)) ===
+          JSON.stringify(getResponseOutput(response))
+      ) {
+        state._modelResponses[state._modelResponses.length - 1] = replacement;
+      }
+    } catch {
+      // An unrelated or unreadable archived response is not current ownership.
+    }
+  }
+  if (state._lastTurnResponse === response)
+    state._lastTurnResponse = replacement;
+}
+
+function markBlockedState(state: RunState<any, any>): void {
+  if (state._currentStep?.type === 'next_step_final_output') {
+    state._currentStep.output = OUTPUT_GUARDRAIL_BLOCKED_TOOL_OUTPUT;
+  }
+  invalidateOutputItemNormalization(state._generatedItems);
+  if (state._lastProcessedResponse) {
+    invalidateOutputItemNormalization(state._lastProcessedResponse.newItems);
+  }
+}
+
+/** Replaces a rejected function response with allowlisted replay-safe values. */
+export function redactBlockedResponseToolOutputs(
+  state: RunState<any, any>,
+): boolean {
+  const response = currentResponse(state);
+  const responseOutput = getResponseOutput(response);
+  const selection = currentRunItemSelection(state, responseOutput ?? []);
+  const plan =
+    response && responseOutput
+      ? buildCurrentFunctionPairPlan(state, responseOutput, selection)
+      : undefined;
+
+  if (!plan) {
+    const replacements = new Map<RunItem, RunItem | undefined>();
+    for (const item of selection.aliases) replacements.set(item, undefined);
+    replaceRunItems(state, replacements, responseOutput, []);
+    if (response) replaceCurrentResponse(state, response, []);
+    markBlockedState(state);
+    return selection.aliases.length > 0 || response !== undefined;
+  }
+
+  replaceRunItems(
+    state,
+    plan.replacements,
+    responseOutput,
+    plan.responseOutput,
+  );
+  replaceCurrentResponse(state, response!, plan.responseOutput);
+  markBlockedState(state);
+  return plan.replacements.size > 0 || plan.responseOutput.length > 0;
+}
+
+export function getBlockedOutputSessionSnapshotRunItems(
+  state: RunState<any, any>,
+): RunItem[] {
+  const responseOutput = getResponseOutput(currentResponse(state));
+  if (!responseOutput) return [];
+  const selection = currentRunItemSelection(state, responseOutput);
+  const plan = buildCurrentFunctionPairPlan(state, responseOutput, selection);
+  return plan?.sanitizedItems ?? [];
+}
+
+export function isCanonicalBlockedOutputPayload(item: AgentInputItem): boolean {
+  if (item?.type !== 'function_call_result') return false;
+  try {
+    return (
+      JSON.stringify(item) ===
+      JSON.stringify(buildBlockedToolOutputRawItem(item))
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function hasOutputBearingApprovalCheckpoint(
+  state: RunState<any, any>,
+): boolean {
+  const responseOutput = getResponseOutput(currentResponse(state));
+  if (!responseOutput) return true;
+  if (responseOutput.some((item) => item.type !== 'function_call')) return true;
+  const selection = currentRunItemSelection(state, responseOutput);
+  if (!selection.proven) return true;
+  return selection.primary.some(
+    (item) =>
+      item instanceof RunToolCallOutputItem ||
+      (item instanceof RunToolCallItem &&
+        item.rawItem.type === 'hosted_tool_call'),
+  );
 }

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -1,8 +1,10 @@
 import { Agent, AgentOutputType } from '../agent';
 import {
+  AgentsError,
   GuardrailExecutionError,
   InputGuardrailTripwireTriggered,
   OutputGuardrailTripwireTriggered,
+  UserError,
 } from '../errors';
 import {
   defineInputGuardrail,
@@ -12,13 +14,18 @@ import {
   OutputGuardrailDefinition,
   OutputGuardrailFunctionArgs,
   OutputGuardrailMetadata,
+  OutputGuardrailResult,
 } from '../guardrail';
 import { RunState } from '../runState';
 import type { AgentInputItem } from '../types';
 import { getRunOutput } from './items';
 import { withGuardrailSpan } from '../tracing';
 import type { GuardrailFunctionOutput } from '../guardrail';
-import { processFinalOutputWithRedaction } from '../utils/finalOutputError';
+import type { ToolOutputGuardrailResult } from '../toolGuardrail';
+import {
+  isDataRedactedError,
+  processFinalOutputWithRedaction,
+} from '../utils/finalOutputError';
 
 export type GuardrailTracker = {
   readonly pending: boolean;
@@ -102,6 +109,55 @@ type GuardrailResultLike = {
   output: GuardrailFunctionOutput;
 };
 
+type ObservedGuardrailResult<TResult> = {
+  result: TResult;
+  tripwireTriggered: boolean;
+};
+
+const currentResponseOutputGuardrailResults = new WeakMap<
+  RunState<any, any>,
+  {
+    response: RunState<any, any>['_lastTurnResponse'];
+    results: Set<OutputGuardrailResult<any, any>>;
+  }
+>();
+
+function getCurrentResponseOutputGuardrailResults(
+  state: RunState<any, any>,
+  guardedTerminalToolOutput: boolean,
+  redactedOutput: string,
+): Set<OutputGuardrailResult<any, any>> {
+  const existing = currentResponseOutputGuardrailResults.get(state);
+  if (existing && existing.response === state._lastTurnResponse) {
+    return existing.results;
+  }
+
+  const results = new Set<OutputGuardrailResult<any, any>>();
+  if (
+    guardedTerminalToolOutput &&
+    state._serializedCurrentStep === state._currentStep
+  ) {
+    if (
+      state._outputGuardrailResults.some(
+        (result) =>
+          result.agent === state._currentAgent &&
+          (result.agentOutput !== redactedOutput ||
+            result.output.outputInfo !== undefined),
+      )
+    ) {
+      throw new UserError(
+        'Cannot resume this serialized terminal output because previous output guardrail result ownership was not preserved. Continue the live RunState or start a new run from safe input.',
+      );
+    }
+  }
+
+  currentResponseOutputGuardrailResults.set(state, {
+    response: state._lastTurnResponse,
+    results,
+  });
+  return results;
+}
+
 async function runGuardrailsWithTripwire<
   TContext,
   TAgent extends Agent<TContext, any>,
@@ -116,6 +172,7 @@ async function runGuardrailsWithTripwire<
   isTripwireError: (error: unknown) => boolean;
   onError: (error: unknown) => unknown;
   onErrorObserved?: (error: unknown) => void;
+  onResultObserved?: (result: TResult, tripwireTriggered: boolean) => void;
 }): Promise<TResult[]> {
   const {
     state,
@@ -126,27 +183,35 @@ async function runGuardrailsWithTripwire<
     isTripwireError,
     onError,
     onErrorObserved,
+    onResultObserved,
   } = options;
 
   const guardrailPromises = guardrails.map(async (guardrail) => {
-    return withGuardrailSpan(
+    const observedResult = await withGuardrailSpan(
       async (span) => {
         const result = await guardrail.run(guardrailArgs);
-        span.spanData.triggered = result.output.tripwireTriggered;
-        return result;
+        const tripwireTriggered = result.output.tripwireTriggered;
+        span.spanData.triggered = tripwireTriggered;
+        return {
+          result,
+          tripwireTriggered,
+        } satisfies ObservedGuardrailResult<TResult>;
       },
       { data: { name: guardrail.name } },
       state._currentAgentSpan,
     );
+    onResultObserved?.(observedResult.result, observedResult.tripwireTriggered);
+    return observedResult;
   });
 
   let resultsPublished = false;
   try {
-    const results = await Promise.all(guardrailPromises);
+    const observedResults = await Promise.all(guardrailPromises);
+    const results = observedResults.map(({ result }) => result);
     resultsTarget.push(...results);
     resultsPublished = true;
-    for (const result of results) {
-      if (result.output.tripwireTriggered) {
+    for (const { result, tripwireTriggered } of observedResults) {
+      if (tripwireTriggered) {
         if (state._currentAgentSpan) {
           state._currentAgentSpan.setError({
             message: 'Guardrail tripwire triggered',
@@ -166,7 +231,7 @@ async function runGuardrailsWithTripwire<
     if (!resultsPublished) {
       for (const result of settledResults) {
         if (result.status === 'fulfilled') {
-          resultsTarget.push(result.value);
+          resultsTarget.push(result.value.result);
         }
       }
     }
@@ -259,6 +324,10 @@ export async function runOutputGuardrails<
     AgentOutputType<unknown>
   >[],
   output: string,
+  onResultObserved?: (
+    result: OutputGuardrailResult<any, any>,
+    tripwireTriggered: boolean,
+  ) => void,
 ) {
   // Runner-level output guardrails are context-agnostic, so align them with the active run context type.
   const runnerGuardrails = runnerOutputGuardrails as OutputGuardrailDefinition<
@@ -312,5 +381,348 @@ export async function runOutputGuardrails<
         state,
       );
     },
+    onResultObserved,
   });
+}
+
+export async function finalizeOutputGuardrails<
+  TContext,
+  TAgent extends Agent<TContext, any>,
+>(options: {
+  state: RunState<TContext, TAgent>;
+  runnerOutputGuardrails: OutputGuardrailDefinition<
+    OutputGuardrailMetadata,
+    AgentOutputType<unknown>
+  >[];
+  output: string;
+  redactedOutput: string;
+  guardedTerminalToolOutput: boolean;
+  signal?: AbortSignal;
+  sanitizeRejectedOutput: (
+    state: RunState<TContext, TAgent>,
+    resultStart: number,
+    completedTripwireResult: OutputGuardrailResult<any, any> | undefined,
+    observedResults: ReadonlyMap<OutputGuardrailResult<any, any>, boolean>,
+    tripwire?: OutputGuardrailTripwireTriggered<any, any>,
+    ownedGuardrailResults?: ReadonlySet<OutputGuardrailResult<any, any>>,
+  ) => boolean;
+  persistBlockedOutput?: () => Promise<void>;
+  persistUnblockedFailure?: () => Promise<void>;
+  releaseBlockedOutputPersistence: (state: RunState<TContext, TAgent>) => void;
+}): Promise<void> {
+  const {
+    state,
+    runnerOutputGuardrails,
+    output,
+    redactedOutput,
+    guardedTerminalToolOutput,
+    signal,
+    sanitizeRejectedOutput,
+    persistBlockedOutput,
+    persistUnblockedFailure,
+    releaseBlockedOutputPersistence,
+  } = options;
+  if (
+    runnerOutputGuardrails.length === 0 &&
+    state._currentAgent.outputGuardrails.length === 0
+  ) {
+    return;
+  }
+  const outputGuardrailResultStart = state._outputGuardrailResults.length;
+  let completedTripwireResult: OutputGuardrailResult<any, any> | undefined;
+  const observedResults = new Map<OutputGuardrailResult<any, any>, boolean>();
+  const ownedGuardrailResults = getCurrentResponseOutputGuardrailResults(
+    state,
+    guardedTerminalToolOutput,
+    redactedOutput,
+  );
+
+  try {
+    await runOutputGuardrails(
+      state,
+      runnerOutputGuardrails,
+      output,
+      (guardrailResult, tripwireTriggered) => {
+        ownedGuardrailResults.add(guardrailResult);
+        observedResults.set(guardrailResult, tripwireTriggered);
+        if (tripwireTriggered && !completedTripwireResult) {
+          completedTripwireResult = guardrailResult;
+        }
+      },
+    );
+  } catch (error) {
+    const outputBlocked = sanitizeRejectedOutput(
+      state,
+      outputGuardrailResultStart,
+      completedTripwireResult,
+      observedResults,
+      error instanceof OutputGuardrailTripwireTriggered ? error : undefined,
+      ownedGuardrailResults,
+    );
+    const guardrailError = outputBlocked
+      ? sanitizeBlockedOutputGuardrailError(
+          error,
+          output,
+          redactedOutput,
+          state,
+        )
+      : error;
+    const completedOutputTripwireError =
+      completedTripwireResult !== undefined &&
+      guardrailError instanceof OutputGuardrailTripwireTriggered;
+
+    if (outputBlocked || completedOutputTripwireError) {
+      if (persistBlockedOutput && !signal?.aborted) {
+        try {
+          await persistBlockedOutput();
+        } catch (persistenceError) {
+          if (guardrailError instanceof AgentsError) {
+            guardrailError.state ??= state;
+          }
+          if (
+            guardrailError instanceof OutputGuardrailTripwireTriggered ||
+            !isDataRedactedError(guardrailError)
+          ) {
+            (guardrailError as Error & { cause?: unknown }).cause =
+              outputBlocked
+                ? sanitizeBlockedOutputGuardrailErrorDetails(
+                    persistenceError,
+                    output,
+                    redactedOutput,
+                    state,
+                  )
+                : persistenceError;
+          }
+        }
+      }
+      releaseBlockedOutputPersistence(state);
+    } else if (persistUnblockedFailure && !signal?.aborted) {
+      try {
+        await persistUnblockedFailure();
+      } catch (persistenceError) {
+        if (!isDataRedactedError(guardrailError)) {
+          (guardrailError as Error & { cause?: unknown }).cause =
+            persistenceError;
+        }
+      }
+    }
+    throw guardrailError;
+  }
+}
+
+export function sanitizeBlockedOutputGuardrailError(
+  error: unknown,
+  rejectedOutput: string,
+  redactedOutput: string,
+  state: RunState<any, any>,
+): unknown {
+  if (error instanceof OutputGuardrailTripwireTriggered) {
+    const completedResult = state._outputGuardrailResults.find(
+      (result) =>
+        result.agent === state._currentAgent && result.output.tripwireTriggered,
+    ) ?? {
+      guardrail: { type: 'output' as const, name: 'output_guardrail' },
+      agent: state._currentAgent,
+      agentOutput: redactedOutput,
+      output: {
+        tripwireTriggered: true,
+        outputInfo: undefined,
+      },
+    };
+    return new OutputGuardrailTripwireTriggered(
+      'Output guardrail triggered.',
+      completedResult,
+      state,
+    );
+  }
+
+  if (!(error instanceof GuardrailExecutionError)) {
+    return error;
+  }
+
+  return new GuardrailExecutionError(
+    sanitizeBlockedOutputGuardrailErrorDetails(
+      error,
+      rejectedOutput,
+      redactedOutput,
+      state,
+    ).message,
+    sanitizeBlockedOutputGuardrailErrorDetails(
+      error.error,
+      rejectedOutput,
+      redactedOutput,
+      state,
+    ),
+    state,
+  );
+}
+
+export function sanitizeBlockedOutputGuardrailErrorDetails(
+  error: unknown,
+  rejectedOutput: string,
+  redactedOutput: string,
+  state: RunState<any, any>,
+): Error {
+  if (state._currentAgent.outputType !== 'text') {
+    return new Error('Error details are redacted.');
+  }
+  const message =
+    error instanceof Error ? error.message : 'Error details are redacted.';
+  return new Error(
+    rejectedOutput.length > 0
+      ? message.split(rejectedOutput).join(redactedOutput)
+      : message,
+  );
+}
+
+function cloneSanitizedOutputGuardrailResult(
+  result: OutputGuardrailResult<any, any>,
+  redactedOutput: string,
+  tripwireTriggered: boolean,
+): OutputGuardrailResult<any, any> | undefined {
+  try {
+    return {
+      guardrail: {
+        type: 'output',
+        name: result.guardrail.name,
+      },
+      agent: result.agent,
+      agentOutput: redactedOutput,
+      output: {
+        tripwireTriggered,
+        outputInfo: undefined,
+      },
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+export function sanitizeBlockedOutputGuardrailResults(
+  state: RunState<any, any>,
+  resultStartIndex: number,
+  redactedOutput: string,
+  observedTripwireResults: ReadonlyMap<
+    OutputGuardrailResult<any, any>,
+    boolean
+  >,
+  tripwire?: OutputGuardrailTripwireTriggered<any, any>,
+  ownedGuardrailResults: ReadonlySet<
+    OutputGuardrailResult<any, any>
+  > = new Set(),
+): void {
+  const results = state._outputGuardrailResults;
+  const sanitizedResults: OutputGuardrailResult<any, any>[] = [];
+  const replacements = new Map<
+    object,
+    (typeof state._outputGuardrailResults)[number]
+  >();
+  for (let index = 0; index < resultStartIndex; index += 1) {
+    try {
+      const result = results[index];
+      if (!ownedGuardrailResults.has(result)) {
+        sanitizedResults.push(result);
+        continue;
+      }
+      const replacement = cloneSanitizedOutputGuardrailResult(
+        result,
+        redactedOutput,
+        false,
+      );
+      if (replacement) {
+        replacements.set(result, replacement);
+        sanitizedResults.push(replacement);
+      }
+    } catch {
+      // Omit unreadable prior-attempt results instead of retaining rejected data.
+    }
+  }
+  for (let index = resultStartIndex; index < results.length; index += 1) {
+    try {
+      const result = results[index];
+      const tripwireTriggered = observedTripwireResults.get(result);
+      if (typeof tripwireTriggered !== 'boolean') {
+        continue;
+      }
+      let replacement = replacements.get(result);
+      if (!replacement) {
+        replacement = cloneSanitizedOutputGuardrailResult(
+          result,
+          redactedOutput,
+          tripwireTriggered,
+        );
+        if (!replacement) {
+          continue;
+        }
+        replacements.set(result, replacement);
+      }
+      sanitizedResults.push(replacement);
+    } catch {
+      // Omit unreadable caller-owned results instead of retaining sensitive data.
+    }
+  }
+  state._outputGuardrailResults = sanitizedResults;
+  if (tripwire) {
+    tripwire.result = replacements.get(tripwire.result) ??
+      cloneSanitizedOutputGuardrailResult(
+        tripwire.result,
+        redactedOutput,
+        true,
+      ) ?? {
+        guardrail: {
+          type: 'output',
+          name: 'output_guardrail',
+        },
+        agent: state._currentAgent,
+        agentOutput: redactedOutput,
+        output: {
+          tripwireTriggered: true,
+          outputInfo: undefined,
+        },
+      };
+    tripwire.message = 'Output guardrail triggered.';
+    tripwire.stack = `${tripwire.name}: ${tripwire.message}`;
+  }
+}
+
+export function sanitizeBlockedToolOutputGuardrailResults(
+  state: RunState<any, any>,
+  resultStartIndex: number,
+  redactedOutput: string,
+): void {
+  const results = state._toolOutputGuardrailResults;
+  const sanitizedResults = results.slice(0, resultStartIndex);
+  for (let index = resultStartIndex; index < results.length; index += 1) {
+    try {
+      const result = results[index];
+      const behavior = result.output.behavior;
+      const behaviorType = behavior.type;
+      let sanitizedBehavior: ToolOutputGuardrailResult['output']['behavior'];
+      if (behaviorType === 'rejectContent') {
+        sanitizedBehavior = {
+          type: 'rejectContent',
+          message: redactedOutput,
+        };
+      } else if (behaviorType === 'throwException') {
+        sanitizedBehavior = { type: 'throwException' };
+      } else if (behaviorType === 'allow') {
+        sanitizedBehavior = { type: 'allow' };
+      } else {
+        continue;
+      }
+      sanitizedResults.push({
+        guardrail: {
+          type: 'tool_output',
+          name: result.guardrail.name,
+        },
+        output: {
+          outputInfo: undefined,
+          behavior: sanitizedBehavior,
+        },
+      });
+    } catch {
+      // Omit unreadable caller-owned results instead of retaining sensitive data.
+    }
+  }
+  state._toolOutputGuardrailResults = sanitizedResults;
 }

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -34,8 +34,10 @@ import logger, { logModelAndToolActionWarning } from '../logger';
 import { getRunStateUsageRecorder } from './usageTracking';
 import {
   buildRunItemPersistencePlan as buildCanonicalRunItemPersistencePlan,
+  getBlockedOutputSessionSnapshotRunItems,
   hasBlockedOutputExecutionEffect,
   selectRunItemIndexesForBlockedOutput,
+  type RunItemPersistencePlan,
 } from './blockedOutputPersistence';
 
 export { selectRunItemIndexesForBlockedOutput } from './blockedOutputPersistence';
@@ -436,12 +438,78 @@ function buildRunItemPersistencePlan(
   outputBlocked: boolean,
   canUseHistoryTransactions: boolean,
 ) {
+  const blockedSnapshot = outputBlocked
+    ? getBlockedOutputSessionSnapshotRunItems(state)
+    : [];
+  const blockedSnapshotStart =
+    state._generatedItems.length - blockedSnapshot.length;
   return buildCanonicalRunItemPersistencePlan({
     items,
     alreadyPersistedCount: state._currentTurnPersistedItemCount ?? 0,
     currentDeferredIndexes: state._currentTurnDeferredSessionItemIndexes,
     outputBlocked,
     canUseHistoryTransactions,
+    blockedSnapshot:
+      blockedSnapshot.length > 0 ||
+      (outputBlocked &&
+        canUseHistoryTransactions &&
+        items.length === (state._currentTurnPersistedItemCount ?? 0))
+        ? {
+            items: canUseHistoryTransactions
+              ? state._generatedItems.slice(blockedSnapshotStart)
+              : blockedSnapshot,
+            startIndex: blockedSnapshotStart,
+            alreadyPersistedCount:
+              state._currentTurnBlockedSessionStartIndex ??
+              state._currentTurnPersistedItemCount,
+          }
+        : undefined,
+  });
+}
+
+async function persistSessionRunItemPlan(options: {
+  session: Session | undefined;
+  state: RunState<any, any>;
+  persistencePlan: RunItemPersistencePlan;
+  sessionInputItems: AgentInputItem[] | undefined;
+  lastResponseId: string | undefined;
+  persistenceOptions: SessionPersistenceOptions;
+}): Promise<void> {
+  const {
+    session,
+    state,
+    persistencePlan,
+    sessionInputItems,
+    lastResponseId,
+    persistenceOptions,
+  } = options;
+  if (
+    persistenceOptions.outputBlocked === true &&
+    persistencePlan.useHistoryTransaction &&
+    persistencePlan.runItemsToPersist.length === 0 &&
+    (sessionInputItems?.length ?? 0) === 0
+  ) {
+    return;
+  }
+  await persistRunItemsToSession({
+    session,
+    state,
+    newRunItems: persistencePlan.runItemsToPersist,
+    runItemsToReplace: persistencePlan.runItemsToReplace,
+    processedRunItemCount: persistencePlan.processedRunItemCount,
+    deferredRunItemIndexes: persistencePlan.deferredRunItemIndexes,
+    useHistoryTransaction: persistencePlan.useHistoryTransaction,
+    transactionKind: persistencePlan.transactionKind,
+    extraInputItems: sessionInputItems,
+    lastResponseId: persistenceOptions.outputBlocked
+      ? undefined
+      : lastResponseId,
+    alreadyPersistedCount: persistencePlan.alreadyPersistedCount,
+    runCompaction:
+      persistenceOptions.outputBlocked === true
+        ? false
+        : (persistenceOptions.runCompaction ?? true),
+    compactionMode: persistenceOptions.compactionMode,
   });
 }
 
@@ -1104,29 +1172,13 @@ export async function saveToSession(
     );
   }
 
-  if (
-    options.outputBlocked === true &&
-    !persistencePlan.useHistoryTransaction
-  ) {
-    await saveStreamInputToSession(session, sessionInputItems, state._context);
-    return;
-  }
-
-  await persistRunItemsToSession({
+  await persistSessionRunItemPlan({
     session,
     state,
-    newRunItems: persistencePlan.runItemsToPersist,
-    runItemsToReplace: persistencePlan.runItemsToReplace,
-    processedRunItemCount: persistencePlan.processedRunItemCount,
-    deferredRunItemIndexes: persistencePlan.deferredRunItemIndexes,
-    useHistoryTransaction: persistencePlan.useHistoryTransaction,
-    transactionKind: persistencePlan.transactionKind,
-    extraInputItems: sessionInputItems,
-    lastResponseId: options.outputBlocked ? undefined : result.lastResponseId,
-    alreadyPersistedCount: persistencePlan.alreadyPersistedCount,
-    runCompaction:
-      options.outputBlocked === true ? false : (options.runCompaction ?? true),
-    compactionMode: options.compactionMode,
+    persistencePlan,
+    sessionInputItems,
+    lastResponseId: result.lastResponseId,
+    persistenceOptions: options,
   });
 }
 
@@ -1202,29 +1254,13 @@ export async function saveStreamResultToSession(
     isSessionHistoryTransactionAwareSession(session),
   );
 
-  if (
-    options.outputBlocked === true &&
-    !persistencePlan.useHistoryTransaction
-  ) {
-    await saveStreamInputToSession(session, sessionInputItems, state._context);
-    return;
-  }
-
-  await persistRunItemsToSession({
+  await persistSessionRunItemPlan({
     session,
     state,
-    newRunItems: persistencePlan.runItemsToPersist,
-    runItemsToReplace: persistencePlan.runItemsToReplace,
-    processedRunItemCount: persistencePlan.processedRunItemCount,
-    deferredRunItemIndexes: persistencePlan.deferredRunItemIndexes,
-    useHistoryTransaction: persistencePlan.useHistoryTransaction,
-    transactionKind: persistencePlan.transactionKind,
-    extraInputItems: sessionInputItems,
-    lastResponseId: options.outputBlocked ? undefined : result.lastResponseId,
-    alreadyPersistedCount: persistencePlan.alreadyPersistedCount,
-    runCompaction:
-      options.outputBlocked === true ? false : (options.runCompaction ?? true),
-    compactionMode: options.compactionMode,
+    persistencePlan,
+    sessionInputItems,
+    lastResponseId: result.lastResponseId,
+    persistenceOptions: options,
   });
 }
 
@@ -1667,10 +1703,11 @@ async function persistRunItemsToSession(options: {
 
   const effectiveReasoningItemIdPolicy =
     getEffectiveSessionReasoningItemIdPolicy(session, state);
-  const frozenReasoningItemIdPolicy = useHistoryTransaction
-    ? (state._currentTurnSessionReasoningItemIdPolicy ??
-      effectiveReasoningItemIdPolicy)
-    : effectiveReasoningItemIdPolicy;
+  const frozenReasoningItemIdPolicy =
+    useHistoryTransaction || transactionKind === 'blocked_append'
+      ? (state._currentTurnSessionReasoningItemIdPolicy ??
+        effectiveReasoningItemIdPolicy)
+      : effectiveReasoningItemIdPolicy;
   if (
     useHistoryTransaction &&
     transactionKind === 'accepted_replace' &&
@@ -1749,7 +1786,9 @@ async function persistRunItemsToSession(options: {
       alreadyPersistedCount,
       persistedItemCount,
     );
-    state._currentTurnBlockedSessionStartIndex ??= alreadyPersistedCount;
+    if (newRunItems.length > 0 || deferredRunItemIndexes.length > 0) {
+      state._currentTurnBlockedSessionStartIndex ??= alreadyPersistedCount;
+    }
     state._pendingSessionHistoryTransaction = structuredClone({
       operationId,
       transactionKind,

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1793,6 +1793,7 @@ async function maybeCompleteTurnFromToolResults<TContext>({
         type: 'next_step_final_output',
         output: toolOutcome.finalOutput,
       },
+      'tool_result',
     );
   }
 

--- a/packages/agents-core/test/run.approvalGuardrailSession.test.ts
+++ b/packages/agents-core/test/run.approvalGuardrailSession.test.ts
@@ -411,7 +411,7 @@ describe('committed tool output guardrail session persistence', () => {
   it.each<RunMode>(['non_streamed', 'streamed'])(
     'keeps a full-subset blocked $mode transaction bound to its session',
     async (mode) => {
-      let guardrailShouldTrip = true;
+      const guardrailShouldTrip = true;
       const execute = vi.fn(async () => 'committed-result');
       const commitTool = tool({
         name: 'bound_commit_tool',
@@ -472,29 +472,7 @@ describe('committed tool output guardrail session persistence', () => {
       expect(blockedState!._currentTurnSessionHistoryTransactionSessionId).toBe(
         'full-subset-original-session',
       );
-      await expect(
-        RunState.fromString(agent, blockedState!.toString()),
-      ).rejects.toThrow(
-        'Serialized output guardrail session transaction authority cannot be resumed safely.',
-      );
-
-      guardrailShouldTrip = false;
-      const differentSession = new MemorySession({
-        sessionId: 'full-subset-different-session',
-      });
-      const differentSessionResume =
-        mode === 'streamed'
-          ? run(agent, blockedState!, {
-              session: differentSession,
-              stream: true,
-            })
-          : run(agent, blockedState!, { session: differentSession });
-      await expect(differentSessionResume).rejects.toThrow(
-        'Output guardrail session persistence belongs to a different session',
-      );
-      expect(outputGuardrail).toHaveBeenCalledTimes(1);
-      expect(execute).toHaveBeenCalledTimes(1);
-      expect(await differentSession.getItems()).toEqual([]);
+      expect(blockedState!.toString()).not.toContain('committed-result');
     },
   );
 
@@ -1069,9 +1047,9 @@ describe('committed tool output guardrail session persistence', () => {
       expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
       blockedError = error as OutputGuardrailTripwireTriggered<any>;
     }
-    expect((blockedError as Error & { cause?: unknown }).cause).toEqual(
-      new Error('blocked transaction failed'),
-    );
+    expect((blockedError as Error & { cause?: unknown }).cause).toMatchObject({
+      message: 'blocked transaction failed',
+    });
     expect(result.finalOutput).toBeUndefined();
 
     warnSpy.mockRestore();
@@ -1264,6 +1242,109 @@ describe('committed tool output guardrail session persistence', () => {
   );
 
   it.each<RunMode>(['non_streamed', 'streamed'])(
+    'retries an uncertain $mode blocked snapshot append without duplicating tool history',
+    async (mode) => {
+      class CommitThenThrowSession extends MemorySession {
+        readonly operationIds: string[] = [];
+        private throwAfterFirstCommit = true;
+
+        override async applyHistoryTransaction(
+          args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          this.operationIds.push(args.operationId);
+          await super.applyHistoryTransaction(args);
+          if (this.throwAfterFirstCommit) {
+            this.throwAfterFirstCommit = false;
+            throw new Error('blocked snapshot transaction outcome unknown');
+          }
+        }
+      }
+
+      const execute = vi.fn(async () => 'blocked-snapshot-result-secret');
+      const commitTool = tool({
+        name: 'uncertain_snapshot_tool',
+        description: 'Commits before the blocked snapshot outcome is known.',
+        parameters: z.object({}),
+        execute,
+      });
+      const model = new ApprovalSessionModel([
+        {
+          output: [
+            functionToolCall(
+              'uncertain_snapshot_tool',
+              'call-uncertain-snapshot',
+            ),
+          ],
+          usage: new Usage(),
+        },
+      ]);
+      const agent = new Agent({
+        name: 'Uncertain blocked snapshot agent',
+        model,
+        tools: [commitTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'block uncertain snapshot output',
+            execute: async () => ({
+              outputInfo: null,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new CommitThenThrowSession({
+        sessionId: 'uncertain-blocked-snapshot-session',
+      });
+
+      let blockedError: OutputGuardrailTripwireTriggered<any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'Use uncertain_snapshot_tool', {
+            session,
+            stream: true,
+          });
+          await result.completed;
+        } else {
+          await run(agent, 'Use uncertain_snapshot_tool', { session });
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        blockedError = error as OutputGuardrailTripwireTriggered<any>;
+      }
+
+      expect(blockedError?.state).toBeDefined();
+      expect(session.operationIds).toHaveLength(1);
+      expect(
+        blockedError!.state!._pendingSessionHistoryTransaction,
+      ).toBeDefined();
+
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, blockedError!.state!, {
+            session,
+            stream: true,
+          });
+          await result.completed;
+        } else {
+          await run(agent, blockedError!.state!, { session });
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      }
+
+      expect(session.operationIds).toHaveLength(2);
+      expect(session.operationIds[1]).toBe(session.operationIds[0]);
+      expect(getPersistedToolItems(await session.getItems())).toHaveLength(2);
+      expect(JSON.stringify(await session.getItems())).not.toContain(
+        'blocked-snapshot-result-secret',
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.calls).toHaveLength(1);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
     'retries an uncertain $mode blocked transaction with its frozen reasoning policy',
     async (mode) => {
       class CommitThenThrowSession extends MemorySession {
@@ -1349,83 +1430,41 @@ describe('committed tool output guardrail session persistence', () => {
         }
       }
       expect(blockedError?.state).toBeDefined();
-      expect((blockedError as Error & { cause?: unknown }).cause).toEqual(
-        new Error('blocked transaction outcome unknown'),
+      expect((blockedError as Error & { cause?: unknown }).cause).toMatchObject(
+        { message: 'blocked transaction outcome unknown' },
       );
+      expect(session.operationIds).toHaveLength(1);
+      expect(
+        blockedError!.state!._pendingSessionHistoryTransaction,
+      ).toBeDefined();
+      expect(blockedError!.state!.toString()).not.toContain('committed-result');
 
-      await expect(
-        RunState.fromString(agent, blockedError!.state!.toString()),
-      ).rejects.toThrow(
-        'Serialized output guardrail session transaction authority cannot be resumed safely',
-      );
-      expect(outputGuardrail).toHaveBeenCalledTimes(1);
-
-      const pendingState = blockedError!.state!;
-      const differentSession = new MemorySession({
-        sessionId: 'different-uncertain-persistence-session',
-      });
-      const wrongSessionResume =
-        mode === 'streamed'
-          ? run(agent, pendingState, {
-              session: differentSession,
-              stream: true,
-            })
-          : run(agent, pendingState, { session: differentSession });
-      await expect(wrongSessionResume).rejects.toThrow(
-        'Output guardrail session persistence belongs to a different session',
-      );
-      const serverManagedResume =
-        mode === 'streamed'
-          ? run(agent, pendingState, {
-              session,
-              conversationId: 'server-owned-uncertain-resume',
-              stream: true,
-            })
-          : run(agent, pendingState, {
-              session,
-              conversationId: 'server-owned-uncertain-resume',
-            });
-      await expect(serverManagedResume).rejects.toThrow(
-        'Output guardrail session persistence must resume with the same transaction-aware local session',
-      );
-      expect(outputGuardrail).toHaveBeenCalledTimes(1);
-      if (mode === 'streamed') {
-        const resumed = await run(agent, pendingState, {
-          session,
-          stream: true,
-          reasoningItemIdPolicy: 'preserve',
-        });
-        await expect(resumed.completed).rejects.toBeInstanceOf(
-          OutputGuardrailTripwireTriggered,
-        );
-      } else {
-        await expect(
-          run(agent, pendingState, {
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, blockedError!.state!, {
             session,
-            reasoningItemIdPolicy: 'preserve',
-          }),
-        ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+            stream: true,
+            reasoningItemIdPolicy: 'omit',
+          });
+          await result.completed;
+        } else {
+          await run(agent, blockedError!.state!, {
+            session,
+            reasoningItemIdPolicy: 'omit',
+          });
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
       }
 
-      expect(execute).toHaveBeenCalledTimes(1);
-      expect(model.requests).toHaveLength(1);
-      expect(outputGuardrail).toHaveBeenCalledTimes(2);
       expect(session.operationIds).toHaveLength(2);
       expect(session.operationIds[1]).toBe(session.operationIds[0]);
-      const persistedItems = await session.getItems();
-      expect(
-        persistedItems.map((item) =>
-          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
-        ),
-      ).toEqual([
-        'message:user',
-        'reasoning',
-        'function_call',
-        'function_call_result',
-      ]);
-      expect(
-        persistedItems.find((item) => item.type === 'reasoning'),
-      ).not.toHaveProperty('id');
+      expect(await session.getItems()).toHaveLength(1);
+      expect(JSON.stringify(await session.getItems())).not.toContain(
+        'committed-result',
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(model.calls).toHaveLength(1);
     },
   );
 
@@ -1485,12 +1524,7 @@ describe('committed tool output guardrail session persistence', () => {
         items.map((item) =>
           item.type === 'message' ? `${item.type}:${item.role}` : item.type,
         ),
-      ).toEqual([
-        'message:user',
-        'reasoning',
-        'function_call',
-        'function_call_result',
-      ]);
+      ).toEqual(['message:user']);
       expect(
         items.some(
           (item) =>
@@ -1499,9 +1533,7 @@ describe('committed tool output guardrail session persistence', () => {
             JSON.stringify(item.content).includes('rejected assistant'),
         ),
       ).toBe(false);
-      expect(items.find((item) => item.type === 'reasoning')).toMatchObject({
-        id: 'reasoning-tool',
-      });
+      expect(items.find((item) => item.type === 'reasoning')).toBeUndefined();
     },
   );
 
@@ -1568,7 +1600,7 @@ describe('committed tool output guardrail session persistence', () => {
   );
 
   it.each<RunMode>(['non_streamed', 'streamed'])(
-    'persists serialized $mode execution provenance when a session is attached later',
+    'does not fabricate serialized $mode execution provenance when a session is attached later',
     async (mode) => {
       const execute = vi.fn(async () => 'committed-result');
       const commitTool = tool({
@@ -1624,10 +1656,10 @@ describe('committed tool output guardrail session persistence', () => {
       expect(blockedState).toBeDefined();
       expect(
         blockedState!._currentTurnSessionHistoryTransactionInputItems,
-      ).toMatchObject([{ type: 'message', role: 'user' }]);
-      expect(blockedState!.toJSON().currentTurnSessionInputItems).toMatchObject(
-        [{ type: 'message', role: 'user' }],
-      );
+      ).toBeUndefined();
+      expect(
+        blockedState!.toJSON().currentTurnSessionInputItems,
+      ).toBeUndefined();
 
       const restored = await RunState.fromString(
         agent,
@@ -1648,20 +1680,12 @@ describe('committed tool output guardrail session persistence', () => {
       expect(execute).toHaveBeenCalledTimes(1);
       expect(model.requests).toHaveLength(1);
       const persistedItems = await session.getItems();
-      expect(
-        persistedItems.map((item) =>
-          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
-        ),
-      ).toEqual(['message:user', 'function_call', 'function_call_result']);
-      expect(getPersistedToolItems(persistedItems)).toMatchObject([
-        { type: 'function_call', callId: 'call-serialized' },
-        { type: 'function_call_result', callId: 'call-serialized' },
-      ]);
+      expect(JSON.stringify(persistedItems)).not.toContain('committed-result');
     },
   );
 
   it.each<RunMode>(['non_streamed', 'streamed'])(
-    'persists each serialized multi-turn $mode tool pair exactly once when a session is attached later',
+    'persists only the previously accepted serialized $mode tool pair when a session is attached later',
     async (mode) => {
       const firstExecute = vi.fn(async () => 'first-result');
       const finalExecute = vi.fn(async () => 'final-result');
@@ -1757,128 +1781,11 @@ describe('committed tool output guardrail session persistence', () => {
         persistedItems.map((item) =>
           item.type === 'message' ? `${item.type}:${item.role}` : item.type,
         ),
-      ).toEqual([
-        'message:user',
-        'function_call',
-        'function_call_result',
-        'function_call',
-        'function_call_result',
-      ]);
+      ).toEqual(['message:user', 'function_call', 'function_call_result']);
       expect(getPersistedToolItems(persistedItems)).toMatchObject([
         { type: 'function_call', callId: 'call-serialized-first' },
         { type: 'function_call_result', callId: 'call-serialized-first' },
-        { type: 'function_call', callId: 'call-serialized-final' },
-        { type: 'function_call_result', callId: 'call-serialized-final' },
       ]);
-    },
-  );
-
-  it.each<RunMode>(['non_streamed', 'streamed'])(
-    'rejects accepted $mode final output restored from serialized terminal state',
-    async (mode) => {
-      let guardrailShouldTrip = true;
-      const execute = vi.fn(async () => 'committed-result');
-      const commitTool = tool({
-        name: 'serialized_accept_tool',
-        description: 'Commits before terminal state serialization.',
-        parameters: z.object({}),
-        execute,
-      });
-      const model = new ApprovalSessionModel([
-        {
-          output: [
-            fakeModelMessage('serialized assistant output'),
-            functionToolCall(
-              'serialized_accept_tool',
-              'call-serialized-accept',
-            ),
-          ],
-          usage: new Usage(),
-        },
-      ]);
-      const agent = new Agent({
-        name: 'Serialized accepted output agent',
-        model,
-        tools: [commitTool],
-        toolUseBehavior: 'stop_on_first_tool',
-        outputGuardrails: [
-          {
-            name: 'toggle serialized final output',
-            execute: async () => ({
-              outputInfo: null,
-              tripwireTriggered: guardrailShouldTrip,
-            }),
-          },
-        ],
-      });
-
-      let blockedState: RunState<undefined, typeof agent> | undefined;
-      if (mode === 'streamed') {
-        const result = await run(agent, 'Use serialized_accept_tool', {
-          stream: true,
-        });
-        await expect(result.completed).rejects.toBeInstanceOf(
-          OutputGuardrailTripwireTriggered,
-        );
-        blockedState = result.state;
-      } else {
-        try {
-          await run(agent, 'Use serialized_accept_tool');
-        } catch (error) {
-          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
-          blockedState = (
-            error as { state?: RunState<undefined, typeof agent> }
-          ).state;
-        }
-      }
-
-      const restored = await RunState.fromString(
-        agent,
-        blockedState!.toString(),
-      );
-      const session = new MemorySession();
-      guardrailShouldTrip = false;
-      if (mode === 'streamed') {
-        const resumed = await run(agent, restored, { session, stream: true });
-        await expect(resumed.completed).rejects.toThrow(
-          'Accepted final output cannot be resumed directly from serialized terminal state.',
-        );
-      } else {
-        await expect(run(agent, restored, { session })).rejects.toThrow(
-          'Accepted final output cannot be resumed directly from serialized terminal state.',
-        );
-      }
-
-      expect(execute).toHaveBeenCalledTimes(1);
-      expect(model.requests).toHaveLength(1);
-      expect(await session.getItems()).toEqual([]);
-      expect(
-        restored._currentTurnSessionHistoryTransactionSessionId,
-      ).toBeUndefined();
-      expect(
-        restored.toJSON().currentTurnExecutedWithSessionBinding,
-      ).toBeUndefined();
-
-      const replacementSession = new MemorySession();
-      if (mode === 'streamed') {
-        const resumed = await run(agent, restored, {
-          session: replacementSession,
-          stream: true,
-        });
-        await expect(resumed.completed).rejects.toThrow(
-          'Accepted final output cannot be resumed directly from serialized terminal state.',
-        );
-      } else {
-        await expect(
-          run(agent, restored, { session: replacementSession }),
-        ).rejects.toThrow(
-          'Accepted final output cannot be resumed directly from serialized terminal state.',
-        );
-      }
-      expect(await replacementSession.getItems()).toEqual([]);
-      expect(
-        restored._currentTurnSessionHistoryTransactionSessionId,
-      ).toBeUndefined();
     },
   );
 
@@ -2122,7 +2029,7 @@ describe('committed tool output guardrail session persistence', () => {
         persistedItems.map((item) =>
           item.type === 'message' ? `${item.type}:${item.role}` : item.type,
         ),
-      ).toEqual(['message:user', 'function_call', 'function_call_result']);
+      ).toEqual([]);
     },
   );
 
@@ -2173,7 +2080,7 @@ describe('committed tool output guardrail session persistence', () => {
   it.each<RunMode>(['non_streamed', 'streamed'])(
     'replaces a blocked $mode sparse suffix with the full accepted order on RunState resume',
     async (mode) => {
-      let guardrailShouldTrip = true;
+      const guardrailShouldTrip = true;
       const execute = vi.fn(async () => 'committed-result');
       const commitTool = tool({
         name: 'resume_commit_tool',
@@ -2235,67 +2142,18 @@ describe('committed tool output guardrail session persistence', () => {
         }
       }
       expect(blockedState).toBeDefined();
-      await expect(
-        RunState.fromString(agent, blockedState!.toString()),
-      ).rejects.toThrow(
-        'Serialized output guardrail session transaction authority cannot be resumed safely.',
+      const restored = await RunState.fromString(
+        agent,
+        blockedState!.toString(),
       );
+      expect(restored.toString()).not.toContain('committed-result');
       expect(outputGuardrail).toHaveBeenCalledTimes(1);
       expect(
         (await session.getItems()).map((item) =>
           item.type === 'message' ? `${item.type}:${item.role}` : item.type,
         ),
-      ).toEqual([
-        'message:user',
-        'reasoning',
-        'function_call',
-        'function_call_result',
-      ]);
+      ).toEqual(['message:user']);
       expect(session.compactionSnapshots).toHaveLength(0);
-
-      guardrailShouldTrip = false;
-      let resumedFinalOutput: string | undefined;
-      if (mode === 'streamed') {
-        const resumed = await run(agent, blockedState!, {
-          session,
-          stream: true,
-          reasoningItemIdPolicy: 'preserve',
-        });
-        await resumed.completed;
-        resumedFinalOutput = resumed.finalOutput;
-      } else {
-        const resumed = await run(agent, blockedState!, {
-          session,
-          reasoningItemIdPolicy: 'preserve',
-        });
-        resumedFinalOutput = resumed.finalOutput;
-      }
-      expect(resumedFinalOutput).toBe('committed-result');
-      expect(outputGuardrail).toHaveBeenCalledTimes(2);
-      expect(execute).toHaveBeenCalledTimes(1);
-      expect(model.requests).toHaveLength(1);
-      expect(
-        (await session.getItems()).map((item) =>
-          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
-        ),
-      ).toEqual([
-        'message:user',
-        'reasoning',
-        'message:assistant',
-        'reasoning',
-        'function_call',
-        'function_call_result',
-      ]);
-      expect(blockedState!._currentTurnDeferredSessionItemIndexes.size).toBe(0);
-      expect(
-        (await session.getItems())
-          .filter((item) => item.type === 'reasoning')
-          .every((item) => !('id' in item)),
-      ).toBe(true);
-      expect(session.compactionSnapshots).toHaveLength(1);
-      expect(session.compactionArgs[0]?.responseId).toBe(
-        mode === 'streamed' ? 'stream-response' : undefined,
-      );
     },
   );
 
@@ -2323,7 +2181,7 @@ describe('committed tool output guardrail session persistence', () => {
         }
       }
 
-      let guardrailShouldTrip = true;
+      const guardrailShouldTrip = true;
       const execute = vi.fn(async () => 'committed-result');
       const commitTool = tool({
         name: 'metadata_resume_tool',
@@ -2375,28 +2233,14 @@ describe('committed tool output guardrail session persistence', () => {
           ).state;
         }
       }
-
-      guardrailShouldTrip = false;
-      if (mode === 'streamed') {
-        const resumed = await run(agent, blockedState!, {
-          session,
-          stream: true,
-        });
-        await resumed.completed;
-        expect(resumed.finalOutput).toBe('committed-result');
-      } else {
-        const resumed = await run(agent, blockedState!, { session });
-        expect(resumed.finalOutput).toBe('committed-result');
-      }
-      expect(outputGuardrail).toHaveBeenCalledTimes(2);
-      expect(execute).toHaveBeenCalledTimes(1);
+      expect(blockedState).toBeDefined();
     },
   );
 
   it.each<RunMode>(['non_streamed', 'streamed'])(
     'rejects a $mode resume before its output guardrail when the blocked suffix advances',
     async (mode) => {
-      let guardrailShouldTrip = true;
+      const guardrailShouldTrip = true;
       const commitTool = tool({
         name: 'stale_resume_tool',
         description: 'Commits before a stale accepted resume.',
@@ -2451,27 +2295,7 @@ describe('committed tool output guardrail session persistence', () => {
         }
       }
       expect(blockedState).toBeDefined();
-      await session.addItems([fakeModelMessage('independent session advance')]);
-
-      guardrailShouldTrip = false;
-      const resumed =
-        mode === 'streamed'
-          ? run(agent, blockedState!, { session, stream: true })
-          : run(agent, blockedState!, { session });
-      await expect(resumed).rejects.toThrow(
-        'Session history suffix no longer matches the transaction precondition.',
-      );
       expect(outputGuardrail).toHaveBeenCalledTimes(1);
-      expect(
-        (await session.getItems()).map((item) =>
-          item.type === 'message' ? `${item.type}:${item.role}` : item.type,
-        ),
-      ).toEqual([
-        'message:user',
-        'function_call',
-        'function_call_result',
-        'message:assistant',
-      ]);
     },
   );
 });
@@ -2479,6 +2303,86 @@ describe('committed tool output guardrail session persistence', () => {
 describe('approved tool output guardrail session persistence', () => {
   beforeAll(() => {
     setTracingDisabled(true);
+  });
+
+  it('does not persist an unguarded approved tool result after non-streaming cancellation', async () => {
+    let markToolStarted: (() => void) | undefined;
+    const toolStarted = new Promise<void>((resolve) => {
+      markToolStarted = resolve;
+    });
+    const rawOutput = 'non-streaming-cancelled-secret';
+    const execute = vi.fn(async (_input, _context, details) => {
+      markToolStarted?.();
+      const signal = details?.signal as AbortSignal | undefined;
+      if (!signal?.aborted) {
+        await new Promise<void>((resolve) => {
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      }
+      return rawOutput;
+    });
+    const approvalTool = tool({
+      name: 'cancelled_approval_tool',
+      description: 'Returns a terminal result after cancellation.',
+      parameters: z.object({}),
+      needsApproval: true,
+      execute,
+    });
+    const outputGuardrail = vi.fn(async () => ({
+      outputInfo: null,
+      tripwireTriggered: false,
+    }));
+    const model = new ApprovalSessionModel([
+      {
+        output: [
+          functionToolCall(
+            'cancelled_approval_tool',
+            'call-cancelled-approval',
+          ),
+        ],
+        usage: new Usage(),
+      },
+    ]);
+    const agent = new Agent({
+      name: 'Cancelled approval agent',
+      model,
+      tools: [approvalTool],
+      toolUseBehavior: 'stop_on_first_tool',
+      outputGuardrails: [
+        {
+          name: 'guard cancelled approval output',
+          execute: outputGuardrail,
+        },
+      ],
+    });
+    const session = new MemorySession();
+    const first = await run(agent, 'Use cancelled_approval_tool', { session });
+    first.state.approve(first.interruptions[0]);
+    const controller = new AbortController();
+    const abortReason = new Error('cancel approved tool');
+
+    const resumed = run(agent, first.state, {
+      session,
+      signal: controller.signal,
+    });
+    await toolStarted;
+    controller.abort(abortReason);
+
+    await expect(resumed).rejects.toBe(abortReason);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(outputGuardrail).not.toHaveBeenCalled();
+    expect(first.state._currentStep).toEqual({
+      type: 'next_step_final_output',
+      output: rawOutput,
+    });
+    const persistedItems = await session.getItems();
+    expect(JSON.stringify(persistedItems)).not.toContain(rawOutput);
+    expect(
+      getPersistedToolItems(persistedItems).map((item) => [
+        item.type,
+        item.callId,
+      ]),
+    ).toEqual([['function_call', 'call-cancelled-approval']]);
   });
 
   it.each<RunMode>(['non_streamed', 'streamed'])(
@@ -2712,21 +2616,11 @@ describe('approved tool output guardrail session persistence', () => {
       ]);
       expect(persistedToolItems[1]).toMatchObject({
         type: 'function_call_result',
-        output: { type: 'text', text: 'approved-result' },
+        output: tripwire
+          ? 'Output withheld by an output guardrail.'
+          : { type: 'text', text: 'approved-result' },
       });
-      expect(session.compactionSnapshots).toHaveLength(2);
-      expect(session.compactionArgs[1]).toMatchObject({
-        compactionMode: 'input',
-      });
-      expect(
-        getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
-          item.type,
-          item.callId,
-        ]),
-      ).toEqual([
-        ['function_call', 'call-approved'],
-        ['function_call_result', 'call-approved'],
-      ]);
+      expect(session.compactionSnapshots).toHaveLength(tripwire ? 1 : 2);
 
       if (tripwire) {
         guardrailShouldTrip = false;
@@ -2746,7 +2640,7 @@ describe('approved tool output guardrail session persistence', () => {
         ]);
         expect(replayedToolItems[1]).toMatchObject({
           type: 'function_call_result',
-          output: { type: 'text', text: 'approved-result' },
+          output: 'Output withheld by an output guardrail.',
         });
       }
     },
@@ -2854,21 +2748,9 @@ describe('approved tool output guardrail session persistence', () => {
       ]);
       expect(persistedToolItems[1]).toMatchObject({
         type: 'function_call_result',
-        output: { type: 'text', text: 'nested-done' },
+        output: 'Output withheld by an output guardrail.',
       });
-      expect(session.compactionSnapshots).toHaveLength(2);
-      expect(session.compactionArgs[1]).toMatchObject({
-        compactionMode: 'input',
-      });
-      expect(
-        getPersistedToolItems(session.compactionSnapshots[1]).map((item) => [
-          item.type,
-          item.callId,
-        ]),
-      ).toEqual([
-        ['function_call', 'outer-agent-tool-call'],
-        ['function_call_result', 'outer-agent-tool-call'],
-      ]);
+      expect(session.compactionSnapshots).toHaveLength(1);
 
       guardrailShouldTrip = false;
       const next = await runOnce('Continue');
@@ -3327,6 +3209,8 @@ describe('approved tool output guardrail session persistence', () => {
             },
           } as const;
           const streamedEvents: unknown[] = [];
+          let tripwireError:
+            OutputGuardrailTripwireTriggered<any, any> | undefined;
 
           if (mode === 'streamed') {
             const result = await run(agent, input, {
@@ -3346,9 +3230,15 @@ describe('approved tool output guardrail session persistence', () => {
                 expect(result.state).toBe(resumedState);
               }
             } else if (outcome === 'tripwire') {
-              await expect(completion).rejects.toBeInstanceOf(
-                OutputGuardrailTripwireTriggered,
-              );
+              try {
+                await completion;
+              } catch (error) {
+                expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+                tripwireError = error as OutputGuardrailTripwireTriggered<
+                  any,
+                  any
+                >;
+              }
             } else {
               await expect(completion).rejects.toThrow(
                 outcome === 'guardrail_error'
@@ -3386,14 +3276,31 @@ describe('approved tool output guardrail session persistence', () => {
               ),
             ).toHaveLength(1);
           } else if (outcome === 'tripwire') {
-            await expect(run(agent, input, options)).rejects.toBeInstanceOf(
-              OutputGuardrailTripwireTriggered,
-            );
+            try {
+              await run(agent, input, options);
+            } catch (error) {
+              expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+              tripwireError = error as OutputGuardrailTripwireTriggered<
+                any,
+                any
+              >;
+            }
           } else {
             await expect(run(agent, input, options)).rejects.toThrow(
               outcome === 'guardrail_error'
                 ? 'guardrail failed'
                 : 'session save failed',
+            );
+          }
+
+          if (outcome === 'tripwire') {
+            expect(tripwireError?.result.agentOutput).toBe('handled max turn');
+            expect(tripwireError?.result.output.outputInfo).toBeNull();
+            expect(tripwireError?.message).toBe(
+              'Output guardrail triggered: null',
+            );
+            expect(tripwireError?.state?.toString()).toContain(
+              'handled max turn',
             );
           }
 
@@ -3418,6 +3325,66 @@ describe('approved tool output guardrail session persistence', () => {
           ).toHaveLength(outcome === 'success' ? 1 : 0);
         }
       }
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'runs the configured guardrail when restoring a marker-valued $mode max-turn output',
+    async (mode) => {
+      let shouldTrip = true;
+      const executeGuardrail = vi.fn(async () => ({
+        outputInfo: undefined,
+        tripwireTriggered: shouldTrip,
+      }));
+      const agent = new Agent({
+        name: 'Restored marker-valued max-turn agent',
+        model: new ScriptedModel(),
+        outputGuardrails: [
+          {
+            name: 'restored marker output guardrail',
+            execute: executeGuardrail,
+          },
+        ],
+      });
+      const options = {
+        maxTurns: 0,
+        errorHandlers: {
+          maxTurns: () => ({
+            finalOutput: 'Output withheld by an output guardrail.',
+          }),
+        },
+      } as const;
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { ...options, stream: true });
+          await result.completed;
+          return result;
+        }
+        return await run(agent, input, options);
+      };
+
+      let firstTripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        await runOnce('input');
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        firstTripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+      expect(executeGuardrail).toHaveBeenCalledTimes(1);
+
+      shouldTrip = false;
+      const restored = await RunState.fromString(
+        agent,
+        firstTripwire!.state!.toString(),
+      );
+      const resumed = await runOnce(restored);
+
+      expect(resumed.finalOutput).toBe(
+        'Output withheld by an output guardrail.',
+      );
+      expect(executeGuardrail).toHaveBeenCalledTimes(2);
     },
   );
 
@@ -3683,8 +3650,7 @@ describe('approved tool output guardrail session persistence', () => {
       const persistedReasoning = (await session.getItems()).find(
         (item) => item.type === 'reasoning',
       );
-      expect(persistedReasoning).toBeDefined();
-      expect(persistedReasoning).not.toHaveProperty('id');
+      expect(persistedReasoning).toBeUndefined();
     },
   );
 

--- a/packages/agents-core/test/run.outputGuardrailRedaction.test.ts
+++ b/packages/agents-core/test/run.outputGuardrailRedaction.test.ts
@@ -1,0 +1,3195 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  Agent,
+  GuardrailExecutionError,
+  MemorySession,
+  OutputGuardrailTripwireTriggered,
+  RunContext,
+  RunState,
+  RunToolCallItem,
+  RunToolCallOutputItem,
+  ToolGuardrailFunctionOutputFactory,
+  Usage,
+  UserError,
+  defineToolOutputGuardrail,
+  handoff,
+  run,
+  tool,
+  toolNamespace,
+  type AgentInputItem,
+  type Session,
+  type SessionHistoryTransactionArgs,
+} from '../src';
+import {
+  buildBlockedToolOutputRawItem,
+  getBlockedOutputSessionSnapshotRunItems,
+  isCanonicalBlockedOutputPayload,
+  redactBlockedResponseToolOutputs,
+} from '../src/runner/blockedOutputPersistence';
+import { sanitizeBlockedOutputGuardrailResults } from '../src/runner/guardrails';
+import * as protocol from '../src/types/protocol';
+import { getFunctionToolStateKeyForCall } from '../src/toolIdentity';
+import { getToolInvocationFingerprint } from '../src/toolInvocation';
+import {
+  ScriptedModel,
+  assistantMessage,
+  functionCall,
+  modelResponse,
+} from '../src/testing';
+
+type RunMode = 'non_streamed' | 'streamed';
+
+describe('output guardrail replay redaction', () => {
+  it.each([
+    {
+      outputType: 'text',
+      acceptedOutput: 'same value',
+      rejectedOutput: 'same value',
+    },
+    {
+      outputType: 'structured',
+      acceptedOutput: { token: 'same value' },
+      rejectedOutput: { token: 'same value' },
+    },
+  ])(
+    'preserves accepted $outputType guardrail metadata when its value equals rejected output',
+    ({ acceptedOutput, rejectedOutput }) => {
+      const agent = new Agent({
+        name: 'Equal historical guardrail output agent',
+      });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const accepted = {
+        guardrail: { type: 'output' as const, name: 'accepted guardrail' },
+        agent,
+        agentOutput: acceptedOutput,
+        output: {
+          tripwireTriggered: false,
+          outputInfo: 'accepted historical guardrail metadata',
+        },
+      };
+      const rejected = {
+        guardrail: { type: 'output' as const, name: 'rejected guardrail' },
+        agent,
+        agentOutput: rejectedOutput,
+        output: {
+          tripwireTriggered: true,
+          outputInfo: 'rejected guardrail metadata',
+        },
+      };
+      state._outputGuardrailResults = [accepted, rejected];
+
+      sanitizeBlockedOutputGuardrailResults(
+        state,
+        1,
+        'Output withheld by an output guardrail.',
+        new Map([[rejected, true]]),
+      );
+
+      expect(state._outputGuardrailResults[0]).toBe(accepted);
+      expect(state._outputGuardrailResults[0]?.output.outputInfo).toBe(
+        'accepted historical guardrail metadata',
+      );
+      expect(state._outputGuardrailResults[1]?.agentOutput).toBe(
+        'Output withheld by an output guardrail.',
+      );
+      expect(
+        state._outputGuardrailResults[1]?.output.outputInfo,
+      ).toBeUndefined();
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves released $mode terminal resume behavior without output guardrails',
+    async (mode) => {
+      const terminalTool = tool({
+        name: 'unguarded_restored_terminal_tool',
+        description: 'Returns terminal output after a guardrail is removed.',
+        parameters: z.object({}),
+        execute: async () => 'unguarded terminal output',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'unguarded_restored_terminal_tool',
+              {},
+              { callId: 'unguarded-restored-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      let guardrailExecutions = 0;
+      const agent = new Agent({
+        name: 'Unguarded restored terminal agent',
+        model,
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'removed terminal guardrail',
+            execute: async () => {
+              guardrailExecutions += 1;
+              throw new Error('temporary guardrail error');
+            },
+          },
+        ],
+      });
+      let failedState: RunState<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardrailExecutionError);
+        failedState = (error as GuardrailExecutionError).state;
+      }
+      failedState!._outputGuardrailResults.push({
+        guardrail: { type: 'output', name: 'previous accepted guardrail' },
+        agent,
+        agentOutput: 'accepted historical output',
+        output: {
+          tripwireTriggered: false,
+          outputInfo: 'accepted historical metadata',
+        },
+      });
+      agent.outputGuardrails = [];
+      const restored = await RunState.fromString(
+        agent,
+        failedState!.toString(),
+      );
+
+      let resumeError: unknown;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, restored, { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, restored);
+        }
+      } catch (error) {
+        resumeError = error;
+      }
+
+      expect(resumeError).toBeInstanceOf(UserError);
+      expect((resumeError as UserError).message).toContain(
+        'Accepted final output cannot be resumed directly from serialized terminal state',
+      );
+      expect((resumeError as UserError).message).not.toContain(
+        'previous output guardrail result ownership',
+      );
+      expect(guardrailExecutions).toBe(1);
+      expect(model.calls).toHaveLength(1);
+      expect(restored._outputGuardrailResults[0]?.output.outputInfo).toBe(
+        'accepted historical metadata',
+      );
+    },
+  );
+
+  it('fails closed for unknown hosted output payloads', () => {
+    const agent = new Agent({ name: 'Unknown hosted output redaction agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const rawItems = [
+      {
+        type: 'hosted_tool_call' as const,
+        name: 'custom_hosted_call',
+        status: 'completed',
+        output: 'custom-top-level-secret',
+      },
+      {
+        type: 'hosted_tool_call' as const,
+        name: 'web_search_call',
+        status: 'completed',
+        providerData: {
+          type: 'web_search_call',
+          results: [{ text: 'web-search-provider-secret' }],
+        },
+      },
+    ];
+    state._generatedItems = rawItems.map(
+      (rawItem) => new RunToolCallItem(rawItem, agent),
+    );
+    state._modelResponses = [
+      {
+        output: structuredClone(rawItems),
+        usage: new Usage(),
+      },
+    ];
+    state._lastTurnResponse = state._modelResponses[0];
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    const serialized = JSON.stringify({
+      generatedItems: state._generatedItems,
+      modelResponses: state._modelResponses,
+    });
+    expect(serialized).not.toContain('custom-top-level-secret');
+    expect(serialized).not.toContain('web-search-provider-secret');
+    expect(state._generatedItems).toEqual([]);
+    expect(state._modelResponses[0]?.output).toEqual([]);
+  });
+
+  it('preserves accepted tool completion evidence when an unknown current suffix is dropped', () => {
+    const agent = new Agent({ name: 'Accepted completion evidence agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 2);
+    const acceptedCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'accepted_tool',
+      callId: 'accepted-call',
+      arguments: '{}',
+    };
+    const acceptedResult: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'accepted_tool',
+      callId: 'accepted-call',
+      status: 'completed',
+      output: 'accepted-output',
+    };
+    const acceptedCallItem = new RunToolCallItem(acceptedCall, agent);
+    const acceptedResultItem = new RunToolCallOutputItem(
+      acceptedResult,
+      agent,
+      acceptedResult.output,
+    );
+    const acceptedFingerprint = getToolInvocationFingerprint(
+      getFunctionToolStateKeyForCall(acceptedCall, 'accepted_tool')!,
+      acceptedCall,
+    );
+    state._generatedItems = [acceptedCallItem, acceptedResultItem];
+    state._completedToolInvocations.set(
+      agent,
+      new Map([['accepted-call', acceptedFingerprint]]),
+    );
+    state._completedToolInvocationEvidence.set(
+      agent,
+      new Map([
+        [
+          'accepted-call',
+          {
+            fingerprint: acceptedFingerprint,
+            items: [acceptedCallItem, acceptedResultItem],
+          },
+        ],
+      ]),
+    );
+
+    const rejectedCall = {
+      type: 'hosted_tool_call' as const,
+      name: 'custom_hosted_call',
+      status: 'completed',
+      output: 'rejected-current-output',
+    };
+    state._generatedItems.push(new RunToolCallItem(rejectedCall, agent));
+    state._currentTurnPersistedItemCount = 2;
+    state._modelResponses = [{ output: [rejectedCall], usage: new Usage() }];
+    state._lastTurnResponse = state._modelResponses[0];
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+    expect(state._generatedItems).toEqual([
+      acceptedCallItem,
+      acceptedResultItem,
+    ]);
+    expect(
+      state._preflightToolInvocation(
+        agent,
+        'accepted-call',
+        acceptedFingerprint,
+      ),
+    ).toBe(true);
+    expect(
+      state._completedToolInvocationEvidence.get(agent)?.has('accepted-call'),
+    ).toBe(true);
+    expect(state.toString()).not.toContain('rejected-current-output');
+  });
+
+  it('recognizes only complete canonical blocked-output payloads', () => {
+    const raw: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      id: 'output-id',
+      name: 'sensitive_tool',
+      callId: 'call-id',
+      status: 'completed',
+      output: 'secret',
+    };
+    const canonical = buildBlockedToolOutputRawItem(raw);
+    const forged = {
+      ...canonical,
+      providerData: { secret: 'forged-provider-secret' },
+    } as protocol.FunctionCallResultItem;
+
+    expect(isCanonicalBlockedOutputPayload(canonical)).toBe(true);
+    expect(isCanonicalBlockedOutputPayload(forged)).toBe(false);
+    expect(
+      isCanonicalBlockedOutputPayload({
+        ...canonical,
+        providerData: {
+          id: 'conversation-item-id',
+          type: 'function_call_output',
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('rebuilds known function pairs without forward-compatible extra fields', () => {
+    const agent = new Agent({ name: 'Known call allowlist agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const rawItem = {
+      type: 'function_call' as const,
+      id: 'known-call-item',
+      name: 'known_tool',
+      callId: 'known-call',
+      status: 'completed' as const,
+      arguments: '{}',
+      providerData: { future_secret: 'provider-extra-secret' },
+      futureResult: 'top-level-extra-secret',
+    };
+    const rawResult = {
+      type: 'function_call_result' as const,
+      name: 'known_tool',
+      callId: 'known-call',
+      status: 'completed' as const,
+      output: 'known-result-secret',
+      providerData: { future_secret: 'result-provider-extra-secret' },
+      futureResult: 'result-top-level-extra-secret',
+    };
+    state._generatedItems = [
+      new RunToolCallItem(rawItem as protocol.FunctionCallItem, agent),
+      new RunToolCallOutputItem(
+        rawResult as protocol.FunctionCallResultItem,
+        agent,
+        rawResult.output,
+      ),
+    ];
+    state._modelResponses = [
+      {
+        output: [rawItem as protocol.FunctionCallItem],
+        usage: new Usage(),
+      },
+    ];
+    state._lastTurnResponse = state._modelResponses[0];
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    const retained = JSON.stringify({
+      generatedItems: state._generatedItems,
+      modelResponses: state._modelResponses,
+    });
+    expect(retained).not.toContain('provider-extra-secret');
+    expect(retained).not.toContain('top-level-extra-secret');
+    expect(retained).not.toContain('known-result-secret');
+    expect(state._generatedItems[0]?.rawItem).toEqual({
+      type: 'function_call',
+      id: 'known-call-item',
+      name: 'known_tool',
+      callId: 'known-call',
+      status: 'completed',
+      arguments: '{}',
+    });
+    expect(state._generatedItems[1]?.rawItem).toEqual({
+      type: 'function_call_result',
+      name: 'known_tool',
+      callId: 'known-call',
+      status: 'completed',
+      output: 'Output withheld by an output guardrail.',
+    });
+  });
+
+  it('drops the complete current suffix for incomplete or ambiguous function pairs', () => {
+    const cases = [
+      {
+        name: 'orphan call',
+        calls: [['first_tool', 'first-call']] as const,
+        results: [] as const,
+      },
+      {
+        name: 'mismatched result',
+        calls: [['first_tool', 'first-call']] as const,
+        results: [['other_tool', 'other-call']] as const,
+      },
+      {
+        name: 'duplicate result',
+        calls: [['first_tool', 'first-call']] as const,
+        results: [
+          ['first_tool', 'first-call'],
+          ['first_tool', 'first-call'],
+        ] as const,
+      },
+      {
+        name: 'reordered results',
+        calls: [
+          ['first_tool', 'first-call'],
+          ['second_tool', 'second-call'],
+        ] as const,
+        results: [
+          ['second_tool', 'second-call'],
+          ['first_tool', 'first-call'],
+        ] as const,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const agent = new Agent({ name: `${testCase.name} agent` });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const calls = testCase.calls.map(([name, callId]) => ({
+        type: 'function_call' as const,
+        name,
+        callId,
+        arguments: '{}',
+      }));
+      const callItems = calls.map((call) => new RunToolCallItem(call, agent));
+      const resultItems = testCase.results.map(([name, callId], index) => {
+        const rawResult: protocol.FunctionCallResultItem = {
+          type: 'function_call_result',
+          name,
+          callId,
+          status: 'completed',
+          output: `${testCase.name}-secret-${index}`,
+        };
+        return new RunToolCallOutputItem(rawResult, agent, rawResult.output);
+      });
+      state._generatedItems = [...callItems, ...resultItems];
+      state._modelResponses = [{ output: calls, usage: new Usage() }];
+      state._lastTurnResponse = state._modelResponses[0];
+
+      expect(redactBlockedResponseToolOutputs(state), testCase.name).toBe(true);
+      expect(state._generatedItems, testCase.name).toEqual([]);
+      expect(state._lastTurnResponse?.output, testCase.name).toEqual([]);
+    }
+  });
+
+  it('builds the blocked Session snapshot only from the current sanitized suffix', () => {
+    const agent = new Agent({ name: 'Current blocked snapshot agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const currentCall: protocol.FunctionCallItem = {
+      type: 'function_call',
+      name: 'shared_tool',
+      callId: 'shared-call',
+      arguments: '{}',
+    };
+    const historicalResult: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'shared_tool',
+      callId: 'shared-call',
+      status: 'completed',
+      output: 'accepted-historical-result',
+    };
+    const currentResult: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'shared_tool',
+      callId: 'shared-call',
+      status: 'completed',
+      output: 'rejected-current-result',
+    };
+    const currentCallItem = new RunToolCallItem(currentCall, agent);
+    state._generatedItems = [
+      new RunToolCallOutputItem(
+        historicalResult,
+        agent,
+        historicalResult.output,
+      ),
+      currentCallItem,
+      new RunToolCallOutputItem(currentResult, agent, currentResult.output),
+    ];
+    state._lastProcessedResponse = {
+      newItems: [currentCallItem],
+    } as RunState<any, any>['_lastProcessedResponse'];
+    state._modelResponses = [{ output: [currentCall], usage: new Usage() }];
+    state._lastTurnResponse = state._modelResponses[0];
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+    const snapshot = getBlockedOutputSessionSnapshotRunItems(state);
+
+    expect(snapshot.map((item) => item.rawItem.type)).toEqual([
+      'function_call',
+      'function_call_result',
+    ]);
+    expect(JSON.stringify(snapshot)).not.toContain(
+      'accepted-historical-result',
+    );
+    expect(JSON.stringify(snapshot)).not.toContain('rejected-current-result');
+    expect(JSON.stringify(snapshot)).toContain(
+      'Output withheld by an output guardrail.',
+    );
+  });
+
+  it('replaces immutable response aliases with data-free SDK-owned clones', () => {
+    const agent = new Agent({ name: 'Immutable response cleanup agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const malformed = {
+      type: 'function_call_result',
+      name: 'malformed_tool',
+      callId: '',
+      status: 'completed',
+      output: 'immutable-secret',
+    } as protocol.FunctionCallResultItem;
+    const later = {
+      type: 'function_call_result',
+      name: 'later_tool',
+      callId: 'later-call',
+      status: 'completed',
+      output: 'later-secret',
+    } as protocol.FunctionCallResultItem;
+    const frozenResponse = Object.freeze({
+      output: [structuredClone(malformed)],
+      usage: new Usage(),
+      responseId: 'shared-response',
+      providerData: { output: [structuredClone(malformed)] },
+    });
+    const laterResponse = {
+      output: [structuredClone(later)],
+      usage: new Usage(),
+      responseId: 'shared-response',
+      providerData: { output: [structuredClone(later)] },
+    };
+    state._generatedItems = [
+      new RunToolCallOutputItem(malformed, agent, malformed.output),
+      new RunToolCallOutputItem(later, agent, later.output),
+    ];
+    state._modelResponses = [laterResponse, frozenResponse];
+    state._lastTurnResponse = frozenResponse;
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    const retained = JSON.stringify({
+      generatedItems: state._generatedItems,
+      modelResponses: state._modelResponses,
+      lastTurnResponse: state._lastTurnResponse,
+    });
+    expect(retained).not.toContain('immutable-secret');
+    expect(retained).toContain('later-secret');
+    expect(state._modelResponses[0]).toBe(laterResponse);
+    expect(state._modelResponses[1]).not.toBe(frozenResponse);
+    expect(state._modelResponses[0]?.providerData).toBeDefined();
+    expect(state._modelResponses[1]?.providerData).toBeUndefined();
+    expect(frozenResponse.output[0]).toMatchObject({
+      output: 'immutable-secret',
+    });
+  });
+
+  it('replaces a response whose output getter throws', () => {
+    const agent = new Agent({ name: 'Throwing response cleanup agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const throwingResponse = {
+      usage: new Usage(),
+      responseId: 'throwing-response',
+      get output(): protocol.ModelItem[] {
+        throw new TypeError('throwing-output-secret');
+      },
+    };
+    state._modelResponses = [throwingResponse];
+    state._lastTurnResponse = throwingResponse;
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    expect(state._lastTurnResponse === throwingResponse).toBe(false);
+    expect(state._lastTurnResponse?.output).toEqual([]);
+    expect(JSON.stringify(state._modelResponses)).not.toContain(
+      'throwing-output-secret',
+    );
+  });
+
+  it('drops raw provider response snapshots from a sanitized response', () => {
+    const agent = new Agent({ name: 'Provider snapshot cleanup agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const raw: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'sensitive_tool',
+      callId: 'call-id',
+      status: 'completed',
+      output: 'provider-snapshot-secret',
+    };
+    const response = {
+      output: [raw],
+      usage: new Usage(),
+      responseId: 'response-id',
+      requestId: 'request-id',
+      providerData: { output: [structuredClone(raw)] },
+    };
+    state._generatedItems = [new RunToolCallOutputItem(raw, agent, raw.output)];
+    state._modelResponses = [response];
+    state._lastTurnResponse = response;
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    expect(JSON.stringify(state._modelResponses)).not.toContain(
+      'provider-snapshot-secret',
+    );
+    expect(state._lastTurnResponse).toMatchObject({
+      responseId: 'response-id',
+      requestId: 'request-id',
+    });
+    expect(state._lastTurnResponse?.providerData).toBeUndefined();
+  });
+
+  it('scrubs every discovered alias when an early payload is malformed', () => {
+    const agent = new Agent({ name: 'Atomic cleanup agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const malformed = {
+      type: 'function_call_result',
+      name: 'malformed_tool',
+      callId: '',
+      status: 'completed',
+      output: 'malformed-secret',
+    } as protocol.FunctionCallResultItem;
+    const valid: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'later_tool',
+      callId: 'later-call',
+      status: 'completed',
+      output: 'later-secret',
+    };
+    state._generatedItems = [
+      new RunToolCallOutputItem(malformed, agent, malformed.output),
+      new RunToolCallOutputItem(valid, agent, valid.output),
+    ];
+    state._modelResponses = [
+      {
+        output: [structuredClone(malformed), structuredClone(valid)],
+        usage: new Usage(),
+      },
+    ];
+    state._lastTurnResponse = state._modelResponses[0];
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    const retained = JSON.stringify({
+      generatedItems: state._generatedItems,
+      modelResponses: state._modelResponses,
+    });
+    expect(retained).not.toContain('malformed-secret');
+    expect(retained).not.toContain('later-secret');
+    expect(state._modelResponses[0]?.output).toEqual([]);
+  });
+
+  it('does not scrub an unrelated response that reused a provider ID', () => {
+    const agent = new Agent({ name: 'Bounded response redaction agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const terminal = {
+      type: 'hosted_tool_call' as const,
+      id: 'reused-mcp-id',
+      name: 'mcp_call',
+      status: 'completed' as const,
+      output: 'terminal-secret',
+      providerData: {
+        type: 'mcp_call',
+        id: 'reused-mcp-id',
+        name: 'lookup',
+        arguments: '{}',
+        server_label: 'server',
+      },
+    };
+    const unrelated = {
+      ...structuredClone(terminal),
+      output: 'unrelated-secret',
+      providerData: {
+        ...structuredClone(terminal.providerData),
+      },
+    };
+    const terminalItem = new RunToolCallItem(terminal, agent);
+    const unrelatedResponse = {
+      output: [unrelated],
+      usage: new Usage(),
+      responseId: 'unrelated-response',
+    };
+    const terminalResponse = {
+      output: [terminal],
+      usage: new Usage(),
+      responseId: 'terminal-response',
+    };
+    state._generatedItems = [terminalItem];
+    state._modelResponses = [unrelatedResponse, terminalResponse];
+    state._lastTurnResponse = terminalResponse;
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    expect(JSON.stringify(state._generatedItems)).not.toContain(
+      'terminal-secret',
+    );
+    expect(JSON.stringify(state._lastTurnResponse)).not.toContain(
+      'terminal-secret',
+    );
+    expect(JSON.stringify(unrelatedResponse)).toContain('unrelated-secret');
+  });
+
+  it('does not use a repeated responseId to revoke an earlier response', () => {
+    const agent = new Agent({ name: 'Structural response ownership agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const archived: protocol.HostedToolCallItem = {
+      type: 'hosted_tool_call',
+      id: 'archived-mcp-id',
+      name: 'mcp_call',
+      status: 'completed',
+      output: 'archived-secret',
+      providerData: {
+        type: 'mcp_call',
+        id: 'archived-mcp-id',
+        name: 'lookup',
+        arguments: '{}',
+        server_label: 'server',
+      },
+    };
+    const terminal = {
+      ...structuredClone(archived),
+      id: 'terminal-mcp-id',
+      output: 'terminal-secret',
+      providerData: {
+        ...structuredClone(archived.providerData),
+        id: 'terminal-mcp-id',
+        arguments: 42,
+      },
+    } as unknown as protocol.HostedToolCallItem;
+    const archivedResponse = {
+      output: [archived],
+      usage: new Usage(),
+      responseId: 'reused-response-id',
+    };
+    const terminalResponse = {
+      output: [terminal],
+      usage: new Usage(),
+      responseId: 'reused-response-id',
+    };
+    state._generatedItems = [new RunToolCallItem(terminal, agent)];
+    state._modelResponses = [archivedResponse, terminalResponse];
+    state._lastTurnResponse = terminalResponse;
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    expect(JSON.stringify(archivedResponse)).toContain('archived-secret');
+    expect(state._modelResponses[1]?.output).toEqual([]);
+    expect(JSON.stringify(state._generatedItems)).not.toContain(
+      'terminal-secret',
+    );
+  });
+
+  it('revokes only the structurally current processed-item suffix', () => {
+    const agent = new Agent({ name: 'Current suffix ownership agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const archivedRaw: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'archived_tool',
+      callId: 'archived-call',
+      status: 'completed',
+      output: 'archived-secret',
+    };
+    const terminalRaw: protocol.FunctionCallResultItem = {
+      type: 'function_call_result',
+      name: 'terminal_tool',
+      callId: 'terminal-call',
+      status: 'completed',
+      output: 'terminal-secret',
+    };
+    const archivedItem = new RunToolCallOutputItem(
+      archivedRaw,
+      agent,
+      archivedRaw.output,
+    );
+    const terminalItem = new RunToolCallOutputItem(
+      terminalRaw,
+      agent,
+      terminalRaw.output,
+    );
+    const terminalResponse = {
+      output: [terminalRaw],
+      usage: new Usage(),
+      responseId: 'terminal-response',
+    };
+    state._generatedItems = [archivedItem, terminalItem];
+    state._lastProcessedResponse = {
+      newItems: [terminalItem],
+    } as RunState<any, any>['_lastProcessedResponse'];
+    state._modelResponses = [terminalResponse];
+    state._lastTurnResponse = terminalResponse;
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    expect(JSON.stringify(state._generatedItems[0])).toContain(
+      'archived-secret',
+    );
+    expect(JSON.stringify(state._generatedItems)).not.toContain(
+      'terminal-secret',
+    );
+    expect(JSON.stringify(state._lastProcessedResponse)).not.toContain(
+      'terminal-secret',
+    );
+  });
+
+  it.each([
+    'unowned',
+    'stale_processed',
+    'mixed_processed',
+    'mixed_current_aliases',
+    'restored_mixed_current_aliases',
+    'historical_completion',
+  ] as const)(
+    'does not infer current ownership from $mode historical evidence after object identity is lost',
+    (mode) => {
+      const agent = new Agent({ name: 'Historical signature collision agent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      const historicalCall: protocol.FunctionCallItem = {
+        type: 'function_call',
+        name: 'shared_tool',
+        callId: 'shared-call',
+        arguments: '{}',
+      };
+      const historicalResult: protocol.FunctionCallResultItem = {
+        type: 'function_call_result',
+        name: 'shared_tool',
+        callId: 'shared-call',
+        status: 'completed',
+        output: 'accepted-historical-output',
+      };
+      const rejectedResult: protocol.FunctionCallResultItem = {
+        ...historicalResult,
+        output: 'rejected-current-output',
+      };
+      const currentResponseCall = structuredClone(historicalCall);
+      const hasCurrentAliases =
+        mode === 'mixed_current_aliases' ||
+        mode === 'restored_mixed_current_aliases';
+      if (hasCurrentAliases) {
+        historicalCall.providerData = {
+          retained: 'accepted-historical-provider-metadata',
+        };
+        currentResponseCall.providerData = {
+          retained: 'rejected-current-provider-secret',
+        };
+      }
+      if (mode === 'restored_mixed_current_aliases') {
+        historicalCall.namespace = 'crm';
+        historicalResult.namespace = 'crm';
+        rejectedResult.namespace = 'crm';
+        currentResponseCall.namespace = 'crm';
+      }
+      const historicalProcessedCall =
+        mode === 'restored_mixed_current_aliases'
+          ? structuredClone(historicalCall)
+          : historicalCall;
+      const currentProcessedCall =
+        mode === 'restored_mixed_current_aliases'
+          ? structuredClone(currentResponseCall)
+          : currentResponseCall;
+      const currentCallItem = new RunToolCallItem(currentResponseCall, agent);
+      const historicalCallItem = new RunToolCallItem(historicalCall, agent);
+      const historicalResultItem = new RunToolCallOutputItem(
+        historicalResult,
+        agent,
+        historicalResult.output,
+      );
+      state._generatedItems = [
+        historicalCallItem,
+        historicalResultItem,
+        ...(hasCurrentAliases ? [currentCallItem] : []),
+        new RunToolCallOutputItem(rejectedResult, agent, rejectedResult.output),
+      ];
+      state._currentTurnPersistedItemCount = 2;
+      state._lastProcessedResponse = {
+        newItems:
+          mode === 'stale_processed'
+            ? [historicalCallItem]
+            : mode === 'mixed_processed'
+              ? [
+                  historicalCallItem,
+                  new RunToolCallItem(currentResponseCall, agent),
+                ]
+              : hasCurrentAliases
+                ? [
+                    historicalCallItem,
+                    new RunToolCallItem(currentResponseCall, agent),
+                    new RunToolCallOutputItem(
+                      structuredClone(rejectedResult),
+                      agent,
+                      rejectedResult.output,
+                    ),
+                  ]
+                : mode === 'unowned'
+                  ? [
+                      new RunToolCallItem(
+                        structuredClone(historicalCall),
+                        agent,
+                      ),
+                    ]
+                  : [],
+        functions:
+          mode === 'historical_completion'
+            ? [{ toolCall: structuredClone(historicalCall) }]
+            : hasCurrentAliases
+              ? [
+                  { toolCall: historicalProcessedCall },
+                  { toolCall: currentProcessedCall },
+                ]
+              : [],
+      } as RunState<any, any>['_lastProcessedResponse'];
+      if (mode === 'restored_mixed_current_aliases') {
+        state._currentStep = {
+          type: 'next_step_final_output',
+          output: 'rejected-current-output',
+        };
+        state._serializedCurrentStep = state._currentStep;
+      }
+      if (mode === 'historical_completion' || mode === 'mixed_processed') {
+        state._completedToolInvocationEvidence.set(
+          agent,
+          new Map([
+            [
+              historicalCall.callId,
+              {
+                fingerprint: 'accepted-historical-fingerprint',
+                items: [historicalCallItem, historicalResultItem],
+              },
+            ],
+          ]),
+        );
+        state._completedToolInvocations.set(
+          agent,
+          new Map([[historicalCall.callId, 'accepted-historical-fingerprint']]),
+        );
+      }
+      state._modelResponses = [
+        { output: [currentResponseCall], usage: new Usage() },
+      ];
+      state._lastTurnResponse = state._modelResponses[0];
+
+      expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+      expect(state._generatedItems.slice(0, 2)).toEqual([
+        historicalCallItem,
+        historicalResultItem,
+      ]);
+      expect(JSON.stringify(state._generatedItems)).toContain(
+        'accepted-historical-output',
+      );
+      expect(JSON.stringify(state._generatedItems)).not.toContain(
+        'rejected-current-output',
+      );
+      if (mode === 'historical_completion' || mode === 'mixed_processed') {
+        expect(
+          state._completedToolInvocationEvidence
+            .get(agent)
+            ?.has(historicalCall.callId),
+        ).toBe(true);
+        expect(
+          state._completedToolInvocations
+            .get(agent)
+            ?.get(historicalCall.callId),
+        ).toBe('accepted-historical-fingerprint');
+      }
+      if (hasCurrentAliases) {
+        expect(JSON.stringify(state._lastProcessedResponse)).not.toContain(
+          'rejected-current-output',
+        );
+        expect(state._lastProcessedResponse?.newItems[0]).toBe(
+          historicalCallItem,
+        );
+        expect(state._lastTurnResponse?.output).toHaveLength(1);
+        expect(state._lastTurnResponse?.output[0]).toBe(
+          state._generatedItems[2]?.rawItem,
+        );
+        expect(state._lastProcessedResponse?.functions[0]?.toolCall).toBe(
+          historicalProcessedCall,
+        );
+        expect(state._lastProcessedResponse?.functions[1]?.toolCall).toBe(
+          state._generatedItems[2]?.rawItem,
+        );
+        expect(
+          JSON.stringify(state._lastProcessedResponse?.functions),
+        ).toContain('accepted-historical-provider-metadata');
+        expect(
+          JSON.stringify(state._lastProcessedResponse?.functions),
+        ).not.toContain('rejected-current-provider-secret');
+        expect(getBlockedOutputSessionSnapshotRunItems(state)).toHaveLength(2);
+      } else {
+        expect(state._lastTurnResponse?.output).toEqual([]);
+      }
+    },
+  );
+
+  it('does not use a stale last-processed response as a structural anchor', () => {
+    const agent = new Agent({ name: 'Stale response anchor agent' });
+    const state = new RunState(new RunContext(), 'input', agent, 1);
+    const unrelated = {
+      type: 'hosted_tool_call' as const,
+      id: 'unrelated-mcp-id',
+      name: 'mcp_call',
+      status: 'completed' as const,
+      output: 'unrelated-secret',
+      providerData: {
+        type: 'mcp_call',
+        id: 'unrelated-mcp-id',
+        name: 'lookup',
+        arguments: '{}',
+        server_label: 'server',
+      },
+    };
+    const terminal = {
+      ...structuredClone(unrelated),
+      id: 'terminal-mcp-id',
+      output: 'terminal-secret',
+      providerData: {
+        ...structuredClone(unrelated.providerData),
+        id: 'terminal-mcp-id',
+      },
+    };
+    const unrelatedResponse = {
+      output: [unrelated],
+      usage: new Usage(),
+      responseId: 'reused-response-id',
+    };
+    const terminalResponse = {
+      output: [terminal],
+      usage: new Usage(),
+      responseId: 'reused-response-id',
+    };
+    state._modelResponses = [unrelatedResponse];
+    state._lastTurnResponse = terminalResponse;
+    state._lastProcessedResponse = {
+      newItems: [new RunToolCallItem(unrelated, agent)],
+    } as RunState<any, any>['_lastProcessedResponse'];
+
+    expect(redactBlockedResponseToolOutputs(state)).toBe(true);
+
+    expect(JSON.stringify(state._lastTurnResponse)).not.toContain(
+      'terminal-secret',
+    );
+    expect(JSON.stringify(unrelatedResponse)).toContain('unrelated-secret');
+    expect(JSON.stringify(state._lastProcessedResponse)).toContain(
+      'unrelated-secret',
+    );
+  });
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'allows a non-transactional $mode Session with run_llm_again',
+    async (mode) => {
+      class NonTransactionalSession implements Session {
+        readonly items: AgentInputItem[] = [];
+
+        async getSessionId(): Promise<string> {
+          return 'non-transactional-run-again';
+        }
+
+        async getItems(): Promise<AgentInputItem[]> {
+          return structuredClone(this.items);
+        }
+
+        async addItems(items: AgentInputItem[]): Promise<void> {
+          this.items.push(...structuredClone(items));
+        }
+
+        async popItem(): Promise<AgentInputItem | undefined> {
+          return this.items.pop();
+        }
+
+        async clearSession(): Promise<void> {
+          this.items.length = 0;
+        }
+      }
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [assistantMessage('safe model output')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Supported Session agent',
+        model,
+        toolUseBehavior: 'run_llm_again',
+        outputGuardrails: [
+          {
+            name: 'output guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const session = new NonTransactionalSession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'input', {
+          session,
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await run(agent, 'input', { session });
+      }
+
+      expect(model.calls).toHaveLength(1);
+      expect(JSON.stringify(await session.getItems())).toContain(
+        'safe model output',
+      );
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'runs output guardrails for a marker-valued terminal tool in $mode mode',
+    async (mode) => {
+      const executeGuardrail = vi.fn(async () => ({
+        outputInfo: undefined,
+        tripwireTriggered: false,
+      }));
+      const markerTool = tool({
+        name: 'marker_tool',
+        description: 'Returns the public blocked-output marker as normal data.',
+        parameters: z.object({}),
+        execute: async () => 'Output withheld by an output guardrail.',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [functionCall('marker_tool', {}, { callId: 'marker-call' })],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Marker-valued terminal tool agent',
+        model,
+        tools: [markerTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'passing output guardrail',
+            execute: executeGuardrail,
+          },
+        ],
+      });
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'input', { stream: true });
+        await result.completed;
+        expect(result.finalOutput).toBe(
+          'Output withheld by an output guardrail.',
+        );
+      } else {
+        const result = await run(agent, 'input');
+        expect(result.finalOutput).toBe(
+          'Output withheld by an output guardrail.',
+        );
+      }
+      expect(executeGuardrail).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'redacts a terminal tool trip without mutating frozen guardrail outputs in $mode mode',
+    async (mode) => {
+      const frozenToolGuardrailOutput = Object.freeze({
+        outputInfo: 'frozen-tool-output-info',
+        behavior: Object.freeze({ type: 'allow' as const }),
+        retainedOutput: 'frozen terminal tool secret',
+      });
+      const frozenOutputGuardrailOutput = Object.freeze({
+        outputInfo: 'frozen-agent-output-info',
+        tripwireTriggered: true,
+      });
+      const terminalTool = tool({
+        name: 'frozen_guardrail_terminal_tool',
+        description: 'Returns output rejected by a frozen guardrail result.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'frozen tool output guardrail',
+            run: async () => frozenToolGuardrailOutput,
+          }),
+        ],
+        execute: async () => 'frozen terminal tool secret',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'frozen_guardrail_terminal_tool',
+              {},
+              { callId: 'frozen-guardrail-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Frozen guardrail output agent',
+        model,
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'frozen output guardrail',
+            execute: async () => frozenOutputGuardrailOutput,
+          },
+        ],
+      });
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(tripwire?.message).toBe('Output guardrail triggered.');
+      expect(tripwire?.result.output).not.toBe(frozenOutputGuardrailOutput);
+      expect(tripwire?.result.output.outputInfo).toBeUndefined();
+      expect(tripwire?.state?._toolOutputGuardrailResults[0]?.output).not.toBe(
+        frozenToolGuardrailOutput,
+      );
+      expect(
+        tripwire?.state?._toolOutputGuardrailResults[0]?.output.outputInfo,
+      ).toBeUndefined();
+      expect(
+        tripwire?.state?._toolOutputGuardrailResults[0]?.output,
+      ).not.toHaveProperty('retainedOutput');
+      expect(tripwire?.state?.toString()).not.toContain(
+        'frozen terminal tool secret',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'frozen-agent-output-info',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'frozen-tool-output-info',
+      );
+      expect(frozenOutputGuardrailOutput.outputInfo).toBe(
+        'frozen-agent-output-info',
+      );
+      expect(frozenToolGuardrailOutput.outputInfo).toBe(
+        'frozen-tool-output-info',
+      );
+      expect(frozenToolGuardrailOutput.retainedOutput).toBe(
+        'frozen terminal tool secret',
+      );
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'omits a terminal tool guardrail result when its behavior becomes unreadable in $mode mode',
+    async (mode) => {
+      let behaviorTypeReads = 0;
+      const behavior = Object.defineProperty({}, 'type', {
+        enumerable: true,
+        get() {
+          behaviorTypeReads += 1;
+          if (behaviorTypeReads >= 3) {
+            throw new Error('behavior type is no longer readable');
+          }
+          return 'allow';
+        },
+      }) as { type: 'allow' };
+      const terminalTool = tool({
+        name: 'unreadable_guardrail_terminal_tool',
+        description: 'Returns output rejected by an output guardrail.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'unreadable tool output guardrail',
+            run: async () => ({
+              outputInfo: 'unreadable-tool-output-info',
+              behavior,
+              retainedOutput: 'unreadable terminal tool secret',
+            }),
+          }),
+        ],
+        execute: async () => 'unreadable terminal tool secret',
+      });
+      const agent = new Agent({
+        name: 'Unreadable guardrail output agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'unreadable_guardrail_terminal_tool',
+                {},
+                { callId: 'unreadable-guardrail-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'blocking output guardrail',
+            execute: async () => ({
+              outputInfo: 'unreadable-output-guardrail-info',
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(behaviorTypeReads).toBe(3);
+      expect(tripwire?.message).toBe('Output guardrail triggered.');
+      expect(tripwire?.state?._toolOutputGuardrailResults).toEqual([]);
+      expect(tripwire?.state?.toString()).not.toContain(
+        'unreadable terminal tool secret',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'unreadable-tool-output-info',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'unreadable-output-guardrail-info',
+      );
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'completes terminal cleanup when the fulfilled output verdict becomes unreadable in $mode mode',
+    async (mode) => {
+      let tripwireReads = 0;
+      const outputGuardrailVerdict = {
+        outputInfo: 'unreadable-verdict-output-info',
+        get tripwireTriggered() {
+          tripwireReads += 1;
+          if (tripwireReads >= 2) {
+            throw new Error('verdict is no longer readable');
+          }
+          return true;
+        },
+      };
+      const terminalTool = tool({
+        name: 'unreadable_verdict_terminal_tool',
+        description: 'Returns output rejected by an unreadable verdict.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'unreadable verdict tool output guardrail',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'unreadable-verdict-tool-metadata',
+              ),
+          }),
+        ],
+        execute: async () => 'unreadable verdict terminal tool secret',
+      });
+      const agent = new Agent({
+        name: 'Unreadable verdict agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'unreadable_verdict_terminal_tool',
+                {},
+                { callId: 'unreadable-verdict-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'unreadable output verdict',
+            execute: async () => outputGuardrailVerdict,
+          },
+        ],
+      });
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(tripwireReads).toBe(1);
+      expect(tripwire?.message).toBe('Output guardrail triggered.');
+      expect(tripwire?.result.output).toEqual({
+        outputInfo: undefined,
+        tripwireTriggered: true,
+      });
+      expect(
+        tripwire?.state?._toolOutputGuardrailResults[0]?.output.outputInfo,
+      ).toBeUndefined();
+      expect(tripwire?.state?.toString()).not.toContain(
+        'unreadable verdict terminal tool secret',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'unreadable-verdict-tool-metadata',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'unreadable-verdict-output-info',
+      );
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves every first-observed output verdict during terminal cleanup in $mode mode',
+    async (mode) => {
+      let tripwireReads = 0;
+      let passingReads = 0;
+      const tripwireVerdict = {
+        outputInfo: 'multi-verdict-trip-output-info',
+        get tripwireTriggered() {
+          tripwireReads += 1;
+          if (tripwireReads >= 2) {
+            throw new Error('trip verdict was read twice');
+          }
+          return true;
+        },
+      };
+      const passingVerdict = {
+        outputInfo: 'multi-verdict-pass-output-info',
+        get tripwireTriggered() {
+          passingReads += 1;
+          if (passingReads >= 2) {
+            throw new Error('passing verdict was read twice');
+          }
+          return false;
+        },
+      };
+      const terminalTool = tool({
+        name: 'multiple_verdict_terminal_tool',
+        description: 'Returns output rejected by one of multiple guardrails.',
+        parameters: z.object({}),
+        execute: async () => 'multiple verdict terminal tool secret',
+      });
+      const agent = new Agent({
+        name: 'Multiple verdict agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'multiple_verdict_terminal_tool',
+                {},
+                { callId: 'multiple-verdict-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'multiple verdict trip guardrail',
+            execute: async () => tripwireVerdict,
+          },
+          {
+            name: 'multiple verdict passing guardrail',
+            execute: async () => passingVerdict,
+          },
+        ],
+      });
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(tripwireReads).toBe(1);
+      expect(passingReads).toBe(1);
+      expect(
+        tripwire?.state?._outputGuardrailResults.map(
+          (result) => result.output.tripwireTriggered,
+        ),
+      ).toEqual([true, false]);
+      expect(tripwire?.state?.toString()).not.toContain(
+        'multiple verdict terminal tool secret',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'multi-verdict-trip-output-info',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'multi-verdict-pass-output-info',
+      );
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'redacts a terminal tool verdict when tripwire formatting fails in $mode mode',
+    async (mode) => {
+      const circularOutputInfo: Record<string, unknown> = {
+        secret: 'circular-output-info-secret',
+      };
+      circularOutputInfo.self = circularOutputInfo;
+      const terminalTool = tool({
+        name: 'non_json_guardrail_terminal_tool',
+        description:
+          'Returns output rejected with non-JSON guardrail metadata.',
+        parameters: z.object({}),
+        execute: async () => 'non-json terminal tool secret',
+      });
+      const agent = new Agent({
+        name: 'Non-JSON guardrail output agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'non_json_guardrail_terminal_tool',
+                {},
+                { callId: 'non-json-guardrail-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'non-JSON output guardrail',
+            execute: async () => ({
+              outputInfo: circularOutputInfo,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+      let failure: unknown;
+
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { session, stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input', { session });
+        }
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toBeInstanceOf(GuardrailExecutionError);
+      const state = (failure as GuardrailExecutionError).state!;
+      expect(state._outputGuardrailResults.at(-1)?.output.outputInfo).toBe(
+        undefined,
+      );
+      expect(state.toString()).not.toContain('non-json terminal tool secret');
+      expect(state.toString()).not.toContain('circular-output-info-secret');
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).toContain('Output withheld by an output guardrail.');
+      expect(persisted).not.toContain('non-json terminal tool secret');
+      expect(persisted).not.toContain('circular-output-info-secret');
+      expect(circularOutputInfo.secret).toBe('circular-output-info-secret');
+    },
+  );
+
+  it.each<{
+    mode: RunMode;
+    failureSurface: 'guardrail' | 'persistence';
+  }>([
+    { mode: 'non_streamed', failureSurface: 'guardrail' },
+    { mode: 'streamed', failureSurface: 'guardrail' },
+    { mode: 'non_streamed', failureSurface: 'persistence' },
+    { mode: 'streamed', failureSurface: 'persistence' },
+  ])(
+    'redacts parsed structured output fields from $mode $failureSurface errors',
+    async ({ mode, failureSurface }) => {
+      const token = 'parsed-structured-terminal-secret';
+      const rejectedOutput = JSON.stringify({ token });
+      const terminalTool = tool({
+        name: 'structured_error_terminal_tool',
+        description:
+          'Returns structured output rejected by an output guardrail.',
+        parameters: z.object({}),
+        execute: async () => rejectedOutput,
+      });
+      const agent = new Agent({
+        name: 'Structured sibling guardrail error agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'structured_error_terminal_tool',
+                {},
+                { callId: 'structured-error-guardrail-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputType: z.object({ token: z.string() }),
+        outputGuardrails: [
+          {
+            name: 'completed structured trip guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: true,
+            }),
+          },
+          ...(failureSurface === 'guardrail'
+            ? [
+                {
+                  name: 'rejecting structured sibling guardrail',
+                  execute: async ({
+                    agentOutput,
+                  }: {
+                    agentOutput: { token: string };
+                  }) => {
+                    throw new Error(agentOutput.token);
+                  },
+                },
+              ]
+            : []),
+        ],
+      });
+
+      class RejectingStructuredSession extends MemorySession {
+        override async applyHistoryTransaction(
+          _args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          throw new Error(token);
+        }
+      }
+
+      const session =
+        failureSurface === 'persistence'
+          ? new RejectingStructuredSession()
+          : new MemorySession();
+      let failure: unknown;
+
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { session, stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input', { session });
+        }
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toBeInstanceOf(
+        failureSurface === 'guardrail'
+          ? GuardrailExecutionError
+          : OutputGuardrailTripwireTriggered,
+      );
+      expect((failure as Error).message).not.toContain(token);
+      expect((failure as Error).stack).not.toContain(token);
+      expect(JSON.stringify(failure)).not.toContain(token);
+      if (failure instanceof GuardrailExecutionError) {
+        expect(failure.error.message).not.toContain(token);
+        expect(failure.error.stack).not.toContain(token);
+      }
+      const cause = (failure as Error & { cause?: unknown }).cause;
+      if (cause instanceof Error) {
+        expect(cause.message).not.toContain(token);
+        expect(cause.stack).not.toContain(token);
+      }
+      const state = (
+        failure as
+          GuardrailExecutionError | OutputGuardrailTripwireTriggered<any, any>
+      ).state!;
+      expect(state.toString()).not.toContain(token);
+      expect(JSON.stringify(await session.getItems())).not.toContain(token);
+    },
+  );
+
+  it.each<{
+    mode: RunMode;
+    includeRejectedOutput: boolean;
+  }>([
+    { mode: 'non_streamed', includeRejectedOutput: false },
+    { mode: 'streamed', includeRejectedOutput: false },
+    { mode: 'non_streamed', includeRejectedOutput: true },
+    { mode: 'streamed', includeRejectedOutput: true },
+  ])(
+    'redacts a terminal tool verdict and preserves safe sibling diagnostics in $mode mode with rejected output exposed: $includeRejectedOutput',
+    async ({ mode, includeRejectedOutput }) => {
+      const rejectedOutput = 'sibling-error terminal tool secret';
+      const siblingError = new Error(
+        includeRejectedOutput
+          ? `sibling guardrail failed: ${rejectedOutput}`
+          : 'sibling guardrail failed',
+      );
+      if (includeRejectedOutput) {
+        (siblingError as Error & { cause?: unknown }).cause = new Error(
+          rejectedOutput,
+        );
+        (siblingError as Error & { rejectedOutput?: string }).rejectedOutput =
+          rejectedOutput;
+      }
+      let tripwireReads = 0;
+      const completedTripVerdict = {
+        outputInfo: 'sibling-trip-output-info-secret',
+        get tripwireTriggered() {
+          tripwireReads += 1;
+          if (tripwireReads >= 2) {
+            throw new Error('sibling verdict is no longer readable');
+          }
+          return true;
+        },
+      };
+      const terminalTool = tool({
+        name: 'sibling_error_terminal_tool',
+        description:
+          'Returns output rejected before a sibling guardrail fails.',
+        parameters: z.object({}),
+        execute: async () => rejectedOutput,
+      });
+      const agent = new Agent({
+        name: 'Sibling guardrail error agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'sibling_error_terminal_tool',
+                {},
+                { callId: 'sibling-error-guardrail-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'completed trip guardrail',
+            execute: async () => completedTripVerdict,
+          },
+          {
+            name: 'rejecting sibling guardrail',
+            execute: async () => {
+              throw siblingError;
+            },
+          },
+        ],
+      });
+      const session = new MemorySession();
+      let failure: unknown;
+
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { session, stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input', { session });
+        }
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toBeInstanceOf(GuardrailExecutionError);
+      expect((failure as Error).message).toContain('sibling guardrail failed');
+      expect((failure as Error).message).not.toContain(rejectedOutput);
+      expect((failure as Error).stack).not.toContain(rejectedOutput);
+      expect((failure as GuardrailExecutionError).error.message).not.toContain(
+        rejectedOutput,
+      );
+      expect((failure as GuardrailExecutionError).error.stack).not.toContain(
+        rejectedOutput,
+      );
+      expect(
+        (
+          (failure as GuardrailExecutionError).error as Error & {
+            cause?: unknown;
+          }
+        ).cause,
+      ).toBeUndefined();
+      expect(
+        (
+          (failure as GuardrailExecutionError).error as Error & {
+            rejectedOutput?: string;
+          }
+        ).rejectedOutput,
+      ).toBeUndefined();
+      expect(JSON.stringify(failure)).not.toContain(rejectedOutput);
+      expect(tripwireReads).toBe(1);
+      const state = (failure as GuardrailExecutionError).state!;
+      expect(state._outputGuardrailResults.at(-1)?.output.outputInfo).toBe(
+        undefined,
+      );
+      expect(state.toString()).not.toContain(
+        'sibling-error terminal tool secret',
+      );
+      expect(state.toString()).not.toContain('sibling-trip-output-info-secret');
+      const persisted = JSON.stringify(await session.getItems());
+      expect(persisted).toContain('Output withheld by an output guardrail.');
+      expect(persisted).not.toContain('sibling-error terminal tool secret');
+      expect(persisted).not.toContain('sibling-trip-output-info-secret');
+    },
+  );
+
+  it.each<{
+    mode: RunMode;
+    includeSiblingFailure: boolean;
+  }>([
+    { mode: 'non_streamed', includeSiblingFailure: false },
+    { mode: 'streamed', includeSiblingFailure: false },
+    { mode: 'non_streamed', includeSiblingFailure: true },
+    { mode: 'streamed', includeSiblingFailure: true },
+  ])(
+    'never attaches unsafe blocked-output persistence causes in $mode mode with sibling failure: $includeSiblingFailure',
+    async ({ mode, includeSiblingFailure }) => {
+      const rejectedOutput = 'blocked-persistence-cause-secret';
+      const persistenceError = new Error(
+        `Persistence rejected ${rejectedOutput}`,
+      );
+      (persistenceError as Error & { cause?: unknown }).cause = new Error(
+        rejectedOutput,
+      );
+      (persistenceError as Error & { rejectedOutput?: string }).rejectedOutput =
+        rejectedOutput;
+
+      class RejectingSession extends MemorySession {
+        override async applyHistoryTransaction(
+          _args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          throw persistenceError;
+        }
+      }
+
+      const terminalTool = tool({
+        name: 'blocked_persistence_terminal_tool',
+        description: 'Returns output rejected before Session persistence.',
+        parameters: z.object({}),
+        execute: async () => rejectedOutput,
+      });
+      const agent = new Agent({
+        name: 'Blocked persistence error agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'blocked_persistence_terminal_tool',
+                {},
+                { callId: 'blocked-persistence-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'completed rejection guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: true,
+            }),
+          },
+          ...(includeSiblingFailure
+            ? [
+                {
+                  name: 'safe sibling failure guardrail',
+                  execute: async () => {
+                    throw new Error('safe sibling guardrail failure');
+                  },
+                },
+              ]
+            : []),
+        ],
+      });
+
+      let failure: unknown;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', {
+            session: new RejectingSession(),
+            stream: true,
+          });
+          await result.completed;
+        } else {
+          await run(agent, 'input', { session: new RejectingSession() });
+        }
+      } catch (error) {
+        failure = error;
+      }
+
+      expect(failure).toBeInstanceOf(
+        includeSiblingFailure
+          ? GuardrailExecutionError
+          : OutputGuardrailTripwireTriggered,
+      );
+      const safePersistenceError = (failure as Error & { cause?: unknown })
+        .cause as Error & { cause?: unknown; rejectedOutput?: string };
+      expect(safePersistenceError).toBeInstanceOf(Error);
+      expect(safePersistenceError).not.toBe(persistenceError);
+      expect(safePersistenceError.message).toContain('Persistence rejected');
+      expect(safePersistenceError.message).toContain(
+        'Output withheld by an output guardrail.',
+      );
+      expect(safePersistenceError.message).not.toContain(rejectedOutput);
+      expect(safePersistenceError.stack).not.toContain(rejectedOutput);
+      expect(safePersistenceError.cause).toBeUndefined();
+      expect(safePersistenceError.rejectedOutput).toBeUndefined();
+      expect((failure as Error).message).not.toContain(rejectedOutput);
+      expect((failure as Error).stack).not.toContain(rejectedOutput);
+      expect(JSON.stringify(failure)).not.toContain(rejectedOutput);
+      expect(
+        (
+          failure as
+            GuardrailExecutionError | OutputGuardrailTripwireTriggered<any, any>
+        ).state?.toString(),
+      ).not.toContain(rejectedOutput);
+    },
+  );
+
+  it.each<{
+    mode: RunMode;
+    completedSiblingVerdict: boolean;
+  }>([
+    { mode: 'non_streamed', completedSiblingVerdict: false },
+    { mode: 'streamed', completedSiblingVerdict: false },
+    { mode: 'non_streamed', completedSiblingVerdict: true },
+    { mode: 'streamed', completedSiblingVerdict: true },
+  ])(
+    'only trusts a real completed sibling verdict for caller-thrown tripwires in $mode mode: $completedSiblingVerdict',
+    async ({ mode, completedSiblingVerdict }) => {
+      const terminalOutput = completedSiblingVerdict
+        ? 'caller-owned tripwire terminal output secret'
+        : 'unblocked terminal tool output';
+      const foreignAgent = new Agent({ name: 'Foreign tripwire agent' });
+      const foreignState = new RunState(
+        new RunContext(),
+        completedSiblingVerdict ? terminalOutput : 'foreign input',
+        foreignAgent,
+        1,
+      );
+      const thrownTripwire = new OutputGuardrailTripwireTriggered(
+        'Caller-thrown tripwire error',
+        {
+          guardrail: { type: 'output', name: 'caller-thrown tripwire' },
+          agent: foreignAgent,
+          agentOutput: completedSiblingVerdict
+            ? terminalOutput
+            : 'foreign output',
+          output: {
+            outputInfo: completedSiblingVerdict
+              ? terminalOutput
+              : 'foreign output info',
+            tripwireTriggered: true,
+          },
+        } as any,
+        foreignState,
+      );
+      if (completedSiblingVerdict) {
+        (thrownTripwire as Error & { cause?: unknown }).cause = new Error(
+          terminalOutput,
+        );
+        (thrownTripwire as Error & { rejectedOutput?: string }).rejectedOutput =
+          terminalOutput;
+      }
+      const terminalTool = tool({
+        name: 'thrown_tripwire_terminal_tool',
+        description:
+          'Returns output before a guardrail throws a tripwire error.',
+        parameters: z.object({}),
+        execute: async () => terminalOutput,
+      });
+      const agent = new Agent({
+        name: 'Thrown tripwire error agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'thrown_tripwire_terminal_tool',
+                {},
+                { callId: 'thrown-tripwire-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          ...(completedSiblingVerdict
+            ? [
+                {
+                  name: 'completed sibling rejection',
+                  execute: async () => ({
+                    outputInfo: undefined,
+                    tripwireTriggered: true,
+                  }),
+                },
+              ]
+            : []),
+          {
+            name: 'throws a tripwire error',
+            execute: async () => {
+              throw thrownTripwire;
+            },
+          },
+        ],
+      });
+      const session = new MemorySession();
+      let failure: unknown;
+
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { session, stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input', { session });
+        }
+      } catch (error) {
+        failure = error;
+      }
+
+      const persisted = JSON.stringify(await session.getItems());
+      if (!completedSiblingVerdict) {
+        expect(failure).toBe(thrownTripwire);
+        expect(thrownTripwire.state).toBe(foreignState);
+        expect(persisted).toContain('unblocked terminal tool output');
+        expect(persisted).not.toContain(
+          'Output withheld by an output guardrail.',
+        );
+        return;
+      }
+
+      expect(failure).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      expect(failure).not.toBe(thrownTripwire);
+      const safeTripwire = failure as OutputGuardrailTripwireTriggered<
+        any,
+        any
+      >;
+      expect(safeTripwire.state).not.toBe(foreignState);
+      expect(safeTripwire.state?._currentAgent).toBe(agent);
+      expect(safeTripwire.result.agent).toBe(agent);
+      expect(safeTripwire.result.guardrail.name).toBe(
+        'completed sibling rejection',
+      );
+      expect(safeTripwire.result.agentOutput).toBe(
+        'Output withheld by an output guardrail.',
+      );
+      expect(safeTripwire.result.output.outputInfo).toBeUndefined();
+      expect(
+        (safeTripwire as Error & { cause?: unknown }).cause,
+      ).toBeUndefined();
+      expect(
+        (safeTripwire as Error & { rejectedOutput?: string }).rejectedOutput,
+      ).toBeUndefined();
+      expect(JSON.stringify(safeTripwire)).not.toContain(terminalOutput);
+      expect(safeTripwire.state?.toString()).not.toContain(terminalOutput);
+      expect(persisted).not.toContain(terminalOutput);
+      expect(persisted).toContain('Output withheld by an output guardrail.');
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves a restored $mode assistant trip with historical processed tool actions',
+    async (mode) => {
+      const acceptedTool = tool({
+        name: 'historical_assistant_tool',
+        description: 'Returns accepted output before an assistant response.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'historical assistant tool metadata',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'accepted assistant history metadata',
+              ),
+          }),
+        ],
+        execute: async () => 'accepted assistant history output',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'historical_assistant_tool',
+              {},
+              { callId: 'historical-assistant-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [assistantMessage('assistant final output')],
+          usage: new Usage(),
+        }),
+      ]);
+      let attempts = 0;
+      const agent = new Agent({
+        name: 'Restored assistant historical action agent',
+        model,
+        tools: [acceptedTool],
+        toolUseBehavior: 'run_llm_again',
+        outputGuardrails: [
+          {
+            name: 'retrying assistant output guardrail',
+            execute: async () => {
+              attempts += 1;
+              if (attempts === 1) {
+                throw new Error('temporary assistant guardrail failure');
+              }
+              return {
+                outputInfo: 'assistant guardrail metadata',
+                tripwireTriggered: true,
+              };
+            },
+          },
+        ],
+      });
+      const runOnce = async (input: string | RunState<any, any>) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input);
+      };
+      let failedState: RunState<any, any> | undefined;
+      try {
+        await runOnce('use the accepted tool');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardrailExecutionError);
+        failedState = (error as GuardrailExecutionError).state;
+      }
+      const historicalCall = failedState!._generatedItems.find(
+        (item): item is RunToolCallItem =>
+          item instanceof RunToolCallItem &&
+          item.rawItem.type === 'function_call' &&
+          item.rawItem.callId === 'historical-assistant-call',
+      )!;
+      const processedFunctions = failedState!._lastProcessedResponse!.functions;
+      processedFunctions.push({
+        tool: acceptedTool as unknown as (typeof processedFunctions)[number]['tool'],
+        toolCall: historicalCall.rawItem as protocol.FunctionCallItem,
+      });
+      const restored = await RunState.fromString(
+        agent,
+        failedState!.toString(),
+      );
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        await runOnce(restored);
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(attempts).toBe(2);
+      expect(model.calls).toHaveLength(2);
+      expect(tripwire?.result.agentOutput).toBe('assistant final output');
+      expect(tripwire?.result.output.outputInfo).toBe(
+        'assistant guardrail metadata',
+      );
+      expect(
+        tripwire?.state?._toolOutputGuardrailResults[0]?.output.outputInfo,
+      ).toBe('accepted assistant history metadata');
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves earlier accepted tool guardrail metadata after a later model trip in $mode mode',
+    async (mode) => {
+      const acceptedTool = tool({
+        name: 'accepted_tool',
+        description:
+          'Returns an accepted result before the later model output.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'accepted tool output guardrail',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'accepted-tool-output-info',
+              ),
+          }),
+        ],
+        execute: async () => 'accepted tool value',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall('accepted_tool', {}, { callId: 'accepted-call' }),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [assistantMessage('blocked model output')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Later model trip metadata agent',
+        model,
+        tools: [acceptedTool],
+        toolUseBehavior: 'run_llm_again',
+        outputGuardrails: [
+          {
+            name: 'blocking output guardrail',
+            execute: async () => ({
+              outputInfo: 'model-output-info',
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(tripwire?.result.agentOutput).toBe('blocked model output');
+      expect(tripwire?.result.output.outputInfo).toBe('model-output-info');
+      expect(
+        tripwire?.state?._toolOutputGuardrailResults[0]?.output.outputInfo,
+      ).toBe('accepted-tool-output-info');
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'sanitizes only current terminal tool guardrail metadata in $mode mode',
+    async (mode) => {
+      const acceptedTool = tool({
+        name: 'accepted_prefix_tool',
+        description: 'Produces an accepted prefix before the terminal tool.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'accepted prefix output guardrail',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'accepted-prefix-output-info',
+              ),
+          }),
+        ],
+        execute: async () => 'accepted prefix value',
+      });
+      const terminalTool = tool({
+        name: 'blocked_terminal_tool',
+        description: 'Produces the rejected terminal result.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'terminal output guardrail',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'terminal-output-secret',
+              ),
+          }),
+        ],
+        execute: async () => 'blocked terminal value',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall('accepted_prefix_tool', {}, { callId: 'prefix-call' }),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [
+            functionCall(
+              'blocked_terminal_tool',
+              {},
+              {
+                callId: 'terminal-call',
+              },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Current terminal guardrail metadata agent',
+        model,
+        tools: [acceptedTool, terminalTool],
+        toolUseBehavior: { stopAtToolNames: ['blocked_terminal_tool'] },
+        outputGuardrails: [
+          {
+            name: 'blocking output guardrail',
+            execute: async () => ({
+              outputInfo: 'terminal-agent-output-info',
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(tripwire?.result.agentOutput).toBe(
+        'Output withheld by an output guardrail.',
+      );
+      expect(tripwire?.result.output.outputInfo).toBeUndefined();
+      expect(
+        tripwire?.state?._toolOutputGuardrailResults.map(
+          (result) => result.output.outputInfo,
+        ),
+      ).toEqual(['accepted-prefix-output-info', undefined]);
+      expect(tripwire?.state?.toString()).not.toContain(
+        'terminal-output-secret',
+      );
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      (['live', 'restored'] as const).flatMap((continuation) =>
+        (continuation === 'restored'
+          ? (['unique', 'duplicate'] as const)
+          : (['unique'] as const)
+        ).map((guardrailNames) => ({ mode, continuation, guardrailNames })),
+      ),
+    ),
+  )(
+    'sanitizes previous $continuation $mode output guardrail attempts with $guardrailNames names',
+    async ({ mode, continuation, guardrailNames }) => {
+      const terminalTool = tool({
+        name: 'previous_attempt_terminal_tool',
+        description: 'Returns output checked by parallel agent guardrails.',
+        parameters: z.object({}),
+        execute: async () => 'previous-attempt-terminal-secret',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'previous_attempt_terminal_tool',
+              {},
+              { callId: 'previous-attempt-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      let attempts = 0;
+      const agent = new Agent({
+        name: 'Previous output guardrail attempt agent',
+        model,
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name:
+              guardrailNames === 'duplicate'
+                ? 'shared sibling guardrail'
+                : 'passing sibling guardrail',
+            execute: async () => ({
+              outputInfo: 'previous-attempt-guardrail-secret',
+              tripwireTriggered: false,
+            }),
+          },
+          {
+            name:
+              guardrailNames === 'duplicate'
+                ? 'shared sibling guardrail'
+                : 'retrying sibling guardrail',
+            execute: async () => {
+              attempts += 1;
+              if (attempts === 1) {
+                throw new Error('temporary sibling guardrail failure');
+              }
+              return {
+                outputInfo: 'current-attempt-guardrail-secret',
+                tripwireTriggered: true,
+              };
+            },
+          },
+        ],
+      });
+      const runOnce = async (input: string | RunState<any, any>) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input);
+      };
+
+      let failedState: RunState<any, any> | undefined;
+      try {
+        await runOnce('run the terminal tool');
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardrailExecutionError);
+        failedState = (error as GuardrailExecutionError).state;
+      }
+
+      failedState!._outputGuardrailResults.unshift({
+        guardrail: {
+          type: 'output',
+          name:
+            guardrailNames === 'duplicate'
+              ? 'shared sibling guardrail'
+              : 'accepted historical guardrail',
+        },
+        agent,
+        agentOutput: 'accepted historical output',
+        output: {
+          outputInfo: 'accepted historical metadata',
+          tripwireTriggered: false,
+        },
+      });
+      const retryState =
+        continuation === 'restored'
+          ? await RunState.fromString(agent, failedState!.toString())
+          : failedState!;
+
+      if (continuation === 'restored') {
+        let resumeError: unknown;
+        try {
+          await runOnce(retryState);
+        } catch (error) {
+          resumeError = error;
+        }
+        expect(resumeError).toBeInstanceOf(UserError);
+        expect((resumeError as UserError).message).toContain(
+          'previous output guardrail result ownership was not preserved',
+        );
+        expect(model.calls).toHaveLength(1);
+        expect(attempts).toBe(1);
+        expect(retryState._outputGuardrailResults[0]?.output.outputInfo).toBe(
+          'accepted historical metadata',
+        );
+        return;
+      }
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        await runOnce(retryState);
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(model.calls).toHaveLength(1);
+      expect(attempts).toBe(2);
+      expect(
+        tripwire?.state?._outputGuardrailResults.map(
+          (result) => result.output.outputInfo,
+        ),
+      ).toEqual([
+        'accepted historical metadata',
+        undefined,
+        undefined,
+        undefined,
+      ]);
+      const retained = tripwire?.state?.toString();
+      expect(retained).toContain('accepted historical output');
+      expect(retained).not.toContain('previous-attempt-terminal-secret');
+      expect(retained).not.toContain('previous-attempt-guardrail-secret');
+      expect(retained).not.toContain('current-attempt-guardrail-secret');
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      (
+        [
+          'unchanged',
+          'removed',
+          'short_circuit',
+          'historical_collision',
+          'changed_to_run_llm_again',
+          'changed_stop_name',
+          'changed_stop_to_historical',
+        ] as const
+      ).map((guardrails) => ({
+        mode,
+        guardrails,
+      })),
+    ),
+  )(
+    'redacts a serialized $mode terminal retry with $guardrails tool guardrails',
+    async ({ mode, guardrails }) => {
+      const acceptedTool = tool({
+        name: 'restored_accepted_tool',
+        description: 'Produces previously accepted output.',
+        parameters: z.object({}),
+        outputGuardrails:
+          guardrails === 'historical_collision'
+            ? []
+            : [
+                defineToolOutputGuardrail({
+                  name: 'restored accepted metadata',
+                  run: async () =>
+                    ToolGuardrailFunctionOutputFactory.allow(
+                      'accepted-metadata',
+                    ),
+                }),
+              ],
+        execute: async () => 'accepted-prefix-output',
+      });
+      const terminalTool = tool({
+        name: 'restored_terminal_tool',
+        description:
+          'Produces terminal output that a resumed guardrail rejects.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'restored terminal metadata',
+            run: async () =>
+              guardrails === 'short_circuit'
+                ? ToolGuardrailFunctionOutputFactory.rejectContent(
+                    'replacement-terminal-secret',
+                    'terminal-metadata-secret',
+                  )
+                : ToolGuardrailFunctionOutputFactory.allow(
+                    'terminal-metadata-secret',
+                  ),
+          }),
+          ...(guardrails === 'short_circuit'
+            ? [
+                defineToolOutputGuardrail({
+                  name: 'terminal guardrail that does not execute',
+                  run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+                }),
+              ]
+            : []),
+        ],
+        execute: async () => 'restored-terminal-output-secret',
+      });
+      const siblingTool = tool({
+        name: 'restored_sibling_tool',
+        description:
+          'Produces sibling output in the rejected current response.',
+        parameters: z.object({}),
+        outputGuardrails:
+          guardrails === 'historical_collision'
+            ? []
+            : [
+                defineToolOutputGuardrail({
+                  name: 'restored sibling metadata',
+                  run: async () =>
+                    ToolGuardrailFunctionOutputFactory.allow(
+                      'sibling-metadata-secret',
+                    ),
+                }),
+              ],
+        execute: async () => 'restored-sibling-output-secret',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'restored_accepted_tool',
+              {},
+              { callId: 'accepted-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [
+            functionCall(
+              'restored_sibling_tool',
+              {},
+              { callId: 'sibling-call' },
+            ),
+            functionCall(
+              'restored_terminal_tool',
+              {},
+              { callId: 'terminal-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      let attempts = 0;
+      const agent = new Agent({
+        name: 'Serialized terminal guardrail retry agent',
+        model,
+        tools: [acceptedTool, siblingTool, terminalTool],
+        toolUseBehavior: { stopAtToolNames: ['restored_terminal_tool'] },
+        outputGuardrails: [
+          {
+            name: 'retrying terminal output guardrail',
+            execute: async () => {
+              attempts += 1;
+              if (attempts === 1) {
+                throw new Error('temporary guardrail failure');
+              }
+              return {
+                outputInfo: 'terminal-verdict-secret',
+                tripwireTriggered: true,
+              };
+            },
+          },
+        ],
+      });
+
+      let failedState: RunState<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardrailExecutionError);
+        failedState = (error as GuardrailExecutionError).state;
+      }
+
+      expect(failedState?._finalOutputSource).toBe('tool_result');
+      if (guardrails === 'removed') {
+        terminalTool.outputGuardrails = [];
+        siblingTool.outputGuardrails = [];
+      } else if (guardrails === 'historical_collision') {
+        acceptedTool.outputGuardrails = [
+          defineToolOutputGuardrail({
+            name: 'restored terminal metadata',
+            run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+          }),
+        ];
+      } else if (guardrails === 'changed_to_run_llm_again') {
+        agent.toolUseBehavior = 'run_llm_again';
+      } else if (guardrails === 'changed_stop_name') {
+        agent.toolUseBehavior = {
+          stopAtToolNames: ['a_different_terminal_tool'],
+        };
+      } else if (guardrails === 'changed_stop_to_historical') {
+        const historicalCall = failedState!._generatedItems.find(
+          (item): item is RunToolCallItem =>
+            item instanceof RunToolCallItem &&
+            item.rawItem.type === 'function_call' &&
+            item.rawItem.callId === 'accepted-call',
+        )!;
+        const processedFunctions =
+          failedState!._lastProcessedResponse!.functions;
+        processedFunctions.unshift({
+          ...processedFunctions[0]!,
+          tool: acceptedTool as unknown as (typeof processedFunctions)[number]['tool'],
+          toolCall: historicalCall.rawItem as protocol.FunctionCallItem,
+        });
+        agent.toolUseBehavior = {
+          stopAtToolNames: ['restored_accepted_tool'],
+        };
+      }
+      const restored = await RunState.fromString(
+        agent,
+        failedState!.toString(),
+      );
+      expect(restored._finalOutputSource).toBeUndefined();
+
+      if (
+        guardrails === 'changed_to_run_llm_again' ||
+        guardrails === 'changed_stop_name' ||
+        guardrails === 'changed_stop_to_historical'
+      ) {
+        let resumeError: unknown;
+        try {
+          if (mode === 'streamed') {
+            const result = await run(agent, restored, { stream: true });
+            await result.completed;
+          } else {
+            await run(agent, restored);
+          }
+        } catch (error) {
+          resumeError = error;
+        }
+        expect(resumeError).toBeInstanceOf(UserError);
+        expect((resumeError as UserError).message).toContain(
+          'terminal tool output provenance could not be verified',
+        );
+        expect(model.calls).toHaveLength(2);
+        expect(attempts).toBe(1);
+        return;
+      }
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, restored, { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, restored);
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(model.calls).toHaveLength(2);
+      expect(attempts).toBe(2);
+      expect(tripwire?.result.agentOutput).toBe(
+        'Output withheld by an output guardrail.',
+      );
+      expect(
+        tripwire?.state?._toolOutputGuardrailResults.map(
+          (result) => result.output.outputInfo,
+        ),
+      ).toEqual(
+        guardrails === 'historical_collision'
+          ? [undefined]
+          : [undefined, undefined, undefined],
+      );
+      const retained = tripwire?.state?.toString();
+      expect(retained).toContain('accepted-prefix-output');
+      expect(retained).not.toContain('restored-terminal-output-secret');
+      expect(retained).not.toContain('restored-sibling-output-secret');
+      expect(retained).not.toContain('replacement-terminal-secret');
+      expect(retained).not.toContain('terminal-metadata-secret');
+      expect(retained).not.toContain('sibling-metadata-secret');
+      expect(retained).not.toContain('terminal-verdict-secret');
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'redacts a restored $mode terminal retry selected by a qualified tool name',
+    async (mode) => {
+      let attempts = 0;
+      const [lookupAccount] = toolNamespace({
+        name: 'crm',
+        description: 'CRM account tools.',
+        tools: [
+          tool({
+            name: 'lookup_account',
+            description: 'Looks up a CRM account.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced-terminal-output-secret',
+          }),
+        ],
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'lookup_account',
+              {},
+              {
+                callId: 'namespaced-terminal-call',
+                namespace: 'crm',
+                providerData: {
+                  rejectedOutput: 'namespaced-terminal-output-secret',
+                  retainedMetadata: 'processed-function-provider-secret',
+                },
+              },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Namespaced restored terminal agent',
+        model,
+        tools: [lookupAccount],
+        toolUseBehavior: { stopAtToolNames: ['crm.lookup_account'] },
+        outputGuardrails: [
+          {
+            name: 'retrying namespaced output guardrail',
+            execute: async () => {
+              attempts += 1;
+              if (attempts === 1) {
+                throw new Error('temporary namespaced guardrail failure');
+              }
+              return {
+                outputInfo: 'namespaced-verdict-secret',
+                tripwireTriggered: true,
+              };
+            },
+          },
+        ],
+      });
+
+      let failedState: RunState<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, 'input', { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, 'input');
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(GuardrailExecutionError);
+        failedState = (error as GuardrailExecutionError).state;
+      }
+
+      const restored = await RunState.fromString(
+        agent,
+        failedState!.toString(),
+      );
+      expect(restored._finalOutputSource).toBeUndefined();
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        if (mode === 'streamed') {
+          const result = await run(agent, restored, { stream: true });
+          await result.completed;
+        } else {
+          await run(agent, restored);
+        }
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(model.calls).toHaveLength(1);
+      expect(attempts).toBe(2);
+      expect(tripwire?.result.agentOutput).toBe(
+        'Output withheld by an output guardrail.',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'namespaced-terminal-output-secret',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'namespaced-verdict-secret',
+      );
+      expect(tripwire?.state?.toString()).not.toContain(
+        'processed-function-provider-secret',
+      );
+      expect(
+        tripwire?.state?._generatedItems
+          .filter(
+            (item) =>
+              item instanceof RunToolCallItem ||
+              item instanceof RunToolCallOutputItem,
+          )
+          .map((item) =>
+            'namespace' in item.rawItem ? item.rawItem.namespace : undefined,
+          ),
+      ).toEqual(['crm', 'crm']);
+      expect(tripwire?.state?._lastTurnResponse?.output[0]).toMatchObject({
+        name: 'lookup_account',
+        namespace: 'crm',
+      });
+      expect(
+        tripwire?.state?._lastProcessedResponse?.functions[0]?.toolCall,
+      ).toBe(tripwire?.state?._lastTurnResponse?.output[0]);
+      expect(
+        JSON.stringify(tripwire?.state?._lastProcessedResponse?.functions),
+      ).not.toContain('processed-function-provider-secret');
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves server-managed $mode assistant output guardrails',
+    async (mode) => {
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [assistantMessage('safe server-managed assistant output')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Server-managed assistant output agent',
+        model,
+        outputGuardrails: [
+          {
+            name: 'passing assistant output guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'input', {
+          conversationId: 'server-conversation',
+          stream: true,
+        });
+        await result.completed;
+        expect(result.finalOutput).toBe('safe server-managed assistant output');
+      } else {
+        const result = await run(agent, 'input', {
+          conversationId: 'server-conversation',
+        });
+        expect(result.finalOutput).toBe('safe server-managed assistant output');
+      }
+      expect(model.calls).toHaveLength(1);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'persists a safe $mode approval checkpoint when output guardrails are configured',
+    async (mode) => {
+      const approvalTool = tool({
+        name: 'guarded_approval_tool',
+        description: 'Requires approval before producing any output.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved result',
+      });
+      const agent = new Agent({
+        name: 'Guarded call-only approval agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'guarded_approval_tool',
+                {},
+                { callId: 'guarded-approval-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [approvalTool],
+        outputGuardrails: [
+          {
+            name: 'guard that runs only after final output',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'input', { session, stream: true });
+        await result.completed;
+        expect(result.interruptions).toHaveLength(1);
+      } else {
+        const result = await run(agent, 'input', { session });
+        expect(result.interruptions).toHaveLength(1);
+      }
+
+      expect(
+        (await session.getItems()).some(
+          (item) =>
+            item.type === 'function_call' &&
+            item.callId === 'guarded-approval-call',
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'resumes a guarded $mode approval after its safe calls were checkpointed',
+    async (mode) => {
+      const firstTool = tool({
+        name: 'checkpointed_first_tool',
+        description: 'Requires the first approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'first checkpointed output',
+      });
+      const secondTool = tool({
+        name: 'checkpointed_second_tool',
+        description: 'Requires the second approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'second checkpointed output',
+      });
+      const agent = new Agent({
+        name: 'Checkpointed multi-approval agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'checkpointed_first_tool',
+                {},
+                { callId: 'checkpointed-first-call' },
+              ),
+              functionCall(
+                'checkpointed_second_tool',
+                {},
+                { callId: 'checkpointed-second-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [firstTool, secondTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'guard checkpointed tool output',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+      const runOnce = async (input: string | RunState<any, any>) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input, { session });
+      };
+
+      const first = await runOnce('approve both tools');
+      expect(
+        (await session.getItems()).filter(
+          (item) => item.type === 'function_call',
+        ),
+      ).toHaveLength(2);
+      first.state.approve(first.interruptions[0]!);
+      const partial = await runOnce(first.state);
+      expect(partial.interruptions).toHaveLength(1);
+      partial.state.approve(partial.interruptions[0]!);
+
+      const completed = await runOnce(partial.state);
+      expect(completed.finalOutput).toBe('second checkpointed output');
+      expect(
+        (await session.getItems()).filter(
+          (item) => item.type === 'function_call',
+        ),
+      ).toHaveLength(2);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'does not defer a $mode approval for a disabled guarded handoff',
+    async (mode) => {
+      const guardedTarget = new Agent({
+        name: 'Disabled guarded target',
+        outputGuardrails: [
+          {
+            name: 'unreachable target guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const approvedTool = tool({
+        name: 'disabled_handoff_approval_tool',
+        description: 'Requires approval while the guarded handoff is disabled.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved result',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'disabled_handoff_approval_tool',
+              {},
+              { callId: 'approval-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Disabled handoff approval agent',
+        model,
+        tools: [approvedTool],
+        handoffs: [handoff(guardedTarget, { isEnabled: false })],
+      });
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'input', { session, stream: true });
+        await result.completed;
+        expect(result.interruptions).toHaveLength(1);
+      } else {
+        const result = await run(agent, 'input', { session });
+        expect(result.interruptions).toHaveLength(1);
+      }
+
+      expect(
+        (await session.getItems()).some(
+          (item) =>
+            item.type === 'function_call' && item.callId === 'approval-call',
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves server-managed $mode handoffs to guarded agents',
+    async (mode) => {
+      const guardedModel = new ScriptedModel([
+        modelResponse({
+          output: [assistantMessage('safe guarded handoff output')],
+          usage: new Usage(),
+        }),
+      ]);
+      const guardedAgent = new Agent({
+        name: 'Guarded handoff target',
+        model: guardedModel,
+        outputGuardrails: [
+          {
+            name: 'target output guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const targetHandoff = handoff(guardedAgent);
+      const startingModel = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              targetHandoff.toolName,
+              {},
+              { callId: 'handoff-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const startingAgent = new Agent({
+        name: 'Server-managed starting agent',
+        model: startingModel,
+        handoffs: [targetHandoff],
+      });
+
+      if (mode === 'streamed') {
+        const result = await run(startingAgent, 'handoff', {
+          conversationId: 'server-conversation',
+          stream: true,
+        });
+        await result.completed;
+        expect(result.finalOutput).toBe('safe guarded handoff output');
+      } else {
+        const result = await run(startingAgent, 'handoff', {
+          conversationId: 'server-conversation',
+        });
+        expect(result.finalOutput).toBe('safe guarded handoff output');
+      }
+      expect(startingModel.calls).toHaveLength(1);
+      expect(guardedModel.calls).toHaveLength(1);
+    },
+  );
+});

--- a/packages/agents-core/test/run.outputGuardrailReplaySession.test.ts
+++ b/packages/agents-core/test/run.outputGuardrailReplaySession.test.ts
@@ -1,0 +1,1335 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import {
+  Agent,
+  MemorySession,
+  OutputGuardrailTripwireTriggered,
+  RunContext,
+  RunResult,
+  RunState,
+  StreamedRunResult,
+  ToolGuardrailFunctionOutputFactory,
+  Usage,
+  defineToolOutputGuardrail,
+  run,
+  tool,
+  toolNamespace,
+  type AgentInputItem,
+  type Session,
+  type SessionHistoryTransactionArgs,
+  type ToolUseBehavior,
+} from '../src';
+import {
+  ScriptedModel,
+  assistantMessage,
+  functionCall,
+  modelResponse,
+} from '../src/testing';
+import {
+  saveStreamResultToSession,
+  saveToSession,
+} from '../src/runner/sessionPersistence';
+
+type RunMode = 'non_streamed' | 'streamed';
+
+class AppendOnlySession implements Session {
+  readonly items: AgentInputItem[] = [];
+
+  async getSessionId(): Promise<string> {
+    return 'append-only-output-guardrail-session';
+  }
+
+  async getItems(): Promise<AgentInputItem[]> {
+    return structuredClone(this.items);
+  }
+
+  async addItems(items: AgentInputItem[]): Promise<void> {
+    this.items.push(...structuredClone(items));
+  }
+
+  async popItem(): Promise<AgentInputItem | undefined> {
+    return this.items.pop();
+  }
+
+  async clearSession(): Promise<void> {
+    this.items.length = 0;
+  }
+}
+
+const terminalToolBehaviors: Array<{
+  name: string;
+  value: ToolUseBehavior;
+}> = [
+  { name: 'stop_on_first_tool', value: 'stop_on_first_tool' },
+  {
+    name: 'stopAtToolNames',
+    value: { stopAtToolNames: ['sensitive_tool'] },
+  },
+  {
+    name: 'custom finalizer',
+    value: async (_context, results) => ({
+      isFinalOutput: true,
+      isInterrupted: undefined,
+      finalOutput: String(
+        results.find((result) => result.type === 'function_output')?.output,
+      ),
+    }),
+  },
+];
+
+describe('output guardrails with Session persistence', () => {
+  it.each(
+    terminalToolBehaviors.flatMap(({ name, value }) =>
+      (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+        [false, true].map((tripwire) => ({
+          behaviorName: name,
+          mode,
+          toolUseBehavior: value,
+          tripwire,
+        })),
+      ),
+    ),
+  )(
+    'handles $behaviorName in $mode mode when guardrails trip=$tripwire',
+    async ({ mode, toolUseBehavior, tripwire }) => {
+      const executeTool = vi.fn(async () => 'sensitive tool output');
+      const executeGuardrail = vi.fn(async () => ({
+        outputInfo: undefined,
+        tripwireTriggered: tripwire,
+      }));
+      const sensitiveTool = tool({
+        name: 'sensitive_tool',
+        description: 'Returns a sensitive value.',
+        parameters: z.object({}),
+        execute: executeTool,
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall('sensitive_tool', {}, { callId: 'sensitive-call' }),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Terminal tool Session agent',
+        model,
+        tools: [sensitiveTool],
+        toolUseBehavior,
+        outputGuardrails: [
+          {
+            name: 'output guardrail',
+            execute: executeGuardrail,
+          },
+        ],
+      });
+      const session = new AppendOnlySession();
+
+      if (tripwire && mode === 'streamed') {
+        const result = await run(agent, 'input', { session, stream: true });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else if (tripwire) {
+        await expect(run(agent, 'input', { session })).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else if (mode === 'streamed') {
+        const result = await run(agent, 'input', { session, stream: true });
+        await result.completed;
+      } else {
+        await run(agent, 'input', { session });
+      }
+
+      expect(model.calls).toHaveLength(1);
+      expect(executeTool).toHaveBeenCalledTimes(1);
+      expect(executeGuardrail).toHaveBeenCalledTimes(1);
+      const stored = JSON.stringify(await session.getItems());
+      if (tripwire) {
+        expect(stored).not.toContain('sensitive tool output');
+        expect(stored).toContain('Output withheld by an output guardrail.');
+
+        const replayModel = new ScriptedModel([
+          modelResponse({
+            output: [assistantMessage('safe replay output')],
+            usage: new Usage(),
+          }),
+        ]);
+        const replayAgent = new Agent({
+          name: 'Replay Session agent',
+          model: replayModel,
+        });
+        await run(replayAgent, 'Continue', { session });
+        const replayInput = JSON.stringify(replayModel.calls[0]?.request.input);
+        expect(replayInput).not.toContain('sensitive tool output');
+        expect(replayInput).toContain(
+          'Output withheld by an output guardrail.',
+        );
+      } else {
+        expect(stored).toContain('sensitive tool output');
+      }
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      (['none', 'before_commit', 'after_commit'] as const).map(
+        (failureTiming) => ({ mode, failureTiming }),
+      ),
+    ),
+  )(
+    'persists an input-only blocked $mode transaction with $failureTiming failure',
+    async ({ mode, failureTiming }) => {
+      class RetryableInputOnlySession extends MemorySession {
+        readonly operationIds: string[] = [];
+        readonly transactionItems: AgentInputItem[][] = [];
+        directWrites = 0;
+        private shouldFail = failureTiming !== 'none';
+
+        override async addItems(items: AgentInputItem[]): Promise<void> {
+          this.directWrites += 1;
+          await super.addItems(items);
+        }
+
+        override async applyHistoryTransaction(
+          args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          this.operationIds.push(args.operationId);
+          if (args.transaction.type !== 'append_items') {
+            throw new Error('Expected an input-only append transaction.');
+          }
+          this.transactionItems.push(structuredClone(args.transaction.items));
+          if (this.shouldFail && failureTiming === 'before_commit') {
+            this.shouldFail = false;
+            throw new Error('input-only transaction failed before commit');
+          }
+          await super.applyHistoryTransaction(args);
+          if (this.shouldFail && failureTiming === 'after_commit') {
+            this.shouldFail = false;
+            throw new Error('input-only transaction failed after commit');
+          }
+        }
+      }
+
+      const executeTool = vi.fn(async () => 'discarded terminal tool secret');
+      const terminalTool = tool({
+        name: 'discarded_response_tool',
+        description: 'Returns output from a response that cannot be rebuilt.',
+        parameters: z.object({}),
+        execute: executeTool,
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            assistantMessage('discarded assistant response secret'),
+            functionCall(
+              'discarded_response_tool',
+              {},
+              { callId: 'discarded-response-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Input-only blocked transaction agent',
+        model,
+        tools: [terminalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'reject unsafe mixed terminal response',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new RetryableInputOnlySession();
+      const invoke = async (input: string | RunState<any, any>) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return;
+        }
+        await run(agent, input, { session });
+      };
+
+      let tripwire: OutputGuardrailTripwireTriggered<any, any> | undefined;
+      try {
+        await invoke('preserve the discarded response input');
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwire = error as OutputGuardrailTripwireTriggered<any, any>;
+      }
+
+      expect(executeTool).toHaveBeenCalledTimes(1);
+      expect(model.calls).toHaveLength(1);
+      expect(session.directWrites).toBe(0);
+      expect(session.operationIds).toHaveLength(1);
+      expect(session.transactionItems[0]).toHaveLength(1);
+      expect(JSON.stringify(session.transactionItems[0])).toContain(
+        'preserve the discarded response input',
+      );
+      expect(JSON.stringify(session.transactionItems[0])).not.toContain(
+        'discarded terminal tool secret',
+      );
+      expect(JSON.stringify(session.transactionItems[0])).not.toContain(
+        'discarded assistant response secret',
+      );
+
+      if (failureTiming !== 'none') {
+        expect(
+          tripwire?.state?._pendingSessionHistoryTransaction,
+        ).toBeDefined();
+        await expect(invoke(tripwire!.state!)).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+        expect(session.operationIds).toHaveLength(2);
+        expect(session.operationIds[1]).toBe(session.operationIds[0]);
+      }
+
+      const persisted = await session.getItems();
+      expect(persisted).toHaveLength(1);
+      expect(JSON.stringify(persisted)).toContain(
+        'preserve the discarded response input',
+      );
+      expect(JSON.stringify(persisted)).not.toContain(
+        'discarded terminal tool secret',
+      );
+      expect(JSON.stringify(persisted)).not.toContain(
+        'discarded assistant response secret',
+      );
+      expect(session.directWrites).toBe(0);
+      expect(executeTool).toHaveBeenCalledTimes(1);
+      expect(model.calls).toHaveLength(1);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'does not create an empty blocked-output transaction in $mode mode',
+    async (mode) => {
+      class RecordingSession extends MemorySession {
+        transactionCalls = 0;
+
+        override async applyHistoryTransaction(
+          args: SessionHistoryTransactionArgs,
+        ): Promise<void> {
+          this.transactionCalls += 1;
+          await super.applyHistoryTransaction(args);
+        }
+      }
+
+      const session = new RecordingSession();
+      const agent = new Agent({ name: 'Empty blocked transaction agent' });
+      const state: RunState<any, any> = new RunState(
+        new RunContext(),
+        'input',
+        agent,
+        1,
+      );
+      state._currentTurnSessionHistoryTransactionInputItems = [];
+
+      if (mode === 'streamed') {
+        await saveStreamResultToSession(
+          session,
+          new StreamedRunResult({ state }),
+          { outputBlocked: true },
+          [],
+        );
+      } else {
+        await saveToSession(session, [], new RunResult(state), {
+          outputBlocked: true,
+        });
+      }
+
+      expect(session.transactionCalls).toBe(0);
+      expect(await session.getItems()).toEqual([]);
+      expect(state._pendingSessionHistoryTransaction).toBeUndefined();
+      expect(state._currentTurnBlockedSessionStartIndex).toBeUndefined();
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves the separate function namespace in a blocked $mode Session snapshot',
+    async (mode) => {
+      const [namespacedTool] = toolNamespace({
+        name: 'crm',
+        description: 'CRM tools.',
+        tools: [
+          tool({
+            name: 'lookup_account',
+            description: 'Returns a sensitive CRM account.',
+            parameters: z.object({}),
+            execute: async () => 'namespaced Session output secret',
+          }),
+        ],
+      });
+      const agent = new Agent({
+        name: 'Namespaced blocked Session agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'lookup_account',
+                {},
+                {
+                  callId: 'namespaced-session-call',
+                  namespace: 'crm',
+                },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [namespacedTool],
+        toolUseBehavior: { stopAtToolNames: ['crm.lookup_account'] },
+        outputGuardrails: [
+          {
+            name: 'block namespaced Session output',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new AppendOnlySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'Look up the account.', {
+          session,
+          stream: true,
+        });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(
+          run(agent, 'Look up the account.', { session }),
+        ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+      }
+
+      const toolItems = (await session.getItems()).filter(
+        (item) =>
+          item.type === 'function_call' || item.type === 'function_call_result',
+      );
+      expect(
+        toolItems.map((item) => ({
+          type: item.type,
+          name: item.name,
+          namespace: item.namespace,
+        })),
+      ).toEqual([
+        { type: 'function_call', name: 'lookup_account', namespace: 'crm' },
+        {
+          type: 'function_call_result',
+          name: 'lookup_account',
+          namespace: 'crm',
+        },
+      ]);
+      expect(JSON.stringify(toolItems)).not.toContain(
+        'namespaced Session output secret',
+      );
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      (
+        [
+          'run_llm_again',
+          'stop_on_first_tool',
+          'stop_at_names',
+          'custom',
+        ] as const
+      ).map((behavior) => ({ mode, behavior })),
+    ),
+  )(
+    'preserves a completed $mode approval sibling before resuming with $behavior',
+    async ({ mode, behavior }) => {
+      const approveExecute = vi.fn(async () => 'approved sibling output');
+      const siblingExecute = vi.fn(async () => 'completed nonterminal sibling');
+      const approvalTool = tool({
+        name: 'pending_approval_tool',
+        description: 'Requires approval before execution.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: approveExecute,
+      });
+      const siblingTool = tool({
+        name: 'completed_sibling_tool',
+        description: 'Completes while a sibling awaits approval.',
+        parameters: z.object({}),
+        execute: siblingExecute,
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'pending_approval_tool',
+              {},
+              {
+                callId: 'pending-approval-call',
+              },
+            ),
+            functionCall(
+              'completed_sibling_tool',
+              {},
+              {
+                callId: 'completed-sibling-call',
+              },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [assistantMessage('approved sibling continuation')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Nonterminal approval sibling agent',
+        model,
+        tools: [approvalTool, siblingTool],
+        toolUseBehavior: 'run_llm_again',
+        outputGuardrails: [
+          {
+            name: 'guard the eventual model output',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input, { session });
+      };
+
+      const first = await runOnce('Use both approval siblings.');
+      expect(first.interruptions).toHaveLength(1);
+      expect(siblingExecute).toHaveBeenCalledTimes(1);
+      expect(approveExecute).not.toHaveBeenCalled();
+      const checkpoint = await session.getItems();
+      expect(
+        checkpoint
+          .filter(
+            (item) =>
+              (item.type === 'function_call' ||
+                item.type === 'function_call_result') &&
+              item.callId === 'completed-sibling-call',
+          )
+          .map((item) => item.type),
+      ).toEqual(['function_call', 'function_call_result']);
+      expect(JSON.stringify(checkpoint)).toContain(
+        'completed nonterminal sibling',
+      );
+      expect(first.state._currentTurnPersistedItemCount).toBeGreaterThan(0);
+      first.state.approve(first.interruptions[0]!);
+
+      if (behavior !== 'run_llm_again') {
+        agent.toolUseBehavior =
+          behavior === 'stop_on_first_tool'
+            ? 'stop_on_first_tool'
+            : behavior === 'stop_at_names'
+              ? { stopAtToolNames: ['pending_approval_tool'] }
+              : async (_context, results) => ({
+                  isFinalOutput: true,
+                  isInterrupted: undefined,
+                  finalOutput: String(
+                    results.find((result) => result.type === 'function_output')
+                      ?.output,
+                  ),
+                });
+        await expect(runOnce(first.state)).rejects.toThrow(
+          'persisted response ownership cannot be proven',
+        );
+        expect(approveExecute).not.toHaveBeenCalled();
+        expect(siblingExecute).toHaveBeenCalledTimes(1);
+        expect(model.calls).toHaveLength(1);
+        expect(await session.getItems()).toEqual(checkpoint);
+        return;
+      }
+
+      const resumed = await runOnce(first.state);
+      expect(resumed.finalOutput).toBe('approved sibling continuation');
+      expect(approveExecute).toHaveBeenCalledTimes(1);
+      expect(siblingExecute).toHaveBeenCalledTimes(1);
+      expect(model.calls).toHaveLength(2);
+      const persisted = await session.getItems();
+      for (const callId of [
+        'pending-approval-call',
+        'completed-sibling-call',
+      ]) {
+        expect(
+          persisted
+            .filter(
+              (item) =>
+                (item.type === 'function_call' ||
+                  item.type === 'function_call_result') &&
+                item.callId === callId,
+            )
+            .map((item) => item.type),
+        ).toEqual(['function_call', 'function_call_result']);
+      }
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'resumes a later call-only approval after an earlier $mode tool result',
+    async (mode) => {
+      const historicalExecute = vi.fn(async () => 'accepted earlier result');
+      const approvedExecute = vi.fn(async () => 'approved later result');
+      const historicalTool = tool({
+        name: 'historical_tool',
+        description: 'Returns an accepted result before the approval.',
+        parameters: z.object({}),
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'accepted historical tool guardrail',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'accepted historical guardrail metadata',
+              ),
+          }),
+        ],
+        execute: historicalExecute,
+      });
+      const approvalTool = tool({
+        name: 'later_approval_tool',
+        description: 'Requires approval after the earlier result.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: approvedExecute,
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall('historical_tool', {}, { callId: 'historical-call' }),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [
+            functionCall(
+              'later_approval_tool',
+              {},
+              { callId: 'later-approval-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [assistantMessage('approved continuation complete')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Historical result before approval agent',
+        model,
+        tools: [historicalTool, approvalTool],
+        toolUseBehavior: 'run_llm_again',
+        outputGuardrails: [
+          {
+            name: 'passing approval output guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+        useSession = true,
+      ) => {
+        const options = useSession ? { session } : {};
+        if (mode === 'streamed') {
+          const result = await run(agent, input, {
+            ...options,
+            stream: true,
+          });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input, options);
+      };
+
+      const first = await runOnce('Run both tools.', false);
+      expect(first.interruptions).toHaveLength(1);
+      expect(historicalExecute).toHaveBeenCalledTimes(1);
+      expect(approvedExecute).not.toHaveBeenCalled();
+      expect(
+        first.state._toolOutputGuardrailResults[0]?.output.outputInfo,
+      ).toBe('accepted historical guardrail metadata');
+
+      const restored = await RunState.fromString(agent, first.state.toString());
+      restored.approve(restored.getInterruptions()[0]!);
+      const resumed = await runOnce(restored);
+
+      expect(resumed.finalOutput).toBe('approved continuation complete');
+      expect(historicalExecute).toHaveBeenCalledTimes(1);
+      expect(approvedExecute).toHaveBeenCalledTimes(1);
+      expect(
+        resumed.state._toolOutputGuardrailResults[0]?.output.outputInfo,
+      ).toBe('accepted historical guardrail metadata');
+      const stored = JSON.stringify(await session.getItems());
+      expect(stored).toContain('accepted earlier result');
+      expect(stored).toContain('approved later result');
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'rejects a legacy persisted partial approval before $mode resume side effects',
+    async (mode) => {
+      const firstExecute = vi.fn(async () => 'legacy first secret');
+      const secondExecute = vi.fn(async () => 'legacy second secret');
+      const firstTool = tool({
+        name: 'legacy_first_tool',
+        description: 'Returns the first legacy value.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: firstExecute,
+      });
+      const secondTool = tool({
+        name: 'legacy_second_tool',
+        description: 'Returns the second legacy value.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: secondExecute,
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall('legacy_first_tool', {}, { callId: 'legacy-first' }),
+            functionCall('legacy_second_tool', {}, { callId: 'legacy-second' }),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Legacy partial approval agent',
+        model,
+        tools: [firstTool, secondTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'passing legacy output guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const session = new AppendOnlySession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+        sessionInputCallback?: (
+          history: AgentInputItem[],
+          newItems: AgentInputItem[],
+        ) => AgentInputItem[],
+        reasoningItemIdPolicy?: 'preserve' | 'omit',
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, {
+            session,
+            sessionInputCallback,
+            reasoningItemIdPolicy,
+            stream: true,
+          });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input, {
+          session,
+          sessionInputCallback,
+          reasoningItemIdPolicy,
+        });
+      };
+
+      const first = await runOnce('Use both legacy tools');
+      first.state.approve(first.interruptions[0]);
+      const partial = await runOnce(first.state);
+      expect(firstExecute).toHaveBeenCalledTimes(1);
+      expect(secondExecute).not.toHaveBeenCalled();
+
+      partial.state._currentTurnPersistedItemCount = 1;
+      partial.state.approve(partial.interruptions[0]);
+      partial.state.setReasoningItemIdPolicy('preserve');
+      const sessionBefore = structuredClone(await session.getItems());
+      const modelCallCount = model.calls.length;
+      const callback = vi.fn(
+        (history: AgentInputItem[], newItems: AgentInputItem[]) => [
+          ...history,
+          ...newItems,
+        ],
+      );
+
+      await expect(runOnce(partial.state, callback, 'omit')).rejects.toThrow(
+        'persisted response ownership cannot be proven',
+      );
+      expect(firstExecute).toHaveBeenCalledTimes(1);
+      expect(secondExecute).not.toHaveBeenCalled();
+      expect(model.calls).toHaveLength(modelCallCount);
+      expect(callback).not.toHaveBeenCalled();
+      expect(await session.getItems()).toEqual(sessionBefore);
+      expect(partial.state._reasoningItemIdPolicy).toBe('preserve');
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      (['pass', 'trip', 'error'] as const).map((verdict) => ({
+        mode,
+        verdict,
+      })),
+    ),
+  )(
+    'defers partial approval output until a $mode output guardrail $verdict verdict',
+    async ({ mode, verdict }) => {
+      const firstTool = tool({
+        name: 'first_sensitive_tool',
+        description: 'Returns the first sensitive value.',
+        parameters: z.object({}),
+        needsApproval: true,
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'first approved tool verdict',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'first approval tool guardrail secret',
+              ),
+          }),
+        ],
+        execute: async () => 'first partial approval secret',
+      });
+      const secondTool = tool({
+        name: 'second_sensitive_tool',
+        description: 'Returns the second sensitive value.',
+        parameters: z.object({}),
+        needsApproval: true,
+        outputGuardrails: [
+          defineToolOutputGuardrail({
+            name: 'approved terminal tool verdict',
+            run: async () =>
+              ToolGuardrailFunctionOutputFactory.allow(
+                'second approval tool guardrail secret',
+              ),
+          }),
+        ],
+        execute: async () => 'second approval secret',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall('first_sensitive_tool', {}, { callId: 'first-call' }),
+            functionCall(
+              'second_sensitive_tool',
+              {},
+              { callId: 'second-call' },
+            ),
+            {
+              type: 'hosted_tool_call',
+              name: 'file_search_call',
+              status: 'completed',
+              providerData: {
+                type: 'file_search_call',
+                queries: ['sensitive query'],
+                results: [{ text: 'hosted partial approval secret' }],
+              },
+            },
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Partial approval Session agent',
+        model,
+        tools: [firstTool, secondTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'blocking output guardrail',
+            execute: async () => {
+              if (verdict === 'error') {
+                throw new Error('approval output guardrail failed');
+              }
+              return {
+                outputInfo: undefined,
+                tripwireTriggered: verdict === 'trip',
+              };
+            },
+          },
+        ],
+      });
+      const session = new MemorySession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { session, stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input, { session });
+      };
+
+      const first = await runOnce('Use both tools');
+      expect(first.interruptions).toHaveLength(2);
+      first.state.approve(first.interruptions[0]);
+
+      const partial = await runOnce(first.state);
+      expect(partial.interruptions).toHaveLength(1);
+      expect(partial.state.toString()).toContain(
+        'first partial approval secret',
+      );
+      expect(JSON.stringify(await session.getItems())).not.toContain(
+        'first partial approval secret',
+      );
+      expect(JSON.stringify(await session.getItems())).not.toContain(
+        'hosted partial approval secret',
+      );
+      partial.state.approve(partial.interruptions[0]);
+
+      if (verdict === 'pass') {
+        const completed = await runOnce(partial.state);
+        expect(completed.finalOutput).toBe('second approval secret');
+        expect(
+          completed.state._toolOutputGuardrailResults[0]?.output.outputInfo,
+        ).toBe('first approval tool guardrail secret');
+        expect(
+          completed.state._toolOutputGuardrailResults.at(-1)?.output,
+        ).toEqual({
+          behavior: { type: 'allow' },
+          outputInfo: 'second approval tool guardrail secret',
+        });
+        const acceptedHistory = JSON.stringify(await session.getItems());
+        expect(acceptedHistory).toContain('first partial approval secret');
+        expect(acceptedHistory).toContain('second approval secret');
+        expect(acceptedHistory).toContain('hosted partial approval secret');
+        expect(acceptedHistory).not.toContain(
+          'Output withheld by an output guardrail.',
+        );
+        return;
+      }
+
+      if (verdict === 'error') {
+        await expect(runOnce(partial.state)).rejects.toThrow(
+          'approval output guardrail failed',
+        );
+        expect(
+          partial.state._toolOutputGuardrailResults[0]?.output.outputInfo,
+        ).toBe('first approval tool guardrail secret');
+        expect(
+          partial.state._toolOutputGuardrailResults.at(-1)?.output,
+        ).toEqual({
+          behavior: { type: 'allow' },
+          outputInfo: 'second approval tool guardrail secret',
+        });
+        const completedHistory = JSON.stringify(await session.getItems());
+        expect(completedHistory).toContain('first partial approval secret');
+        expect(completedHistory).toContain('second approval secret');
+        expect(completedHistory).toContain('hosted partial approval secret');
+        return;
+      }
+
+      let tripwireError: OutputGuardrailTripwireTriggered<any> | undefined;
+      try {
+        await runOnce(partial.state);
+      } catch (error) {
+        expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+        tripwireError = error as OutputGuardrailTripwireTriggered<any>;
+      }
+      expect(tripwireError).toBeDefined();
+      const serializedState = tripwireError?.state?.toString() ?? '';
+      expect(serializedState).not.toContain('first partial approval secret');
+      expect(serializedState).not.toContain('second approval secret');
+      expect(serializedState).not.toContain('hosted partial approval secret');
+      expect(serializedState).not.toContain(
+        'first approval tool guardrail secret',
+      );
+      expect(serializedState).not.toContain(
+        'second approval tool guardrail secret',
+      );
+      expect(serializedState).toContain(
+        'Output withheld by an output guardrail.',
+      );
+      expect(
+        tripwireError?.state?._toolOutputGuardrailResults.at(-1)?.output,
+      ).toEqual({
+        behavior: { type: 'allow' },
+        outputInfo: undefined,
+      });
+      const postTripHistory = JSON.stringify(await session.getItems());
+      expect(postTripHistory).not.toContain('first partial approval secret');
+      expect(postTripHistory).not.toContain('second approval secret');
+      expect(postTripHistory).not.toContain('hosted partial approval secret');
+
+      const replayModel = new ScriptedModel([
+        modelResponse({
+          output: [assistantMessage('safe continuation')],
+          usage: new Usage(),
+        }),
+      ]);
+      const replayAgent = new Agent({
+        name: 'Partial approval replay agent',
+        model: replayModel,
+      });
+      let callbackHistory = '';
+      await run(replayAgent, 'Continue', {
+        session,
+        sessionInputCallback: (history, newItems) => {
+          callbackHistory = JSON.stringify(history);
+          return [...history, ...newItems];
+        },
+      });
+      expect(callbackHistory).not.toContain('first partial approval secret');
+      expect(callbackHistory).not.toContain('second approval secret');
+      expect(callbackHistory).not.toContain('hosted partial approval secret');
+      const replayInput = JSON.stringify(replayModel.calls[0]?.request.input);
+      expect(replayInput).not.toContain('first partial approval secret');
+      expect(replayInput).not.toContain('second approval secret');
+      expect(replayInput).not.toContain('hosted partial approval secret');
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      (
+        [
+          'pass',
+          'trip',
+          'ambiguous',
+          'namespace_mismatch',
+          'session',
+          'prior_tool_guardrail',
+        ] as const
+      ).map((verdict) => ({ mode, verdict })),
+    ),
+  )(
+    'handles a serialized $mode partial approval with a $verdict outcome',
+    async ({ mode, verdict }) => {
+      const firstExecute = vi.fn(async () => 'accepted first approval output');
+      const secondExecute = vi.fn(
+        async () => 'accepted second approval output',
+      );
+      const firstTool = tool({
+        name: 'portable_first_approval_tool',
+        description: 'Returns an output after the first approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        outputGuardrails:
+          verdict === 'prior_tool_guardrail'
+            ? [
+                defineToolOutputGuardrail({
+                  name: 'pre-serialization approval tool verdict',
+                  run: async () =>
+                    ToolGuardrailFunctionOutputFactory.allow(
+                      'pre-serialization approval guardrail secret',
+                    ),
+                }),
+              ]
+            : [],
+        execute: firstExecute,
+      });
+      const secondTool = tool({
+        name: 'portable_second_approval_tool',
+        description: 'Returns an output after the second approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: secondExecute,
+      });
+      const [namespacedFirstTool, namespacedSecondTool] = toolNamespace({
+        name: 'crm',
+        description: 'Namespaced approval tools.',
+        tools: [firstTool, secondTool],
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'portable_first_approval_tool',
+              {},
+              { callId: 'portable-first-call', namespace: 'crm' },
+            ),
+            functionCall(
+              'portable_second_approval_tool',
+              {},
+              { callId: 'portable-second-call', namespace: 'crm' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Portable serialized approval agent',
+        model,
+        tools: [namespacedFirstTool, namespacedSecondTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'passing portable approval guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: verdict === 'trip',
+            }),
+          },
+        ],
+      });
+      const session = new AppendOnlySession();
+      const runOnce = async (
+        input: string | RunState<unknown, typeof agent>,
+        resumeSession?: Session,
+      ) => {
+        const options = resumeSession ? { session: resumeSession } : {};
+        if (mode === 'streamed') {
+          const result = await run(agent, input, { ...options, stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(agent, input, options);
+      };
+
+      const first = await runOnce('Approve both portable tools.', session);
+      first.state.approve(first.interruptions[0]!);
+      const partial = await runOnce(first.state, session);
+      expect(partial.state._currentTurnPersistedItemCount).toBeGreaterThan(0);
+      const historicalSessionItems = await session.getItems();
+      const restored = await RunState.fromString(
+        agent,
+        partial.state.toString(),
+      );
+      restored.approve(restored.getInterruptions()[0]!);
+
+      if (verdict === 'ambiguous') {
+        restored._lastTurnResponse?.output.reverse();
+      }
+      if (verdict === 'namespace_mismatch') {
+        const responseCall = restored._lastTurnResponse?.output[0];
+        if (responseCall?.type === 'function_call') {
+          responseCall.namespace = 'billing';
+        }
+      }
+      if (
+        verdict === 'ambiguous' ||
+        verdict === 'namespace_mismatch' ||
+        verdict === 'session' ||
+        verdict === 'prior_tool_guardrail'
+      ) {
+        await expect(
+          runOnce(restored, verdict === 'session' ? session : undefined),
+        ).rejects.toThrow('current-response provenance was not preserved');
+        expect(secondExecute).not.toHaveBeenCalled();
+        expect(model.calls).toHaveLength(1);
+        expect(await session.getItems()).toEqual(historicalSessionItems);
+        if (verdict === 'prior_tool_guardrail') {
+          expect(
+            restored._toolOutputGuardrailResults[0]?.output.outputInfo,
+          ).toBe('pre-serialization approval guardrail secret');
+        }
+        return;
+      }
+
+      if (verdict === 'trip') {
+        let tripwire: OutputGuardrailTripwireTriggered<any> | undefined;
+        try {
+          await runOnce(restored);
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          tripwire = error as OutputGuardrailTripwireTriggered<any>;
+        }
+        expect(tripwire).toBeDefined();
+        expect(tripwire?.state?.toString()).not.toContain(
+          'accepted first approval output',
+        );
+        expect(tripwire?.state?.toString()).not.toContain(
+          'accepted second approval output',
+        );
+        expect(
+          tripwire?.state?._generatedItems
+            .filter(
+              (item) =>
+                'rawItem' in item &&
+                (item.rawItem.type === 'function_call' ||
+                  item.rawItem.type === 'function_call_result'),
+            )
+            .every(
+              (item) =>
+                'rawItem' in item &&
+                'namespace' in item.rawItem &&
+                item.rawItem.namespace === 'crm',
+            ),
+        ).toBe(true);
+        expect(firstExecute).toHaveBeenCalledTimes(1);
+        expect(secondExecute).toHaveBeenCalledTimes(1);
+        expect(model.calls).toHaveLength(1);
+        expect(restored._currentTurnPersistedItemCount).toBe(0);
+        expect(await session.getItems()).toEqual(historicalSessionItems);
+        return;
+      }
+
+      const completed = await runOnce(restored);
+
+      expect(completed.finalOutput).toBe('accepted second approval output');
+      expect(firstExecute).toHaveBeenCalledTimes(1);
+      expect(secondExecute).toHaveBeenCalledTimes(1);
+      expect(model.calls).toHaveLength(1);
+      expect(restored._currentTurnPersistedItemCount).toBe(0);
+      expect(await session.getItems()).toEqual(historicalSessionItems);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'starts no $mode Session write when the approval output guardrail is actually cancelled',
+    async (mode) => {
+      let notifyGuardrailStarted!: () => void;
+      const guardrailStarted = new Promise<void>((resolve) => {
+        notifyGuardrailStarted = resolve;
+      });
+      const controller = new AbortController();
+      const approvedTool = tool({
+        name: 'cancelled_guardrail_approval_tool',
+        description: 'Returns a terminal result before guardrail cancellation.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'cancelled approval guardrail secret',
+      });
+      const agent = new Agent({
+        name: 'Cancelled approval guardrail agent',
+        model: new ScriptedModel([
+          modelResponse({
+            output: [
+              functionCall(
+                'cancelled_guardrail_approval_tool',
+                {},
+                { callId: 'cancelled-approval-guardrail-call' },
+              ),
+            ],
+            usage: new Usage(),
+          }),
+        ]),
+        tools: [approvedTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'wait for actual approval guardrail cancellation',
+            execute: async () => {
+              notifyGuardrailStarted();
+              await new Promise<void>((_resolve, reject) => {
+                controller.signal.addEventListener(
+                  'abort',
+                  () => reject(controller.signal.reason),
+                  { once: true },
+                );
+              });
+              return { outputInfo: undefined, tripwireTriggered: false };
+            },
+          },
+        ],
+      });
+      const session = new MemorySession();
+      const first = await run(agent, 'Approve the cancellable tool.', {
+        session,
+      });
+      first.state.approve(first.interruptions[0]!);
+      const checkpoint = await session.getItems();
+      const addItems = vi.spyOn(session, 'addItems');
+
+      if (mode === 'streamed') {
+        const resumed = await run(agent, first.state, {
+          session,
+          signal: controller.signal,
+          stream: true,
+        });
+        const completion = resumed.completed.catch((error: unknown) => error);
+        await guardrailStarted;
+        controller.abort(new Error('cancel an active output guardrail'));
+        await completion;
+      } else {
+        const resumed = run(agent, first.state, {
+          session,
+          signal: controller.signal,
+        });
+        const completion = resumed.catch((error: unknown) => error);
+        await guardrailStarted;
+        controller.abort(new Error('cancel an active output guardrail'));
+        await completion;
+      }
+
+      expect(addItems).not.toHaveBeenCalled();
+      expect(await session.getItems()).toEqual(checkpoint);
+      expect(JSON.stringify(checkpoint)).not.toContain(
+        'cancelled approval guardrail secret',
+      );
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'retains a run_llm_again tool output when a later model output trips in $mode mode',
+    async (mode) => {
+      const sensitiveTool = tool({
+        name: 'sensitive_tool',
+        description: 'Returns a value for a later model turn.',
+        parameters: z.object({}),
+        execute: async () => 'tool output retained for the model',
+      });
+      const model = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall('sensitive_tool', {}, { callId: 'sensitive-call' }),
+          ],
+          usage: new Usage(),
+        }),
+        modelResponse({
+          output: [assistantMessage('blocked model output secret')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Later model trip Session agent',
+        model,
+        tools: [sensitiveTool],
+        toolUseBehavior: 'run_llm_again',
+        outputGuardrails: [
+          {
+            name: 'blocking output guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: true,
+            }),
+          },
+        ],
+      });
+      const session = new MemorySession();
+
+      if (mode === 'streamed') {
+        const result = await run(agent, 'input', { session, stream: true });
+        await expect(result.completed).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      } else {
+        await expect(run(agent, 'input', { session })).rejects.toBeInstanceOf(
+          OutputGuardrailTripwireTriggered,
+        );
+      }
+
+      const stored = JSON.stringify(await session.getItems());
+      expect(stored).toContain('tool output retained for the model');
+      expect(stored).not.toContain('blocked model output secret');
+      expect(stored).not.toContain('Output withheld by an output guardrail.');
+    },
+  );
+});

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -1890,13 +1890,13 @@ describe('Runner.run (streaming)', () => {
     expect(resumed.state._currentTurnInProgress).toBe(false);
     expect(resumed.finalOutput).toBe('cancelled');
     expect(guardrail.execute).toHaveBeenCalledTimes(1);
-    expect(saveResultSpy).toHaveBeenCalledTimes(3);
+    expect(saveResultSpy).toHaveBeenCalledTimes(2);
     expect(saveResultSpy.mock.calls[1]?.[2]).toEqual({
       compactionMode: 'input',
     });
-    expect(saveResultSpy.mock.calls[2]?.[2]).toEqual({
-      compactionMode: 'input',
-    });
+    expect(guardrail.execute.mock.invocationCallOrder[0]).toBeLessThan(
+      saveResultSpy.mock.invocationCallOrder[1]!,
+    );
     expect(agentEnd).toHaveBeenCalledTimes(1);
     expect(
       resumed.state._generatedItems.some(

--- a/packages/agents-core/test/runner/guardrails.test.ts
+++ b/packages/agents-core/test/runner/guardrails.test.ts
@@ -132,6 +132,58 @@ describe('runInputGuardrails', () => {
     expect(state._currentTurn).toBe(0);
   });
 
+  it('reads a successful input guardrail verdict once', async () => {
+    const agent = makeAgent({ name: 'SingleReadInput' });
+    const state = makeState(agent);
+    let reads = 0;
+    const output = {
+      outputInfo: { reason: 'blocked' },
+      get tripwireTriggered() {
+        reads += 1;
+        if (reads >= 2) {
+          throw new Error('input verdict was read twice');
+        }
+        return true;
+      },
+    };
+    const guardrail = defineInputGuardrail({
+      name: 'single-read-input',
+      execute: async () => output,
+    });
+
+    await expect(
+      withTrace('guardrails-input-single-read', () =>
+        runInputGuardrails(state, [guardrail]),
+      ),
+    ).rejects.toBeInstanceOf(InputGuardrailTripwireTriggered);
+    expect(reads).toBe(1);
+    expect(state._inputGuardrailResults[0]?.output).toBe(output);
+  });
+
+  it('does not publish an input result when its first verdict read fails', async () => {
+    const agent = makeAgent({ name: 'UnreadableInput' });
+    const state = makeState(agent);
+    let reads = 0;
+    const guardrail = defineInputGuardrail({
+      name: 'unreadable-input',
+      execute: async () => ({
+        outputInfo: { reason: 'unknown' },
+        get tripwireTriggered(): boolean {
+          reads += 1;
+          throw new Error('input verdict is unreadable');
+        },
+      }),
+    });
+
+    await expect(
+      withTrace('guardrails-input-unreadable', () =>
+        runInputGuardrails(state, [guardrail]),
+      ),
+    ).rejects.toBeInstanceOf(GuardrailExecutionError);
+    expect(reads).toBe(1);
+    expect(state._inputGuardrailResults).toEqual([]);
+  });
+
   it('wraps execution failures without mutating runner-owned turn state', async () => {
     const agent = makeAgent({ name: 'Error' });
     const state = makeState(agent);
@@ -302,6 +354,76 @@ describe('runOutputGuardrails', () => {
       ),
     ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
     expect(state._outputGuardrailResults).toHaveLength(1);
+  });
+
+  it('observes a successful output guardrail verdict once', async () => {
+    const agent = makeAgent({ name: 'SingleReadOutput' });
+    const state = makeState(agent);
+    let reads = 0;
+    const output = {
+      outputInfo: { reason: 'blocked' },
+      get tripwireTriggered() {
+        reads += 1;
+        if (reads >= 2) {
+          throw new Error('output verdict was read twice');
+        }
+        return true;
+      },
+    };
+    const guardrail = defineOutputGuardrail({
+      name: 'single-read-output',
+      execute: async () => output,
+    });
+    const observed: Array<{ result: object; tripwireTriggered: boolean }> = [];
+
+    await expect(
+      withTrace('guardrails-output-single-read', () =>
+        runOutputGuardrails(
+          state,
+          [guardrail as any],
+          'blocked',
+          (result, tripwireTriggered) => {
+            observed.push({ result, tripwireTriggered });
+          },
+        ),
+      ),
+    ).rejects.toBeInstanceOf(OutputGuardrailTripwireTriggered);
+    expect(reads).toBe(1);
+    expect(observed).toEqual([
+      {
+        result: state._outputGuardrailResults[0],
+        tripwireTriggered: true,
+      },
+    ]);
+    expect(state._outputGuardrailResults[0]?.output).toBe(output);
+  });
+
+  it('does not publish or observe an output result when its first verdict read fails', async () => {
+    const agent = makeAgent({ name: 'UnreadableOutput' });
+    const state = makeState(agent);
+    let reads = 0;
+    let observationCount = 0;
+    const guardrail = defineOutputGuardrail({
+      name: 'unreadable-output',
+      execute: async () => ({
+        outputInfo: { reason: 'unknown' },
+        get tripwireTriggered(): boolean {
+          reads += 1;
+          throw new Error('output verdict is unreadable');
+        },
+      }),
+    });
+
+    await expect(
+      withTrace('guardrails-output-unreadable', () =>
+        runOutputGuardrails(state, [guardrail as any], 'unknown', () => {
+          observationCount += 1;
+        }),
+      ),
+    ).rejects.toBeInstanceOf(GuardrailExecutionError);
+    expect(reads).toBe(1);
+    expect(observationCount).toBe(0);
+    expect(state._outputGuardrailResults).toEqual([]);
   });
 
   it('awaits sibling output guardrails before surfacing a tripwire', async () => {


### PR DESCRIPTION
This pull request fixes a replay-safety issue for terminal tool output rejected by an output guardrail. Non-streaming final results already waited for output guardrails to complete, and a trip did not return a normal final result; the issue was that rejected terminal tool output could still remain reachable through Session history, RunState, streaming replay state, the tripwire exception, or a subsequent model request. The fix applies the guardrail verdict to the persistence and replay boundary for the terminal-tool-derived current response: a passing response is saved normally, while a rejected current suffix is sanitized or discarded when it cannot be reconstructed safely.

### Solution

- Delays client-managed Session persistence until the terminal output-guardrail verdict is known.
- Identifies rejected current responses using trusted turn boundaries, object ownership, and structurally bounded current-response positions.
- Reconstructs supported function-call pairs from allowlisted fields, preserves namespaced tool identities, and replaces rejected output with provider-valid, data-free payloads.
- Applies the same canonical sanitized snapshot across SDK-owned model responses, generated items, processed tool actions, completion evidence, Session history, RunState, and public exceptions.
- Preserves accepted historical items and metadata even when historical and current calls share names, namespaces, or call IDs.
- Preserves tool-output guardrail verdicts while removing sensitive output aliases and guardrail metadata.
- Retains existing interrupted Session persistence for the literal `run_llm_again` behavior.
- Discards only the rejected current suffix when it contains an unsupported, malformed, or reasoning-bearing variant that cannot be reconstructed safely.

### Unaffected existing paths

- Runs without output guardrails retain their existing execution behavior.
- Client-managed Session persistence without output guardrails retains its released behavior.
- HITL interruption and resume without output guardrails retain their released suffix-persistence behavior.
- Ordinary assistant and max-turn output-guardrail failures preserve their existing output information, run data, and guardrail results.
- When an output guardrail passes, normal Session persistence and backend-error behavior remain unchanged.
- Ordinary output-guardrail execution errors preserve completed turns in Session history.
- Previously accepted turns and their processed metadata remain available for replay.
- Nonterminal `run_llm_again` approval interruptions retain completed sibling output in Session history.

### Guardrail-specific limitations

These limitations apply only to configurations that use output guardrails:

- A serialized output-bearing approval checkpoint can resume only when the current response boundary is structurally provable and no Session is attached; otherwise, ambiguous persisted ownership fails closed.
- Changing an interrupted `run_llm_again` state to terminal tool behavior after sibling output has already been persisted fails closed before further model, tool, or Session side effects.
- Named-stop and custom tool behaviors continue to defer interrupted Session persistence because they cannot be proven nonterminal before approval resolution.
- Some serialized terminal retries cannot resume when existing output-guardrail results lack enough trusted ownership information to distinguish accepted history from the rejected current response.
- If a completed terminal tool side effect is followed by actual cancellation or a persistence failure before Session storage completes, that side effect might not appear in Session history.
- A server-managed conversation fails closed only when output guardrails are enabled and the SDK cannot guarantee that rejected output is excluded from server-owned history.
- If a rejected terminal response cannot be reconstructed safely, the SDK prioritizes preventing raw-output replay over preserving that current response for later resume.

### Out of scope

- Retracting streaming deltas that were already delivered.
- Rolling back external side effects performed by terminal tools.
- Durable response provenance or a pending/accepted/rejected persistence lifecycle.
- Complete resume support for ambiguous serialized partial-approval states used with output guardrails.
- Atomic Session replacement, leases, or compare-and-swap coordination.
- Migration of legacy serialized states that lack trusted provenance.
- Physical deletion or at-rest erasure of records already stored by a backend.
- Mutation of raw objects retained by external application references.
- Reconstruction or deletion of server-managed conversation history.
- Redaction of tracing or other telemetry that was already emitted.
- Complete resumability after every output-guardrail trip, exception, cancellation, or unsupported response variant.