### PR TITLE
fix(openai): reject ignored explicit-client options

### DIFF
--- a/.changeset/reject-openai-provider-client-options.md
+++ b/.changeset/reject-openai-provider-client-options.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: reject organization and project with explicit OpenAIProvider clients

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -63,6 +63,12 @@ export class OpenAIProvider implements ModelProvider {
           'Cannot provide both websocketBaseURL and openAIClient',
         );
       }
+      if (typeof this.#options.organization !== 'undefined') {
+        throw new Error('Cannot provide both organization and openAIClient');
+      }
+      if (typeof this.#options.project !== 'undefined') {
+        throw new Error('Cannot provide both project and openAIClient');
+      }
       this.#client = this.#options.openAIClient as OpenAI;
     }
     this.#useResponses = this.#options.useResponses;

--- a/packages/agents-openai/test/openaiProvider.test.ts
+++ b/packages/agents-openai/test/openaiProvider.test.ts
@@ -59,6 +59,26 @@ describe('OpenAIProvider', () => {
     ).toThrow();
   });
 
+  it('throws when organization and openAIClient are provided', () => {
+    expect(
+      () =>
+        new OpenAIProvider({
+          organization: 'org-test',
+          openAIClient: {} as any,
+        }),
+    ).toThrow('Cannot provide both organization and openAIClient');
+  });
+
+  it('throws when project and openAIClient are provided', () => {
+    expect(
+      () =>
+        new OpenAIProvider({
+          project: 'proj-test',
+          openAIClient: {} as any,
+        }),
+    ).toThrow('Cannot provide both project and openAIClient');
+  });
+
   it('returns responses model when useResponses true', async () => {
     const provider = new OpenAIProvider({
       openAIClient: new FakeClient() as any,


### PR DESCRIPTION
This pull request fixes `OpenAIProvider` construction when a preconfigured `openAIClient` is combined with provider-level `organization` or `project` values. Those options were previously ignored because the supplied client was reused; construction now rejects both combinations with actionable errors, matching the ownership checks for the other client-construction options.