### PR TITLE
feat(sandbox): allow labels on Docker sandbox containers

### DIFF
--- a/.changeset/calm-docker-labels.md
+++ b/.changeset/calm-docker-labels.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: allow labels on Docker sandbox containers

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -161,8 +161,10 @@ import {
  *   same canonical approval identity, and adds sandbox session-state envelope version 4
  *   so Docker network-isolation state cannot be consumed by older SDKs that would drop it
  *   during container replacement.
+ * - 1.20: Adds sandbox session-state envelope version 5 so Docker labels cannot be
+ *   consumed by older SDKs that would drop them during container replacement.
  */
-export const CURRENT_SCHEMA_VERSION = '1.19' as const;
+export const CURRENT_SCHEMA_VERSION = '1.20' as const;
 export const SUPPORTED_SCHEMA_VERSIONS = [
   '1.0',
   '1.1',
@@ -183,6 +185,7 @@ export const SUPPORTED_SCHEMA_VERSIONS = [
   '1.16',
   '1.17',
   '1.18',
+  '1.19',
   CURRENT_SCHEMA_VERSION,
 ] as const;
 type SupportedSchemaVersion = (typeof SUPPORTED_SCHEMA_VERSIONS)[number];
@@ -197,6 +200,14 @@ function schemaVersionSupportsV118State(
 }
 
 function schemaVersionSupportsV119State(
+  schemaVersion: SupportedSchemaVersion,
+): boolean {
+  return (
+    schemaVersion === '1.19' || schemaVersionSupportsV120State(schemaVersion)
+  );
+}
+
+function schemaVersionSupportsV120State(
   schemaVersion: SupportedSchemaVersion,
 ): boolean {
   return schemaVersion === CURRENT_SCHEMA_VERSION;
@@ -1457,6 +1468,7 @@ const sandboxSessionStateEnvelopeSchema = z.object({
       z.ZodLiteral<1>,
       z.ZodLiteral<2>,
       z.ZodLiteral<3>,
+      z.ZodLiteral<4>,
       z.ZodLiteral<typeof SANDBOX_SESSION_STATE_VERSION>,
     ],
   ),
@@ -3189,14 +3201,16 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
     schemaVersion === '1.17' ||
     schemaVersionSupportsV118State(schemaVersion);
   const supportsVersion3 = schemaVersionSupportsV118State(schemaVersion);
+  const supportsVersion4 = schemaVersionSupportsV119State(schemaVersion);
   if (
     envelopes.every(
       (envelope) =>
         envelope.version === 1 ||
         (envelope.version === 2 && supportsVersion2) ||
         (envelope.version === 3 && supportsVersion3) ||
+        (envelope.version === 4 && supportsVersion4) ||
         (envelope.version === SANDBOX_SESSION_STATE_VERSION &&
-          schemaVersionSupportsV119State(schemaVersion)),
+          schemaVersionSupportsV120State(schemaVersion)),
     )
   ) {
     return;
@@ -3207,9 +3221,10 @@ function assertSchemaVersionSupportsSandboxSessionEnvelope(
       envelope.version !== 1 &&
       !(envelope.version === 2 && supportsVersion2) &&
       !(envelope.version === 3 && supportsVersion3) &&
+      !(envelope.version === 4 && supportsVersion4) &&
       !(
         envelope.version === SANDBOX_SESSION_STATE_VERSION &&
-        schemaVersionSupportsV119State(schemaVersion)
+        schemaVersionSupportsV120State(schemaVersion)
       ),
   )?.version;
   throw new UserError(

--- a/packages/agents-core/src/sandbox/sandboxes/docker.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/docker.ts
@@ -145,6 +145,7 @@ import {
   normalizeExposedPorts,
 } from './shared/sessionStateValues';
 import {
+  isStringRecord,
   readOptionalNumberArray,
   readOptionalString,
   readString,
@@ -168,6 +169,11 @@ const DOCKER_OWNERSHIP_LABEL = 'openai-agents-sandbox';
 const DOCKER_SESSION_IDENTITY_LABEL = 'openai-agents-sandbox.session-identity';
 const DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL =
   'openai-agents-sandbox.mount-authority-fingerprint';
+const RESERVED_DOCKER_LABELS = new Set([
+  DOCKER_OWNERSHIP_LABEL,
+  DOCKER_SESSION_IDENTITY_LABEL,
+  DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL,
+]);
 
 type DockerNetworkMode = 'none';
 
@@ -175,6 +181,13 @@ export interface DockerSandboxClientOptions extends SandboxClientOptions {
   image?: string;
   exposedPorts?: number[];
   networkMode?: DockerNetworkMode;
+  /**
+   * User-defined labels applied to created Docker containers.
+   *
+   * The SDK-owned ownership, session identity, and mount-authority labels are
+   * reserved and cannot be overridden.
+   */
+  labels?: Record<string, string>;
   workspaceBaseDir?: string;
   snapshot?: LocalSandboxSnapshotSpec;
   concurrencyLimits?: SandboxConcurrencyLimits;
@@ -194,6 +207,7 @@ export interface DockerSandboxSessionState extends UnixLocalSandboxSessionState 
   defaultUser?: string;
   configuredExposedPorts?: number[];
   networkMode?: DockerNetworkMode;
+  labels?: Record<string, string>;
   dockerVolumeNames?: string[];
   snapshotExcludedPaths?: string[];
 }
@@ -1011,7 +1025,17 @@ export class DockerSandboxClient implements SandboxClient<
   >();
 
   constructor(options: DockerSandboxClientOptions = {}) {
-    this.options = options;
+    this.options = {
+      ...options,
+      ...(options.labels === undefined
+        ? {}
+        : {
+            labels: normalizeDockerLabels(
+              options.labels,
+              'DockerSandboxClient labels',
+            ),
+          }),
+    };
   }
 
   async create(
@@ -1036,6 +1060,7 @@ export class DockerSandboxClient implements SandboxClient<
     };
     const { configuredExposedPorts, networkMode } =
       resolveDockerNetworkConfiguration(this.options, createArgs.options);
+    const labels = resolveDockerLabels(this.options, createArgs.options);
     const environment = await manifest.resolveEnvironment();
     validateMountEnvironmentCredentialBoundaries(manifest, environment);
     await ensureDockerAvailable();
@@ -1075,6 +1100,7 @@ export class DockerSandboxClient implements SandboxClient<
       defaultUser,
       exposedPorts: configuredExposedPorts,
       networkMode,
+      labels,
     });
     const session = new DockerSandboxSession({
       state: {
@@ -1092,6 +1118,7 @@ export class DockerSandboxClient implements SandboxClient<
         defaultUser,
         configuredExposedPorts,
         networkMode,
+        labels: { ...labels },
         dockerVolumeNames: container.volumeNames,
       },
       archiveLimits: resolvedOptions.archiveLimits,
@@ -1163,6 +1190,15 @@ export class DockerSandboxClient implements SandboxClient<
           exposedPorts: undefined,
         };
       }
+      const labels = resolveDockerLabels(
+        this.options,
+        options.clientOptions,
+        state,
+      );
+      resumeState = {
+        ...resumeState,
+        labels,
+      };
     }
     assertMountCredentialsRebound(resumeState);
     assertHostPathGrantsRebound(resumeState);
@@ -1209,6 +1245,15 @@ export class DockerSandboxClient implements SandboxClient<
         ? { configuredExposedPorts, networkMode }
         : undefined,
     );
+    const persistedLabels = normalizeDockerLabels(
+      input.state.labels,
+      'Docker sandbox session state labels',
+    );
+    resolveDockerLabels(
+      this.options,
+      options.clientOptions,
+      input.source === 'explicit' ? { labels: persistedLabels } : undefined,
+    );
   }
 
   async canReusePreservedOwnedSession(
@@ -1238,6 +1283,11 @@ export class DockerSandboxClient implements SandboxClient<
       ...this.options,
       ...options.clientOptions,
     };
