### PR TITLE
docs: document output guardrail replay safety

### DIFF
--- a/docs/src/content/docs/guides/guardrails.mdx
+++ b/docs/src/content/docs/guides/guardrails.mdx
@@ -10,10 +10,11 @@ import toolGuardrailsExample from '../../../../../examples/docs/guardrails/toolG
 
 Guardrails can run alongside your agents or block execution until they complete, allowing you to perform checks and validations on user input or agent output. For example, you may run a lightweight model as a guardrail before invoking an expensive model. If the guardrail detects malicious usage, it can trigger an error and stop the costly model from running.
 
-There are two kinds of guardrails:
+There are three guardrail families:
 
 1. **Input guardrails** run on the initial user input.
 2. **Output guardrails** run on the final agent output.
+3. **Tool guardrails** run around each custom function-tool invocation.
 
 ## Workflow boundaries
 
@@ -52,6 +53,16 @@ Output guardrails run in 3 steps:
 
 Output guardrail functions also receive an optional `details` object with the underlying `modelResponse` and the generated output items for the turn. Use this when the final output alone is not enough to decide whether the response should pass, for example when you want to inspect the full generated item list or provider response metadata before tripping the guardrail.
 
+### Rejected terminal tool outputs
+
+When `toolUseBehavior` makes a completed function-tool result the run's final output, output guardrails evaluate that result before the SDK treats the result as replayable final data. The guardrail receives the original candidate output. If the guardrail trips, the SDK replaces the rejected terminal result with `Output withheld by an output guardrail.` in SDK-owned run state, replay data, session history, and the public tripwire error.
+
+The SDK also sanitizes metadata that could retain aliases of the rejected output. For the current response, `OutputGuardrailResult.agentOutput` becomes the same placeholder and `OutputGuardrailResult.outputInfo` is removed. Current tool output guardrail results retain their verdict but omit `outputInfo`; a `rejectContent` result uses the placeholder as its message. Results and history from earlier accepted turns remain unchanged.
+
+For a recognized function call and result pair, the SDK preserves replay-safe identity and status fields while replacing the result content. If the SDK cannot prove which current response items belong to the rejected terminal output, it discards the ambiguous current-response suffix or fails closed instead of replaying it.
+
+This protection does not undo external tool side effects, retract output already emitted to application code, erase data already stored outside the SDK's control, or modify application-owned references to raw provider data.
+
 ## Tool guardrails
 
 Tool guardrails wrap **function tools** and let you validate or block tool calls before and after execution. They are configured on the tool itself (via `tool()` options) and run for every invocation of that tool.
@@ -73,7 +84,7 @@ Tool guardrails apply to function tools you define with `tool()`. Handoffs are p
 
 ## Tripwires
 
