### PR TITLE
fix(openai): reject truncated empty Chat Completions

### DIFF
--- a/.changeset/reject-empty-truncated-chat-completions.md
+++ b/.changeset/reject-empty-truncated-chat-completions.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: reject truncated empty Chat Completions

--- a/packages/agents-openai/src/openaiChatCompletionsModel.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsModel.ts
@@ -44,8 +44,16 @@ import {
   CONTENT_FILTER_REFUSAL_MESSAGE,
   shouldSynthesizeContentFilterRefusal,
 } from './openaiChatCompletionsContentFilter';
-import { snapshotRawUsage } from '@openai/agents-core/utils/internal';
+import {
+  reportModelFailureUsage,
+  snapshotRawUsage,
+} from '@openai/agents-core/utils/internal';
 import { FAKE_ID } from './openaiItemIds';
+import {
+  createTruncatedEmptyChatCompletionError,
+  isTruncatedEmptyChatCompletion,
+  isTruncatedEmptyChatCompletionError,
+} from './openaiChatCompletionsTruncation';
 
 export { FAKE_ID };
 
@@ -199,6 +207,47 @@ export class OpenAIChatCompletionsModel implements Model {
           if (span && request.tracing === true) {
             span.spanData.output = [response];
           }
+          const normalizedMessage = response.choices?.[0]?.message;
+          const hasStrictCustomToolCall = Boolean(
+            this.#strictFeatureValidation &&
+            normalizedMessage?.tool_calls?.some(
+              (toolCall) => toolCall.type === 'custom',
+            ),
+          );
+          if (
+            normalizedMessage &&
+            !hasStrictCustomToolCall &&
+            isTruncatedEmptyChatCompletion({
+              finishReason: response.choices[0]?.finish_reason,
+              hasText:
+                typeof normalizedMessage.content === 'string' &&
+                normalizedMessage.content.length > 0,
+              hasRefusal:
+                typeof normalizedMessage.refusal === 'string' &&
+                normalizedMessage.refusal.length > 0,
+              hasAudio: normalizedMessage.audio != null,
+              hasReasoning: hasReasoningContent(normalizedMessage),
+              hasFunctionCall: Boolean(
+                normalizedMessage.tool_calls?.some(
+                  (toolCall) => toolCall.type === 'function',
+                ),
+              ),
+            })
+          ) {
+            const error = createTruncatedEmptyChatCompletionError();
+            const failureUsage = toResponseUsage(
+              response.usage ?? {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+              },
+            );
+            if (span) {
+              span.spanData.usage = failureUsage;
+            }
+            reportModelFailureUsage(request, error, new Usage(failureUsage));
+            throw error;
+          }
           return { response, rawResponse, rawUsage, preservedUsage };
         },
         undefined,
