### PR TITLE
Pin LF line endings so Windows clones keep fixture hashes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep checkouts as LF so fixture hashes and workflow tests stay stable on Windows.
+* text=auto eol=lf


### PR DESCRIPTION
### Summary
A clean Windows clone with Git autocrlf converts tracked files to CRLF. Fixture hash pins and a workflow string assertion then fail even though git status is clean.

This adds a repository .gitattributes so files check out as LF.

### Test plan
On a Windows clone with autocrlf true, run the runState compatibility tests and the workflow policy test.

### Issue number
Closes #1709

### Checks
No package code changed, so no changeset. Tests that hash fixtures should now pass on Windows checkouts.