### PR TITLE
fix(core): detach aggregated usage records

### DIFF
--- a/.changeset/calm-usage-snapshots.md
+++ b/.changeset/calm-usage-snapshots.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: detach source usage records during aggregation

--- a/packages/agents-core/src/usage.ts
+++ b/packages/agents-core/src/usage.ts
@@ -88,6 +88,19 @@ export class RequestUsage {
   }
 }
 
+function cloneTokenDetails(
+  details: Record<string, number>,
+): Record<string, number> {
+  return { ...details };
+}
+
+function cloneRequestUsage(input: RequestUsageInput): RequestUsage {
+  const cloned = new RequestUsage(input);
+  cloned.inputTokensDetails = cloneTokenDetails(cloned.inputTokensDetails);
+  cloned.outputTokensDetails = cloneTokenDetails(cloned.outputTokensDetails);
+  return cloned;
+}
+
 /**
  * Tracks token usage and request counts for an agent run.
  */
@@ -196,11 +209,15 @@ export class Usage {
     this.totalTokens += newUsage.totalTokens ?? 0;
     if (newUsage.inputTokensDetails) {
       // The type does not allow undefined, but it could happen runtime
-      this.inputTokensDetails.push(...newUsage.inputTokensDetails);
+      this.inputTokensDetails.push(
+        ...newUsage.inputTokensDetails.map(cloneTokenDetails),
+      );
     }
     if (newUsage.outputTokensDetails) {
       // The type does not allow undefined, but it could happen runtime
-      this.outputTokensDetails.push(...newUsage.outputTokensDetails);
+      this.outputTokensDetails.push(
+        ...newUsage.outputTokensDetails.map(cloneTokenDetails),
+      );
     }
 
     if (
@@ -209,14 +226,12 @@ export class Usage {
     ) {
       this.requestUsageEntries ??= [];
       this.requestUsageEntries.push(
-        ...newUsage.requestUsageEntries.map((entry) =>
-          entry instanceof RequestUsage ? entry : new RequestUsage(entry),
-        ),
+        ...newUsage.requestUsageEntries.map(cloneRequestUsage),
       );
     } else if (newUsage.requests === 1 && newUsage.totalTokens > 0) {
       this.requestUsageEntries ??= [];
       this.requestUsageEntries.push(
-        new RequestUsage({
+        cloneRequestUsage({
           inputTokens: newUsage.inputTokens,
           outputTokens: newUsage.outputTokens,
           totalTokens: newUsage.totalTokens,

--- a/packages/agents-core/test/usage.test.ts
+++ b/packages/agents-core/test/usage.test.ts
@@ -243,6 +243,118 @@ describe('Usage', () => {
     ]);
   });
 
+  it('detaches existing request usage entries from source mutations', () => {
+    const firstEntry = new RequestUsage({
+      inputTokens: 5,
+      outputTokens: 6,
+      totalTokens: 11,
+      inputTokensDetails: { cached_tokens: 1 },
+      outputTokensDetails: { reasoning_tokens: 2 },
+      endpoint: 'responses.create',
+    });
+    const secondEntry = new RequestUsage({
+      inputTokens: 3,
+      outputTokens: 1,
+      totalTokens: 4,
+      inputTokensDetails: { cached_tokens: 0 },
+      outputTokensDetails: { reasoning_tokens: 1 },
+      endpoint: 'responses.compact',
+    });
+    const source = new Usage({
+      requests: 2,
+      inputTokens: 8,
+      outputTokens: 7,
+      totalTokens: 15,
+      requestUsageEntries: [firstEntry, secondEntry],
+    });
+    const aggregated = new Usage();
+
+    aggregated.add(source);
+
+    expect(aggregated.requestUsageEntries).toHaveLength(2);
+    expect(aggregated.requestUsageEntries?.[0]).toBeInstanceOf(RequestUsage);
+    expect(aggregated.requestUsageEntries?.[1]).toBeInstanceOf(RequestUsage);
+    expect(aggregated.requestUsageEntries?.[0]).not.toBe(firstEntry);
+    expect(aggregated.requestUsageEntries?.[1]).not.toBe(secondEntry);
+    expect(aggregated.requestUsageEntries?.[0].inputTokensDetails).not.toBe(
+      firstEntry.inputTokensDetails,
+    );
+    expect(aggregated.requestUsageEntries?.[0].outputTokensDetails).not.toBe(
+      firstEntry.outputTokensDetails,
+    );
+
+    firstEntry.inputTokens = 99;
+    firstEntry.inputTokensDetails.cached_tokens = 99;
+    firstEntry.outputTokensDetails.reasoning_tokens = 99;
+    secondEntry.endpoint = 'mutated';
+
+    expect(aggregated.requests).toBe(2);
+    expect(aggregated.inputTokens).toBe(8);
+    expect(aggregated.outputTokens).toBe(7);
+    expect(aggregated.totalTokens).toBe(15);
+    expect(aggregated.requestUsageEntries).toEqual([
+      new RequestUsage({
+        inputTokens: 5,
+        outputTokens: 6,
+        totalTokens: 11,
+        inputTokensDetails: { cached_tokens: 1 },
+        outputTokensDetails: { reasoning_tokens: 2 },
+        endpoint: 'responses.create',
+      }),
+      new RequestUsage({
+        inputTokens: 3,
+        outputTokens: 1,
+        totalTokens: 4,
+        inputTokensDetails: { cached_tokens: 0 },
+        outputTokensDetails: { reasoning_tokens: 1 },
+        endpoint: 'responses.compact',
+      }),
+    ]);
+  });
+
+  it('detaches synthesized and top-level details from source mutations', () => {
+    const source = new Usage({
+      requests: 1,
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      inputTokensDetails: { cached_tokens: 2 },
+      outputTokensDetails: { reasoning_tokens: 3 },
+    });
+    const aggregated = new Usage();
+
+    aggregated.add(source);
+
+    expect(aggregated.inputTokensDetails[0]).not.toBe(
+      source.inputTokensDetails[0],
+    );
+    expect(aggregated.outputTokensDetails[0]).not.toBe(
+      source.outputTokensDetails[0],
+    );
+    expect(aggregated.requestUsageEntries?.[0]).toBeInstanceOf(RequestUsage);
+    expect(aggregated.requestUsageEntries?.[0].inputTokensDetails).not.toBe(
+      source.inputTokensDetails[0],
+    );
+    expect(aggregated.requestUsageEntries?.[0].outputTokensDetails).not.toBe(
+      source.outputTokensDetails[0],
+    );
+
+    source.inputTokensDetails[0].cached_tokens = 99;
+    source.outputTokensDetails[0].reasoning_tokens = 99;
+
+    expect(aggregated.inputTokensDetails).toEqual([{ cached_tokens: 2 }]);
+    expect(aggregated.outputTokensDetails).toEqual([{ reasoning_tokens: 3 }]);
+    expect(aggregated.requestUsageEntries).toEqual([
+      new RequestUsage({
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+        inputTokensDetails: { cached_tokens: 2 },
+        outputTokensDetails: { reasoning_tokens: 3 },
+      }),
+    ]);
+  });
+
   it('preserves endpoint metadata on request usage entries', () => {
     const aggregated = new Usage();
 


### PR DESCRIPTION
This pull request fixes `Usage.add()` retaining mutable aliases to source request entries and token-detail records, which allowed later source mutations to change an existing aggregate. Aggregation now creates shallow, destination-owned snapshots for authoritative and synthesized `RequestUsage` entries and top-level details while preserving totals, ordering, endpoint metadata, normalization, serialization, and existing lifecycle semantics.