-When a guardrail fails, it signals this via a tripwire. As soon as a tripwire is triggered, the runner throws the corresponding error and halts execution.
+When a guardrail fails, it signals this via a tripwire. The runner first waits for sibling guardrails that started in the same batch to settle and records their completed results. The runner then throws the corresponding error and halts further run processing. With parallel input guardrails, model or tool work may already have started as described in [Execution modes](#execution-modes).
 
 ## Implementing a guardrail
 

--- a/docs/src/content/docs/guides/human-in-the-loop.mdx
+++ b/docs/src/content/docs/guides/human-in-the-loop.mdx
@@ -92,6 +92,8 @@ The human-in-the-loop flow is designed to be interruptible for longer periods of
 
 You can serialize the state using `result.state.toString()` (or `JSON.stringify(result.state)`) and resume later on by passing the serialized state into `RunState.fromString(agent, serializedState)` where `agent` is the instance of the agent that triggered the overall run.
 
+Output guardrails impose a stricter resume boundary when an approved function-tool result can become the run's final output. A live `RunState` can retain output ownership information that is not available after serialization. If a serialized checkpoint cannot prove which response owns the pending output, or an ambiguous output-bearing checkpoint is resumed with a session attached, the SDK fails closed with a `UserError` before further model, tool, or session side effects. Start a new run from safe input when this happens. Rebuild the same agent graph and preserve the original `toolUseBehavior`; do not assume that every output-bearing partial approval can round-trip through serialized state.
+
 When `RunState` is serialized, the SDK records stable agent identities for the handoff and `Agent.asTool()` graph. This lets paused runs resume even when distinct agents share the same `name`, as long as the process that resumes the run rebuilds the same agent graph.
 
 The `agent` passed to `RunState.fromString(agent, serializedState)` is the root of that rebuilt graph. During deserialization, the SDK traverses that agent's handoffs and `Agent.asTool()` references, then resolves every serialized agent reference in the state against the rebuilt graph. This includes the current agent and nested references held by generated items, processed model responses, and queued next steps.

--- a/docs/src/content/docs/guides/results.mdx
+++ b/docs/src/content/docs/guides/results.mdx
@@ -160,6 +160,8 @@ The `runContext` property is the supported public view of the run context on the
 
 `rawResponses` contains the raw model responses collected during the run. Multi-step runs can produce more than one response, for example across handoffs or repeated tool/model cycles.
 
+If an output guardrail rejects a terminal function-tool result, the SDK sanitizes the current response in `rawResponses` together with the other SDK-owned replay surfaces. Do not rely on rejected terminal tool output remaining inspectable through this property. See [Rejected terminal tool outputs](/openai-agents-js/guides/guardrails#rejected-terminal-tool-outputs) for the redaction boundary and limitations.
+
 Each response can also include `requestId`, the provider's request identifier when one is available. The OpenAI Responses and Chat Completions models populate it for streamed and non-streamed HTTP requests; treat it as optional because some providers and transports do not expose one.
 
 For Chat Completions text output, inspect the normalized `output_text` part's `providerData.annotations` to read URL citations. Non-streamed responses preserve the provider's message annotations. Streamed responses retain valid `url_citation` annotations received with text, deduplicate repeated citations, and ignore malformed or unsupported annotation shapes.
@@ -173,6 +175,8 @@ When `modelSettings.preserveRawUsage` is `true`, each completed response can als
 The `inputGuardrailResults` and `outputGuardrailResults` properties contain agent-level guardrail results. Tool guardrail results are exposed separately via `toolInputGuardrailResults` and `toolOutputGuardrailResults`.
 
 Use these arrays when you want to log guardrail decisions, inspect extra metadata returned by guardrail functions, or debug why a run was blocked.
+
+For a rejected terminal function-tool result, the SDK intentionally sanitizes current-response guardrail metadata. In `outputGuardrailResults`, `agentOutput` becomes `Output withheld by an output guardrail.` and `outputInfo` is removed. Current `toolOutputGuardrailResults` retain their verdict but omit `outputInfo`, and a `rejectContent` result uses the same placeholder as its message. Earlier accepted historical results remain unchanged.
 
 If one guardrail fails to execute, results from sibling guardrails that completed successfully remain in the run state. For streamed runs, inspect the result arrays after `completed` rejects; for non-streamed runs, the `GuardrailExecutionError` carries the same settled `state`.
 

--- a/docs/src/content/docs/guides/sessions.mdx
+++ b/docs/src/content/docs/guides/sessions.mdx
@@ -24,9 +24,7 @@ This removes the need to manually call `toInputList()` or stitch history between
 
 > Tip: To run the `OpenAIConversationsSession` examples on this page, set the `OPENAI_API_KEY` environment variable (or provide an `apiKey` when constructing the session) so the SDK can call the Conversations API.
 
-Use sessions when you want the SDK to manage client-side memory for you. If you are already using
-OpenAI server-managed state with `conversationId` or `previousResponseId`, you usually do not also
-need a session for the same conversation history.
+Use sessions when you want the SDK to manage client-side memory for you. If you are already using OpenAI server-managed state with `conversationId` or `previousResponseId`, you usually do not also need a session for the same conversation history.
 
 ---
 
@@ -44,8 +42,7 @@ Use `OpenAIConversationsSession` to sync memory with the [Conversations API](htt
 
 Reusing the same session instance ensures the agent receives the full conversation history before every turn and automatically persists new items. Switching to a different `Session` implementation requires no other code changes.
 
-For local demos, tests, or process-local chat state, `MemorySession` provides the same interface
-without talking to OpenAI:
+For local demos, tests, or process-local chat state, `MemorySession` provides the same interface without talking to OpenAI:
 
 <Code
   lang="typescript"
@@ -55,27 +52,26 @@ without talking to OpenAI:
 
 `OpenAIConversationsSession` constructor options:
 
-| Option           | Type     | Notes                                                          |
-| ---------------- | -------- | -------------------------------------------------------------- |
+| Option | Type | Notes |
+| --- | --- | --- |
 | `conversationId` | `string` | Reuse an existing conversation instead of creating one lazily. |
-| `client`         | `OpenAI` | Pass a preconfigured OpenAI client.                            |
-| `apiKey`         | `string` | API key used when creating an internal OpenAI client.          |
-| `baseURL`        | `string` | Base URL for OpenAI-compatible endpoints.                      |
-| `organization`   | `string` | OpenAI organization ID for requests.                           |
-| `project`        | `string` | OpenAI project ID for requests.                                |
+| `client` | `OpenAI` | Pass a preconfigured OpenAI client. |
+| `apiKey` | `string` | API key used when creating an internal OpenAI client. |
+| `baseURL` | `string` | Base URL for OpenAI-compatible endpoints. |
+| `organization` | `string` | OpenAI organization ID for requests. |
+| `project` | `string` | OpenAI project ID for requests. |
 
 `MemorySession` constructor options:
 
-| Option         | Type               | Notes                                                                    |
-| -------------- | ------------------ | ------------------------------------------------------------------------ |
-| `sessionId`    | `string`           | Stable identifier for logs or tests. Generated automatically by default. |
-| `initialItems` | `AgentInputItem[]` | Seed the session with existing history.                                  |
-| `logger`       | `Logger`           | Override the logger used for debug output.                               |
+| Option | Type | Notes |
+| --- | --- | --- |
+| `sessionId` | `string` | Stable identifier for logs or tests. Generated automatically by default. |
+| `initialItems` | `AgentInputItem[]` | Seed the session with existing history. |
+| `logger` | `Logger` | Override the logger used for debug output. |
 
 `MemorySession` stores everything in local process memory, so it is reset when your process exits.
 
-If you need to pre-create a conversation ID before constructing the session, use
-`startOpenAIConversationsSession(client?)` and pass the returned ID as `conversationId`.
+If you need to pre-create a conversation ID before constructing the session, use `startOpenAIConversationsSession(client?)` and pass the returned ID as `conversationId`.
 
 ---
 
@@ -87,6 +83,8 @@ If you need to pre-create a conversation ID before constructing the session, use
 - **After a non-streaming run** one call to `session.addItems()` persists both the original user input and the model outputs from the latest turn.
 - **For streaming runs** it writes the user input first and appends streamed outputs once the turn completes.
 - **When resuming from `RunResult.state`** (for approvals or other interruptions) keep passing the same `session`. The resumed turn is added to memory without re-preparing the input.
+
+When an output guardrail rejects a terminal function-tool result, the runner does not add the raw rejected result to new session history. The runner persists a replay-safe placeholder for a recognized function call and result pair, and omits an ambiguous current-response suffix rather than storing output whose ownership it cannot prove. This protection does not undo external tool side effects or erase data that an application stored outside the session pipeline.
 
 ---
 
@@ -153,13 +151,9 @@ When you pass an array of `AgentInputItem`s as the run input, provide a `session
   title="Truncate history with sessionInputCallback"
 />
 
-For string inputs the runner merges history automatically, so the callback is optional. The callback
-only runs when your turn input is already an item array.
+For string inputs the runner merges history automatically, so the callback is optional. The callback only runs when your turn input is already an item array.
 
-If you are also using `conversationId` or `previousResponseId`, keep at least one new item from the
-current turn in the callback result. Those server-managed APIs depend on the current-turn delta. If
-the callback drops every new item, the SDK restores the original new inputs and logs a warning
-instead of sending an empty delta.
+If you are also using `conversationId` or `previousResponseId`, keep at least one new item from the current turn in the callback result. Those server-managed APIs depend on the current-turn delta. If the callback drops every new item, the SDK restores the original new inputs and logs a warning instead of sending an empty delta.
 
 ---
 
@@ -175,7 +169,9 @@ Human-in-the-loop flows often pause a run to wait for approval:
   title="Resume a run with the same session"
 />
 
-When you resume from a previous `RunState`, the new turn is appended to the same memory record to preserve a single conversation history. Human-in-the-loop (HITL) flows stay fully compatible—approval checkpoints still round-trip through `RunState` while the session keeps the conversation history complete.
+When you resume from a previous `RunState`, the new turn is appended to the same memory record to preserve a single conversation history. Most human-in-the-loop (HITL) approval checkpoints round-trip through `RunState` while the session keeps the conversation history complete.
+
+Output guardrails impose a stricter boundary when an approved function-tool result can become the final output. If a serialized checkpoint does not contain enough provenance to identify the current output safely, the SDK fails closed before further model, tool, or session side effects. Some output-bearing approval checkpoints therefore cannot be resumed from serialized state with a session attached. Start a new run from safe input when the SDK reports this condition; do not work around it by replaying the rejected raw items.
 
 ---
 
@@ -193,27 +189,24 @@ When you resume from a previous `RunState`, the new turn is appended to the same
 
 `OpenAIResponsesCompactionSession` constructor options:
 
-| Option                    | Type                                          | Notes                                                                                                                                                 |
-| ------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `client`                  | `OpenAI`                                      | OpenAI client used for `responses.compact`.                                                                                                           |
-| `underlyingSession`       | `Session`                                     | Backing session store to clear/rewrite with compacted items. Defaults to an in-memory session for demos and must not be `OpenAIConversationsSession`. |
-| `model`                   | `OpenAI.ResponsesModel`                       | Model used for compaction requests. Defaults to the SDK's current default OpenAI model.                                                               |
-| `compactionMode`          | `'auto' \| 'previous_response_id' \| 'input'` | Controls whether compaction uses server response chaining or local input items.                                                                       |
-| `shouldTriggerCompaction` | `(context) => boolean \| Promise<boolean>`    | Custom trigger hook based on `responseId`, `compactionMode`, candidate items, and current session items.                                              |
+| Option | Type | Notes |
+| --- | --- | --- |
+| `client` | `OpenAI` | OpenAI client used for `responses.compact`. |
+| `underlyingSession` | `Session` | Backing session store to clear/rewrite with compacted items. Defaults to an in-memory session for demos and must not be `OpenAIConversationsSession`. |
+| `model` | `OpenAI.ResponsesModel` | Model used for compaction requests. Defaults to the SDK's current default OpenAI model. |
+| `compactionMode` | `'auto' \| 'previous_response_id' \| 'input'` | Controls whether compaction uses server response chaining or local input items. |
+| `shouldTriggerCompaction` | `(context) => boolean \| Promise<boolean>` | Custom trigger hook based on `responseId`, `compactionMode`, candidate items, and current session items. |
 
-`compactionMode: 'previous_response_id'` is useful when you are already chaining turns with
-Responses API response IDs. `compactionMode: 'input'` rebuilds compaction requests from the current
-session items instead, which is helpful when the response chain is unavailable or you want the
-underlying session contents to be the source of truth.
+`compactionMode: 'previous_response_id'` is useful when you are already chaining turns with Responses API response IDs. `compactionMode: 'input'` rebuilds compaction requests from the current session items instead, which is helpful when the response chain is unavailable or you want the underlying session contents to be the source of truth.
 
 `runCompaction(args)` options:
 
-| Option           | Type                                          | Notes                                                             |
-| ---------------- | --------------------------------------------- | ----------------------------------------------------------------- |
-| `responseId`     | `string`                                      | Latest Responses API response id for `previous_response_id` mode. |
-| `compactionMode` | `'auto' \| 'previous_response_id' \| 'input'` | Optional per-call override of the configured mode.                |
-| `store`          | `boolean`                                     | Indicates whether the last run stored server state.               |
-| `force`          | `boolean`                                     | Bypass `shouldTriggerCompaction` and compact immediately.         |
+| Option | Type | Notes |
+| --- | --- | --- |
+| `responseId` | `string` | Latest Responses API response id for `previous_response_id` mode. |
+| `compactionMode` | `'auto' \| 'previous_response_id' \| 'input'` | Optional per-call override of the configured mode. |
+| `store` | `boolean` | Indicates whether the last run stored server state. |
+| `force` | `boolean` | Bypass `shouldTriggerCompaction` and compact immediately. |
 
 `OpenAIResponsesCompactionSession` serializes mutations issued through the same wrapper instance. Calls to `runCompaction()`, `addItems()`, `popItem()`, and `clearSession()` run in invocation order, and the queue continues after a rejected operation, so later wrapper mutations do not interleave with replacement or rollback. A successful replacement or rollback keeps the wrapper's cached history aligned with the underlying session. If both replacement and restoration fail, recover the underlying session before continuing. This ordering guarantee does not coordinate a different wrapper instance or direct mutation of `underlyingSession`; coordinate those access paths in your application.
 


### PR DESCRIPTION
This pull request updates the 0.17.0 documentation for the output guardrail replay-safety behavior introduced by #1712.

It documents terminal tool-output withholding and diagnostic sanitization across run results and sessions, the fail-closed serialized approval boundary, and the three guardrail families and sibling-settlement timing. It also clarifies which external effects and application-owned data remain outside the SDK's redaction boundary.