### PR TITLE
fix(core): surface falsy guardrail failures

### DIFF
--- a/.changeset/fail-closed-falsy-guardrail-errors.md
+++ b/.changeset/fail-closed-falsy-guardrail-errors.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): surface guardrail failures even when rejection reasons are falsy

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -67,7 +67,7 @@ export const createGuardrailTracker = (): GuardrailTracker => {
   };
 
   const throwIfError = async () => {
-    if (error) {
+    if (failed) {
       if (promise) {
         await promise;
       }
@@ -79,7 +79,7 @@ export const createGuardrailTracker = (): GuardrailTracker => {
     if (promise) {
       await promise;
     }
-    if (error && !options?.suppressErrors) {
+    if (failed && !options?.suppressErrors) {
       throw error;
     }
   };

--- a/packages/agents-core/test/guardrailTrackerFalsyErrors.test.ts
+++ b/packages/agents-core/test/guardrailTrackerFalsyErrors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { createGuardrailTracker } from '../src/runner/guardrails';
+
+async function captureRejection(promise: Promise<void>) {
+  try {
+    await promise;
+    return { rejected: false as const, reason: undefined };
+  } catch (reason) {
+    return { rejected: true as const, reason };
+  }
+}
+
+const falsyReasons: unknown[] = [null, undefined, 0, false, ''];
+
+describe('createGuardrailTracker', () => {
+  it.each(falsyReasons)(
+    'awaitCompletion preserves a falsy rejection reason: %p',
+    async (reason) => {
+      const tracker = createGuardrailTracker();
+      tracker.setPromise(Promise.reject(reason));
+
+      const result = await captureRejection(tracker.awaitCompletion());
+
+      expect(tracker.failed).toBe(true);
+      expect(result.rejected).toBe(true);
+      expect(result.reason).toBe(reason);
+    },
+  );
+
+  it.each(falsyReasons)(
+    'throwIfError preserves a falsy stored error: %p',
+    async (reason) => {
+      const tracker = createGuardrailTracker();
+      tracker.setError(reason);
+
+      const result = await captureRejection(tracker.throwIfError());
+
+      expect(tracker.failed).toBe(true);
+      expect(result.rejected).toBe(true);
+      expect(result.reason).toBe(reason);
+    },
+  );
+});


### PR DESCRIPTION
This pull request resolves #1732.

`createGuardrailTracker()` already records guardrail failure independently with its `failed` flag, but `throwIfError()` and `awaitCompletion()` currently decide whether to rethrow by testing the stored rejection reason for truthiness. Since JavaScript promises may reject with any value, failures such as `Promise.reject(null)` or `Promise.reject(false)` are silently swallowed.

## Changes

- use the tracker's explicit `failed` state when deciding whether to rethrow
- preserve the original rejection value, including falsy values
- keep `suppressErrors` behavior unchanged
- add focused coverage for `null`, `undefined`, `0`, `false`, and an empty string
- add a patch changeset for `@openai/agents-core`

## Validation

The branch is based on upstream `main` at `e548762a44bb26277be67707450af7f9c4fa1aa9`. The runtime diff is exactly two truthiness checks, plus one focused test and one patch changeset.

Full repository verification is left to GitHub Actions because this environment does not have a usable local checkout/toolchain.