### PR TITLE
fix(core): strip created_by from RunItem replay

### DIFF
--- a/.changeset/strip-created-by-replay.md
+++ b/.changeset/strip-created-by-replay.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: strip output-only created_by metadata at replay boundaries

--- a/packages/agents-core/src/runner/items.ts
+++ b/packages/agents-core/src/runner/items.ts
@@ -271,8 +271,11 @@ export function extractOutputItemsFromRunItems(
       if (cached) {
         return cached;
       }
-      const withoutNullStatusItem = withoutNullStatus(
+      const withoutOutputOnlyMetadata = stripOutputOnlyCreatedBy(
         item.rawItem as AgentInputItem,
+      );
+      const withoutNullStatusItem = withoutNullStatus(
+        withoutOutputOnlyMetadata,
       );
       const normalizedItem =
         normalizationKey === 'omit'
@@ -286,6 +289,52 @@ export function extractOutputItemsFromRunItems(
       normalizedOutputItemByRunItem.set(item, cachedByPolicy);
       return normalizedItem;
     });
+}
+
+function stripOutputOnlyCreatedBy(item: AgentInputItem): AgentInputItem {
+  if (!item || typeof item !== 'object') {
+    return item;
+  }
+
+  const candidate = item as Record<string, unknown>;
+  const hasTopLevelCreatedBy = Object.prototype.hasOwnProperty.call(
+    candidate,
+    'created_by',
+  );
+  const output = candidate.output;
+  const hasShellOutputCreatedBy =
+    candidate.type === 'shell_call_output' &&
+    Array.isArray(output) &&
+    output.some(
+      (entry) =>
+        entry !== null &&
+        typeof entry === 'object' &&
+        Object.prototype.hasOwnProperty.call(entry, 'created_by'),
+    );
+
+  if (!hasTopLevelCreatedBy && !hasShellOutputCreatedBy) {
+    return item;
+  }
+
+  const { created_by: _createdBy, ...withoutCreatedBy } = candidate;
+  const normalized = withoutCreatedBy as Record<string, unknown>;
+
+  if (hasShellOutputCreatedBy) {
+    normalized.output = (output as unknown[]).map((entry) => {
+      if (
+        entry === null ||
+        typeof entry !== 'object' ||
+        !Object.prototype.hasOwnProperty.call(entry, 'created_by')
+      ) {
+        return entry;
+      }
+      const { created_by: _chunkCreatedBy, ...withoutChunkCreatedBy } =
+        entry as Record<string, unknown>;
+      return withoutChunkCreatedBy;
+    });
+  }
+
+  return normalized as AgentInputItem;
 }
 
 function withoutNullStatus(item: AgentInputItem): AgentInputItem {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -10282,7 +10282,19 @@ describe('Runner.run', () => {
       id: 'cmp_inline',
       encrypted_content: 'ciphertext',
       created_by: 'compaction_endpoint',
-      providerData: { extra: 'value' },
+      providerData: {
+        created_by: 'third-party-provider',
+        extra: 'value',
+      },
+    };
+    const REPLAYED_COMPACTION_ITEM: protocol.CompactionItem = {
+      type: 'compaction',
+      id: 'cmp_inline',
+      encrypted_content: 'ciphertext',
+      providerData: {
+        created_by: 'third-party-provider',
+        extra: 'value',
+      },
     };
 
     it('replays a compaction marker in provider order on the next request', async () => {
@@ -10322,7 +10334,7 @@ describe('Runner.run', () => {
       expect(model.requests).toHaveLength(2);
       const secondInput = getRequestInputItems(model.requests[1]);
       expect(secondInput).toHaveLength(3);
-      expect(secondInput[0]).toEqual(COMPACTION_ITEM);
+      expect(secondInput[0]).toEqual(REPLAYED_COMPACTION_ITEM);
       expect(secondInput[1]).toMatchObject({
         type: 'function_call',
         callId: 'call_lookup',
@@ -10336,8 +10348,9 @@ describe('Runner.run', () => {
           content: 'identifiable old user input',
         }),
       );
-      expect(result.output).toContainEqual(COMPACTION_ITEM);
-      expect(result.history[0]).toEqual(COMPACTION_ITEM);
+      expect(result.output).toContainEqual(REPLAYED_COMPACTION_ITEM);
+      expect(result.history[0]).toEqual(REPLAYED_COMPACTION_ITEM);
+      expect(result.newItems[0]?.rawItem).toEqual(COMPACTION_ITEM);
     });
 
     it('rewrites ordinary session history from the latest compaction marker', async () => {
@@ -10364,12 +10377,12 @@ describe('Runner.run', () => {
 
       expect(clearSession).toHaveBeenCalledOnce();
       const stored = await session.getItems();
-      expect(stored[0]).toEqual(COMPACTION_ITEM);
+      expect(stored[0]).toEqual(REPLAYED_COMPACTION_ITEM);
       expect(stored).toHaveLength(2);
 
       await run(agent, 'later user input', { session });
       const laterInput = getRequestInputItems(model.requests[1]);
-      expect(laterInput[0]).toEqual(COMPACTION_ITEM);
+      expect(laterInput[0]).toEqual(REPLAYED_COMPACTION_ITEM);
       expect(laterInput).not.toContainEqual(
         expect.objectContaining({ content: 'earlier stored input' }),
       );

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -1944,7 +1944,19 @@ export function registerRunStateCompactionTests(): void {
         id: 'cmp_1',
         encrypted_content: 'ciphertext',
         created_by: 'compaction_endpoint',
-        providerData: { extra: 'value' },
+        providerData: {
+          created_by: 'third-party-provider',
+          extra: 'value',
+        },
+      };
+      const replayedCompactionItem: protocol.CompactionItem = {
+        type: 'compaction',
+        id: 'cmp_1',
+        encrypted_content: 'ciphertext',
+        providerData: {
+          created_by: 'third-party-provider',
+          extra: 'value',
+        },
       };
 
       function stateWithCompaction(agent: Agent<any, any>) {
@@ -3088,7 +3100,7 @@ export function registerRunStateCompactionTests(): void {
         expect(
           restored._lastProcessedResponse?.newItems.map((item) => item.type),
         ).toEqual(['tool_call_item', 'tool_approval_item']);
-        expect(restored.history[0]).toEqual(compactionItem);
+        expect(restored.history[0]).toEqual(replayedCompactionItem);
         expect(restored.getInterruptions()).toHaveLength(1);
       });
 
@@ -3157,7 +3169,7 @@ export function registerRunStateCompactionTests(): void {
           'tool_call_item',
           'tool_approval_item',
         ]);
-        expect(restored.history[0]).toEqual(compactionItem);
+        expect(restored.history[0]).toEqual(replayedCompactionItem);
         expect(restored.getInterruptions()).toHaveLength(1);
         expect((restored._generatedItems[0] as RunCompactionItem).agent).toBe(
           agent,
@@ -3270,7 +3282,7 @@ export function registerRunStateCompactionTests(): void {
           'tool_call_item',
           'tool_approval_item',
         ]);
-        expect(restored.history[0]).toEqual(compactionItem);
+        expect(restored.history[0]).toEqual(replayedCompactionItem);
         expect(restored.getInterruptions()).toHaveLength(1);
         expect((restored._generatedItems[0] as RunCompactionItem).agent).toBe(
           agent,

--- a/packages/agents-core/test/runner/items.helpers.test.ts
+++ b/packages/agents-core/test/runner/items.helpers.test.ts
@@ -725,6 +725,154 @@ describe('prepareModelInputItems', () => {
 });
 
 describe('extractOutputItemsFromRunItems', () => {
+  it('strips protocol created_by metadata without mutating provider data or raw items', () => {
+    const agent = new Agent({ name: 'HelperAgent' });
+    const functionCall = {
+      type: 'function_call',
+      id: 'fc_created_by',
+      callId: 'call_created_by',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      providerData: {
+        created_by: 'server',
+        retained: 'function metadata',
+      },
+    } satisfies protocol.FunctionCallItem;
+    const compaction = {
+      type: 'compaction',
+      id: 'cmp_created_by',
+      encrypted_content: 'ciphertext',
+      created_by: 'compaction_endpoint',
+      providerData: {
+        created_by: 'third-party-provider',
+        retained: 'compaction metadata',
+      },
+    } satisfies protocol.CompactionItem;
+    const shellOutput = {
+      type: 'shell_call_output',
+      callId: 'shell_created_by',
+      status: 'completed',
+      providerData: {
+        created_by: 'server',
+        retained: 'shell metadata',
+      },
+      output: [
+        {
+          stdout: 'ok',
+          stderr: '',
+          outcome: { type: 'exit', exitCode: 0 },
+          created_by: 'server',
+          retained: 'chunk metadata',
+        },
+      ],
+    } satisfies protocol.ShellCallResultItem;
+    const functionRunItem = new RunToolCallItem(functionCall, agent);
+    const compactionRunItem = new RunCompactionItem(compaction, agent);
+    const shellRunItem = new RunToolCallOutputItem(shellOutput, agent, 'ok');
+
+    const [convertedFunctionCall, convertedCompaction, convertedShellOutput] =
+      extractOutputItemsFromRunItems([
+        functionRunItem,
+        compactionRunItem,
+        shellRunItem,
+      ]);
+
+    expect(convertedFunctionCall).toEqual({
+      type: 'function_call',
+      id: 'fc_created_by',
+      callId: 'call_created_by',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      providerData: {
+        created_by: 'server',
+        retained: 'function metadata',
+      },
+    });
+    expect(convertedCompaction).toEqual({
+      type: 'compaction',
+      id: 'cmp_created_by',
+      encrypted_content: 'ciphertext',
+      providerData: {
+        created_by: 'third-party-provider',
+        retained: 'compaction metadata',
+      },
+    });
+    expect(convertedShellOutput).toEqual({
+      type: 'shell_call_output',
+      callId: 'shell_created_by',
+      status: 'completed',
+      providerData: {
+        created_by: 'server',
+        retained: 'shell metadata',
+      },
+      output: [
+        {
+          stdout: 'ok',
+          stderr: '',
+          outcome: { type: 'exit', exitCode: 0 },
+          retained: 'chunk metadata',
+        },
+      ],
+    });
+    expect(functionRunItem.rawItem).toBe(functionCall);
+    expect(convertedFunctionCall).toBe(functionCall);
+    expect(functionRunItem.rawItem.providerData).toHaveProperty(
+      'created_by',
+      'server',
+    );
+    expect(compactionRunItem.rawItem).toBe(compaction);
+    expect(compactionRunItem.rawItem).toHaveProperty(
+      'created_by',
+      'compaction_endpoint',
+    );
+    expect(shellRunItem.rawItem).toBe(shellOutput);
+    expect(shellRunItem.rawItem.providerData).toHaveProperty(
+      'created_by',
+      'server',
+    );
+    expect(shellOutput.output[0]).toHaveProperty('created_by', 'server');
+    expect(functionRunItem.toJSON().rawItem).toBe(functionCall);
+    expect(compactionRunItem.toJSON().rawItem).toBe(compaction);
+    expect(shellRunItem.toJSON().rawItem).toBe(shellOutput);
+
+    const [cachedFunctionCall, cachedCompaction, cachedShellOutput] =
+      extractOutputItemsFromRunItems([
+        functionRunItem,
+        compactionRunItem,
+        shellRunItem,
+      ]);
+    expect(cachedFunctionCall).toBe(convertedFunctionCall);
+    expect(cachedCompaction).toBe(convertedCompaction);
+    expect(cachedShellOutput).toBe(convertedShellOutput);
+  });
+
+  it('preserves identity when output-only metadata does not need normalization', () => {
+    const agent = new Agent({ name: 'HelperAgent' });
+    const message: protocol.AssistantMessageItem = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        { type: 'output_text', text: 'hello' },
+        { type: 'refusal', refusal: 'no' },
+        {
+          type: 'audio',
+          audio: 'base64-audio',
+          format: 'wav',
+          transcript: 'hello',
+        },
+      ],
+    };
+    const runItem = new RunMessageOutputItem(message, agent);
+
+    const [converted] = extractOutputItemsFromRunItems([runItem]);
+
+    expect(converted).toBe(message);
+    expect(extractOutputItemsFromRunItems([runItem])[0]).toBe(converted);
+  });
+
   it('omits null statuses from model input history', () => {
     const agent = new Agent({ name: 'HelperAgent' });
     const message = {

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -2194,6 +2194,19 @@ function stripSdkGeneratedPlaceholderItemId<
   return itemWithoutId as T;
 }
 
+function stripOutputOnlyCreatedBy<T extends OpenAI.Responses.ResponseInputItem>(
+  item: T,
+): T {
+  if (!Object.prototype.hasOwnProperty.call(item, 'created_by')) {
+    return item;
+  }
+
+  const { created_by: _createdBy, ...withoutCreatedBy } = item as T & {
+    created_by?: string;
+  };
+  return withoutCreatedBy as T;
+}
+
 function getInputItems(
   input: ModelRequest['input'],
 ): OpenAI.Responses.ResponseInputItem[] {
@@ -2206,7 +2219,7 @@ function getInputItems(
     ];
   }
 
-  return input.map((item): OpenAI.Responses.ResponseInputItem => {
+  const inputItems = input.map((item): OpenAI.Responses.ResponseInputItem => {
     if (isMessageItem(item)) {
       return getMessageItem(item);
     }
@@ -2743,6 +2756,7 @@ function getInputItems(
     const exhaustive = item satisfies never;
     throw new UserError(`Unsupported item ${JSON.stringify(exhaustive)}`);
   });
+  return inputItems.map(stripOutputOnlyCreatedBy);
 }
 
 // As of May 29, the output is always screenshot putput

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -1212,7 +1212,7 @@ describe('getInputItems', () => {
     });
   });
 
-  it('preserves official tool search metadata when replaying tool search outputs', () => {
+  it('strips output-only created_by when replaying tool search outputs', () => {
     const items = getInputItems([
       {
         type: 'tool_search_output',
@@ -1234,7 +1234,33 @@ describe('getInputItems', () => {
       tools: [],
       call_id: 'call_ts_1',
       execution: 'client',
-      created_by: 'assistant',
+    });
+  });
+
+  it('strips output-only created_by after expanding provider data', () => {
+    const items = getInputItems([
+      {
+        type: 'function_call',
+        id: 'fc_created_by',
+        callId: 'call_created_by',
+        name: 'lookup',
+        arguments: '{}',
+        status: 'completed',
+        providerData: {
+          created_by: 'assistant',
+          retained: 'provider metadata',
+        },
+      },
+    ] as any);
+
+    expect(items[0]).toEqual({
+      type: 'function_call',
+      id: 'fc_created_by',
+      call_id: 'call_created_by',
+      name: 'lookup',
+      arguments: '{}',
+      status: 'completed',
+      retained: 'provider metadata',
     });
   });
 


### PR DESCRIPTION
This pull request fixes SDK-generated RunItem replay by removing output-only `created_by` metadata before model input is assembled.

The central conversion path now strips the field from supported top-level items, provider data, and shell output chunks with copy-on-change semantics, while keeping the original raw item intact for observability and serialization. It also aligns run, session, and restored RunState history expectations and adds regression coverage for identity, caching, and preserved payload semantics.