@@ -334,6 +383,7 @@ export class OpenAIChatCompletionsModel implements Model {
     const span = request.tracing
       ? createGenerationSpan(undefined, getModelTracingParent(request))
       : undefined;
+    let response: OpenAI.Chat.Completions.ChatCompletion | undefined;
     try {
       if (span) {
         span.spanData.model = this.#model;
@@ -356,7 +406,7 @@ export class OpenAIChatCompletionsModel implements Model {
         true,
       );
 
-      const response: OpenAI.Chat.Completions.ChatCompletion = {
+      response = {
         id: FAKE_ID,
         created: Math.floor(Date.now() / 1000),
         model: this.#model,
@@ -408,7 +458,38 @@ export class OpenAIChatCompletionsModel implements Model {
         span.spanData.output = [response];
       }
     } catch (error) {
+      const truncatedResponse =
+        response !== undefined && isTruncatedEmptyChatCompletionError(error)
+          ? response
+          : undefined;
+      if (truncatedResponse) {
+        reportModelFailureUsage(
+          request,
+          error,
+          new Usage(
+            toResponseUsage(
+              truncatedResponse.usage ?? {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+              },
+            ),
+          ),
+        );
+      }
       if (span) {
+        if (truncatedResponse) {
+          if (request.tracing === true) {
+            span.spanData.output = [truncatedResponse];
+          }
+          span.spanData.usage = toResponseUsage(
+            truncatedResponse.usage ?? {
+              prompt_tokens: 0,
+              completion_tokens: 0,
+              total_tokens: 0,
+            },
+          );
+        }
         span.setError({
           message: 'Error streaming response',
           data: {

--- a/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsStreaming.ts
@@ -14,6 +14,10 @@ import {
   CONTENT_FILTER_REFUSAL_MESSAGE,
   shouldSynthesizeContentFilterRefusal,
 } from './openaiChatCompletionsContentFilter';
+import {
+  createTruncatedEmptyChatCompletionError,
+  isTruncatedEmptyChatCompletion,
+} from './openaiChatCompletionsTruncation';
 
 type StreamingState = {
   started: boolean;
@@ -420,6 +424,19 @@ export async function* convertChatCompletionsStreamToResponses(
     prompt_tokens_details: usage?.prompt_tokens_details,
     completion_tokens_details: usage?.completion_tokens_details,
   };
+
+  if (
+    isTruncatedEmptyChatCompletion({
+      finishReason: state.finishReason,
+      hasText: Boolean(state.text_content?.text),
+      hasRefusal: Boolean(state.refusal_content?.refusal),
+      hasAudio: state.audio !== null,
+      hasReasoning: state.reasoning.length > 0,
+      hasFunctionCall: Object.keys(state.function_calls).length > 0,
+    })
+  ) {
+    throw createTruncatedEmptyChatCompletionError();
+  }
 
   // Compose final response
   const finalEvent: protocol.StreamEventResponseCompleted = {

--- a/packages/agents-openai/src/openaiChatCompletionsTruncation.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsTruncation.ts
@@ -1,0 +1,64 @@
+import { ModelBehaviorError } from '@openai/agents-core';
+
+export const CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR =
+  "Chat Completions response terminated with finish_reason='length' but produced no assistant text, tool call, or refusal.";
+
+const CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR_BRAND = Symbol(
+  'openaiChatCompletionsEmptyTruncationError',
+);
+
+export type TruncatedEmptyChatCompletionError = ModelBehaviorError & {
+  readonly unsafeToReplay: true;
+  readonly responseStarted: true;
+  readonly [CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR_BRAND]: true;
+};
+
+export function createTruncatedEmptyChatCompletionError(): TruncatedEmptyChatCompletionError {
+  const error = new ModelBehaviorError(
+    CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR,
+  ) as TruncatedEmptyChatCompletionError;
+  Object.defineProperties(error, {
+    unsafeToReplay: { value: true },
+    responseStarted: { value: true },
+    [CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR_BRAND]: { value: true },
+  });
+  return error;
+}
+
+export function isTruncatedEmptyChatCompletionError(
+  error: unknown,
+): error is TruncatedEmptyChatCompletionError {
+  return (
+    error instanceof ModelBehaviorError &&
+    (error as Partial<TruncatedEmptyChatCompletionError>)[
+      CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR_BRAND
+    ] === true
+  );
+}
+
+export type ChatCompletionsOutputState = {
+  finishReason: string | null | undefined;
+  hasText: boolean;
+  hasRefusal: boolean;
+  hasAudio: boolean;
+  hasReasoning: boolean;
+  hasFunctionCall: boolean;
+};
+
+export function isTruncatedEmptyChatCompletion({
+  finishReason,
+  hasText,
+  hasRefusal,
+  hasAudio,
+  hasReasoning,
+  hasFunctionCall,
+}: ChatCompletionsOutputState): boolean {
+  return (
+    finishReason === 'length' &&
+    !hasText &&
+    !hasRefusal &&
+    !hasAudio &&
+    !hasReasoning &&
+    !hasFunctionCall
+  );
+}

--- a/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.scenario.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@openai/agents-core';
 import * as AgentsCore from '@openai/agents-core';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
+import { CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR } from '../src/openaiChatCompletionsTruncation';
 import { HEADERS } from '../src/defaults';
 
 type ChunkDelta = {
@@ -375,6 +376,279 @@ describe('OpenAIChatCompletionsModel streaming scenarios', () => {
         prompt_tokens: 3,
         completion_tokens: 6,
         total_tokens: 9,
+      });
+    } finally {
+      createGenerationSpanSpy.mockRestore();
+      setTracingDisabled(true);
+    }
+  });
+
+  it('records response, usage, and error evidence for a truncated empty stream', async () => {
+    setTracingDisabled(false);
+    const createGenerationSpanSpy = vi.spyOn(
+      AgentsCore,
+      'createGenerationSpan',
+    );
+
+    try {
+      const stream = {
+        async *[Symbol.asyncIterator]() {
+          yield makeChunk(
+            {},
+            {
+              prompt_tokens: 11,
+              completion_tokens: 7,
+              total_tokens: 18,
+              prompt_tokens_details: { cached_tokens: 2 },
+              completion_tokens_details: { reasoning_tokens: 6 },
+            },
+          );
+          yield {
+            ...makeChunk({}),
+            choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+          } as any;
+        },
+      };
+
+      const create = vi.fn().mockResolvedValue(stream);
+      const client = {
+        chat: { completions: { create } },
+        baseURL: 'https://example',
+      };
+      const model = new OpenAIChatCompletionsModel(client as any, 'gpt-stream');
+      const request: any = {
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+        signal: undefined,
+      };
+
+      const error = await withTrace('truncated-stream-trace', async () => {
+        for await (const _event of model.getStreamedResponse(request)) {
+          // Drain.
+        }
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(AgentsCore.ModelBehaviorError);
+      expect(error).toMatchObject({
+        unsafeToReplay: true,
+        responseStarted: true,
+      });
+      const generationSpan = createGenerationSpanSpy.mock.results
+        .map((result) => result.value as AgentsCore.Span<any>)
+        .find((span) => span?.spanData?.type === 'generation');
+      expect(generationSpan?.spanData.output?.[0]).toMatchObject({
+        choices: [],
+        usage: {
+          prompt_tokens: 11,
+          completion_tokens: 7,
+          total_tokens: 18,
+        },
+      });
+      expect(generationSpan?.spanData.usage).toEqual({
+        requests: 1,
+        input_tokens: 11,
+        output_tokens: 7,
+        total_tokens: 18,
+        input_tokens_details: { cached_tokens: 2 },
+        output_tokens_details: { reasoning_tokens: 6 },
+      });
+      expect(generationSpan?.error).toMatchObject({
+        message: 'Error streaming response',
+        data: { error: expect.stringContaining("finish_reason='length'") },
+      });
+    } finally {
+      createGenerationSpanSpy.mockRestore();
+      setTracingDisabled(true);
+    }
+  });
+
+  it.each([
+    [
+      'reported',
+      { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+      { requests: 1, inputTokens: 11, outputTokens: 7, totalTokens: 18 },
+    ],
+    [
+      'omitted',
+      undefined,
+      { requests: 1, inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    ],
+  ])(
+    'records failed usage when streamed usage is %s',
+    async (_label, usage, expectedUsage) => {
+      const stream = {
+        async *[Symbol.asyncIterator]() {
+          yield makeChunk({}, usage);
+          yield {
+            ...makeChunk({}),
+            choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+          } as any;
+        },
+      };
+      const create = vi.fn().mockResolvedValue(stream);
+      const model = new OpenAIChatCompletionsModel(
+        {
+          chat: { completions: { create } },
+          baseURL: 'https://example',
+        } as any,
+        'gpt-stream',
+      );
+      const agent = new Agent({ name: 'Truncated stream agent', model });
+      const result = await new Runner().run(agent, 'hello', { stream: true });
+
+      const error = await (async () => {
+        try {
+          for await (const _event of result) {
+            // Consume the stream.
+          }
+        } catch (caught) {
+          return caught;
+        }
+        return undefined;
+      })();
+
+      expect(error).toBeInstanceOf(AgentsCore.ModelBehaviorError);
+      expect(result.state.usage).toMatchObject(expectedUsage);
+      expect(create).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does not classify a same-message iterator error as terminal truncation', async () => {
+    setTracingDisabled(false);
+    const createGenerationSpanSpy = vi.spyOn(
+      AgentsCore,
+      'createGenerationSpan',
+    );
+
+    try {
+      const iteratorError = new AgentsCore.ModelBehaviorError(
+        CHAT_COMPLETIONS_EMPTY_TRUNCATION_ERROR,
+      );
+      const stream = {
+        async *[Symbol.asyncIterator]() {
+          yield makeChunk(
+            {},
+            {
+              prompt_tokens: 11,
+              completion_tokens: 7,
+              total_tokens: 18,
+            },
+          );
+          yield {
+            ...makeChunk({}),
+            choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+          } as any;
+          throw iteratorError;
+        },
+      };
+      const create = vi.fn().mockResolvedValue(stream);
+      const model = new OpenAIChatCompletionsModel(
+        {
+          chat: { completions: { create } },
+          baseURL: 'https://example',
+        } as any,
+        'gpt-stream',
+      );
+      const request: any = {
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+        signal: undefined,
+      };
+
+      const error = await withTrace('same-message-iterator-error', async () => {
+        for await (const _event of model.getStreamedResponse(request)) {
+          // Drain.
+        }
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBe(iteratorError);
+      expect(error).not.toHaveProperty('unsafeToReplay');
+      expect(error).not.toHaveProperty('responseStarted');
+      const generationSpan = createGenerationSpanSpy.mock.results
+        .map((result) => result.value as AgentsCore.Span<any>)
+        .find((span) => span?.spanData?.type === 'generation');
+      expect(generationSpan?.spanData.output).toBeUndefined();
+      expect(generationSpan?.spanData.usage).toBeUndefined();
+    } finally {
+      createGenerationSpanSpy.mockRestore();
+      setTracingDisabled(true);
+    }
+  });
+
+  it('does not synthesize terminal trace evidence for malformed streamed audio', async () => {
+    setTracingDisabled(false);
+    const createGenerationSpanSpy = vi.spyOn(
+      AgentsCore,
+      'createGenerationSpan',
+    );
+
+    try {
+      const stream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            ...makeChunk({}),
+            choices: [
+              {
+                index: 0,
+                delta: { audio: 'not-an-object' },
+                finish_reason: null,
+              },
+            ],
+            usage: {
+              prompt_tokens: 11,
+              completion_tokens: 7,
+              total_tokens: 18,
+            },
+          } as any;
+        },
+      };
+
+      const create = vi.fn().mockResolvedValue(stream);
+      const client = {
+        chat: { completions: { create } },
+        baseURL: 'https://example',
+      };
+      const model = new OpenAIChatCompletionsModel(client as any, 'gpt-stream');
+      const request: any = {
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+        signal: undefined,
+      };
+
+      const error = await withTrace('malformed-audio-trace', async () => {
+        for await (const _event of model.getStreamedResponse(request)) {
+          // Drain.
+        }
+      }).catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(AgentsCore.ModelBehaviorError);
+      expect((error as Error).message).toContain(
+        'expected delta.audio to be an object',
+      );
+      const generationSpan = createGenerationSpanSpy.mock.results
+        .map((result) => result.value as AgentsCore.Span<any>)
+        .find((span) => span?.spanData?.type === 'generation');
+      expect(generationSpan?.spanData.output).toBeUndefined();
+      expect(generationSpan?.spanData.usage).toBeUndefined();
+      expect(generationSpan?.error).toMatchObject({
+        message: 'Error streaming response',
+        data: {
+          error: expect.stringContaining(
+            'expected delta.audio to be an object',
+          ),
+        },
       });
     } finally {
       createGenerationSpanSpy.mockRestore();

--- a/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsModel.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   Agent,
+  ModelBehaviorError,
   Runner,
   Span,
   Trace,
   setTraceProcessors,
   withTrace,
   setTracingDisabled,
+  type RetryPolicyContext,
   type TracingProcessor,
 } from '@openai/agents-core';
 import { OpenAIChatCompletionsModel } from '../src/openaiChatCompletionsModel';
@@ -275,6 +277,10 @@ describe('OpenAIChatCompletionsModel', () => {
       total_tokens: 5,
     });
     expect(result.usage.inputTokens).toBe(3);
+    const generationSpan = processor.spansEnded.find(
+      (span) => span.spanData.type === 'generation',
+    );
+    expect(generationSpan?.spanData.usage).toBeUndefined();
   });
 
   it('counts the request when the provider omits usage', async () => {
@@ -687,6 +693,222 @@ describe('OpenAIChatCompletionsModel', () => {
       },
     ]);
   });
+
+  it.each([null, ''])(
+    'rejects a truncated empty message (content: %j)',
+    async (content) => {
+      const client = new FakeClient();
+      client.chat.completions.create.mockResolvedValue({
+        id: 'truncated-response',
+        choices: [
+          {
+            finish_reason: 'length',
+            message: { role: 'assistant', content },
+          },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+      } as any);
+
+      const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+      await expect(
+        withTrace('truncated-empty', () =>
+          model.getResponse({
+            input: 'u',
+            modelSettings: {},
+            tools: [],
+            outputType: 'text',
+            handoffs: [],
+            tracing: false,
+          } as any),
+        ),
+      ).rejects.toThrow(ModelBehaviorError);
+    },
+  );
+
+  it.each([
+    ['text', { role: 'assistant', content: 'partial' }],
+    ['whitespace text', { role: 'assistant', content: ' ' }],
+    [
+      'refusal',
+      { role: 'assistant', content: null, refusal: 'provider refusal' },
+    ],
+    ['audio', { role: 'assistant', content: null, audio: { data: 'abc' } }],
+    [
+      'reasoning',
+      { role: 'assistant', content: null, reasoning: 'partial reasoning' },
+    ],
+    [
+      'function call',
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{}' },
+          },
+        ],
+      },
+    ],
+  ])('preserves truncated output containing %s', async (_label, message) => {
+    const client = new FakeClient();
+    const response = {
+      id: 'partial-response',
+      choices: [{ finish_reason: 'length', message }],
+      usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+    } as any;
+    Object.defineProperty(response, '_request_id', {
+      value: 'req_partial_123',
+      enumerable: false,
+    });
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const result = await withTrace('truncated-partial', () =>
+      model.getResponse({
+        input: 'u',
+        modelSettings: { preserveRawUsage: true },
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      } as any),
+    );
+
+    expect(result.output).toHaveLength(1);
+    expect(result.providerData).toBe(response);
+    expect(result.requestId).toBe('req_partial_123');
+    expect(result.rawUsage).toEqual({
+      prompt_tokens: 3,
+      completion_tokens: 4,
+      total_tokens: 7,
+    });
+  });
+
+  it('records response, usage, and error evidence for a truncated empty message', async () => {
+    const processor = new RecordingProcessor();
+    setTraceProcessors([processor]);
+    setTracingDisabled(false);
+
+    const client = new FakeClient();
+    const response = {
+      id: 'truncated-response',
+      choices: [
+        {
+          finish_reason: 'length',
+          message: { role: 'assistant', content: null },
+        },
+      ],
+      usage: {
+        prompt_tokens: 11,
+        completion_tokens: 7,
+        total_tokens: 18,
+        prompt_tokens_details: { cached_tokens: 2 },
+        completion_tokens_details: { reasoning_tokens: 6 },
+      },
+    } as any;
+    client.chat.completions.create.mockResolvedValue(response);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    const error = await withTrace('truncated-empty-trace', () =>
+      model.getResponse({
+        input: 'u',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+      } as any),
+    ).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(ModelBehaviorError);
+    expect(error).toMatchObject({
+      unsafeToReplay: true,
+      responseStarted: true,
+    });
+    const generationSpan = processor.spansEnded.find(
+      (span) => span.spanData.type === 'generation',
+    );
+    expect(generationSpan?.spanData.output).toEqual([response]);
+    expect(generationSpan?.spanData.usage).toEqual({
+      requests: 1,
+      input_tokens: 11,
+      output_tokens: 7,
+      total_tokens: 18,
+      input_tokens_details: { cached_tokens: 2 },
+      output_tokens_details: { reasoning_tokens: 6 },
+    });
+    expect(generationSpan?.error?.message).toContain("finish_reason='length'");
+  });
+
+  it.each([
+    [
+      'reported',
+      { prompt_tokens: 11, completion_tokens: 7, total_tokens: 18 },
+      { requests: 1, input_tokens: 11, output_tokens: 7, total_tokens: 18 },
+    ],
+    [
+      'omitted',
+      undefined,
+      { requests: 1, input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+    ],
+  ])(
+    'vetoes replay and records task and turn usage when usage is %s',
+    async (_label, usage, expectedUsage) => {
+      const processor = new RecordingProcessor();
+      setTraceProcessors([processor]);
+      setTracingDisabled(false);
+
+      const client = new FakeClient();
+      client.chat.completions.create.mockResolvedValue({
+        id: 'truncated-response',
+        choices: [
+          {
+            finish_reason: 'length',
+            message: { role: 'assistant', content: null },
+          },
+        ],
+        usage,
+      } as any);
+      const retryPolicy = vi.fn((_context: RetryPolicyContext) => true);
+      const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+      const runner = new Runner({
+        model: 'gpt',
+        modelProvider: { getModel: () => model },
+        modelSettings: {
+          retry: {
+            maxRetries: 1,
+            policy: retryPolicy,
+            backoff: { initialDelayMs: 0, jitter: false },
+          },
+        },
+      });
+
+      const error = await runner
+        .run(new Agent({ name: 'Truncated response agent' }), 'hello')
+        .catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect(client.chat.completions.create).toHaveBeenCalledTimes(1);
+      expect(retryPolicy).toHaveBeenCalledTimes(1);
+      expect(retryPolicy.mock.calls[0]?.[0]).toMatchObject({
+        replaySafety: 'unsafe',
+        responseStarted: true,
+      });
+      const taskSpan = processor.spansEnded.find(
+        (candidate) => candidate.spanData.type === 'task',
+      );
+      expect(taskSpan?.spanData.usage).toMatchObject(expectedUsage);
+      const turnSpan = processor.spansEnded.find(
+        (candidate) => candidate.spanData.type === 'turn',
+      );
+      expect(turnSpan?.spanData.usage).toMatchObject({
+        input_tokens: expectedUsage.input_tokens,
+        output_tokens: expectedUsage.output_tokens,
+      });
+    },
+  );
 
   it.each([null, ''])(
     'surfaces an empty content-filtered message as a refusal (content: %j)',
@@ -1454,12 +1676,48 @@ describe('OpenAIChatCompletionsModel', () => {
     expect(result.output).toEqual([]);
   });
 
+  it('rejects a truncated message containing only an ignored custom tool call', async () => {
+    const client = new FakeClient();
+    client.chat.completions.create.mockResolvedValue({
+      id: 'r',
+      choices: [
+        {
+          finish_reason: 'length',
+          message: {
+            tool_calls: [
+              {
+                id: 'call1',
+                type: 'custom',
+                custom: { name: 'raw_tool', input: 'payload' },
+              },
+            ],
+          },
+        },
+      ],
+    } as any);
+
+    const model = new OpenAIChatCompletionsModel(client as any, 'gpt');
+    await expect(
+      withTrace('truncated-custom', () =>
+        model.getResponse({
+          input: 'u',
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: false,
+        } as any),
+      ),
+    ).rejects.toThrow(ModelBehaviorError);
+  });
+
   it('rejects custom tool calls in strict mode', async () => {
     const client = new FakeClient();
     const response = {
       id: 'r',
       choices: [
         {
+          finish_reason: 'length',
           message: {
             tool_calls: [
               {

--- a/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsStreaming.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { UserError } from '@openai/agents-core';
+import { ModelBehaviorError, UserError } from '@openai/agents-core';
 import { convertChatCompletionsStreamToResponses } from '../src/openaiChatCompletionsStreaming';
 import { FAKE_ID } from '../src/openaiChatCompletionsModel';
 import logger from '../src/logger';
@@ -96,6 +96,160 @@ describe('convertChatCompletionsStreamToResponses', () => {
         },
       },
     ]);
+  });
+
+  it('rejects an annotation-only truncated stream after emitting raw events', async () => {
+    const response = {
+      id: 'truncated-response',
+      choices: [],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    const usage = {
+      prompt_tokens: 11,
+      completion_tokens: 7,
+      total_tokens: 18,
+      completion_tokens_details: { reasoning_tokens: 6 },
+    };
+    const annotationChunk = makeChunk({ annotations: [urlCitation()] }, usage);
+    const terminalChunk = {
+      ...makeChunk({}),
+      choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+    } as any;
+
+    async function* stream() {
+      yield annotationChunk;
+      yield terminalChunk;
+    }
+
+    const events: any[] = [];
+    let caught: unknown;
+    try {
+      for await (const event of convertChatCompletionsStreamToResponses(
+        response,
+        stream() as any,
+        { preserveRawUsage: true },
+      )) {
+        events.push(event);
+      }
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(ModelBehaviorError);
+    expect((caught as Error).message).toContain("finish_reason='length'");
+    expect(events.filter((event) => event.type === 'model')).toEqual([
+      expect.objectContaining({ event: annotationChunk }),
+      expect.objectContaining({ event: terminalChunk }),
+    ]);
+    expect(events.some((event) => event.type === 'response_done')).toBe(false);
+    expect(response.usage).toEqual({
+      prompt_tokens: 11,
+      completion_tokens: 7,
+      total_tokens: 18,
+      prompt_tokens_details: undefined,
+      completion_tokens_details: { reasoning_tokens: 6 },
+    });
+  });
+
+  it('preserves a late iterator error after an empty length terminal chunk', async () => {
+    const response = {
+      id: 'truncated-response',
+      choices: [],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    } as any;
+    const usageChunk = makeChunk(
+      {},
+      {
+        prompt_tokens: 11,
+        completion_tokens: 7,
+        total_tokens: 18,
+      },
+    );
+    const terminalChunk = {
+      ...makeChunk({}),
+      choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+    } as any;
+    const transportError = new Error('stream connection failed');
+
+    async function* stream() {
+      yield usageChunk;
+      yield terminalChunk;
+      throw transportError;
+    }
+
+    const events: any[] = [];
+    let caught: unknown;
+    try {
+      for await (const event of convertChatCompletionsStreamToResponses(
+        response,
+        stream() as any,
+        { preserveRawUsage: true },
+      )) {
+        events.push(event);
+      }
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(transportError);
+    expect(events.filter((event) => event.type === 'model')).toEqual([
+      expect.objectContaining({ event: usageChunk }),
+      expect.objectContaining({ event: terminalChunk }),
+    ]);
+    expect(events.some((event) => event.type === 'response_done')).toBe(false);
+    expect(response).toMatchObject({
+      choices: [],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    });
+  });
+
+  it.each([
+    ['whitespace text', { content: ' ' }],
+    ['refusal', { refusal: 'provider refusal' }],
+    ['audio', { audio: { id: 'audio-1', data: 'abc' } }],
+    ['reasoning', { reasoning: 'partial reasoning' }],
+    [
+      'function call',
+      {
+        tool_calls: [
+          {
+            index: 0,
+            id: 'call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{}' },
+          },
+        ],
+      },
+    ],
+  ])('preserves a truncated stream containing %s', async (_label, delta) => {
+    const response = { id: 'partial-response' } as any;
+    const usage = {
+      prompt_tokens: 3,
+      completion_tokens: 4,
+      total_tokens: 7,
+    };
+
+    async function* stream() {
+      yield makeChunk(delta, usage);
+      yield {
+        ...makeChunk({}),
+        choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+      } as any;
+    }
+
+    const events: any[] = [];
+    for await (const event of convertChatCompletionsStreamToResponses(
+      response,
+      stream() as any,
+      { preserveRawUsage: true },
+    )) {
+      events.push(event);
+    }
+
+    const final = events.at(-1);
+    expect(final.type).toBe('response_done');
+    expect(final.response.output).toHaveLength(1);
+    expect(final.response.rawUsage).toEqual(usage);
   });
 
   it('emits protocol events for streamed chat completions', async () => {
@@ -1299,11 +1453,43 @@ describe('convertChatCompletionsStreamToResponses', () => {
     ).toBe(false);
   });
 
-  it('rejects streamed custom tool calls in strict mode', async () => {
+  it('rejects a truncated stream containing only an ignored custom tool call', async () => {
     async function* stream() {
       yield makeChunk({
         tool_calls: [{ index: 0, id: 'call1', type: 'custom' }],
       });
+      yield {
+        ...makeChunk({}),
+        choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+      } as any;
+    }
+
+    await expect(async () => {
+      for await (const _event of convertChatCompletionsStreamToResponses(
+        { id: 'r' } as any,
+        stream() as any,
+      )) {
+        // Consume the stream.
+      }
+    }).rejects.toThrow(ModelBehaviorError);
+  });
+
+  it('rejects streamed custom tool calls in strict mode', async () => {
+    async function* stream() {
+      yield {
+        ...makeChunk({
+          tool_calls: [{ index: 0, id: 'call1', type: 'custom' }],
+        }),
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index: 0, id: 'call1', type: 'custom' }],
+            },
+            finish_reason: 'length',
+          },
+        ],
+      } as any;
     }
 
     await expect(async () => {


### PR DESCRIPTION
This pull request fixes the OpenAI Chat Completions adapter so responses ending with `finish_reason="length"` and no supported assistant output raise `ModelBehaviorError` in both streaming and non-streaming flows.

It preserves partial text, refusals, audio, reasoning, and function calls; keeps existing `content_filter` and strict custom-tool behavior unchanged; and retains provider response, request ID, usage, raw events, and generation-span evidence before surfacing the error. It also adds focused regression coverage and a patch changeset for `@openai/agents-openai`.