+    try {
+      resolveDockerLabels(this.options, options.clientOptions, state);
+    } catch {
+      return false;
+    }
     const { configuredExposedPorts, networkMode } =
       resolveDockerNetworkConfiguration(this.options, options.clientOptions);
     if (
@@ -1280,6 +1330,10 @@ export class DockerSandboxClient implements SandboxClient<
     options: SandboxSessionSerializationOptions = {},
   ): Promise<Record<string, unknown>> {
     assertSandboxSessionStateUsable(state);
+    const labels = normalizeDockerLabels(
+      state.labels,
+      'Docker sandbox session state labels',
+    );
     validateMountEnvironmentCredentialBoundaries(
       state.manifest,
       state.environment,
@@ -1325,6 +1379,7 @@ export class DockerSandboxClient implements SandboxClient<
       ...(state.networkMode !== undefined
         ? { networkMode: state.networkMode }
         : {}),
+      labels,
       dockerVolumeNames: state.dockerVolumeNames ?? [],
       exposedPorts: state.exposedPorts ?? null,
     };
@@ -1354,6 +1409,10 @@ export class DockerSandboxClient implements SandboxClient<
       defaultUser:
         readOptionalString(state, 'defaultUser') ?? getHostDockerUser(),
       networkMode,
+      labels: normalizeDockerLabels(
+        state.labels,
+        'Serialized Docker sandbox session state labels',
+      ),
       dockerVolumeNames: readStringArray(state.dockerVolumeNames),
     };
   }
@@ -1376,6 +1435,10 @@ export class DockerSandboxClient implements SandboxClient<
           trustedConfig?.clientOptions as
             DockerSandboxClientOptions | undefined,
         );
