### PR TITLE
fix(openai): honor provider client options over defaults

### DIFF
--- a/.changeset/honor-openai-provider-client-options.md
+++ b/.changeset/honor-openai-provider-client-options.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: honor OpenAIProvider client options over the default client

--- a/packages/agents-openai/src/openaiProvider.ts
+++ b/packages/agents-openai/src/openaiProvider.ts
@@ -85,9 +85,17 @@ export class OpenAIProvider implements ModelProvider {
   #getClient(): OpenAI {
     // If the constructor does not accept the OpenAI client,
     if (!this.#client) {
+      const hasProviderClientOptions = [
+        this.#options.apiKey,
+        this.#options.baseURL,
+        this.#options.organization,
+        this.#options.project,
+      ].some((value) => typeof value !== 'undefined');
       this.#client =
-        // this provider checks if there is the default client first,
-        (getDefaultOpenAIClient() as OpenAI | undefined) ??
+        // Provider-specific construction options take precedence over the SDK-wide default client.
+        (!hasProviderClientOptions
+          ? (getDefaultOpenAIClient() as OpenAI | undefined)
+          : undefined) ??
         // and then manually creates a new one.
         new OpenAI({
           apiKey: this.#options.apiKey ?? getDefaultOpenAIKey(),

--- a/packages/agents-openai/test/openaiProvider.test.ts
+++ b/packages/agents-openai/test/openaiProvider.test.ts
@@ -191,6 +191,88 @@ describe('OpenAIProvider', () => {
     expect(OpenAIMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      optionName: 'apiKey',
+      providerOptions: { apiKey: 'provider-key' },
+      expectedClientOptions: { apiKey: 'provider-key' },
+    },
+    {
+      optionName: 'baseURL',
+      providerOptions: { baseURL: 'https://provider.example.test/v1' },
+      expectedClientOptions: {
+        baseURL: 'https://provider.example.test/v1',
+      },
+    },
+    {
+      optionName: 'organization',
+      providerOptions: { organization: 'org-provider' },
+      expectedClientOptions: { organization: 'org-provider' },
+    },
+    {
+      optionName: 'project',
+      providerOptions: { project: 'proj-provider' },
+      expectedClientOptions: { project: 'proj-provider' },
+    },
+  ])(
+    'uses provider $optionName instead of the default client',
+    async ({ providerOptions, expectedClientOptions }) => {
+      setDefaultOpenAIClient({ client: 'default' } as any);
+      setDefaultOpenAIKey('default-key');
+      const provider = new OpenAIProvider({
+        ...providerOptions,
+        useResponses: true,
+      });
+
+      const model = await provider.getModel('gpt-4.1');
+
+      expect(model).toBeInstanceOf(OpenAIResponsesModel);
+      expect(OpenAIMock).toHaveBeenCalledTimes(1);
+      expect(OpenAIMock).toHaveBeenCalledWith(
+        expect.objectContaining(expectedClientOptions),
+      );
+    },
+  );
+
+  it.each(['apiKey', 'baseURL', 'organization', 'project'])(
+    'treats an explicit empty %s as a client construction option',
+    async (optionName) => {
+      setDefaultOpenAIClient({ client: 'default' } as any);
+      setDefaultOpenAIKey('default-key');
+      const provider = new OpenAIProvider({
+        [optionName]: '',
+        useResponses: true,
+      });
+
+      await provider.getModel('gpt-4.1');
+
+      expect(OpenAIMock).toHaveBeenCalledTimes(1);
+      expect(OpenAIMock).toHaveBeenCalledWith(
+        expect.objectContaining({ [optionName]: '' }),
+      );
+    },
+  );
+
+  it('does not treat websocketBaseURL as an HTTP client construction option', async () => {
+    const defaultClient = {
+      baseURL: 'https://default-client.example/v1',
+      responses: { create: vi.fn(), compact: vi.fn() },
+      chat: { completions: { create: vi.fn() } },
+    } as any;
+    setDefaultOpenAIClient(defaultClient);
+    const provider = new OpenAIProvider({
+      websocketBaseURL: 'wss://provider.example.test/v1',
+      useResponses: true,
+      useResponsesWebSocket: true,
+    });
+
+    const model = await provider.getModel('gpt-4.1');
+
+    expect(model).toBeInstanceOf(OpenAIResponsesWSModel);
+    expect((model as any)._client).toBe(defaultClient);
+    expect(OpenAIMock).not.toHaveBeenCalled();
+  });
+
   it('passes strict feature validation to chat completions models', async () => {
     const provider = new OpenAIProvider({
       openAIClient: new FakeClient() as any,


### PR DESCRIPTION
This pull request fixes `OpenAIProvider` client construction so explicitly supplied `apiKey`, `baseURL`, `organization`, or `project` options create a provider-specific OpenAI client even when an SDK-wide default client is configured. It preserves default-client reuse when those options are omitted, keeps `websocketBaseURL` transport-only, and adds regression coverage for each precedence case, including explicitly empty values.