### PR TITLE
fix(core): reject unsuccessful OpenAI Responses terminal states

### DIFF
--- a/.changeset/reject-terminal-responses.md
+++ b/.changeset/reject-terminal-responses.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: reject unsuccessful OpenAI Responses terminal states without losing billed usage

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -515,6 +515,15 @@ function rollbackUnstartedTurn(
   return true;
 }
 
+function recordModelFailureUsage(
+  usage: Usage,
+  state: RunState<any, any>,
+  recordUsage: (usage: Usage) => void,
+): void {
+  state.usage.add(usage);
+  recordUsage(usage);
+}
+
 function assertPendingInputServerOwnership(
   state: RunState<any, any>,
   conversationId: string | undefined,
@@ -1735,12 +1744,16 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             const pendingModelResponse = getResponseWithRetry(
               preparedCall.model,
               modelRequest,
-              serverConversationTracker
-                ? {
-                    onPossiblyAcceptedRequestFailure: () =>
-                      markServerInputAccepted(false),
-                  }
-                : undefined,
+              {
+                onModelFailureUsage: (usage) =>
+                  recordModelFailureUsage(usage, state, recordUsage),
+                ...(serverConversationTracker
+                  ? {
+                      onPossiblyAcceptedRequestFailure: () =>
+                        markServerInputAccepted(false),
+                    }
+                  : {}),
+              },
             );
             if (deferLocalPendingInputAdmission) {
               const modelResponseOutcome = pendingModelResponse.then(
@@ -2638,6 +2651,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                     this.config.traceIncludeSensitiveData,
                   ),
                 },
+                {
+                  onModelFailureUsage: (usage) =>
+                    recordModelFailureUsage(usage, result.state, recordUsage),
+                },
               );
               markAbortReconciliationComplete(
                 abortReconciliationState,
@@ -2696,6 +2713,8 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               preparedCall.model,
               modelRequest,
               {
+                onModelFailureUsage: (usage) =>
+                  recordModelFailureUsage(usage, result.state, recordUsage),
                 onModelTimeout: () => {
                   timedOutModelCallFailed = true;
                 },

--- a/packages/agents-core/src/runner/modelRetry.ts
+++ b/packages/agents-core/src/runner/modelRetry.ts
@@ -14,6 +14,11 @@ import type {
 import { ModelTimeoutError, UserError } from '../errors';
 import type { StreamEvent } from '../types/protocol';
 import { RequestUsage, Usage } from '../usage';
+import {
+  attachModelFailureUsage,
+  consumeModelFailureUsage,
+  createModelFailureUsageScope,
+} from './usageTracking';
 
 const DEFAULT_INITIAL_DELAY_MS = 250;
 const DEFAULT_MAX_DELAY_MS = 2_000;
@@ -68,6 +73,7 @@ type EvaluateRetryParams = {
 };
 
 type ModelRetryHandlers = {
+  onModelFailureUsage?: (usage: Usage) => void;
   onModelTimeout?: () => void;
   onPossiblyAcceptedRequestFailure?: () => void;
 };
@@ -82,42 +88,128 @@ type ModelAttemptScope = {
 
 function addFailedRetryAttemptsToUsage(
   usage: Usage,
-  failedRetryAttempts: number,
+  failedUsage: Array<Usage | undefined>,
 ): Usage {
-  if (failedRetryAttempts <= 0) {
+  if (failedUsage.length === 0) {
     return usage;
   }
 
   const inferredEndpoint = usage.requestUsageEntries?.[0]?.endpoint;
-  const requestUsageEntries = [
-    ...Array.from(
-      { length: failedRetryAttempts },
-      () =>
-        new RequestUsage({
-          endpoint: inferredEndpoint,
+  const combinedUsage = new Usage();
+  for (const failedAttemptUsage of failedUsage) {
+    combinedUsage.add(
+      failedAttemptUsage ??
+        new Usage({
+          requests: 1,
+          requestUsageEntries: [
+            new RequestUsage({
+              endpoint: inferredEndpoint,
+            }),
+          ],
         }),
-    ),
-    ...(usage.requestUsageEntries?.map((entry) => new RequestUsage(entry)) ?? [
-      new RequestUsage({
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
-        totalTokens: usage.totalTokens,
-        inputTokensDetails: usage.inputTokensDetails[0],
-        outputTokensDetails: usage.outputTokensDetails[0],
-        endpoint: inferredEndpoint,
-      }),
-    ]),
-  ];
+    );
+  }
 
-  return new Usage({
-    requests: usage.requests + failedRetryAttempts,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    totalTokens: usage.totalTokens,
-    inputTokensDetails: usage.inputTokensDetails,
-    outputTokensDetails: usage.outputTokensDetails,
-    requestUsageEntries,
-  });
+  combinedUsage.add(
+    usage.requestUsageEntries?.length
+      ? usage
+      : new Usage({
+          requests: usage.requests,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          totalTokens: usage.totalTokens,
+          inputTokensDetails: usage.inputTokensDetails,
+          outputTokensDetails: usage.outputTokensDetails,
+          requestUsageEntries: [
+            new RequestUsage({
+              inputTokens: usage.inputTokens,
+              outputTokens: usage.outputTokens,
+              totalTokens: usage.totalTokens,
+              inputTokensDetails: usage.inputTokensDetails[0],
+              outputTokensDetails: usage.outputTokensDetails[0],
+              endpoint: inferredEndpoint,
+            }),
+          ],
+        }),
+  );
+  return combinedUsage;
+}
+
+function combineKnownFailureUsage(
+  failedUsage: Array<Usage | undefined>,
+): Usage | undefined {
+  let combinedUsage: Usage | undefined;
+  for (const usage of failedUsage) {
+    if (!usage) {
+      continue;
+    }
+    combinedUsage ??= new Usage();
+    combinedUsage.add(usage);
+  }
+  return combinedUsage;
+}
+
+function createFailedAttemptUsageTracker(
+  onFailureUsage: ModelRetryHandlers['onModelFailureUsage'],
+) {
+  const failedUsage: Array<Usage | undefined> = [];
+  let pendingUsage: Usage | undefined;
+  const report = (usage: Usage) => {
+    pendingUsage ??= new Usage();
+    pendingUsage.add(usage);
+    // Runner accounting must not depend on a later response being admitted.
+    onFailureUsage?.(usage);
+  };
+  const finishAttempt = () => {
+    failedUsage.push(pendingUsage);
+    pendingUsage = undefined;
+  };
+  const takeKnownUsage = () => {
+    if (pendingUsage) {
+      finishAttempt();
+    }
+    const knownUsage = combineKnownFailureUsage(failedUsage);
+    failedUsage.length = 0;
+    return knownUsage;
+  };
+  return {
+    report,
+    hasAttempts: () => failedUsage.length > 0 || pendingUsage !== undefined,
+    record(error: unknown): void {
+      const usage = consumeModelFailureUsage(error);
+      if (usage) {
+        report(usage);
+      }
+      finishAttempt();
+    },
+    addTo(usage: Usage): Usage {
+      if (pendingUsage) {
+        finishAttempt();
+      }
+      const combinedUsage = addFailedRetryAttemptsToUsage(
+        usage,
+        onFailureUsage
+          ? failedUsage.filter((attemptUsage) => attemptUsage === undefined)
+          : failedUsage,
+      );
+      failedUsage.length = 0;
+      return combinedUsage;
+    },
+    finishFailure(error: unknown): void {
+      const replacementUsage = consumeModelFailureUsage(error);
+      if (replacementUsage) {
+        report(replacementUsage);
+      }
+      const knownUsage = takeKnownUsage();
+      if (knownUsage && !onFailureUsage) {
+        attachModelFailureUsage(error, knownUsage);
+      }
+    },
+    close(): void {
+      failedUsage.length = 0;
+      pendingUsage = undefined;
+    },
+  };
 }
 
 function withRunnerManagedRetry(request: ModelRequest): ModelRequest {
@@ -1068,115 +1160,134 @@ export async function getResponseWithRetry(
   const retryBackoff = request.modelSettings.retry?.backoff;
   const timeoutMs = validateModelTimeoutMs(request.modelSettings);
 
+  const failedAttemptUsage = createFailedAttemptUsageTracker(
+    handlers.onModelFailureUsage,
+  );
   let attempt = 1;
-  while (true) {
-    const requestForAttempt = shouldDisableProviderManagedRetry(
-      request,
-      attempt,
-    )
-      ? withRunnerManagedRetry(request)
-      : request;
-    const attemptScope = createModelAttemptScope(requestForAttempt, timeoutMs);
-    try {
-      const response = await model.getResponse(attemptScope.request);
-      throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
-      if (attemptScope.timedOut()) {
-        throw (
-          attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
-        );
-      }
-      if (attempt === 1) {
-        return response;
-      }
-      return {
-        ...response,
-        usage: addFailedRetryAttemptsToUsage(response.usage, attempt - 1),
-      };
-    } catch (caughtError) {
-      attemptScope.cleanup();
-      const error = attemptScope.normalizeError(caughtError);
-      let providerAdvice: ModelRetryAdvice | undefined;
-      try {
-        providerAdvice = await awaitWithTimedModelCallParentAbort(
-          getRetryAdvice(model, {
-            request,
-            error: caughtError,
-            stream: false,
-            attempt,
-          }),
-          request.signal,
-          timeoutMs,
-        );
-      } catch (retryAdviceError) {
-        if (attemptScope.timedOut() && isStatefulRequest(request)) {
-          handlers.onPossiblyAcceptedRequestFailure?.();
-        }
-        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
-        throw retryAdviceError;
-      }
-      providerAdvice = withTimeoutReplayAuthority(
-        providerAdvice,
-        attemptScope.timedOut(),
+  try {
+    while (true) {
+      const requestForAttempt = shouldDisableProviderManagedRetry(
+        request,
+        attempt,
+      )
+        ? withRunnerManagedRetry(request)
+        : request;
+      const attemptScope = createModelAttemptScope(
+        requestForAttempt,
+        timeoutMs,
       );
-      const authority = createProviderRetryAuthority(providerAdvice);
-      const markPossiblyAcceptedFailure = () => {
-        if (
-          requestMayHaveBeenAccepted(authority) ||
-          (attemptScope.timedOut() &&
-            isStatefulRequest(request) &&
-            authority.replaySafety !== 'safe')
-        ) {
-          handlers.onPossiblyAcceptedRequestFailure?.();
-        }
-      };
-      const throwIfParentAbortedAfterTimedFailure = () => {
-        if (timeoutMs !== undefined && request.signal?.aborted) {
-          markPossiblyAcceptedFailure();
-          throwAbortError(request.signal);
-        }
-      };
-      throwIfParentAbortedAfterTimedFailure();
-      let decision: ResolvedRetryDecision;
+      const usageScope = createModelFailureUsageScope(
+        attemptScope.request,
+        failedAttemptUsage.report,
+      );
       try {
-        decision = await awaitWithTimedModelCallParentAbort(
-          evaluateRetry({
-            error,
-            attempt,
-            maxRetries,
-            retryPolicy,
-            retryBackoff,
-            signal: request.signal,
-            stream: false,
-            request,
-            emittedVisibleEvent: false,
-            emittedRawModelEvent: false,
-            providerAdvice,
-          }),
-          request.signal,
-          timeoutMs,
-        );
-      } catch (retryError) {
-        markPossiblyAcceptedFailure();
+        const response = await model.getResponse(usageScope.request);
         throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
-        throw retryError;
-      }
-      throwIfParentAbortedAfterTimedFailure();
+        if (attemptScope.timedOut()) {
+          throw (
+            attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
+          );
+        }
+        if (!failedAttemptUsage.hasAttempts()) {
+          return response;
+        }
+        return {
+          ...response,
+          usage: failedAttemptUsage.addTo(response.usage),
+        };
+      } catch (caughtError) {
+        failedAttemptUsage.record(caughtError);
+        attemptScope.cleanup();
+        const error = attemptScope.normalizeError(caughtError);
+        let providerAdvice: ModelRetryAdvice | undefined;
+        try {
+          providerAdvice = await awaitWithTimedModelCallParentAbort(
+            getRetryAdvice(model, {
+              request,
+              error: caughtError,
+              stream: false,
+              attempt,
+            }),
+            request.signal,
+            timeoutMs,
+          );
+        } catch (retryAdviceError) {
+          if (attemptScope.timedOut() && isStatefulRequest(request)) {
+            handlers.onPossiblyAcceptedRequestFailure?.();
+          }
+          throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+          throw retryAdviceError;
+        }
+        providerAdvice = withTimeoutReplayAuthority(
+          providerAdvice,
+          attemptScope.timedOut(),
+        );
+        const authority = createProviderRetryAuthority(providerAdvice);
+        const markPossiblyAcceptedFailure = () => {
+          if (
+            requestMayHaveBeenAccepted(authority) ||
+            (attemptScope.timedOut() &&
+              isStatefulRequest(request) &&
+              authority.replaySafety !== 'safe')
+          ) {
+            handlers.onPossiblyAcceptedRequestFailure?.();
+          }
+        };
+        const throwIfParentAbortedAfterTimedFailure = () => {
+          if (timeoutMs !== undefined && request.signal?.aborted) {
+            markPossiblyAcceptedFailure();
+            throwAbortError(request.signal);
+          }
+        };
+        throwIfParentAbortedAfterTimedFailure();
+        let decision: ResolvedRetryDecision;
+        try {
+          decision = await awaitWithTimedModelCallParentAbort(
+            evaluateRetry({
+              error,
+              attempt,
+              maxRetries,
+              retryPolicy,
+              retryBackoff,
+              signal: request.signal,
+              stream: false,
+              request,
+              emittedVisibleEvent: false,
+              emittedRawModelEvent: false,
+              providerAdvice,
+            }),
+            request.signal,
+            timeoutMs,
+          );
+        } catch (retryError) {
+          markPossiblyAcceptedFailure();
+          throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+          throw retryError;
+        }
+        throwIfParentAbortedAfterTimedFailure();
 
-      if (!decision.retry) {
-        markPossiblyAcceptedFailure();
-        throw error;
-      }
+        if (!decision.retry) {
+          markPossiblyAcceptedFailure();
+          throw error;
+        }
 
-      try {
-        await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
-      } catch (retryDelayError) {
-        markPossiblyAcceptedFailure();
-        throw retryDelayError;
+        try {
+          await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+        } catch (retryDelayError) {
+          markPossiblyAcceptedFailure();
+          throw retryDelayError;
+        }
+        attempt += 1;
+      } finally {
+        usageScope.close();
+        attemptScope.cleanup();
       }
-      attempt += 1;
-    } finally {
-      attemptScope.cleanup();
     }
+  } catch (error) {
+    failedAttemptUsage.finishFailure(error);
+    throw error;
+  } finally {
+    failedAttemptUsage.close();
   }
 }
 
@@ -1190,150 +1301,171 @@ export async function* getStreamedResponseWithRetry(
   const retryBackoff = request.modelSettings.retry?.backoff;
   const timeoutMs = validateModelTimeoutMs(request.modelSettings);
 
+  const failedAttemptUsage = createFailedAttemptUsageTracker(
+    handlers.onModelFailureUsage,
+  );
   let attempt = 1;
-  while (true) {
-    let emittedVisibleEvent = false;
-    let emittedRawModelEvent = false;
-    const requestForAttempt = shouldDisableProviderManagedRetry(
-      request,
-      attempt,
-    )
-      ? withRunnerManagedRetry(request)
-      : request;
-    const attemptScope = createModelAttemptScope(requestForAttempt, timeoutMs);
-    try {
-      for await (const event of model.getStreamedResponse(
+  try {
+    while (true) {
+      let emittedVisibleEvent = false;
+      let emittedRawModelEvent = false;
+      const requestForAttempt = shouldDisableProviderManagedRetry(
+        request,
+        attempt,
+      )
+        ? withRunnerManagedRetry(request)
+        : request;
+      const attemptScope = createModelAttemptScope(
+        requestForAttempt,
+        timeoutMs,
+      );
+      const usageScope = createModelFailureUsageScope(
         attemptScope.request,
-      )) {
+        failedAttemptUsage.report,
+      );
+      try {
+        for await (const event of model.getStreamedResponse(
+          usageScope.request,
+        )) {
+          throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+          if (attemptScope.timedOut()) {
+            throw (
+              attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
+            );
+          }
+          if (event.type === 'model') {
+            emittedRawModelEvent = true;
+          }
+          emittedVisibleEvent = true;
+          if (event.type === 'response_done') {
+            attemptScope.cleanup();
+          }
+          if (
+            event.type === 'response_done' &&
+            failedAttemptUsage.hasAttempts()
+          ) {
+            yield {
+              ...event,
+              response: {
+                ...event.response,
+                usage: failedAttemptUsage.addTo(
+                  new Usage(event.response.usage),
+                ),
+              },
+            };
+            continue;
+          }
+          yield event;
+        }
         throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
         if (attemptScope.timedOut()) {
           throw (
             attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
           );
         }
-        if (event.type === 'model') {
-          emittedRawModelEvent = true;
+        return;
+      } catch (caughtError) {
+        failedAttemptUsage.record(caughtError);
+        attemptScope.cleanup();
+        const error = attemptScope.normalizeError(caughtError);
+        const markTimedOutFailure = () => {
+          if (attemptScope.timedOut()) {
+            handlers.onModelTimeout?.();
+          }
+        };
+        let providerAdvice: ModelRetryAdvice | undefined;
+        try {
+          providerAdvice = await awaitWithTimedModelCallParentAbort(
+            getRetryAdvice(model, {
+              request,
+              error: caughtError,
+              stream: true,
+              attempt,
+            }),
+            request.signal,
+            timeoutMs,
+          );
+        } catch (retryAdviceError) {
+          markTimedOutFailure();
+          if (attemptScope.timedOut() && isStatefulRequest(request)) {
+            handlers.onPossiblyAcceptedRequestFailure?.();
+          }
+          throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+          throw retryAdviceError;
         }
-        emittedVisibleEvent = true;
-        if (event.type === 'response_done') {
-          attemptScope.cleanup();
-        }
-        if (event.type === 'response_done' && attempt > 1) {
-          yield {
-            ...event,
-            response: {
-              ...event.response,
-              usage: addFailedRetryAttemptsToUsage(
-                new Usage(event.response.usage),
-                attempt - 1,
-              ),
-            },
-          };
-          continue;
-        }
-        yield event;
-      }
-      throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
-      if (attemptScope.timedOut()) {
-        throw (
-          attemptScope.timeoutError() ?? createModelTimeoutError(timeoutMs!)
+        providerAdvice = withTimeoutReplayAuthority(
+          providerAdvice,
+          attemptScope.timedOut(),
         );
-      }
-      return;
-    } catch (caughtError) {
-      attemptScope.cleanup();
-      const error = attemptScope.normalizeError(caughtError);
-      const markTimedOutFailure = () => {
-        if (attemptScope.timedOut()) {
-          handlers.onModelTimeout?.();
-        }
-      };
-      let providerAdvice: ModelRetryAdvice | undefined;
-      try {
-        providerAdvice = await awaitWithTimedModelCallParentAbort(
-          getRetryAdvice(model, {
-            request,
-            error: caughtError,
-            stream: true,
-            attempt,
-          }),
-          request.signal,
-          timeoutMs,
-        );
-      } catch (retryAdviceError) {
-        markTimedOutFailure();
-        if (attemptScope.timedOut() && isStatefulRequest(request)) {
-          handlers.onPossiblyAcceptedRequestFailure?.();
-        }
-        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
-        throw retryAdviceError;
-      }
-      providerAdvice = withTimeoutReplayAuthority(
-        providerAdvice,
-        attemptScope.timedOut(),
-      );
-      const authority = createProviderRetryAuthority(providerAdvice);
-      const markPossiblyAcceptedFailure = () => {
-        if (
-          requestMayHaveBeenAccepted(authority) ||
-          (attemptScope.timedOut() &&
-            isStatefulRequest(request) &&
-            authority.replaySafety !== 'safe')
-        ) {
-          handlers.onPossiblyAcceptedRequestFailure?.();
-        }
-      };
-      const throwIfParentAbortedAfterTimedFailure = () => {
-        if (timeoutMs !== undefined && request.signal?.aborted) {
+        const authority = createProviderRetryAuthority(providerAdvice);
+        const markPossiblyAcceptedFailure = () => {
+          if (
+            requestMayHaveBeenAccepted(authority) ||
+            (attemptScope.timedOut() &&
+              isStatefulRequest(request) &&
+              authority.replaySafety !== 'safe')
+          ) {
+            handlers.onPossiblyAcceptedRequestFailure?.();
+          }
+        };
+        const throwIfParentAbortedAfterTimedFailure = () => {
+          if (timeoutMs !== undefined && request.signal?.aborted) {
+            markPossiblyAcceptedFailure();
+            throwAbortError(request.signal);
+          }
+        };
+        throwIfParentAbortedAfterTimedFailure();
+        let decision: ResolvedRetryDecision;
+        try {
+          decision = await awaitWithTimedModelCallParentAbort(
+            evaluateRetry({
+              error,
+              attempt,
+              maxRetries,
+              retryPolicy,
+              retryBackoff,
+              signal: request.signal,
+              stream: true,
+              request,
+              emittedVisibleEvent,
+              emittedRawModelEvent,
+              providerAdvice,
+              allowUnsafeStreamReplayApproval: attemptScope.timedOut(),
+            }),
+            request.signal,
+            timeoutMs,
+          );
+        } catch (retryError) {
+          markTimedOutFailure();
           markPossiblyAcceptedFailure();
-          throwAbortError(request.signal);
+          throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
+          throw retryError;
         }
-      };
-      throwIfParentAbortedAfterTimedFailure();
-      let decision: ResolvedRetryDecision;
-      try {
-        decision = await awaitWithTimedModelCallParentAbort(
-          evaluateRetry({
-            error,
-            attempt,
-            maxRetries,
-            retryPolicy,
-            retryBackoff,
-            signal: request.signal,
-            stream: true,
-            request,
-            emittedVisibleEvent,
-            emittedRawModelEvent,
-            providerAdvice,
-            allowUnsafeStreamReplayApproval: attemptScope.timedOut(),
-          }),
-          request.signal,
-          timeoutMs,
-        );
-      } catch (retryError) {
-        markTimedOutFailure();
-        markPossiblyAcceptedFailure();
-        throwIfTimedModelCallParentAborted(request.signal, timeoutMs);
-        throw retryError;
-      }
-      throwIfParentAbortedAfterTimedFailure();
+        throwIfParentAbortedAfterTimedFailure();
 
-      if (!decision.retry) {
-        markTimedOutFailure();
-        markPossiblyAcceptedFailure();
-        throw error;
-      }
+        if (!decision.retry) {
+          markTimedOutFailure();
+          markPossiblyAcceptedFailure();
+          throw error;
+        }
 
-      try {
-        await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
-      } catch (retryDelayError) {
-        markTimedOutFailure();
-        markPossiblyAcceptedFailure();
-        throw retryDelayError;
+        try {
+          await waitForRetryDelay(request.signal, decision.delayMs ?? 0);
+        } catch (retryDelayError) {
+          markTimedOutFailure();
+          markPossiblyAcceptedFailure();
+          throw retryDelayError;
+        }
+        attempt += 1;
+      } finally {
+        usageScope.close();
+        attemptScope.cleanup();
       }
-      attempt += 1;
-    } finally {
-      attemptScope.cleanup();
     }
+  } catch (error) {
+    failedAttemptUsage.finishFailure(error);
+    throw error;
+  } finally {
+    failedAttemptUsage.close();
   }
 }

--- a/packages/agents-core/src/runner/usageTracking.ts
+++ b/packages/agents-core/src/runner/usageTracking.ts
@@ -1,4 +1,4 @@
-import type { Usage } from '../usage';
+import { Usage } from '../usage';
 
 export type UsageRecorder = (usage: Usage) => void;
 
@@ -7,6 +7,32 @@ const TOOL_USAGE_RECORDER_SYMBOL = Symbol.for(
 );
 const runnerParentUsageRecorders = new WeakMap<object, UsageRecorder>();
 const runStateUsageRecorders = new WeakMap<object, UsageRecorder>();
+const modelFailureUsageRecorders = new WeakMap<object, UsageRecorder>();
+
+const modelFailureUsageByError = new WeakMap<object, Usage>();
+
+function cloneUsage(usage: Usage): Usage {
+  return new Usage({
+    requests: usage.requests,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    totalTokens: usage.totalTokens,
+    inputTokensDetails: usage.inputTokensDetails.map((details) => ({
+      ...details,
+    })),
+    outputTokensDetails: usage.outputTokensDetails.map((details) => ({
+      ...details,
+    })),
+    requestUsageEntries: usage.requestUsageEntries?.map((entry) => ({
+      inputTokens: entry.inputTokens,
+      outputTokens: entry.outputTokens,
+      totalTokens: entry.totalTokens,
+      inputTokensDetails: { ...entry.inputTokensDetails },
+      outputTokensDetails: { ...entry.outputTokensDetails },
+      endpoint: entry.endpoint,
+    })),
+  });
+}
 
 export function setRunnerParentUsageRecorder(
   runner: object,
@@ -66,4 +92,56 @@ export function getToolUsageRecorder(
 
 export function recordToolUsage(details: unknown, usage: Usage): void {
   getToolUsageRecorder(details)?.(usage);
+}
+
+export function createModelFailureUsageScope<T extends { _internal?: object }>(
+  request: T,
+  recorder: UsageRecorder,
+): { request: T; close: () => void } {
+  const internal = { ...request._internal };
+  modelFailureUsageRecorders.set(internal, recorder);
+  return {
+    request: { ...request, _internal: internal },
+    close: () => modelFailureUsageRecorders.delete(internal),
+  };
+}
+
+export function reportModelFailureUsage(
+  request: object,
+  error: unknown,
+  usage: Usage,
+): void {
+  const internal = (request as { _internal?: object })._internal;
+  const recorder = internal && modelFailureUsageRecorders.get(internal);
+  if (recorder) {
+    recorder(cloneUsage(usage));
+  } else {
+    attachModelFailureUsage(error, usage);
+  }
+}
+
+export function attachModelFailureUsage(error: unknown, usage: Usage): void {
+  if (!error || typeof error !== 'object') {
+    return;
+  }
+
+  const existing = modelFailureUsageByError.get(error);
+  const combinedUsage = cloneUsage(usage);
+  if (existing) {
+    combinedUsage.add(existing);
+  }
+  modelFailureUsageByError.set(error, combinedUsage);
+}
+
+export function consumeModelFailureUsage(error: unknown): Usage | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+
+  const usage = modelFailureUsageByError.get(error);
+  if (!usage) {
+    return undefined;
+  }
+  modelFailureUsageByError.delete(error);
+  return cloneUsage(usage);
 }

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -1,5 +1,9 @@
 export { formatInlineData, getInlineMediaType } from './inlineData';
-export { recordToolUsage } from '../runner/usageTracking';
+export {
+  attachModelFailureUsage,
+  reportModelFailureUsage,
+  recordToolUsage,
+} from '../runner/usageTracking';
 export {
   assertValidCompactionItems,
   CompactionItemValidationError,

--- a/packages/agents-core/test/retryPolicy.test.ts
+++ b/packages/agents-core/test/retryPolicy.test.ts
@@ -1,6 +1,9 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   Agent,
+  InputGuardrailTripwireTriggered,
+  MemorySession,
+  ModelTimeoutError,
   retryPolicies,
   run,
   Runner,
@@ -17,6 +20,15 @@ import type {
 } from '../src/model';
 import type { StreamEvent } from '../src/types/protocol';
 import { RequestUsage, Usage } from '../src/usage';
+import {
+  getResponseWithRetry,
+  getStreamedResponseWithRetry,
+} from '../src/runner/modelRetry';
+import {
+  attachModelFailureUsage,
+  consumeModelFailureUsage,
+  reportModelFailureUsage,
+} from '../src/runner/usageTracking';
 import {
   ScriptedModel,
   modelError,
@@ -47,6 +59,29 @@ function errorWith<T extends Record<string, unknown>>(
 
 function textResponse(text: string, usage = new Usage({ requests: 1 })) {
   return modelResponse({ usage, output: [fakeModelMessage(text)] });
+}
+
+function responseUsage(inputTokens: number, outputTokens: number): Usage {
+  return new Usage({
+    requests: 1,
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    requestUsageEntries: [
+      new RequestUsage({
+        inputTokens,
+        outputTokens,
+        totalTokens: inputTokens + outputTokens,
+        endpoint: 'responses.create',
+      }),
+    ],
+  });
+}
+
+async function consumeRetryStream(model: Model, request: ModelRequest) {
+  for await (const _event of getStreamedResponseWithRetry(model, request)) {
+    // Consume the stream through its final success or error boundary.
+  }
 }
 
 beforeAll(() => {
@@ -996,14 +1031,16 @@ describe('retry policies', () => {
       responseStarted?: boolean;
       statefulRequest?: boolean;
     }> = [];
+    const firstError = new Error('request may have been accepted');
+    attachModelFailureUsage(firstError, responseUsage(3, 4));
     const model = new ScriptedModel([
-      modelError(new Error('request may have been accepted'), {
+      modelError(firstError, {
         suggested: false,
         replaySafety: 'unsafe',
         responseStarted: true,
         reason: 'request may have been accepted',
       }),
-      textResponse('Explicitly approved replay'),
+      textResponse('Explicitly approved replay', responseUsage(1, 1)),
     ]);
 
     const result = await run(
@@ -1036,6 +1073,563 @@ describe('retry policies', () => {
       responseStarted: true,
       statefulRequest: false,
     });
+    expect(result.state.usage).toMatchObject({
+      requests: 2,
+      inputTokens: 4,
+      outputTokens: 5,
+      totalTokens: 9,
+    });
+    expect(result.state.usage.requestUsageEntries).toEqual([
+      expect.objectContaining({
+        inputTokens: 3,
+        outputTokens: 4,
+        endpoint: 'responses.create',
+      }),
+      expect.objectContaining({
+        inputTokens: 1,
+        outputTokens: 1,
+        endpoint: 'responses.create',
+      }),
+    ]);
+    expect(result.rawResponses[0]?.usage).toMatchObject({
+      requests: 1,
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 2,
+    });
+  });
+
+  it('preserves known usage when an approved replay also fails', async () => {
+    const firstError = new Error('first terminal failure');
+    const finalError = new Error('final terminal failure');
+    attachModelFailureUsage(firstError, responseUsage(2, 3));
+    attachModelFailureUsage(finalError, responseUsage(5, 7));
+    const unsafeReplayAdvice = {
+      suggested: false,
+      replaySafety: 'unsafe' as const,
+      responseStarted: true,
+    };
+    const model = new ScriptedModel([
+      modelError(firstError, unsafeReplayAdvice),
+      modelError(finalError, unsafeReplayAdvice),
+    ]);
+
+    const error = await getResponseWithRetry(model, {
+      modelSettings: {
+        retry: {
+          maxRetries: 1,
+          backoff: { initialDelayMs: 0, jitter: false },
+          policy: () => ({ retry: true, approveUnsafeReplay: true }),
+        },
+      },
+    } as unknown as ModelRequest).catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBe(finalError);
+    expect(consumeModelFailureUsage(error)).toMatchObject({
+      requests: 2,
+      inputTokens: 7,
+      outputTokens: 10,
+      totalTokens: 17,
+      requestUsageEntries: [
+        expect.objectContaining({ inputTokens: 2, outputTokens: 3 }),
+        expect.objectContaining({ inputTokens: 5, outputTokens: 7 }),
+      ],
+    });
+    expect(consumeModelFailureUsage(error)).toBeUndefined();
+  });
+
+  it('moves known terminal usage to a retry policy error', async () => {
+    const terminalError = new Error('terminal failure');
+    const policyError = Object.freeze(new Error('retry policy failed'));
+    attachModelFailureUsage(terminalError, responseUsage(8, 13));
+    const model = new ScriptedModel([
+      modelError(terminalError, {
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      }),
+    ]);
+
+    const error = await getResponseWithRetry(model, {
+      modelSettings: {
+        retry: {
+          maxRetries: 1,
+          policy: () => {
+            throw policyError;
+          },
+        },
+      },
+    } as unknown as ModelRequest).catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBe(policyError);
+    expect(consumeModelFailureUsage(error)).toMatchObject({
+      requests: 1,
+      inputTokens: 8,
+      outputTokens: 13,
+      totalTokens: 21,
+    });
+  });
+
+  it('moves known terminal usage to a frozen retry advice error', async () => {
+    const terminalError = new Error('terminal failure');
+    const adviceError = Object.freeze(new Error('retry advice failed'));
+    attachModelFailureUsage(terminalError, responseUsage(3, 5));
+    const model = new ScriptedModel([
+      modelError(terminalError, () => {
+        throw adviceError;
+      }),
+    ]);
+
+    const error = await getResponseWithRetry(model, {
+      modelSettings: { retry: { maxRetries: 1 } },
+    } as unknown as ModelRequest).catch((caughtError: unknown) => caughtError);
+
+    expect(error).toBe(adviceError);
+    expect(consumeModelFailureUsage(error)).toMatchObject({
+      requests: 1,
+      inputTokens: 3,
+      outputTokens: 5,
+      totalTokens: 8,
+    });
+  });
+
+  it('moves known terminal usage to a frozen retry delay cancellation', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const terminalError = new Error('terminal failure');
+    const cancellationError = Object.freeze(new Error('retry cancelled'));
+    attachModelFailureUsage(terminalError, responseUsage(5, 8));
+    const model = new ScriptedModel([
+      modelError(terminalError, {
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      }),
+    ]);
+
+    try {
+      const resultPromise = getResponseWithRetry(model, {
+        signal: controller.signal,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            policy: () => ({
+              retry: true,
+              approveUnsafeReplay: true,
+              delayMs: 100,
+            }),
+          },
+        },
+      } as unknown as ModelRequest);
+
+      await vi.advanceTimersByTimeAsync(50);
+      controller.abort(cancellationError);
+      const error = await resultPromise.catch(
+        (caughtError: unknown) => caughtError,
+      );
+
+      expect(error).toBe(cancellationError);
+      expect(consumeModelFailureUsage(error)).toMatchObject({
+        requests: 1,
+        inputTokens: 5,
+        outputTokens: 8,
+        totalTokens: 13,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves known usage when a safe streaming retry succeeds', async () => {
+    const terminalError = new Error('retryable provider failure');
+    attachModelFailureUsage(terminalError, responseUsage(3, 4));
+    const model = new ScriptedModel([
+      modelError(terminalError, { suggested: true, replaySafety: 'safe' }),
+      textResponse('Recovered', responseUsage(1, 1)),
+    ]);
+    const result = await run(
+      new Agent({
+        name: 'StreamingUsageRetryAgent',
+        model,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: retryPolicies.providerSuggested(),
+          },
+        },
+      }),
+      'hello',
+      { stream: true },
+    );
+
+    await result.completed;
+    expect(result.state.usage).toMatchObject({
+      requests: 2,
+      inputTokens: 4,
+      outputTokens: 5,
+      totalTokens: 9,
+    });
+    expect(result.state.usage.requestUsageEntries).toHaveLength(2);
+    expect(consumeModelFailureUsage(terminalError)).toBeUndefined();
+  });
+
+  it.each([false, true])(
+    'retains failed usage when a guardrail rejects after retry success (stream=%s)',
+    async (stream) => {
+      let releaseGuardrail!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseGuardrail = resolve;
+      });
+      const firstError = new Error('retryable provider failure');
+      attachModelFailureUsage(firstError, responseUsage(3, 4));
+      const finishRetry = async () => {
+        releaseGuardrail();
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        return {
+          usage: responseUsage(1, 1),
+          output: [fakeModelMessage('Blocked retry output')],
+        };
+      };
+      const model = new ScriptedModel([
+        modelError(firstError, { suggested: true, replaySafety: 'safe' }),
+        stream
+          ? modelStreamResponder(() =>
+              (async function* () {
+                const response = await finishRetry();
+                yield {
+                  type: 'response_done',
+                  response: { id: 'blocked_retry', ...response },
+                } satisfies StreamEvent;
+              })(),
+            )
+          : modelResponder(finishRetry),
+      ]);
+      const session = new MemorySession();
+      const agent = new Agent({
+        name: 'RetryAdmissionGuardrailAgent',
+        model,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: retryPolicies.providerSuggested(),
+          },
+        },
+        inputGuardrails: [
+          {
+            name: 'parallel',
+            execute: async () => {
+              await gate;
+              return { outputInfo: null, tripwireTriggered: true };
+            },
+          },
+        ],
+      });
+      let error: unknown;
+      try {
+        if (stream) {
+          const result = await run(agent, 'hello', { stream: true, session });
+          await result.completed;
+        } else {
+          await run(agent, 'hello', { session });
+        }
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeInstanceOf(InputGuardrailTripwireTriggered);
+      const state = (error as InputGuardrailTripwireTriggered).state!;
+      // Non-streaming already records the successful response before this guardrail.
+      expect(state.usage).toMatchObject({
+        requests: stream ? 1 : 2,
+        totalTokens: stream ? 7 : 9,
+      });
+      expect(state.usage.requestUsageEntries).toHaveLength(stream ? 1 : 2);
+      expect(state._modelResponses).toHaveLength(stream ? 0 : 1);
+      expect(await session.getItems()).toEqual([]);
+      expect(model.calls).toHaveLength(2);
+      expect(consumeModelFailureUsage(firstError)).toBeUndefined();
+    },
+  );
+
+  it.each([false, true])(
+    'preserves direct retry aggregation without a Runner (stream=%s)',
+    async (stream) => {
+      const firstError = new Error('retryable provider failure');
+      attachModelFailureUsage(firstError, responseUsage(3, 4));
+      const model = new ScriptedModel([
+        modelError(firstError, { suggested: true, replaySafety: 'safe' }),
+        textResponse('Recovered', responseUsage(1, 1)),
+      ]);
+      const request = {
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: retryPolicies.providerSuggested(),
+          },
+        },
+      } as unknown as ModelRequest;
+      let usage: Usage | undefined;
+      if (stream) {
+        for await (const event of getStreamedResponseWithRetry(
+          model,
+          request,
+        )) {
+          if (event.type === 'response_done') {
+            usage = new Usage(event.response.usage);
+          }
+        }
+      } else {
+        usage = (await getResponseWithRetry(model, request)).usage;
+      }
+      expect(usage).toMatchObject({ requests: 2, totalTokens: 9 });
+      expect(usage?.requestUsageEntries).toHaveLength(2);
+    },
+  );
+
+  it('does not recount failed attempts after streaming usage was delivered', async () => {
+    const firstError = new Error('retryable provider failure');
+    const cleanupError = new Error('stream cleanup failed');
+    attachModelFailureUsage(firstError, responseUsage(3, 4));
+    const done = createDoneEvent('Recovered');
+    if (done.type === 'response_done') {
+      done.response.usage = responseUsage(1, 1);
+    }
+    const model = new ScriptedModel([
+      modelError(firstError, { suggested: true, replaySafety: 'safe' }),
+      modelStream(
+        (async function* () {
+          yield done;
+          throw cleanupError;
+        })(),
+      ),
+    ]);
+    const result = await run(
+      new Agent({
+        name: 'StreamingUsageCleanupAgent',
+        model,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            backoff: { initialDelayMs: 0, jitter: false },
+            policy: retryPolicies.providerSuggested(),
+          },
+        },
+      }),
+      'hello',
+      { stream: true },
+    );
+
+    await expect(result.completed).rejects.toBe(cleanupError);
+    expect(result.state.usage).toMatchObject({ requests: 2, totalTokens: 9 });
+    expect(result.state.usage.requestUsageEntries).toHaveLength(2);
+    expect(consumeModelFailureUsage(cleanupError)).toBeUndefined();
+  });
+
+  it.each(['advice', 'policy', 'delay'] as const)(
+    'moves known streamed usage to a frozen retry %s error',
+    async (phase) => {
+      const controller = new AbortController();
+      const terminalError = new Error('streamed terminal failure');
+      const replacementError = Object.freeze(
+        new Error(`retry ${phase} failed`),
+      );
+      attachModelFailureUsage(terminalError, responseUsage(3, 5));
+      const model = new ScriptedModel([
+        modelError(terminalError, () => {
+          if (phase === 'advice') {
+            throw replacementError;
+          }
+          return { suggested: true, replaySafety: 'safe' };
+        }),
+      ]);
+      const error = await consumeRetryStream(model, {
+        signal: controller.signal,
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            policy: () => {
+              if (phase === 'policy') {
+                throw replacementError;
+              }
+              queueMicrotask(() => controller.abort(replacementError));
+              return { retry: true, delayMs: 100 };
+            },
+          },
+        },
+      } as unknown as ModelRequest).catch((caught: unknown) => caught);
+
+      expect(error).toBe(replacementError);
+      expect(consumeModelFailureUsage(error)).toMatchObject({
+        requests: 1,
+        inputTokens: 3,
+        outputTokens: 5,
+        totalTokens: 8,
+      });
+      expect(consumeModelFailureUsage(error)).toBeUndefined();
+    },
+  );
+
+  it('moves known streamed usage to a normalized model timeout', async () => {
+    vi.useFakeTimers();
+    const terminalError = new Error('terminal failure after timeout');
+    attachModelFailureUsage(terminalError, responseUsage(2, 3));
+    const model = new ScriptedModel([
+      modelStreamResponder((call) =>
+        (async function* () {
+          yield* [];
+          await new Promise<void>((resolve) =>
+            call.request.signal?.addEventListener('abort', () => resolve(), {
+              once: true,
+            }),
+          );
+          throw terminalError;
+        })(),
+      ),
+    ]);
+
+    try {
+      const result = consumeRetryStream(model, {
+        modelSettings: { timeoutMs: 25 },
+      } as unknown as ModelRequest).catch((caught: unknown) => caught);
+      await vi.advanceTimersByTimeAsync(25);
+      const error = await result;
+
+      expect(error).toBeInstanceOf(ModelTimeoutError);
+      expect(consumeModelFailureUsage(error)).toMatchObject({
+        requests: 1,
+        inputTokens: 2,
+        outputTokens: 3,
+        totalTokens: 5,
+      });
+      expect(consumeModelFailureUsage(terminalError)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flushes reported usage when the retry iterator is returned early', async () => {
+    const terminalError = new Error('terminal failure');
+    const recordUsage = vi.fn();
+    // This double preserves the exact internal request identity used by the recorder.
+    const model: Model = {
+      async getResponse() {
+        throw new Error('not used');
+      },
+      async *getStreamedResponse(request) {
+        reportModelFailureUsage(request, terminalError, responseUsage(3, 4));
+        yield { type: 'model', event: { type: 'provider.terminal' } as any };
+        throw terminalError;
+      },
+    };
+    const iterator = getStreamedResponseWithRetry(
+      model,
+      { modelSettings: {} } as ModelRequest,
+      { onModelFailureUsage: recordUsage },
+    )[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).value?.type).toBe('model');
+    expect(recordUsage).toHaveBeenCalledTimes(1);
+    await iterator.return?.();
+    expect(recordUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsage.mock.calls[0][0]).toMatchObject({
+      requests: 1,
+      totalTokens: 7,
+    });
+    expect(consumeModelFailureUsage(terminalError)).toBeUndefined();
+  });
+
+  it('includes usage already carried by a retry replacement error', async () => {
+    const terminalError = new Error('terminal failure');
+    const replacementError = Object.freeze(new Error('policy failure'));
+    attachModelFailureUsage(terminalError, responseUsage(3, 4));
+    attachModelFailureUsage(replacementError, responseUsage(2, 3));
+    const recordUsage = vi.fn();
+    const model = new ScriptedModel([
+      modelError(terminalError, { suggested: true, replaySafety: 'safe' }),
+    ]);
+
+    await expect(
+      getResponseWithRetry(
+        model,
+        {
+          modelSettings: {
+            retry: {
+              maxRetries: 1,
+              policy: () => {
+                throw replacementError;
+              },
+            },
+          },
+        } as unknown as ModelRequest,
+        { onModelFailureUsage: recordUsage },
+      ),
+    ).rejects.toBe(replacementError);
+    expect(recordUsage).toHaveBeenCalledTimes(2);
+    const recordedUsage = new Usage();
+    for (const [usage] of recordUsage.mock.calls) {
+      recordedUsage.add(usage);
+    }
+    expect(recordedUsage).toMatchObject({
+      requests: 2,
+      totalTokens: 12,
+    });
+    expect(consumeModelFailureUsage(replacementError)).toBeUndefined();
+  });
+
+  it('records usage from handled stream abort and reconciliation failures', async () => {
+    const abortError = new DOMException('aborted', 'AbortError');
+    const reconciliationError = new Error('reconciliation failed');
+    attachModelFailureUsage(abortError, responseUsage(3, 4));
+    attachModelFailureUsage(reconciliationError, responseUsage(2, 3));
+    const model = new ScriptedModel([
+      modelStreamResponder(() =>
+        (async function* () {
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.created',
+              response: { id: 'resp_usage_abort' },
+            },
+          } as StreamEvent;
+          yield {
+            type: 'model',
+            event: {
+              type: 'response.output_item.done',
+              item: {
+                type: 'function_call',
+                id: 'fc_usage_abort',
+                call_id: 'call_usage_abort',
+                name: 'slow_tool',
+                arguments: '{}',
+                status: 'completed',
+              },
+            },
+          } as StreamEvent;
+          throw abortError;
+        })(),
+      ),
+      modelError(reconciliationError),
+    ]);
+    const result = await run(
+      new Agent({ name: 'ReconciliationUsageAgent', model }),
+      'hello',
+      { stream: true, conversationId: 'conv_usage_abort' },
+    );
+
+    await expect(result.completed).resolves.toBeUndefined();
+    expect(model.calls).toHaveLength(2);
+    expect(result.state.usage).toMatchObject({
+      requests: 2,
+      inputTokens: 5,
+      outputTokens: 7,
+      totalTokens: 12,
+    });
+    expect(result.state.usage.requestUsageEntries).toHaveLength(2);
+    expect(consumeModelFailureUsage(abortError)).toBeUndefined();
+    expect(consumeModelFailureUsage(reconciliationError)).toBeUndefined();
   });
 
   it('does not treat missing response-start evidence as explicit false', async () => {

--- a/packages/agents-core/test/runner/usageTracking.test.ts
+++ b/packages/agents-core/test/runner/usageTracking.test.ts
@@ -2,12 +2,49 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Usage } from '../../src/usage';
 import {
+  attachModelFailureUsage,
+  consumeModelFailureUsage,
+  createModelFailureUsageScope,
   getToolUsageRecorder,
   recordToolUsage,
+  reportModelFailureUsage,
   setToolUsageRecorder,
 } from '../../src/runner/usageTracking';
 
 describe('runner usage tracking', () => {
+  it('isolates request scopes and falls back to errors after scope cleanup', () => {
+    const request = Object.freeze({ _internal: { runnerManagedRetry: true } });
+    const firstRecorder = vi.fn();
+    const secondRecorder = vi.fn();
+    const first = createModelFailureUsageScope(request, firstRecorder);
+    const second = createModelFailureUsageScope(request, secondRecorder);
+    const firstError = Object.freeze(new Error('first'));
+    const secondError = Object.freeze(new Error('second'));
+    const usage = new Usage({ inputTokens: 3, outputTokens: 4 });
+
+    reportModelFailureUsage({ ...first.request }, firstError, usage);
+    reportModelFailureUsage(second.request, secondError, usage);
+    usage.inputTokens = 99;
+
+    expect(firstRecorder).toHaveBeenCalledTimes(1);
+    expect(secondRecorder).toHaveBeenCalledTimes(1);
+    expect(firstRecorder.mock.calls[0][0].inputTokens).toBe(3);
+    expect(consumeModelFailureUsage(firstError)).toBeUndefined();
+    expect(first.request._internal).not.toBe(second.request._internal);
+    expect(request._internal).toEqual({ runnerManagedRetry: true });
+
+    first.close();
+    first.close();
+    reportModelFailureUsage(
+      first.request,
+      firstError,
+      new Usage({ totalTokens: 5 }),
+    );
+    expect(firstRecorder).toHaveBeenCalledTimes(1);
+    expect(consumeModelFailureUsage(firstError)?.totalTokens).toBe(5);
+    second.close();
+  });
+
   it('records tool usage through non-enumerable tool details metadata', () => {
     const details = {};
     const recorder = vi.fn();
@@ -20,5 +57,100 @@ describe('runner usage tracking', () => {
     expect(recorder).toHaveBeenCalledOnce();
     expect(recorder).toHaveBeenCalledWith(usage);
     expect(Object.keys(details)).toEqual([]);
+  });
+
+  it('consumes detached model failure usage exactly once', () => {
+    const error = new Error('model failed');
+    const usage = new Usage({
+      inputTokens: 3,
+      outputTokens: 4,
+      totalTokens: 7,
+      inputTokensDetails: { cachedTokens: 1 },
+      requestUsageEntries: [
+        {
+          inputTokens: 3,
+          outputTokens: 4,
+          totalTokens: 7,
+          endpoint: 'responses.create',
+        },
+      ],
+    });
+
+    attachModelFailureUsage(error, usage);
+    usage.inputTokens = 100;
+
+    const consumed = consumeModelFailureUsage(error);
+    expect(consumed).toMatchObject({
+      requests: 1,
+      inputTokens: 3,
+      outputTokens: 4,
+      totalTokens: 7,
+    });
+    expect(consumed?.requestUsageEntries?.[0]?.endpoint).toBe(
+      'responses.create',
+    );
+    expect(consumeModelFailureUsage(error)).toBeUndefined();
+    expect(Object.keys(error)).toEqual([]);
+  });
+
+  it('prepends newly attached usage to unconsumed failure usage', () => {
+    const error = new Error('model failed after retry');
+    attachModelFailureUsage(
+      error,
+      new Usage({
+        requests: 1,
+        inputTokens: 5,
+        requestUsageEntries: [
+          {
+            inputTokens: 5,
+            outputTokens: 0,
+            totalTokens: 5,
+            endpoint: 'responses.create',
+          },
+        ],
+      }),
+    );
+    attachModelFailureUsage(
+      error,
+      new Usage({
+        requests: 1,
+        inputTokens: 3,
+        requestUsageEntries: [
+          {
+            inputTokens: 3,
+            outputTokens: 0,
+            totalTokens: 3,
+            endpoint: 'responses.create',
+          },
+        ],
+      }),
+    );
+
+    const consumed = consumeModelFailureUsage(error);
+    expect(consumed).toMatchObject({ requests: 2, inputTokens: 8 });
+    expect(
+      consumed?.requestUsageEntries?.map((entry) => entry.inputTokens),
+    ).toEqual([3, 5]);
+    expect(consumeModelFailureUsage(error)).toBeUndefined();
+  });
+
+  it('tracks failure usage without mutating a frozen error', () => {
+    const error = Object.freeze(new Error('frozen model error'));
+
+    expect(() =>
+      attachModelFailureUsage(
+        error,
+        new Usage({ inputTokens: 2, outputTokens: 3, totalTokens: 5 }),
+      ),
+    ).not.toThrow();
+
+    expect(consumeModelFailureUsage(error)).toMatchObject({
+      inputTokens: 2,
+      outputTokens: 3,
+      totalTokens: 5,
+    });
+    expect(consumeModelFailureUsage(error)).toBeUndefined();
+    expect(Object.keys(error)).toEqual([]);
+    expect(Object.getOwnPropertySymbols(error)).toEqual([]);
   });
 });

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -361,6 +361,11 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     return this.#normalizedResponses.get(response) ?? response;
   }
 
+  /** @internal */
+  protected override _getUnsuccessfulResponseTerminalType(): undefined {
+    return undefined;
+  }
+
   protected override _getResponseUsage(
     response: OpenAI.Responses.Response,
   ): Usage {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -7,6 +7,7 @@ import {
   resetCurrentSpan,
   protocol,
   UserError,
+  ModelBehaviorError,
 } from '@openai/agents-core';
 import type {
   ModelRetryAdvice,
@@ -78,6 +79,7 @@ import {
   normalizeHostedMcpRequireApproval,
 } from '@openai/agents-core/utils';
 import {
+  reportModelFailureUsage,
   assertValidCompactionItems,
   formatInlineData,
   getInlineMediaType,
@@ -379,8 +381,10 @@ function markUnsafeWebSocketReplayError(
     unsafeToReplay?: boolean;
     responseStarted?: boolean;
   };
-  replayError.unsafeToReplay = true;
-  if (responseStarted) {
+  if (replayError.unsafeToReplay !== true) {
+    replayError.unsafeToReplay = true;
+  }
+  if (responseStarted && replayError.responseStarted !== true) {
     replayError.responseStarted = true;
   }
 }
@@ -3227,6 +3231,7 @@ const TERMINAL_RESPONSES_STREAM_EVENT_TYPES = new Set([
   'response.failed',
   'response.incomplete',
   'response.error',
+  'error',
 ]);
 
 function isTerminalResponsesStreamEventType(
@@ -3236,6 +3241,51 @@ function isTerminalResponsesStreamEventType(
     typeof eventType === 'string' &&
     TERMINAL_RESPONSES_STREAM_EVENT_TYPES.has(eventType)
   );
+}
+
+type UnsuccessfulResponseError = ModelBehaviorError & {
+  readonly unsafeToReplay: true;
+  readonly responseStarted: true;
+};
+
+function getUnsuccessfulResponseTerminalType(
+  response: OpenAI.Responses.Response | undefined,
+  eventType?: string,
+): string | undefined {
+  if (
+    eventType === 'response.failed' ||
+    eventType === 'response.incomplete' ||
+    eventType === 'response.error' ||
+    eventType === 'error' ||
+    (eventType === 'response.completed' && !response)
+  ) {
+    return eventType;
+  }
+
+  const status = (response as { status?: unknown } | undefined)?.status;
+  return status === 'failed' || status === 'incomplete'
+    ? `response.${status}`
+    : undefined;
+}
+
+function createUnsuccessfulResponseError(
+  terminalType: string,
+  request: ModelRequest,
+  usage?: Usage,
+): UnsuccessfulResponseError {
+  const error = new ModelBehaviorError(
+    terminalType === 'response.completed'
+      ? 'OpenAI Responses terminal event "response.completed" is missing its required response payload.'
+      : `OpenAI Responses request ended with unsuccessful terminal state "${terminalType}".`,
+  ) as UnsuccessfulResponseError;
+  Object.defineProperties(error, {
+    unsafeToReplay: { value: true },
+    responseStarted: { value: true },
+  });
+  if (usage) {
+    reportModelFailureUsage(request, error, usage);
+  }
+  return error;
 }
 
 type ResponseStreamWithRequestID =
@@ -3331,6 +3381,16 @@ export class OpenAIResponsesModel implements Model {
     response: OpenAI.Responses.Response,
   ): OpenAI.Responses.Response {
     return response;
+  }
+
+  /**
+   * @internal
+   */
+  protected _getUnsuccessfulResponseTerminalType(
+    response: OpenAI.Responses.Response | undefined,
+    eventType?: string,
+  ): string | undefined {
+    return getUnsuccessfulResponseTerminalType(response, eventType);
   }
 
   /**
@@ -3653,11 +3713,23 @@ export class OpenAIResponsesModel implements Model {
             : undefined;
         const preservedUsage =
           rawUsage !== undefined ? this._getResponseUsage(response) : undefined;
+        const terminalType =
+          this._getUnsuccessfulResponseTerminalType(response);
 
         if (request.tracing) {
           span.spanData.response_id = response.id;
-          span.spanData._input = request.input;
-          span.spanData._response = response;
+          if (request.tracing === true || !terminalType) {
+            span.spanData._input = request.input;
+            span.spanData._response = response;
+          }
+        }
+
+        if (terminalType) {
+          throw createUnsuccessfulResponseError(
+            terminalType,
+            request,
+            preservedUsage ?? this._getResponseUsage(response),
+          );
         }
 
         return { response, rawUsage, preservedUsage };
@@ -3692,6 +3764,7 @@ export class OpenAIResponsesModel implements Model {
     const span = request.tracing
       ? createResponseSpan(undefined, getModelTracingParent(request))
       : undefined;
+    let terminalError: UnsuccessfulResponseError | undefined;
     try {
       if (span) {
         span.start();
@@ -3734,33 +3807,64 @@ export class OpenAIResponsesModel implements Model {
         } else if (isTerminalResponsesStreamEventType(eventType)) {
           const terminalEvent =
             event as OpenAI.Responses.ResponseStreamEvent & {
-              response: OpenAI.Responses.Response;
+              response?: OpenAI.Responses.Response;
             };
-          finalResponse = terminalEvent.response;
-          const { response, ...remainingEvent } = terminalEvent;
-          const {
-            output: _output,
-            usage: _usage,
-            id,
-            ...remainingResponse
-          } = response;
-          const responseForSDKOutput = this._getResponseForSDKOutput(response);
-          yield {
-            type: 'response_done',
-            response: {
-              id: id,
-              requestId: getOpenAIResponseRequestId(response),
-              output: this._convertResponseOutputItems(
-                responseForSDKOutput.output as Array<Record<string, any>>,
-              ),
-              usage: this._getStreamedResponseUsage(response),
-              ...(request.modelSettings.preserveRawUsage === true
-                ? { rawUsage: snapshotRawUsage(response.usage) }
-                : {}),
-              providerData: remainingResponse,
-            },
-            providerData: remainingEvent,
-          };
+          const terminalResponse = terminalEvent.response;
+          const unsuccessfulTerminalType =
+            this._getUnsuccessfulResponseTerminalType(
+              terminalResponse,
+              eventType,
+            );
+          if (unsuccessfulTerminalType) {
+            terminalError = createUnsuccessfulResponseError(
+              unsuccessfulTerminalType,
+              request,
+              terminalResponse
+                ? this._getResponseUsage(terminalResponse)
+                : undefined,
+            );
+            if (terminalResponse) {
+              finalResponse = terminalResponse;
+            }
+            if (span && terminalResponse) {
+              span.spanData.response_id = terminalResponse.id;
+              if (request.tracing === true) {
+                span.spanData._response = terminalResponse;
+              }
+            }
+            if (span?.error === null) {
+              span.setError({
+                message: terminalError.message,
+              });
+            }
+          } else if (terminalResponse) {
+            finalResponse = terminalResponse;
+            const { response: _response, ...remainingEvent } = terminalEvent;
+            const {
+              output: _output,
+              usage: _usage,
+              id,
+              ...remainingResponse
+            } = terminalResponse;
+            const responseForSDKOutput =
+              this._getResponseForSDKOutput(terminalResponse);
+            yield {
+              type: 'response_done',
+              response: {
+                id: id,
+                requestId: getOpenAIResponseRequestId(terminalResponse),
+                output: this._convertResponseOutputItems(
+                  responseForSDKOutput.output as Array<Record<string, any>>,
+                ),
+                usage: this._getStreamedResponseUsage(terminalResponse),
+                ...(request.modelSettings.preserveRawUsage === true
+                  ? { rawUsage: snapshotRawUsage(terminalResponse.usage) }
+                  : {}),
+                providerData: remainingResponse,
+              },
+              providerData: remainingEvent,
+            };
+          }
         } else if (eventType === 'response.output_text.delta') {
           const { delta, ...remainingEvent } = event as unknown as {
             delta: string;
@@ -3796,26 +3900,32 @@ export class OpenAIResponsesModel implements Model {
             },
           };
         }
+        if (terminalError) {
+          throw terminalError;
+        }
       }
 
       if (request.tracing && span && finalResponse) {
         span.spanData.response_id = finalResponse.id;
-        span.spanData._response = finalResponse;
+        if (request.tracing === true || !terminalError) {
+          span.spanData._response = finalResponse;
+        }
       }
     } catch (error) {
-      if (span) {
+      const errorToThrow = terminalError ?? error;
+      if (span?.error === null) {
         span.setError({
           message: 'Error streaming response',
           data: {
             error: request.tracing
-              ? String(error)
-              : error instanceof Error
-                ? error.name
+              ? String(errorToThrow)
+              : errorToThrow instanceof Error
+                ? errorToThrow.name
                 : undefined,
           },
         });
       }
-      throw error;
+      throw errorToThrow;
     } finally {
       if (span) {
         span.end();
@@ -3933,8 +4043,21 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
         receivedResponseEvent = true;
         const eventType = (event as { type?: string }).type;
         if (isTerminalResponsesStreamEventType(eventType)) {
-          finalResponse = (event as { response: OpenAI.Responses.Response })
-            .response;
+          const terminalResponse = (
+            event as { response?: OpenAI.Responses.Response }
+          ).response;
+          const unsuccessfulTerminalType =
+            this._getUnsuccessfulResponseTerminalType(
+              terminalResponse,
+              eventType,
+            );
+          if (unsuccessfulTerminalType && !terminalResponse) {
+            throw createUnsuccessfulResponseError(
+              unsuccessfulTerminalType,
+              request,
+            );
+          }
+          finalResponse = terminalResponse;
         }
       }
 
@@ -4055,12 +4178,6 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
           isRecord(payload) && typeof payload.type === 'string'
             ? payload.type
             : undefined;
-
-        if (eventType === 'error') {
-          throw new Error(
-            `Responses websocket error: ${JSON.stringify(payload)}`,
-          );
-        }
 
         const event = payload as OpenAI.Responses.ResponseStreamEvent;
         const isTerminalResponseEvent =

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -11,6 +11,7 @@ import {
   retryPolicies,
   Runner,
   type AgentInputItem,
+  type ModelRequest,
   type Session,
   setDefaultModelProvider,
   setTraceProcessors,
@@ -18,6 +19,7 @@ import {
   withTrace,
   type ResponseStreamEvent,
   Span,
+  ModelBehaviorError,
 } from '@openai/agents-core';
 import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
 import { FAKE_ID } from '../src/openaiItemIds';
@@ -489,6 +491,244 @@ describe('OpenAIResponsesModel', () => {
       expect(result.responseId).toBe('res1');
       expect(result.rawUsage).toBeUndefined();
     });
+  });
+
+  it.each(['failed', 'incomplete'] as const)(
+    'getResponse rejects an unsuccessful %s response before output processing',
+    async (status) => {
+      const sensitiveDetail = 'sensitive-provider-detail';
+      const fakeResponse = {
+        id: 'resp_unsuccessful',
+        status,
+        usage: {
+          input_tokens: 3,
+          output_tokens: 4,
+          total_tokens: 7,
+        },
+        output: [{ type: 'unsupported_output', secret: sensitiveDetail }],
+        error: { message: sensitiveDetail },
+        incomplete_details: { reason: sensitiveDetail },
+      };
+      const createMock = vi.fn().mockResolvedValue(fakeResponse);
+      const model = new OpenAIResponsesModel(
+        { responses: { create: createMock } } as unknown as OpenAI,
+        'gpt-test',
+      );
+      const request = {
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any;
+
+      const error = await withTrace('test', () =>
+        model.getResponse(request),
+      ).catch((caught: unknown) => caught as any);
+
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect(error.message).toBe(
+        `OpenAI Responses request ended with unsuccessful terminal state "response.${status}".`,
+      );
+      expect(error.message).not.toContain(sensitiveDetail);
+      expect(error.data).toBeUndefined();
+      expect(Object.keys(error)).not.toContain('unsafeToReplay');
+      expect(Object.keys(error)).not.toContain('responseStarted');
+      expect(
+        model.getRetryAdvice({ error, request, stream: false, attempt: 1 }),
+      ).toMatchObject({
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      });
+    },
+  );
+
+  it('preserves incomplete response usage in Runner accounting', async () => {
+    setTracingDisabled(false);
+    let taskSpan: Span<any> | undefined;
+    let turnSpan: Span<any> | undefined;
+    setTraceProcessors([
+      {
+        async onTraceStart() {},
+        async onTraceEnd() {},
+        async onSpanStart() {},
+        async onSpanEnd(span: Span<any>) {
+          if (span.spanData.type === 'task') {
+            taskSpan = span;
+          }
+          if (span.spanData.type === 'turn') {
+            turnSpan = span;
+          }
+        },
+        async shutdown() {},
+        async forceFlush() {},
+      },
+    ]);
+    const model = new OpenAIResponsesModel(
+      {
+        responses: {
+          create: vi.fn().mockResolvedValue({
+            id: 'resp_incomplete_usage',
+            status: 'incomplete',
+            usage: {
+              input_tokens: 3,
+              output_tokens: 4,
+              total_tokens: 7,
+              input_tokens_details: { cached_tokens: 1 },
+              output_tokens_details: { reasoning_tokens: 2 },
+            },
+            output: [],
+            incomplete_details: { reason: 'max_output_tokens' },
+          }),
+        },
+      } as unknown as OpenAI,
+      'gpt-test',
+    );
+    const agent = new Agent({ name: 'IncompleteUsageAgent', model });
+
+    const error = await new Runner()
+      .run(agent, 'hello')
+      .catch((caught: unknown) => caught as any);
+
+    expect(error).toBeInstanceOf(ModelBehaviorError);
+    expect(taskSpan?.spanData.usage).toMatchObject({
+      requests: 1,
+      input_tokens: 3,
+      output_tokens: 4,
+      total_tokens: 7,
+    });
+    expect(turnSpan?.spanData.usage).toMatchObject({
+      input_tokens: 3,
+      output_tokens: 4,
+      cached_input_tokens: 1,
+    });
+  });
+
+  it('getResponse accepts an explicitly completed response', async () => {
+    const model = new OpenAIResponsesModel(
+      {
+        responses: {
+          create: vi.fn().mockResolvedValue({
+            id: 'resp_completed',
+            status: 'completed',
+            usage: {},
+            output: [],
+          }),
+        },
+      } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    const result = await withTrace('test', () =>
+      model.getResponse({
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any),
+    );
+
+    expect(result.responseId).toBe('resp_completed');
+    expect(result.output).toEqual([]);
+  });
+
+  it('redacts an unsuccessful non-streaming response from no-data tracing', async () => {
+    setTracingDisabled(false);
+    let responseSpan: Span<any> | undefined;
+    setTraceProcessors([
+      {
+        async onTraceStart() {},
+        async onTraceEnd() {},
+        async onSpanStart() {},
+        async onSpanEnd(span: Span<any>) {
+          if (span.spanData.type === 'response') {
+            responseSpan = span;
+          }
+        },
+        async shutdown() {},
+        async forceFlush() {},
+      },
+    ]);
+    const sensitiveDetail = 'sensitive-no-data-response';
+    const model = new OpenAIResponsesModel(
+      {
+        responses: {
+          create: vi.fn().mockResolvedValue({
+            id: 'resp_no_data_incomplete',
+            status: 'incomplete',
+            usage: {},
+            output: [],
+            incomplete_details: { reason: sensitiveDetail },
+          }),
+        },
+      } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    await expect(
+      withTrace('test', () =>
+        model.getResponse({
+          systemInstructions: undefined,
+          input: sensitiveDetail,
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: 'enabled_without_data',
+          signal: undefined,
+        } as any),
+      ),
+    ).rejects.toThrow(ModelBehaviorError);
+
+    expect(responseSpan?.spanData.response_id).toBe('resp_no_data_incomplete');
+    expect(responseSpan?.spanData._input).toBeUndefined();
+    expect(responseSpan?.spanData._response).toBeUndefined();
+    expect(JSON.stringify(responseSpan?.error)).not.toContain(sensitiveDetail);
+  });
+
+  it('does not persist an unsuccessful non-streaming response as a successful turn', async () => {
+    const fakeResponse = {
+      id: 'resp_incomplete_tool',
+      status: 'incomplete',
+      usage: {},
+      output: [
+        {
+          type: 'function_call',
+          id: 'fc_incomplete',
+          call_id: 'call_incomplete',
+          name: 'lookup',
+          arguments: '{}',
+        },
+      ],
+    };
+    const model = new OpenAIResponsesModel(
+      {
+        responses: { create: vi.fn().mockResolvedValue(fakeResponse) },
+      } as unknown as OpenAI,
+      'gpt-test',
+    );
+    const addItems = vi.fn(async (_items: AgentInputItem[]) => {});
+    const session: Session = {
+      getSessionId: vi.fn().mockResolvedValue('terminal-failure-session'),
+      getItems: vi.fn().mockResolvedValue([]),
+      addItems,
+      popItem: vi.fn().mockResolvedValue(undefined),
+      clearSession: vi.fn().mockResolvedValue(undefined),
+    };
+    const agent = new Agent({ name: 'TerminalFailureAgent', model });
+
+    await expect(
+      new Runner().run(agent, 'persist-me', { session }),
+    ).rejects.toThrow(ModelBehaviorError);
+    expect(addItems).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -4985,6 +5225,681 @@ describe('OpenAIResponsesModel', () => {
     expect(
       received.filter((event) => event.type === 'response_done'),
     ).toHaveLength(1);
+  });
+
+  it.each([
+    ['response.incomplete', 'incomplete'],
+    ['response.failed', 'failed'],
+    ['error', undefined],
+  ] as const)(
+    'rejects terminal stream event %s after preserving the raw event and cleanup',
+    async (terminalEventType, status) => {
+      let cleanedUp = false;
+      const sensitiveDetail = 'sensitive-stream-detail';
+      const terminalEvent =
+        terminalEventType === 'error'
+          ? ({
+              type: 'error',
+              code: 'server_error',
+              message: sensitiveDetail,
+              param: null,
+              sequence_number: 0,
+            } satisfies OpenAIResponseStreamEvent)
+          : {
+              type: terminalEventType,
+              response: {
+                id: 'resp_stream_unsuccessful',
+                status,
+                output: [],
+                usage: {},
+                error: { message: sensitiveDetail },
+                incomplete_details: { reason: sensitiveDetail },
+              },
+              sequence_number: 0,
+            };
+      async function* fakeStream() {
+        try {
+          yield terminalEvent;
+        } finally {
+          cleanedUp = true;
+        }
+      }
+      const model = new OpenAIResponsesModel(
+        {
+          responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+        } as unknown as OpenAI,
+        'model-stream',
+      );
+      const request = {
+        systemInstructions: undefined,
+        input: 'data',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any;
+      const received: ResponseStreamEvent[] = [];
+
+      const error = await (async () => {
+        try {
+          for await (const event of model.getStreamedResponse(request)) {
+            received.push(event);
+          }
+        } catch (caught) {
+          return caught;
+        }
+      })();
+
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect((error as Error).message).toBe(
+        `OpenAI Responses request ended with unsuccessful terminal state "${terminalEventType}".`,
+      );
+      expect((error as Error).message).not.toContain(sensitiveDetail);
+      expect(cleanedUp).toBe(true);
+      expect(
+        received.filter((event) => event.type === 'response_done'),
+      ).toEqual([]);
+      expect(
+        received.filter(
+          (event) =>
+            event.type === 'model' && event.event.type === terminalEventType,
+        ),
+      ).toHaveLength(1);
+      expect(
+        model.getRetryAdvice({ error, request, stream: true, attempt: 1 }),
+      ).toMatchObject({
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      });
+    },
+  );
+
+  it.each([undefined, null])(
+    'rejects a completed stream event with response=%s',
+    async (response) => {
+      setTracingDisabled(false);
+      let responseSpan: Span<any> | undefined;
+      setTraceProcessors([
+        {
+          async onTraceStart() {},
+          async onTraceEnd() {},
+          async onSpanStart(span: Span<any>) {
+            if (span.spanData.type === 'response') {
+              responseSpan = span;
+            }
+          },
+          async onSpanEnd() {},
+          async shutdown() {},
+          async forceFlush() {},
+        },
+      ]);
+      const terminalEvent = {
+        type: 'response.completed',
+        ...(response === undefined ? {} : { response }),
+        sequence_number: 0,
+      };
+      let cleanedUp = false;
+      let readPastTerminal = false;
+      async function* fakeStream() {
+        try {
+          yield terminalEvent;
+          readPastTerminal = true;
+        } finally {
+          cleanedUp = true;
+        }
+      }
+      const model = new OpenAIResponsesModel(
+        {
+          responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+        } as unknown as OpenAI,
+        'model-stream',
+      );
+      const request = {
+        systemInstructions: undefined,
+        input: 'sensitive malformed response input',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: 'enabled_without_data',
+      } as ModelRequest;
+      const message =
+        'OpenAI Responses terminal event "response.completed" is missing its required response payload.';
+      const error = await withTrace('test', async () => {
+        const iterator = model
+          .getStreamedResponse(request)
+          [Symbol.asyncIterator]();
+        expect((await iterator.next()).value).toMatchObject({
+          type: 'model',
+          event: terminalEvent,
+        });
+        expect(responseSpan?.error).toEqual({ message });
+        return iterator.next().catch((caught: unknown) => caught);
+      });
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect((error as Error).message).toBe(message);
+      expect(JSON.stringify(responseSpan?.spanData)).not.toContain(
+        request.input,
+      );
+      expect(cleanedUp).toBe(true);
+      expect(readPastTerminal).toBe(false);
+      expect(
+        model.getRetryAdvice({ error, request, stream: true, attempt: 1 }),
+      ).toMatchObject({
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      });
+    },
+  );
+
+  it('closes the stream after the first unsuccessful terminal', async () => {
+    setTracingDisabled(false);
+    let responseSpan: Span<any> | undefined;
+    setTraceProcessors([
+      {
+        async onTraceStart() {},
+        async onTraceEnd() {},
+        async onSpanStart() {},
+        async onSpanEnd(span: Span<any>) {
+          if (span.spanData.type === 'response') {
+            responseSpan = span;
+          }
+        },
+        async shutdown() {},
+        async forceFlush() {},
+      },
+    ]);
+    let cleanedUp = false;
+    const unsuccessfulEvent = {
+      type: 'response.incomplete',
+      response: {
+        id: 'resp_first_incomplete',
+        status: 'incomplete',
+        output: [],
+        usage: {
+          input_tokens: 3,
+          output_tokens: 4,
+          total_tokens: 7,
+          input_tokens_details: { cached_tokens: 1 },
+          output_tokens_details: { reasoning_tokens: 2 },
+        },
+        incomplete_details: { reason: 'max_output_tokens' },
+      },
+      sequence_number: 0,
+    } as const;
+    const laterCompletedEvent: OpenAIResponseStreamEvent = {
+      type: 'response.completed',
+      response: {
+        id: 'resp_later_completed',
+        status: 'completed',
+        output: [],
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      } as any,
+      sequence_number: 1,
+    };
+    async function* fakeStream() {
+      try {
+        yield unsuccessfulEvent;
+        yield laterCompletedEvent;
+      } finally {
+        cleanedUp = true;
+      }
+    }
+    const model = new OpenAIResponsesModel(
+      {
+        responses: {
+          create: vi.fn().mockImplementation(async () => fakeStream()),
+        },
+      } as unknown as OpenAI,
+      'model-stream',
+    );
+    const request = {
+      systemInstructions: undefined,
+      input: 'data',
+      modelSettings: {},
+      tools: [],
+      outputType: 'text',
+      handoffs: [],
+      tracing: 'enabled_without_data',
+      signal: undefined,
+    } as any;
+    const received: ResponseStreamEvent[] = [];
+
+    const error = await withTrace('test', async () => {
+      return await (async () => {
+        try {
+          for await (const event of model.getStreamedResponse(request)) {
+            received.push(event);
+          }
+        } catch (caught) {
+          return caught;
+        }
+      })();
+    });
+
+    expect(error).toBeInstanceOf(ModelBehaviorError);
+    expect((error as Error).message).toContain('response.incomplete');
+    expect(cleanedUp).toBe(true);
+    expect(received.filter((event) => event.type === 'response_done')).toEqual(
+      [],
+    );
+    expect(
+      received
+        .filter((event) => event.type === 'model')
+        .map((event) => event.event.type),
+    ).toEqual(['response.incomplete']);
+    expect(responseSpan?.spanData.response_id).toBe('resp_first_incomplete');
+    expect(responseSpan?.spanData._response).toBeUndefined();
+
+    setTracingDisabled(true);
+    const agent = new Agent({
+      name: 'TerminalFailureAgent',
+      model,
+      modelSettings: { timeoutMs: 25 },
+    });
+    const result = await new Runner().run(agent, 'hello', { stream: true });
+
+    await expect(result.completed).rejects.toThrow('response.incomplete');
+    expect(result.state.usage.requests).toBe(1);
+    expect(result.state.usage.inputTokens).toBe(3);
+    expect(result.state.usage.outputTokens).toBe(4);
+    expect(result.state.usage.totalTokens).toBe(7);
+    expect(result.state.usage.requestUsageEntries?.[0]).toMatchObject({
+      inputTokens: 3,
+      outputTokens: 4,
+      totalTokens: 7,
+      endpoint: 'responses.create',
+    });
+    expect(result.state._modelResponses).toEqual([]);
+  });
+
+  it('preserves terminal usage when cancellation precedes raw-event forwarding', async () => {
+    const controller = new AbortController();
+    let cleanedUp = false;
+    async function* fakeStream() {
+      try {
+        queueMicrotask(() => controller.abort());
+        yield {
+          type: 'response.incomplete',
+          response: {
+            id: 'resp_cancel_before_forwarding',
+            status: 'incomplete',
+            output: [],
+            usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+          },
+          sequence_number: 0,
+        } as const;
+      } finally {
+        cleanedUp = true;
+      }
+    }
+    const model = new OpenAIResponsesModel(
+      {
+        responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+      } as unknown as OpenAI,
+      'model-stream',
+    );
+    const result = await new Runner().run(
+      new Agent({
+        name: 'EarlyCancellationAgent',
+        model,
+        modelSettings: { timeoutMs: 10_000 },
+      }),
+      'hello',
+      { stream: true, signal: controller.signal },
+    );
+
+    await expect(result.completed).resolves.toBeUndefined();
+    expect(result.state.usage).toMatchObject({ requests: 1, totalTokens: 7 });
+    expect(result.state.usage.requestUsageEntries).toHaveLength(1);
+    expect(result.rawResponses).toEqual([]);
+    expect(cleanedUp).toBe(true);
+  });
+
+  it('preserves terminal usage when an input guardrail closes the stream', async () => {
+    let releaseGuardrail!: () => void;
+    const guardrailGate = new Promise<void>((resolve) => {
+      releaseGuardrail = resolve;
+    });
+    let cleanedUp = false;
+    async function* fakeStream() {
+      try {
+        yield {
+          type: 'response.incomplete',
+          response: {
+            id: 'resp_guardrail_before_forwarding',
+            status: 'incomplete',
+            output: [],
+            usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+          },
+          sequence_number: 0,
+        } as const;
+      } finally {
+        cleanedUp = true;
+      }
+    }
+    // Pause the real adapter's terminal event until the parallel guardrail settles.
+    class PausedTerminalModel extends OpenAIResponsesModel {
+      override async *getStreamedResponse(request: ModelRequest) {
+        for await (const event of super.getStreamedResponse(request)) {
+          releaseGuardrail();
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          yield event;
+        }
+      }
+    }
+    const model = new PausedTerminalModel(
+      {
+        responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+      } as unknown as OpenAI,
+      'model-stream',
+    );
+    const result = await new Runner().run(
+      new Agent({
+        name: 'TerminalGuardrailAgent',
+        model,
+        inputGuardrails: [
+          {
+            name: 'parallel guardrail',
+            execute: async () => {
+              await guardrailGate;
+              return { outputInfo: null, tripwireTriggered: true };
+            },
+          },
+        ],
+      }),
+      'hello',
+      { stream: true },
+    );
+
+    await expect(result.completed).rejects.toMatchObject({
+      name: 'InputGuardrailTripwireTriggered',
+    });
+    expect(result.state.usage).toMatchObject({ requests: 1, totalTokens: 7 });
+    expect(result.state.usage.requestUsageEntries).toHaveLength(1);
+    expect(result.rawResponses).toEqual([]);
+    expect(cleanedUp).toBe(true);
+  });
+
+  it.each(['default', 'custom'] as const)(
+    'preserves terminal usage when %s cancellation replaces the streamed failure',
+    async (reasonType) => {
+      setTracingDisabled(false);
+      const usageSpans: Span<any>[] = [];
+      setTraceProcessors([
+        {
+          async onTraceStart() {},
+          async onTraceEnd() {},
+          async onSpanStart() {},
+          async onSpanEnd(span: Span<any>) {
+            if (
+              span.spanData.type === 'task' ||
+              span.spanData.type === 'turn'
+            ) {
+              usageSpans.push(span);
+            }
+          },
+          async shutdown() {},
+          async forceFlush() {},
+        },
+      ]);
+      const controller = new AbortController();
+      const cancellationError =
+        reasonType === 'custom'
+          ? new Error('cancelled after terminal event')
+          : undefined;
+      let cleanedUp = false;
+      async function* fakeStream() {
+        try {
+          yield {
+            type: 'response.incomplete',
+            response: {
+              id: 'resp_incomplete_before_cancel',
+              status: 'incomplete',
+              output: [],
+              usage: { input_tokens: 3, output_tokens: 4, total_tokens: 7 },
+            },
+            sequence_number: 0,
+          } as const;
+        } finally {
+          cleanedUp = true;
+        }
+      }
+      // Control the cancellation boundary after the real adapter emits its raw event.
+      class CancelAfterTerminalModel extends OpenAIResponsesModel {
+        override async *getStreamedResponse(request: ModelRequest) {
+          for await (const event of super.getStreamedResponse(request)) {
+            yield event;
+            if (
+              event.type === 'model' &&
+              event.event.type === 'response.incomplete'
+            ) {
+              controller.abort(cancellationError);
+            }
+          }
+        }
+      }
+      const model = new CancelAfterTerminalModel(
+        {
+          responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+        } as unknown as OpenAI,
+        'model-stream',
+      );
+      const agent = new Agent({
+        name: 'TerminalCancellationAgent',
+        model,
+        modelSettings: { timeoutMs: 10_000 },
+      });
+      const result = await new Runner().run(agent, 'hello', {
+        stream: true,
+        signal: controller.signal,
+      });
+
+      if (cancellationError) {
+        await expect(result.completed).rejects.toBe(cancellationError);
+      } else {
+        await expect(result.completed).resolves.toBeUndefined();
+      }
+      expect(result.state.usage).toMatchObject({
+        requests: 1,
+        inputTokens: 3,
+        outputTokens: 4,
+        totalTokens: 7,
+      });
+      expect(result.state.usage.requestUsageEntries).toHaveLength(1);
+      expect(result.state._modelResponses).toEqual([]);
+      expect(usageSpans).toHaveLength(2);
+      for (const span of usageSpans) {
+        expect(span.spanData.usage).toMatchObject({
+          input_tokens: 3,
+          output_tokens: 4,
+        });
+      }
+      expect(cleanedUp).toBe(true);
+    },
+  );
+
+  it('closes a stalled terminal stream before runner timeout can replace the failure', async () => {
+    let cleanedUp = false;
+    async function* fakeStream() {
+      try {
+        yield {
+          type: 'response.incomplete',
+          response: {
+            id: 'resp_incomplete_before_timeout',
+            status: 'incomplete',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 0,
+        } as const;
+        await new Promise<void>(() => {});
+      } finally {
+        cleanedUp = true;
+      }
+    }
+    const model = new OpenAIResponsesModel(
+      {
+        responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+      } as unknown as OpenAI,
+      'model-stream',
+    );
+    const agent = new Agent({
+      name: 'TerminalTimeoutAgent',
+      model,
+      modelSettings: { timeoutMs: 25 },
+    });
+    const result = await new Runner().run(agent, 'hello', { stream: true });
+
+    await expect(result.completed).rejects.toThrow(ModelBehaviorError);
+    expect(result.error).toBeInstanceOf(ModelBehaviorError);
+    expect((result.error as Error).message).toContain('response.incomplete');
+    expect(cleanedUp).toBe(true);
+    expect(result.state.usage.requests).toBe(1);
+  });
+
+  it.each(['response.incomplete', 'error'] as const)(
+    'records a redacted span error before yielding terminal event %s',
+    async (terminalEventType) => {
+      setTracingDisabled(false);
+      const sensitiveDetail = 'sensitive-span-detail';
+      const terminalEvent =
+        terminalEventType === 'error'
+          ? ({
+              type: 'error',
+              code: 'server_error',
+              message: sensitiveDetail,
+              param: null,
+              sequence_number: 0,
+            } satisfies OpenAIResponseStreamEvent)
+          : ({
+              type: 'response.incomplete',
+              response: {
+                id: 'resp_traced_incomplete',
+                status: 'incomplete',
+                output: [],
+                usage: {},
+                incomplete_details: { reason: sensitiveDetail },
+              },
+              sequence_number: 0,
+            } as any);
+      async function* fakeStream() {
+        yield terminalEvent;
+      }
+      const model = new OpenAIResponsesModel(
+        {
+          responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+        } as unknown as OpenAI,
+        'model-stream',
+      );
+      const setErrorSpy = vi.spyOn(Span.prototype, 'setError');
+
+      await withTrace('test', async () => {
+        const iterator = model
+          .getStreamedResponse({
+            systemInstructions: undefined,
+            input: 'data',
+            modelSettings: {},
+            tools: [],
+            outputType: 'text',
+            handoffs: [],
+            tracing: true,
+            signal: undefined,
+          } as any)
+          [Symbol.asyncIterator]();
+        const first = await iterator.next();
+
+        expect(first.value).toMatchObject({
+          type: 'model',
+          event: { type: terminalEventType },
+        });
+        expect(setErrorSpy).toHaveBeenCalledWith({
+          message: `OpenAI Responses request ended with unsuccessful terminal state "${terminalEventType}".`,
+        });
+        expect(JSON.stringify(setErrorSpy.mock.calls)).not.toContain(
+          sensitiveDetail,
+        );
+        await iterator.return?.();
+      });
+
+      setErrorSpy.mockRestore();
+      setTracingDisabled(true);
+    },
+  );
+
+  it('redacts an unsuccessful terminal response when a no-data tracing consumer stops early', async () => {
+    setTracingDisabled(false);
+    let responseSpan: Span<any> | undefined;
+    setTraceProcessors([
+      {
+        async onTraceStart() {},
+        async onTraceEnd() {},
+        async onSpanStart() {},
+        async onSpanEnd(span: Span<any>) {
+          if (span.spanData.type === 'response') {
+            responseSpan = span;
+          }
+        },
+        async shutdown() {},
+        async forceFlush() {},
+      },
+    ]);
+    const sensitiveDetail = 'sensitive-no-data-stream';
+    async function* fakeStream() {
+      yield {
+        type: 'response.incomplete',
+        response: {
+          id: 'resp_no_data_stream',
+          status: 'incomplete',
+          output: [],
+          usage: {},
+          incomplete_details: { reason: sensitiveDetail },
+        },
+        sequence_number: 0,
+      } as any;
+    }
+    const model = new OpenAIResponsesModel(
+      {
+        responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+      } as unknown as OpenAI,
+      'model-stream',
+    );
+
+    await withTrace('test', async () => {
+      const iterator = model
+        .getStreamedResponse({
+          systemInstructions: undefined,
+          input: sensitiveDetail,
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: 'enabled_without_data',
+          signal: undefined,
+        } as any)
+        [Symbol.asyncIterator]();
+
+      expect(await iterator.next()).toMatchObject({
+        value: {
+          type: 'model',
+          event: { type: 'response.incomplete' },
+        },
+      });
+      await iterator.return?.();
+    });
+
+    expect(responseSpan?.spanData.response_id).toBe('resp_no_data_stream');
+    expect(responseSpan?.spanData._input).toBeUndefined();
+    expect(responseSpan?.spanData._response).toBeUndefined();
+    expect(JSON.stringify(responseSpan?.error)).not.toContain(sensitiveDetail);
   });
 
   it('prevents extra_body from overriding streamed request mode', async () => {

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -10,8 +10,10 @@ import {
 import type OpenAI from 'openai';
 import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
 import {
+  ModelBehaviorError,
   setTracingDisabled,
   type ResponseStreamEvent,
+  withTrace,
 } from '@openai/agents-core';
 import { HEADERS } from '../src/defaults';
 import { OpenAIResponsesWSModel } from '../src/openaiResponsesModel';
@@ -723,9 +725,9 @@ describe('OpenAIResponsesWSModel', () => {
   it.each([
     ['response.incomplete', 'incomplete'],
     ['response.failed', 'failed'],
-    ['response.error', 'failed'],
+    ['error', undefined],
   ] as const)(
-    'emits response_done for terminal websocket stream event %s',
+    'rejects terminal websocket stream event %s without response_done',
     async (terminalEventType, expectedStatus) => {
       const fakeClient = createFakeClient();
 
@@ -736,19 +738,33 @@ describe('OpenAIResponsesWSModel', () => {
             response: { id: 'resp_init', status: 'in_progress' },
             sequence_number: 0,
           } as any);
-          socket.queueJSON({
-            type: terminalEventType,
-            response: {
-              id: 'resp_terminal',
-              status: expectedStatus,
-              output: [],
-              usage: {},
-              ...(terminalEventType === 'response.incomplete'
-                ? { incomplete_details: { reason: 'max_output_tokens' } }
-                : {}),
-            },
-            sequence_number: 1,
-          } as any);
+          socket.queueJSON(
+            terminalEventType === 'error'
+              ? {
+                  type: 'error',
+                  code: 'server_error',
+                  message: 'sensitive websocket error',
+                  param: null,
+                  sequence_number: 1,
+                }
+              : {
+                  type: terminalEventType,
+                  response: {
+                    id: 'resp_terminal',
+                    status: expectedStatus,
+                    output: [],
+                    usage: {},
+                    ...(terminalEventType === 'response.incomplete'
+                      ? {
+                          incomplete_details: {
+                            reason: 'max_output_tokens',
+                          },
+                        }
+                      : {}),
+                  },
+                  sequence_number: 1,
+                },
+          );
         });
       };
 
@@ -765,21 +781,26 @@ describe('OpenAIResponsesWSModel', () => {
       };
 
       const received: ResponseStreamEvent[] = [];
-      for await (const event of model.getStreamedResponse(request as any)) {
-        received.push(event);
-      }
+      const error = await (async () => {
+        try {
+          for await (const event of model.getStreamedResponse(request as any)) {
+            received.push(event);
+          }
+        } catch (caught) {
+          return caught;
+        }
+      })();
 
       expect(received.some((event) => event.type === 'response_started')).toBe(
         true,
       );
-      const responseDone = received.find(
-        (event) => event.type === 'response_done',
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect((error as Error).message).toContain(terminalEventType);
+      expect((error as Error).message).not.toContain(
+        'sensitive websocket error',
       );
-      expect(responseDone).toBeDefined();
-      expect((responseDone as any).response.id).toBe('resp_terminal');
-      expect((responseDone as any).response.requestId).toBeUndefined();
-      expect((responseDone as any).response.providerData?.status).toBe(
-        expectedStatus,
+      expect(received.some((event) => event.type === 'response_done')).toBe(
+        false,
       );
       expect(
         received.some(
@@ -788,6 +809,82 @@ describe('OpenAIResponsesWSModel', () => {
             (event as any).event?.type === terminalEventType,
         ),
       ).toBe(true);
+      expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+      expect(
+        model.getRetryAdvice({
+          error,
+          request: request as any,
+          stream: true,
+          attempt: 1,
+        }),
+      ).toMatchObject({
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      });
+    },
+  );
+
+  it.each(['response.incomplete', 'error'] as const)(
+    'reuses the websocket after terminal stream event %s',
+    async (firstTerminalEventType) => {
+      const fakeClient = createFakeClient();
+      let requestCount = 0;
+
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          requestCount += 1;
+          socket.queueJSON(
+            requestCount === 1 && firstTerminalEventType === 'error'
+              ? {
+                  type: 'error',
+                  code: 'server_error',
+                  message: 'retry with a new request',
+                  param: null,
+                  sequence_number: 0,
+                }
+              : {
+                  type:
+                    requestCount === 1
+                      ? 'response.incomplete'
+                      : 'response.completed',
+                  response: {
+                    id: `resp_${requestCount}`,
+                    status: requestCount === 1 ? 'incomplete' : 'completed',
+                    output: [],
+                    usage: {},
+                  },
+                  sequence_number: 0,
+                },
+          );
+        });
+      };
+
+      const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+      const request = {
+        systemInstructions: undefined,
+        input: 'ping',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+      const consume = async () => {
+        for await (const _event of model.getStreamedResponse(request as any)) {
+          // Consume the entire stream so the request lock can be released.
+        }
+      };
+
+      await expect(consume()).rejects.toThrow(ModelBehaviorError);
+      const result = await withTrace('test', () =>
+        model.getResponse(request as any),
+      );
+
+      expect(result.responseId).toBe('resp_2');
+      expect(TestWebSocket.instances).toHaveLength(1);
+      expect(TestWebSocket.instances[0]?.sent).toHaveLength(2);
     },
   );
 
@@ -960,9 +1057,8 @@ describe('OpenAIResponsesWSModel', () => {
   it.each([
     ['response.incomplete', 'incomplete'],
     ['response.failed', 'failed'],
-    ['response.error', 'failed'],
   ] as const)(
-    'returns terminal websocket responses in non-stream mode (%s)',
+    'rejects terminal websocket responses in non-stream mode (%s)',
     async (terminalEventType, expectedStatus) => {
       const fakeClient = createFakeClient();
 
@@ -998,21 +1094,110 @@ describe('OpenAIResponsesWSModel', () => {
         signal: undefined,
       };
 
-      const result = await (model as any)._fetchResponse(request as any, false);
+      const error = await withTrace('test', () =>
+        model.getResponse(request as any),
+      ).catch((caught: unknown) => caught as any);
 
-      expect(result.id).toBe('resp_done');
-      expect(result.status).toBe(expectedStatus);
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect(error.message).toContain(`response.${expectedStatus}`);
       expect(TestWebSocket.instances[0]?.sent).toHaveLength(1);
+      expect(
+        model.getRetryAdvice({
+          error,
+          request: request as any,
+          stream: false,
+          attempt: 1,
+        }),
+      ).toMatchObject({
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      });
     },
   );
 
-  it('marks post-consumption terminal response validation failures as unsafe', async () => {
+  it.each([false, true])(
+    'rejects a missing terminal response payload (stream=%s)',
+    async (stream) => {
+      const fakeClient = createFakeClient();
+
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          socket.queueJSON({
+            type: 'response.completed',
+            ...(socket.sent.length > 1
+              ? { response: { id: 'resp_recovered', output: [], usage: {} } }
+              : {}),
+            sequence_number: 0,
+          });
+        });
+      };
+
+      const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+      const request = {
+        systemInstructions: undefined,
+        input: 'ping',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      };
+
+      const received: ResponseStreamEvent[] = [];
+      const error = await withTrace('test', async () => {
+        if (!stream) {
+          return model.getResponse(request as any);
+        }
+        for await (const event of model.getStreamedResponse(request as any)) {
+          received.push(event);
+        }
+      }).catch((err: unknown) => err as any);
+
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect(error.message).toBe(
+        'OpenAI Responses terminal event "response.completed" is missing its required response payload.',
+      );
+      expect(error.unsafeToReplay).toBe(true);
+      expect(error.responseStarted).toBe(true);
+      expect(
+        model.getRetryAdvice({
+          error,
+          request: request as any,
+          stream,
+          attempt: 1,
+        }),
+      ).toMatchObject({
+        suggested: false,
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      });
+      expect(
+        received.filter((event) => event.type === 'response_done'),
+      ).toEqual([]);
+      expect(received.filter((event) => event.type === 'model')).toHaveLength(
+        stream ? 1 : 0,
+      );
+      const recovered = await withTrace('test', () =>
+        model.getResponse(request as any),
+      );
+      expect(recovered.responseId).toBe('resp_recovered');
+      expect(TestWebSocket.instances).toHaveLength(1);
+      expect(TestWebSocket.instances[0]?.sent).toHaveLength(2);
+    },
+  );
+
+  it('rejects a first-frame websocket error with a redacted model error', async () => {
     const fakeClient = createFakeClient();
 
     TestWebSocket.onCreate = (socket) => {
       socket.onSend(() => {
         socket.queueJSON({
-          type: 'response.completed',
+          type: 'error',
+          code: 'server_error',
+          message: 'sensitive invalid request',
+          param: null,
           sequence_number: 0,
         });
       });
@@ -1030,75 +1215,15 @@ describe('OpenAIResponsesWSModel', () => {
       signal: undefined,
     };
 
-    const error = await (model as any)
-      ._fetchResponse(request as any, false)
-      .catch(
-        (err: unknown) =>
-          err as Error & {
-            unsafeToReplay?: boolean;
-            responseStarted?: boolean;
-          },
-      );
+    const error = await withTrace('test', () =>
+      model.getResponse(request as any),
+    ).catch((err: unknown) => err as any);
 
+    expect(error).toBeInstanceOf(ModelBehaviorError);
     expect(error.message).toBe(
-      'Responses websocket stream ended without a terminal response event.',
+      'OpenAI Responses request ended with unsuccessful terminal state "error".',
     );
-    expect(error.unsafeToReplay).toBe(true);
-    expect(error.responseStarted).toBe(true);
-    expect(
-      model.getRetryAdvice({
-        error,
-        request: request as any,
-        stream: false,
-        attempt: 1,
-      }),
-    ).toMatchObject({
-      suggested: false,
-      replaySafety: 'unsafe',
-      responseStarted: true,
-    });
-  });
-
-  it('surfaces first-frame websocket error payloads without feature-disabled wrapping', async () => {
-    const fakeClient = createFakeClient();
-
-    TestWebSocket.onCreate = (socket) => {
-      socket.onSend(() => {
-        socket.queueJSON({
-          type: 'error',
-          error: {
-            message: 'invalid request',
-          },
-        });
-      });
-    };
-
-    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
-    const request = {
-      systemInstructions: undefined,
-      input: 'ping',
-      modelSettings: {},
-      tools: [],
-      outputType: 'text',
-      handoffs: [],
-      tracing: false,
-      signal: undefined,
-    };
-
-    const error = await (model as any)
-      ._fetchResponse(request as any, false)
-      .catch(
-        (err: unknown) =>
-          err as Error & {
-            unsafeToReplay?: boolean;
-            responseStarted?: boolean;
-          },
-      );
-
-    expect(error).toBeInstanceOf(Error);
-    expect(error.message).toContain('Responses websocket error:');
-    expect(error.message).toContain('invalid request');
-    expect(error.message).not.toContain('feature may not be enabled');
+    expect(error.message).not.toContain('sensitive invalid request');
     expect(error.unsafeToReplay).toBe(true);
     expect(error.responseStarted).toBe(true);
     expect(


### PR DESCRIPTION
This pull request fixes ordinary OpenAI Responses turns that previously treated `failed`, `incomplete`, and streamed `response.error` terminal outcomes as successful completions.

It rejects those outcomes before output, tool, or session processing across HTTP and Responses WebSocket paths. Streaming callers still receive the raw terminal event, while cleanup completes and automatic replay is prevented.

Errors and no-data tracing retain only deterministic terminal metadata. Completed and status-less responses, along with the released hosted multi-agent protocol, remain compatible.