+      const labels = resolveDockerLabels(
+        this.options,
+        trustedConfig?.clientOptions as DockerSandboxClientOptions | undefined,
+      );
       const trustedState: DockerSandboxSessionState = {
         ...state,
         sessionIdentity: undefined,
@@ -1389,6 +1452,7 @@ export class DockerSandboxClient implements SandboxClient<
         defaultUser: getHostDockerUser(),
         configuredExposedPorts,
         networkMode,
+        labels,
         dockerVolumeNames: [],
         exposedPorts: undefined,
       };
@@ -1412,6 +1476,14 @@ export class DockerSandboxClient implements SandboxClient<
         const inspection = await inspectRunningDockerContainerForReuse(state);
         if (inspection.reusable) {
           return state;
+        }
+        if (
+          inspection.ownershipVerified &&
+          inspection.requiredLabelsMatch === false
+        ) {
+          throw new UserError(
+            'Existing Docker sandbox labels do not match required labels. Start a fresh sandbox session instead.',
+          );
         }
         if (!inspection.ownershipVerified) {
           throw new UserError(
@@ -1448,16 +1520,18 @@ export class DockerSandboxClient implements SandboxClient<
       }
     }
 
-    if (
-      containerRunning &&
-      !dockerContainerIdentityMatches(
-        state.sessionIdentity,
-        await inspectDockerContainerLabels(state.containerId),
-      )
-    ) {
-      throw new UserError(
-        'Docker sandbox container identity could not be verified. Refusing to resume or replace the running container.',
-      );
+    if (containerRunning) {
+      const labels = await inspectDockerContainerLabels(state.containerId);
+      if (!dockerContainerIdentityMatches(state.sessionIdentity, labels)) {
+        throw new UserError(
+          'Docker sandbox container identity could not be verified. Refusing to resume or replace the running container.',
+        );
+      }
+      if (!dockerRequiredLabelsMatch(state.labels, labels)) {
+        throw new UserError(
+          'Existing Docker sandbox labels do not match required labels. Start a fresh sandbox session instead.',
+        );
+      }
     }
     if (!(await localSnapshotIsRestorable(state))) {
       throw new UserError(
@@ -1541,6 +1615,10 @@ export class DockerSandboxClient implements SandboxClient<
       defaultUser: state.defaultUser,
       exposedPorts: state.configuredExposedPorts,
       networkMode: state.networkMode,
+      labels: normalizeDockerLabels(
+        state.labels,
+        'Docker sandbox session state labels',
+      ),
     });
     const nextState = {
       ...state,
@@ -1550,6 +1628,10 @@ export class DockerSandboxClient implements SandboxClient<
       ),
       workspaceRootPath,
       containerId: container.containerId,
+      labels: normalizeDockerLabels(
+        state.labels,
+        'Docker sandbox session state labels',
+      ),
       dockerVolumeNames: container.volumeNames,
       exposedPorts: undefined,
     };
