### PR TITLE
fix(core): preserve handoff callback errors

### DIFF
--- a/.changeset/preserve-handoff-callback-errors.md
+++ b/.changeset/preserve-handoff-callback-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): preserve handoff callback errors after input validation

--- a/packages/agents-core/src/handoff.ts
+++ b/packages/agents-core/src/handoff.ts
@@ -377,12 +377,9 @@ export function handoff<
           'Handoff function expected non empty input',
         );
       }
+      let parsed: any;
       try {
-        // verify that it's valid input but we don't care about the result
-        const parsed = await parser(inputJsonString);
-        if (config.onHandoff) {
-          await config.onHandoff(context, parsed);
-        }
+        parsed = await parser(inputJsonString);
       } catch (error) {
         addErrorToCurrentSpan({
           message: `Invalid JSON provided`,
@@ -394,6 +391,9 @@ export function handoff<
           );
         }
         throw new ModelBehaviorError('Invalid JSON provided');
+      }
+      if (config.onHandoff) {
+        await config.onHandoff(context, parsed);
       }
     } else {
       await config.onHandoff?.(context);

--- a/packages/agents-core/test/handoffCallbackErrors.test.ts
+++ b/packages/agents-core/test/handoffCallbackErrors.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { Agent } from '../src/agent';
+import { handoff } from '../src/handoff';
+import { RunContext } from '../src/runContext';
+
+describe('handoff callback errors', () => {
+  it('preserves an onHandoff error after valid input is parsed', async () => {
+    const target = new Agent({ name: 'Target' });
+    const callbackError = new Error('database unavailable');
+    const h = handoff(target, {
+      inputType: z.object({ reason: z.string() }),
+      onHandoff: async () => {
+        throw callbackError;
+      },
+    });
+
+    await expect(
+      h.onInvokeHandoff(new RunContext(), '{"reason":"billing"}'),
+    ).rejects.toBe(callbackError);
+  });
+});


### PR DESCRIPTION
This pull request resolves #1731.

A handoff with `inputType` currently runs both input parsing and the user-provided `onHandoff` callback inside the same parse-error `try/catch`. If the callback throws after valid input has already been parsed, the SDK replaces the application error with `ModelBehaviorError("Invalid JSON provided")` and logs it as a parsing failure.

## Changes

- limit invalid-JSON handling to the handoff input parser
- invoke `onHandoff` after parsing succeeds, outside the parse-error catch
- preserve the original callback exception unchanged
- retain the existing `ModelBehaviorError` behavior for malformed or schema-invalid handoff input
- add focused regression coverage
- add a patch changeset for `@openai/agents-core`

## Validation

The branch is based on upstream `main` at `e548762a44bb26277be67707450af7f9c4fa1aa9`. The diff is limited to the handoff parser/callback boundary, one focused test, and one patch changeset.

Full repository verification is left to GitHub Actions because this environment does not have a usable local checkout/toolchain.