### PR TITLE
docs: fix access token typo in connectors example

### DIFF
--- a/examples/connectors/index.ts
+++ b/examples/connectors/index.ts
@@ -8,7 +8,7 @@ import {
 async function main(verbose: boolean, stream: boolean): Promise<void> {
   // 1. Visit https://developers.google.com/oauthplayground/
   // 2. Input https://www.googleapis.com/auth/calendar.events as the required scope
-  // 3. Grab the acccess token starting with "ya29."
+  // 3. Grab the access token starting with "ya29."
   const authorization = process.env.GOOGLE_CALENDAR_AUTHORIZATION;
   if (!authorization) {
     throw new Error(


### PR DESCRIPTION
This pull request fixes a spelling error in the Google Calendar connector setup instructions, making the access-token step clearer.