@@ -1653,6 +1735,7 @@ function assertDockerManifestSupported(manifest: Manifest): void {
 type DockerContainerReuseInspection = {
   ownershipVerified: boolean;
   reusable: boolean;
+  requiredLabelsMatch?: boolean;
 };
 
 async function inspectRunningDockerContainerForReuse(
@@ -1668,6 +1751,13 @@ async function inspectRunningDockerContainerForReuse(
   }
   if (!dockerContainerIdentityMatches(sessionIdentity, labels)) {
     return { ownershipVerified: false, reusable: false };
+  }
+  if (!dockerRequiredLabelsMatch(state.labels, labels)) {
+    return {
+      ownershipVerified: true,
+      reusable: false,
+      requiredLabelsMatch: false,
+    };
   }
   const workspaceMountBeforeInspect = await resolveDockerWorkspaceMount(
     state.workspaceRootPath,
@@ -1750,6 +1840,13 @@ async function inspectLegacyDockerContainerForReuse(
     labels[DOCKER_MOUNT_AUTHORITY_FINGERPRINT_LABEL] !== undefined
   ) {
     return { ownershipVerified: false, reusable: false };
+  }
+  if (!dockerRequiredLabelsMatch(state.labels, labels)) {
+    return {
+      ownershipVerified: true,
+      reusable: false,
+      requiredLabelsMatch: false,
+    };
   }
 
   const workspaceMountBeforeInspect = await resolveDockerWorkspaceMount(
@@ -2182,6 +2279,86 @@ function dockerExposedPortSetsEqual(left: number[], right: number[]): boolean {
   );
 }
 
+function normalizeDockerLabels(
+  value: unknown,
+  source: string,
+): Record<string, string> {
+  if (value === undefined) {
+    return {};
+  }
+  if (!isStringRecord(value)) {
+    throw new UserError(`${source} must be a record of string values.`);
+  }
+  const labels = { ...value };
+  for (const key of Object.keys(labels)) {
+    if (RESERVED_DOCKER_LABELS.has(key)) {
+      throw new UserError(
+        `${source} cannot override reserved SDK label "${key}".`,
+      );
+    }
+  }
+  return labels;
+}
+
+function dockerLabelRecordsEqual(
+  left: Record<string, string>,
+  right: Record<string, string>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  return (
+    leftKeys.length === Object.keys(right).length &&
+    leftKeys.every((key) => right[key] === left[key])
+  );
+}
+
+function resolveDockerLabels(
+  clientOptions: DockerSandboxClientOptions,
+  perRunOptions?: DockerSandboxClientOptions,
+  explicitStateFallback?: Pick<DockerSandboxSessionState, 'labels'>,
+): Record<string, string> {
+  const trustedLabels =
+    perRunOptions?.labels !== undefined
+      ? normalizeDockerLabels(
+          perRunOptions.labels,
+          'DockerSandboxClient per-run labels',
+        )
+      : clientOptions.labels !== undefined
+        ? normalizeDockerLabels(
+            clientOptions.labels,
+            'DockerSandboxClient labels',
+          )
+        : undefined;
+  const persistedLabels = explicitStateFallback
+    ? normalizeDockerLabels(
+        explicitStateFallback.labels,
+        'Docker sandbox session state labels',
+      )
+    : undefined;
+  if (
+    trustedLabels !== undefined &&
+    persistedLabels !== undefined &&
+    !dockerLabelRecordsEqual(trustedLabels, persistedLabels)
+  ) {
+    throw new UserError(
+      'DockerSandboxClient labels cannot be changed when resuming explicit session state. Start a fresh sandbox session instead.',
+    );
+  }
+  return { ...(trustedLabels ?? persistedLabels ?? {}) };
+}
+
+function dockerRequiredLabelsMatch(
+  requiredLabels: Record<string, string> | undefined,
+  actualLabels: Record<string, unknown> | undefined,
+): boolean {
+  const normalizedRequiredLabels = normalizeDockerLabels(
+    requiredLabels,
+    'Docker sandbox session state labels',
+  );
+  return Object.entries(normalizedRequiredLabels).every(
+    ([key, value]) => actualLabels?.[key] === value,
+  );
+}
+
 function validateDockerNetworkConfiguration(
   networkMode: unknown,
   exposedPorts: number[] | undefined,
@@ -2497,7 +2674,12 @@ async function startDockerContainer(args: {
   defaultUser?: string;
   exposedPorts?: number[];
   networkMode?: DockerNetworkMode;
+  labels?: Record<string, string>;
 }): Promise<{ containerId: string; volumeNames: string[] }> {
+  const labels = normalizeDockerLabels(
+    args.labels,
+    'Docker sandbox container labels',
+  );
   validateDockerNetworkConfiguration(args.networkMode, args.exposedPorts);
   const envArgs = Object.entries(args.environment).flatMap(([key, value]) => [
     '-e',
@@ -2509,6 +2691,10 @@ async function startDockerContainer(args: {
     `127.0.0.1::${port}`,
   ]);
   const networkArgs = args.networkMode ? ['--network', args.networkMode] : [];
+  const labelArgs = Object.entries(labels).flatMap(([key, value]) => [
+    '--label',
+    `${key}=${value}`,
+  ]);
   const containerName = `openai-agents-sandbox-${randomUUID().slice(0, 8)}`;
   const workspaceMount = await resolveDockerWorkspaceMount(
     args.workspaceRootPath,
@@ -2531,6 +2717,7 @@ async function startDockerContainer(args: {
       '-d',
       '--name',
       containerName,
+      ...labelArgs,
       '--label',
       `${DOCKER_OWNERSHIP_LABEL}=true`,
       '--label',

--- a/packages/agents-core/src/sandbox/session.ts
+++ b/packages/agents-core/src/sandbox/session.ts
@@ -6,11 +6,12 @@ import type { Entry } from './entries';
 import type { Manifest } from './manifest';
 import type { Snapshot } from './snapshot';
 
-export const SANDBOX_SESSION_STATE_VERSION = 4 as const;
+export const SANDBOX_SESSION_STATE_VERSION = 5 as const;
 export const SUPPORTED_SANDBOX_SESSION_STATE_VERSIONS = [
   1,
   2,
   3,
+  4,
   SANDBOX_SESSION_STATE_VERSION,
 ] as const;
 export type SandboxSessionStateVersion =

--- a/packages/agents-core/test/fixtures/run-state/README.md
+++ b/packages/agents-core/test/fixtures/run-state/README.md
@@ -10,7 +10,7 @@ This directory is immutable compatibility evidence for released `RunState` write
 
 Each historical fixture records its package version, release tag, full source commit, npm integrity, scenario, path, and SHA-256 in `sources.json`. The published package and npm integrity identify the primary writer artifact; the tag and commit are supplementary source provenance. Minimal fixtures prove the writer format for every published schema. Feature and resume fixtures are intentionally limited to durable boundaries that need more than an empty state to exercise compatibility.
 
-The released `1.17` sandbox format predates the mount-credential redaction boundary added by schema `1.18`. The `v0.16.0` writer fixtures establish the released `1.18` boundary, including canonical per-call approval identity. Current schema `1.19` changes mixed sticky and exact approval decisions to resolve the exact call first and adds the next sandbox envelope version for Docker network-isolation state. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
+The released `1.17` sandbox format predates the mount-credential redaction boundary added by schema `1.18`. The `v0.16.0` writer fixtures establish the released `1.18` boundary, including canonical per-call approval identity. The `v0.17.0` writer fixture establishes the released `1.19` boundary for exact-call approval precedence and Docker network-isolation state. Current schema `1.20` adds the next sandbox envelope version for Docker labels. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
 
 ## Regeneration
 

--- a/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
+++ b/packages/agents-core/test/fixtures/run-state/generate-corpus.mts
@@ -441,6 +441,8 @@ function generateNegativeFixtures(outputRoot: string) {
   sandboxV3.sandbox = sandbox(3);
   const sandboxV4 = readHistorical('1.18');
   sandboxV4.sandbox = sandbox(4);
+  const sandboxV5 = readHistorical('1.19');
+  sandboxV5.sandbox = sandbox(5);
   const protoKey = readHistorical('1.0');
   const protoContext = JSON.parse(
     '{"__proto__":{"polluted":"sentinel-not-a-secret"}}',
@@ -471,6 +473,11 @@ function generateNegativeFixtures(outputRoot: string) {
       'v1.18-sandbox-v4',
       sandboxV4,
       'does not support sandbox session state version 4',
+    ],
+    [
+      'v1.19-sandbox-v5',
+      sandboxV5,
+      'does not support sandbox session state version 5',
     ],
   ] as const;
   const records = fixtures.map(([scenario, payload, expectedError]) => {

--- a/packages/agents-core/test/fixtures/run-state/historical/v1.19-minimal.json
+++ b/packages/agents-core/test/fixtures/run-state/historical/v1.19-minimal.json
@@ -1,5 +1,5 @@
 {
-  "$schemaVersion": "1.20",
+  "$schemaVersion": "1.19",
   "currentTurn": 0,
   "currentAgent": {
     "name": "HistoricalAgent"

--- a/packages/agents-core/test/fixtures/run-state/negative/v1.19-sandbox-v5.json
+++ b/packages/agents-core/test/fixtures/run-state/negative/v1.19-sandbox-v5.json
@@ -1,5 +1,5 @@
 {
-  "$schemaVersion": "1.20",
+  "$schemaVersion": "1.19",
   "currentTurn": 0,
   "currentAgent": {
     "name": "HistoricalAgent"
@@ -36,5 +36,18 @@
   "completedToolInvocations": [],
   "completedToolInvocationEvidence": [],
   "ambiguousToolInvocationCallIds": [],
-  "trace": null
+  "trace": null,
+  "sandbox": {
+    "backendId": "fixture-sandbox",
+    "currentAgentKey": "HistoricalAgent",
+    "currentAgentName": "HistoricalAgent",
+    "sessionState": {
+      "version": 5,
+      "backendId": "fixture-sandbox",
+      "manifest": {},
+      "workspaceReady": true,
+      "providerState": {}
+    },
+    "sessionsByAgent": {}
+  }
 }

--- a/packages/agents-core/test/fixtures/run-state/sources.json
+++ b/packages/agents-core/test/fixtures/run-state/sources.json
@@ -1,6 +1,6 @@
 {
   "formatVersion": 1,
-  "currentSchemaAtCreation": "1.19",
+  "currentSchemaAtCreation": "1.20",
   "schemas": [
     {
       "schemaVersion": "1.0",
@@ -316,15 +316,31 @@
     },
     {
       "schemaVersion": "1.19",
+      "status": "published_writer",
+      "packageVersion": "0.17.0",
+      "tag": "v0.17.0",
+      "commit": "0319b657e64e0c132629fe9ed4d524f7cde93445",
+      "npmIntegrity": "sha512-lyoF860313ypeKSPRsdmyNK1ypF8/ocShN2EwCcKUpF4VvRWa5AUVKL6VXO/keQMwNPZw5SACAf1siU9uMvUNg==",
+      "fixtures": [
+        {
+          "scenario": "minimal",
+          "kind": "minimal",
+          "path": "historical/v1.19-minimal.json",
+          "sha256": "e2ac4f6f2ba1631eb8c95c35c7d1895a30d40a5077dbd5476107e57a01de1edb"
+        }
+      ]
+    },
+    {
+      "schemaVersion": "1.20",
       "status": "current_unreleased",
-      "reason": "Supported on main but not emitted by the latest released package v0.16.0; includes exact-call approval precedence and sandbox envelope version 4."
+      "reason": "Supported on main but not emitted by the latest released package v0.17.0; adds sandbox envelope version 5 for Docker labels."
     }
   ],
   "expectedNormalizedFixtures": [
     {
       "sourceSchemaVersion": "1.0",
       "path": "expected/v1.0-normalized-current.json",
-      "sha256": "e2ac4f6f2ba1631eb8c95c35c7d1895a30d40a5077dbd5476107e57a01de1edb"
+      "sha256": "d0b04e02da08785999fbdb02e2478903371358408015d112c6c0c663578d75cb"
     }
   ],
   "negativeFixtures": [
@@ -369,6 +385,12 @@
       "path": "negative/v1.18-sandbox-v4.json",
       "sha256": "7792da13fda1bd76b59499ea13051cef593d59f391a125920d299cf9e6c24869",
       "expectedError": "does not support sandbox session state version 4"
+    },
+    {
+      "scenario": "v1.19-sandbox-v5",
+      "path": "negative/v1.19-sandbox-v5.json",
+      "sha256": "9d57447885d36c6d1bbc71cb4ba3c7de2c4fd2fcc3d8053b1704a791cd003c90",
+      "expectedError": "does not support sandbox session state version 5"
     },
     {
       "scenario": "prototype-key",

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -684,11 +684,61 @@ export function registerRunStateCoreTests(): void {
       };
       const serialized = state.toJSON();
       serialized.$schemaVersion = '1.18';
+      serialized.sandbox!.sessionState.version = 4;
 
       await expect(
         RunState.fromString(agent, JSON.stringify(serialized)),
       ).rejects.toThrow(
         'Run state schema version 1.18 does not support sandbox session state version 4.',
+      );
+    });
+
+    it('keeps reading schema 1.19 payloads with sandbox session state version 4', async () => {
+      const agent = new Agent({ name: 'VersionFourSandboxEnvelopeAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._sandbox = {
+        backendId: 'unix-local',
+        currentAgentKey: 'VersionFourSandboxEnvelopeAgent',
+        currentAgentName: 'VersionFourSandboxEnvelopeAgent',
+        sessionState: sandboxSessionStateEnvelope({
+          workspaceId: 'ws_version_four',
+        }),
+        sessionsByAgent: {},
+      };
+      const serialized = state.toJSON();
+      serialized.$schemaVersion = '1.19';
+      serialized.sandbox!.sessionState.version = 4;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored._sandbox?.sessionState.version).toBe(4);
+      expect(() => restored.toString()).toThrow(
+        /must be resumed through the Runner/u,
+      );
+    });
+
+    it('rejects sandbox session state version 5 under released schema 1.19', async () => {
+      const agent = new Agent({ name: 'VersionFiveSandboxEnvelopeAgent' });
+      const state = new RunState(new RunContext(), 'input', agent, 1);
+      state._sandbox = {
+        backendId: 'unix-local',
+        currentAgentKey: 'VersionFiveSandboxEnvelopeAgent',
+        currentAgentName: 'VersionFiveSandboxEnvelopeAgent',
+        sessionState: sandboxSessionStateEnvelope({
+          workspaceId: 'ws_version_five',
+        }),
+        sessionsByAgent: {},
+      };
+      const serialized = state.toJSON();
+      serialized.$schemaVersion = '1.19';
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow(
+        'Run state schema version 1.19 does not support sandbox session state version 5.',
       );
     });
 

--- a/packages/agents-core/test/runState.compatibility.test.ts
+++ b/packages/agents-core/test/runState.compatibility.test.ts
@@ -119,6 +119,7 @@ describe('historical RunState compatibility corpus', () => {
       '1.15',
       '1.17',
       '1.18',
+      '1.19',
     ]);
     expect(
       manifest.schemas
@@ -129,7 +130,7 @@ describe('historical RunState compatibility corpus', () => {
       manifest.schemas
         .filter((entry) => entry.status === 'current_unreleased')
         .map((entry) => entry.schemaVersion),
-    ).toEqual(['1.19']);
+    ).toEqual(['1.20']);
   });
 
   it('pins every fixture to immutable bytes and complete writer provenance', () => {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -348,6 +348,7 @@ describe('DockerSandboxClient unit behavior', () => {
       ]),
     );
     expect(runCall?.[1]).not.toContain('--network');
+    expect(Object.keys(dockerRunLabels(runCall?.[1] ?? []))).toHaveLength(3);
     const imageArgIndex = runCall?.[1].indexOf('custom:image') ?? -1;
     expect(runCall?.[1].slice(imageArgIndex + 1, imageArgIndex + 3)).toEqual([
       '/bin/sh',
@@ -385,6 +386,114 @@ describe('DockerSandboxClient unit behavior', () => {
       { timeoutMs: 30_000 },
     );
     await expect(stat(session.state.workspaceRootPath)).rejects.toThrow();
+  });
+
+  it('applies, copies, overrides, and serializes user-defined labels', async () => {
+    let runCount = 0;
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          runCount += 1;
+          return success(`container-labels-${runCount}\n`);
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const constructorLabels = { team: 'platform', tier: 'default' };
+    const perRunLabels = { workload: 'eval', tier: 'override' };
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+      labels: constructorLabels,
+      snapshot: new NoopSnapshotSpec(),
+    });
+    constructorLabels.team = 'mutated';
+
+    const constructorSession = await client.create(new Manifest());
+    const session = await client.create(new Manifest(), {
+      labels: perRunLabels,
+    });
+    perRunLabels.workload = 'mutated';
+
+    const runCalls = processMocks.runSandboxProcess.mock.calls.filter(
+      ([, args]) => args[0] === 'run',
+    );
+    expect(dockerRunLabels(runCalls[0]?.[1] ?? [])).toMatchObject({
+      team: 'platform',
+      tier: 'default',
+      'openai-agents-sandbox': 'true',
+      [dockerSessionIdentityLabel]: constructorSession.state.sessionIdentity,
+    });
+    const runArgs = runCalls[1]?.[1];
+    expect(dockerRunLabels(runArgs ?? [])).toMatchObject({
+      workload: 'eval',
+      tier: 'override',
+      'openai-agents-sandbox': 'true',
+      [dockerSessionIdentityLabel]: session.state.sessionIdentity,
+    });
+    expect(dockerRunLabels(runArgs ?? [])).not.toHaveProperty('team');
+    expect(session.state.labels).toEqual({
+      workload: 'eval',
+      tier: 'override',
+    });
+    expect(session.state.labels).not.toBe(perRunLabels);
+
+    const serialized = await client.serializeSessionState(session.state);
+    expect(serialized.labels).toEqual({
+      workload: 'eval',
+      tier: 'override',
+    });
+    expect(serialized.labels).not.toBe(session.state.labels);
+    const deserialized = await client.deserializeSessionState(serialized);
+    expect(deserialized.labels).toEqual({
+      workload: 'eval',
+      tier: 'override',
+    });
+    expect(deserialized.labels).not.toBe(serialized.labels);
+
+    const legacy = { ...serialized };
+    delete legacy.labels;
+    await expect(client.deserializeSessionState(legacy)).resolves.toMatchObject(
+      { labels: {} },
+    );
+
+    await constructorSession.close();
+    await session.close();
+  });
+
+  it.each([
+    'openai-agents-sandbox',
+    dockerSessionIdentityLabel,
+    dockerMountAuthorityFingerprintLabel,
+  ])('rejects reserved label %s before side effects', async (label) => {
+    expect(
+      () =>
+        new DockerSandboxClient({
+          workspaceBaseDir: rootDir,
+          labels: { [label]: 'caller-value' },
+        }),
+    ).toThrow(`cannot override reserved SDK label "${label}"`);
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    await expect(readdir(rootDir)).resolves.toEqual([]);
+  });
+
+  it('rejects non-string per-run labels before Docker or filesystem effects', async () => {
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+
+    await expect(
+      client.create(new Manifest(), {
+        labels: { invalid: 42 } as never,
+      }),
+    ).rejects.toThrow('per-run labels must be a record of string values');
+
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    await expect(readdir(rootDir)).resolves.toEqual([]);
   });
 
   it.each(['bridge', 'host', null, 42])(
@@ -3189,6 +3298,98 @@ describe('DockerSandboxClient unit behavior', () => {
     await session.close();
   });
 
+  it('requires configured labels for live reuse while allowing unrelated labels', async () => {
+    const inspections = new Map<string, DockerContainerInspection>();
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          inspections.set('container-labels', dockerRunInspection(args));
+          return success('container-labels\n');
+        }
+        if (args[0] === 'inspect') {
+          return dockerInspectionResult(inspections, args) ?? success('true\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest(), {
+      labels: { team: 'platform' },
+    });
+    const inspection = inspections.get('container-labels')!;
+    inspection.labels.unrelated = 'allowed';
+
+    await expect(
+      client.canReusePreservedOwnedSession(session.state),
+    ).resolves.toBe(true);
+    await expect(
+      client.canReusePreservedOwnedSession(session.state, {
+        clientOptions: { labels: { team: 'other' } },
+      }),
+    ).resolves.toBe(false);
+
+    inspection.labels.team = 'other';
+    await expect(client.resume(session.state)).rejects.toThrow(
+      'Existing Docker sandbox labels do not match required labels',
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalledWith(
+      'docker',
+      ['rm', '-f', 'container-labels'],
+      { timeoutMs: 30_000 },
+    );
+    expect(
+      processMocks.runSandboxProcess.mock.calls.filter(
+        ([, args]) => args[0] === 'run',
+      ),
+    ).toHaveLength(1);
+
+    inspection.labels.team = 'platform';
+    const resumed = await client.resume(session.state);
+    expect(resumed.state.containerId).toBe('container-labels');
+    await resumed.close();
+  });
+
+  it('rejects explicit resume label changes before provider side effects', async () => {
+    processMocks.runSandboxProcess.mockImplementation(
+      async (_command: string, args: string[]) => {
+        if (args[0] === 'version') {
+          return success('Docker version test');
+        }
+        if (args[0] === 'run') {
+          return success('container-labels\n');
+        }
+        if (args[0] === 'rm') {
+          return success();
+        }
+        return failure('unexpected docker command');
+      },
+    );
+    const client = new DockerSandboxClient({ workspaceBaseDir: rootDir });
+    const session = await client.create(new Manifest(), {
+      labels: { team: 'platform' },
+    });
+    processMocks.runSandboxProcess.mockClear();
+
+    await expect(
+      client.resume(session.state, {
+        clientOptions: { labels: { team: 'other' } },
+      }),
+    ).rejects.toThrow(
+      'DockerSandboxClient labels cannot be changed when resuming explicit session state',
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+
+    await session.close();
+  });
+
   it('verifies actual Docker network isolation before live reuse', async () => {
     const inspections = new Map<string, DockerContainerInspection>();
     processMocks.runSandboxProcess.mockImplementation(
@@ -5010,9 +5211,15 @@ describe('DockerSandboxClient unit behavior', () => {
       snapshot: null,
       image: 'custom:image',
       containerId: 'container-stopped',
+      labels: { team: 'platform' },
     });
 
     expect(session.state.containerId).toBe('container-restarted');
+    expect(session.state.labels).toEqual({ team: 'platform' });
+    const runArgs = processMocks.runSandboxProcess.mock.calls.find(
+      ([, args]) => args[0] === 'run',
+    )?.[1];
+    expect(dockerRunLabels(runArgs ?? [])).toMatchObject({ team: 'platform' });
     expect(processMocks.runSandboxProcess).toHaveBeenCalledWith(
       'docker',
       [
@@ -5209,6 +5416,7 @@ describe('DockerSandboxClient unit behavior', () => {
       workspaceBaseDir: rootDir,
       image: 'client:image',
       exposedPorts: [3000],
+      labels: { source: 'constructor' },
       snapshot: {
         type: 'local',
         baseDir: rootDir,
@@ -5240,6 +5448,7 @@ describe('DockerSandboxClient unit behavior', () => {
     };
     serialized.defaultUser = 'root';
     serialized.configuredExposedPorts = [9999];
+    serialized.labels = { source: 'untrusted-state' };
     expect(serialized.snapshotFingerprint).toEqual(expect.any(String));
     expect(serialized.snapshotFingerprintVersion).toBe(
       'workspace_tree_sha256_v1',
@@ -5269,6 +5478,7 @@ describe('DockerSandboxClient unit behavior', () => {
         clientOptions: {
           image: 'run:image',
           exposedPorts: [4000],
+          labels: { source: 'trusted-run' },
           workspaceBaseDir: rootDir,
         },
         snapshot: {
@@ -5300,6 +5510,7 @@ describe('DockerSandboxClient unit behavior', () => {
     });
     expect(restored.state.defaultUser).not.toBe('root');
     expect(restored.state.configuredExposedPorts).toEqual([4000]);
+    expect(restored.state.labels).toEqual({ source: 'trusted-run' });
     const restoredRunArgs = processMocks.runSandboxProcess.mock.calls.filter(
       ([, args]) => args[0] === 'run',
     )[1]?.[1];
@@ -5316,6 +5527,12 @@ describe('DockerSandboxClient unit behavior', () => {
     expect(restoredRunArgs).not.toContain('UNTRUSTED_ENV=untrusted-value');
     expect(restoredRunArgs).not.toContain('127.0.0.1::9999');
     expect(restoredRunArgs).not.toContain('untrusted:image');
+    expect(dockerRunLabels(restoredRunArgs ?? [])).toMatchObject({
+      source: 'trusted-run',
+    });
+    expect(dockerRunLabels(restoredRunArgs ?? [])).not.toMatchObject({
+      source: 'untrusted-state',
+    });
     await expect(
       readFile(join(session.state.workspaceRootPath, 'notes.txt'), 'utf8'),
     ).resolves.toBe('drifted\n');


### PR DESCRIPTION
This pull request adds user-defined labels to Docker sandbox containers.

It protects the SDK-owned ownership and identity labels, preserves configured labels across explicit session serialization and container replacement, and recreates RunState resources using current trusted configuration. It also advances the durable RunState and sandbox envelope versions so older readers cannot silently discard label semantics.