### PR TITLE
fix(sandbox): make provider error inspection fail-safe

### DIFF
--- a/.changeset/failsafe-provider-errors.md
+++ b/.changeset/failsafe-provider-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix(sandbox): make provider error inspection fail-safe

--- a/packages/agents-extensions/src/sandbox/shared/session.ts
+++ b/packages/agents-extensions/src/sandbox/shared/session.ts
@@ -10,6 +10,9 @@ import { isRecord } from './typeGuards';
 
 export { withSandboxSpan };
 
+const UNINSPECTABLE_PROVIDER_ERROR =
+  'Provider error could not be inspected safely.';
+
 export async function closeRemoteSessionOnManifestError(
   providerName: string,
   session: { close(): Promise<void> },
@@ -95,7 +98,7 @@ export async function withProviderError<T>(
         },
       );
     }
-    if (error instanceof UserError) {
+    if (safelyIsUserError(error)) {
       throw error;
     }
     const cause = providerErrorMessage(error);
@@ -115,11 +118,15 @@ export async function withProviderError<T>(
 }
 
 export function isProviderSandboxNotFoundError(error: unknown): boolean {
-  if (isNotFoundErrorRecord(error, new Set())) {
-    return true;
+  try {
+    if (isNotFoundErrorRecord(error, new Set())) {
+      return true;
+    }
+  } catch {
+    // Fall through to the fail-safe text path below.
   }
 
-  const text = errorMessage(error).trim();
+  const text = providerErrorMessage(error).trim();
   return isNotFoundErrorMessage(text);
 }
 
@@ -133,7 +140,7 @@ export function assertResumeRecreateAllowed(
   error: unknown,
   context: ResumeRecreateErrorContext,
 ): void {
-  if (error instanceof UserError) {
+  if (safelyIsUserError(error)) {
     throw error;
   }
 
@@ -155,7 +162,13 @@ export function assertResumeRecreateAllowed(
 }
 
 export function providerErrorMessage(error: unknown): string {
-  const message = errorMessage(error);
+  let message = UNINSPECTABLE_PROVIDER_ERROR;
+  try {
+    const inspectedMessage = errorMessage(error);
+    message = safelyCoerceProviderErrorText(inspectedMessage) ?? message;
+  } catch {
+    // Keep the generic fail-safe message.
+  }
   const details = providerErrorDetails(error);
   const detailText = formatProviderErrorDetailSummary(details);
   if (!detailText) {
@@ -165,25 +178,52 @@ export function providerErrorMessage(error: unknown): string {
 }
 
 export function providerErrorDetails(error: unknown): Record<string, unknown> {
-  return collectProviderErrorDetails(error, new Set<object>(), 0);
+  try {
+    return collectProviderErrorDetails(error, new Set<object>(), 0);
+  } catch {
+    return {};
+  }
 }
 
 export function providerErrorRetryability(error: unknown): boolean | null {
-  return readProviderErrorRetryability(error, new Set<object>(), 0);
-}
-
-function safelyReadProviderErrorRetryability(error: unknown): boolean | null {
   try {
-    return providerErrorRetryability(error);
+    return readProviderErrorRetryability(error, new Set<object>(), 0);
   } catch {
     return null;
   }
 }
 
-function errorMessage(error: unknown): string {
+function safelyReadProviderErrorRetryability(error: unknown): boolean | null {
+  return providerErrorRetryability(error);
+}
+
+function safelyIsUserError(error: unknown): error is UserError {
+  try {
+    return error instanceof UserError;
+  } catch {
+    return false;
+  }
+}
+
+function safelyCoerceProviderErrorText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return String(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function errorMessage(error: unknown): unknown {
   const message = error instanceof Error ? error.message : String(error);
   if (error instanceof SandboxProviderError && error.details) {
-    return `${message} Details: ${formatErrorDetails(error.details)}`;
+    const safeMessage = safelyCoerceProviderErrorText(message);
+    if (safeMessage === undefined) {
+      return undefined;
+    }
+    return `${safeMessage} Details: ${formatErrorDetails(error.details)}`;
   }
   return message;
 }

--- a/packages/agents-extensions/test/sandbox/providerErrorFailsafe.test.ts
+++ b/packages/agents-extensions/test/sandbox/providerErrorFailsafe.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { SandboxProviderError } from '@openai/agents-core/sandbox';
+import {
+  assertResumeRecreateAllowed,
+  providerErrorDetails,
+  providerErrorMessage,
+  providerErrorRetryability,
+  withProviderError,
+} from '../../src/sandbox/shared';
+
+function hostileProviderError(): object {
+  return new Proxy(
+    {},
+    {
+      get() {
+        throw new Error('provider metadata trap');
+      },
+      getPrototypeOf() {
+        throw new Error('provider prototype trap');
+      },
+    },
+  );
+}
+
+function malformedMessageError(message: unknown): Error {
+  const error = new Error('placeholder');
+  Object.defineProperty(error, 'message', {
+    configurable: true,
+    value: message,
+  });
+  return error;
+}
+
+describe('sandbox provider error inspection', () => {
+  it('keeps diagnostic helpers fail-safe for hostile provider errors', () => {
+    const error = hostileProviderError();
+
+    expect(providerErrorMessage(error)).toBe(
+      'Provider error could not be inspected safely.',
+    );
+    expect(providerErrorDetails(error)).toEqual({});
+    expect(providerErrorRetryability(error)).toBeNull();
+  });
+
+  it('wraps hostile provider failures as SandboxProviderError', async () => {
+    const providerFailure = hostileProviderError();
+    let thrown: unknown;
+
+    try {
+      await withProviderError(
+        'ProviderSandboxClient',
+        'provider',
+        'create sandbox',
+        async () => {
+          throw providerFailure;
+        },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(SandboxProviderError);
+    expect((thrown as Error).message).toContain(
+      'Provider error could not be inspected safely.',
+    );
+    expect((thrown as SandboxProviderError).details).toMatchObject({
+      provider: 'provider',
+      operation: 'create sandbox',
+      retryable: null,
+      cause: 'Provider error could not be inspected safely.',
+    });
+  });
+
+  it('safely coerces malformed non-string Error messages', async () => {
+    const providerFailure = malformedMessageError(Symbol('provider failure'));
+
+    expect(providerErrorMessage(providerFailure)).toBe(
+      'Symbol(provider failure)',
+    );
+
+    await expect(
+      withProviderError(
+        'ProviderSandboxClient',
+        'provider',
+        'create sandbox',
+        async () => {
+          throw providerFailure;
+        },
+      ),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('Symbol(provider failure)'),
+    });
+  });
+
+  it('falls back when malformed Error messages cannot be stringified', async () => {
+    const providerFailure = malformedMessageError({
+      toString() {
+        throw new Error('message conversion trap');
+      },
+    });
+
+    expect(providerErrorMessage(providerFailure)).toBe(
+      'Provider error could not be inspected safely.',
+    );
+
+    await expect(
+      withProviderError(
+        'ProviderSandboxClient',
+        'provider',
+        'create sandbox',
+        async () => {
+          throw providerFailure;
+        },
+      ),
+    ).rejects.toBeInstanceOf(SandboxProviderError);
+  });
+
+  it('keeps hostile resume failures inside the provider error boundary', () => {
+    expect(() =>
+      assertResumeRecreateAllowed(hostileProviderError(), {
+        providerName: 'ProviderSandboxClient',
+        provider: 'provider',
+      }),
+    ).toThrow(SandboxProviderError);
+  });
+});


### PR DESCRIPTION
### Summary

Keep sandbox provider failures inside the SDK's error boundary even when the thrown value cannot be inspected normally.

Provider integrations may throw arbitrary values. Today, diagnostic handling assumes operations such as `instanceof`, property access, and string conversion are safe. A Proxy with throwing traps, or an `Error` whose `message` is malformed, can therefore make the error-inspection path throw a second exception instead of returning a `SandboxProviderError` with safe diagnostics.

### Changes

- make provider message extraction fall back to a stable generic diagnostic when inspection or coercion throws
- make provider detail and retryability extraction fail closed to `{}` and `null`
- guard `UserError` classification against hostile prototype access
- keep resume/not-found inspection inside the same fail-safe boundary
- preserve the existing rich provider diagnostics for ordinary errors
- add a patch changeset for `@openai/agents-extensions`

### Test plan

Added focused regression coverage for:

- Proxy-backed provider errors whose property/prototype access throws
- wrapping hostile provider failures as `SandboxProviderError`
- non-string `Error.message` values
- message values whose string conversion itself throws
- hostile failures during resume/recreate classification

The branch is based directly on current upstream `main` at `443c33eac060a5441fb73ac30054c8f1c07fc811` and is 0 commits behind it.

### Risk

Low. Normal provider errors continue through the existing diagnostic extraction path. The new behavior is limited to cases where inspecting the provider's thrown value would itself fail.

### Issue number

None. Found while auditing sandbox provider failure handling.