### PR TITLE
fix(core): preserve sandbox failures during error serialization

### DIFF
--- a/.changeset/safe-sandbox-error-serialization.md
+++ b/.changeset/safe-sandbox-error-serialization.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve sandbox failures when error serialization fails

--- a/packages/agents-core/src/sandbox/events.ts
+++ b/packages/agents-core/src/sandbox/events.ts
@@ -48,6 +48,8 @@ export type SandboxHttpEventSinkOptions = {
 };
 
 const sandboxEventSinks = new Set<SandboxEventSink>();
+const UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE =
+  'Sandbox operation failed with an unserializable error.';
 
 export function addSandboxEventSink(sink: SandboxEventSink): () => void {
   sandboxEventSinks.add(sink);
@@ -133,32 +135,74 @@ export function createChainedSandboxEventSink(
 }
 
 export function serializeSandboxEventError(error: unknown): SandboxEventError {
-  if (error instanceof Error) {
-    const code = readErrorCode(error);
-    const retryable = readErrorRetryability(error);
+  let isError = false;
+  try {
+    isError = error instanceof Error;
+  } catch {
     return {
-      name: error.name,
-      message: error.message,
+      message: UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE,
+    };
+  }
+
+  if (isError) {
+    const errorValue = error as Error;
+    const name = readStringErrorProperty(errorValue, 'name');
+    const message =
+      readStringErrorProperty(errorValue, 'message') ??
+      UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE;
+    const code = readErrorCode(errorValue);
+    const retryable = readErrorRetryability(errorValue);
+    return {
+      ...(name !== undefined ? { name } : {}),
+      message,
       ...(code ? { code } : {}),
       ...(retryable !== undefined ? { retryable } : {}),
     };
   }
 
   return {
-    message: String(error),
+    message: stringifyThrownValue(error),
   };
 }
 
+function readStringErrorProperty(
+  error: Error,
+  property: 'name' | 'message',
+): string | undefined {
+  try {
+    const value = error[property];
+    return typeof value === 'string' ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function readErrorCode(error: Error): string | undefined {
-  const code = (error as { code?: unknown }).code;
-  return typeof code === 'string' ? code : undefined;
+  try {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function readErrorRetryability(error: Error): boolean | null | undefined {
-  const retryable = (error as { retryable?: unknown }).retryable;
-  return typeof retryable === 'boolean' || retryable === null
-    ? retryable
-    : undefined;
+  try {
+    const retryable = (error as { retryable?: unknown }).retryable;
+    return typeof retryable === 'boolean' || retryable === null
+      ? retryable
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function stringifyThrownValue(error: unknown): string {
+  try {
+    return String(error);
+  } catch {
+    return UNSERIALIZABLE_SANDBOX_ERROR_MESSAGE;
+  }
 }
 
 function readGlobalFetch(): SandboxHttpEventFetch | undefined {

--- a/packages/agents-core/test/sandboxErrorSerialization.test.ts
+++ b/packages/agents-core/test/sandboxErrorSerialization.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  addSandboxEventSink,
+  clearSandboxEventSinks,
+  type SandboxEvent,
+  withSandboxSpan,
+} from '../src/sandbox';
+
+describe('sandbox error serialization', () => {
+  afterEach(() => {
+    clearSandboxEventSinks();
+  });
+
+  it('preserves the original failure when a thrown value cannot be stringified', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+    const operationError = {
+      toString() {
+        throw new Error('serialization failed');
+      },
+    };
+
+    await expect(
+      withSandboxSpan('sandbox.exec', { cmd: 'false' }, async () => {
+        throw operationError;
+      }),
+    ).rejects.toBe(operationError);
+
+    expect(events).toHaveLength(2);
+    expect(events[1]).toMatchObject({
+      type: 'sandbox_operation',
+      name: 'sandbox.exec',
+      phase: 'error',
+      error: {
+        message: 'Sandbox operation failed with an unserializable error.',
+      },
+    });
+  });
+
+  it('preserves safe Error fields when optional metadata access throws', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+    const operationError = new Error('provider failed');
+    Object.defineProperty(operationError, 'code', {
+      get() {
+        throw new Error('metadata access failed');
+      },
+    });
+
+    await expect(
+      withSandboxSpan('sandbox.start', {}, async () => {
+        throw operationError;
+      }),
+    ).rejects.toBe(operationError);
+
+    expect(events[1]?.error).toEqual({
+      name: 'Error',
+      message: 'provider failed',
+    });
+  });
+
+  it('preserves the original failure when Error classification throws', async () => {
+    const events: SandboxEvent[] = [];
+    addSandboxEventSink((event) => {
+      events.push(event);
+    });
+    const operationError = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error('classification failed');
+        },
+      },
+    );
+
+    await expect(
+      withSandboxSpan('sandbox.exec', { cmd: 'false' }, async () => {
+        throw operationError;
+      }),
+    ).rejects.toBe(operationError);
+
+    expect(events[1]?.error).toEqual({
+      message: 'Sandbox operation failed with an unserializable error.',
+    });
+  });
+});


### PR DESCRIPTION
### Summary

Prevent sandbox telemetry serialization from replacing the original operation failure when the thrown value has hostile or malformed error metadata.

`withSandboxSpan()` records an error event before rethrowing the operation failure. The event serializer currently assumes that `instanceof Error`, `String(error)`, and optional properties such as `code` and `retryable` can be read safely. Those operations can themselves throw for Proxy-backed values or accessor properties, causing telemetry handling to obscure the failure the sandbox operation actually raised.

### Changes

- make Error classification fail-safe
- read `name`, `message`, `code`, and `retryable` defensively
- fall back to a stable diagnostic when an arbitrary thrown value cannot be converted to text
- preserve all safely readable Error fields when only optional metadata access fails
- add a patch changeset for `@openai/agents-core`

### Test plan

Added regressions verifying that:

- an unserializable thrown value is still rethrown by `withSandboxSpan()` unchanged
- the emitted error event uses a safe fallback message
- a throwing optional `code` getter does not discard a valid Error name/message
- Proxy-backed Error classification failures do not replace the original sandbox exception

The branch is based directly on current upstream `main` at `443c33eac060a5441fb73ac30054c8f1c07fc811` and is 0 commits behind it.

### Risk

Low. Ordinary Error serialization is unchanged in shape. The additional guards only apply when classification, property access, or string conversion throws.

### Issue number

None. Found while auditing sandbox telemetry failure handling.