### PR TITLE
fix(docs): preserve canonical localized heading anchors

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,10 +1,12 @@
 // @ts-check
+import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import starlight from '@astrojs/starlight';
 import { createStarlightTypeDocPlugin } from 'starlight-typedoc';
 import tailwindcss from '@tailwindcss/vite';
 import starlightLlmsTxt from 'starlight-llms-txt';
+import { rehypeCanonicalHeadingIds } from './src/plugins/rehypeCanonicalHeadingIds';
 
 const [mainStarlightTypeDoc, mainTypeDocSidebarGroup] =
   createStarlightTypeDocPlugin();
@@ -472,6 +474,19 @@ const sidebar = [
 export default defineConfig({
   site: 'https://openai.github.io',
   base: 'openai-agents-js',
+
+  markdown: {
+    rehypePlugins: [
+      [
+        rehypeCanonicalHeadingIds,
+        {
+          contentRoot: fileURLToPath(
+            new URL('./src/content/docs/', import.meta.url),
+          ),
+        },
+      ],
+    ],
+  },
 
   integrations: [
     starlight({

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,6 +24,8 @@
     "typedoc-plugin-markdown": "^4.12.0"
   },
   "devDependencies": {
+    "@astrojs/markdown-remark": "^7.2.0",
+    "remark-mdx": "^3.1.1",
     "tailwindcss": "^4.3.2",
     "tsx": "^4.22.4",
     "typedoc-plugin-frontmatter": "^1.3.1",

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,7 +1,23 @@
 import { defineCollection } from 'astro:content';
+import { z } from 'astro/zod';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-	docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema({
+      extend: z.object({
+        canonicalHeadingIds: z
+          .array(
+            z.object({
+              depth: z.number().int().min(2).max(6),
+              id: z.string().min(1),
+              aliases: z.array(z.string().min(1)),
+            }),
+          )
+          .optional(),
+      }),
+    }),
+  }),
 };

--- a/docs/src/plugins/rehypeCanonicalHeadingIds.ts
+++ b/docs/src/plugins/rehypeCanonicalHeadingIds.ts
@@ -1,0 +1,197 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { rehypeHeadingIds } from '@astrojs/markdown-remark';
+import {
+  assertNoUnsupportedHeadingNodes,
+  canonicalHeadingIds,
+  CANONICAL_HEADING_IDS_FIELD,
+  type CanonicalHeadingId,
+} from '../scripts/headingAnchors';
+
+type HastNode = {
+  type: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
+type AstroVFile = {
+  path?: string;
+  value: unknown;
+  data: {
+    astro?: {
+      frontmatter?: Record<string, unknown>;
+    };
+  };
+};
+
+const assignLocalizedHeadingIds = rehypeHeadingIds() as unknown as (
+  tree: HastNode,
+  file: AstroVFile,
+) => void;
+
+function collectHeadings(node: HastNode, headings: HastNode[]): void {
+  if (
+    node.type === 'element' &&
+    node.tagName &&
+    /^h[1-6]$/.test(node.tagName)
+  ) {
+    headings.push(node);
+  }
+  for (const child of node.children ?? []) {
+    collectHeadings(child, headings);
+  }
+}
+
+function isCanonicalHeadingId(value: unknown): value is CanonicalHeadingId {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as CanonicalHeadingId).depth === 'number' &&
+    Number.isInteger((value as CanonicalHeadingId).depth) &&
+    (value as CanonicalHeadingId).depth >= 2 &&
+    (value as CanonicalHeadingId).depth <= 6 &&
+    typeof (value as CanonicalHeadingId).id === 'string' &&
+    (value as CanonicalHeadingId).id.length > 0 &&
+    Array.isArray((value as CanonicalHeadingId).aliases) &&
+    (value as CanonicalHeadingId).aliases.every(
+      (alias) => typeof alias === 'string' && alias.length > 0,
+    ) &&
+    new Set((value as CanonicalHeadingId).aliases).size ===
+      (value as CanonicalHeadingId).aliases.length &&
+    !(value as CanonicalHeadingId).aliases.includes(
+      (value as CanonicalHeadingId).id,
+    )
+  );
+}
+
+export function rehypeCanonicalHeadingIds({
+  contentRoot,
+}: {
+  contentRoot: string;
+}) {
+  return async (tree: HastNode, file: AstroVFile): Promise<void> => {
+    const rawMetadata =
+      file.data.astro?.frontmatter?.[CANONICAL_HEADING_IDS_FIELD];
+    let sourceHeadings: CanonicalHeadingId[] | undefined;
+    if (file.path) {
+      const [locale, ...sourceSegments] = path
+        .relative(contentRoot, file.path)
+        .split(path.sep);
+      if (['ja', 'ko', 'zh'].includes(locale) && /\.mdx?$/.test(file.path)) {
+        const sourcePath = path.join(contentRoot, ...sourceSegments);
+        let source: string;
+        try {
+          source = await fs.readFile(sourcePath, 'utf8');
+        } catch (error) {
+          throw new Error(
+            `Cannot read the English heading source ${sourcePath} for ${file.path}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        // Use the same syntax validation and Astro slug derivation as translation.
+        await canonicalHeadingIds(String(file.value));
+        sourceHeadings = await canonicalHeadingIds(source);
+      }
+    }
+    if (rawMetadata === undefined && sourceHeadings === undefined) {
+      return;
+    }
+    assertNoUnsupportedHeadingNodes(tree, file.path ?? 'documentation page');
+    if (
+      rawMetadata !== undefined &&
+      (!Array.isArray(rawMetadata) || !rawMetadata.every(isCanonicalHeadingId))
+    ) {
+      throw new Error(
+        `Invalid ${CANONICAL_HEADING_IDS_FIELD} metadata in ${file.path ?? 'documentation page'}.`,
+      );
+    }
+
+    const allHeadings: HastNode[] = [];
+    collectHeadings(tree, allHeadings);
+    const headings = allHeadings.filter((heading) => heading.tagName !== 'h1');
+    const renderedDepths = headings.map((heading) =>
+      Number(heading.tagName?.slice(1)),
+    );
+    const stored = rawMetadata as CanonicalHeadingId[] | undefined;
+    if (
+      stored !== undefined &&
+      JSON.stringify(renderedDepths) !==
+        JSON.stringify(stored.map(({ depth }) => depth))
+    ) {
+      throw new Error(
+        `Canonical heading metadata does not match the rendered headings in ${file.path ?? 'documentation page'}.`,
+      );
+    }
+
+    assignLocalizedHeadingIds(tree, file);
+    // A lagging translation has no reliable positional mapping after insertions or deletions.
+    const current = sourceHeadings ?? stored;
+    const canonicalIds = headings.map((heading, index) =>
+      current?.length === headings.length
+        ? current[index].id
+        : heading.properties?.id,
+    );
+    const identityOwners = new Map<string, number>();
+    for (const heading of allHeadings) {
+      if (
+        heading.tagName === 'h1' &&
+        typeof heading.properties?.id === 'string'
+      ) {
+        identityOwners.set(heading.properties.id, -1);
+      }
+    }
+    for (const [index, id] of canonicalIds.entries()) {
+      if (typeof id !== 'string' || id.length === 0) {
+        throw new Error(
+          `Astro did not assign a localized heading ID in ${file.path ?? 'documentation page'}.`,
+        );
+      }
+      const owner = identityOwners.get(id);
+      if (owner !== undefined && owner !== index) {
+        throw new Error(
+          `Heading ID ${JSON.stringify(id)} identifies multiple headings in ${file.path ?? 'documentation page'}.`,
+        );
+      }
+      identityOwners.set(id, index);
+    }
+    for (const [index, heading] of headings.entries()) {
+      heading.properties ??= {};
+      const localizedId = heading.properties.id;
+      const canonicalId = canonicalIds[index];
+      if (typeof localizedId !== 'string' || localizedId.length === 0) {
+        throw new Error(
+          `Astro did not assign a localized heading ID in ${file.path ?? 'documentation page'}.`,
+        );
+      }
+      heading.properties.id = canonicalId;
+      const aliases = [
+        ...new Set(
+          [
+            ...(stored ? [stored[index].id, ...stored[index].aliases] : []),
+            localizedId,
+          ].filter((alias) => alias !== canonicalId),
+        ),
+      ];
+      for (const alias of aliases) {
+        const owner = identityOwners.get(alias);
+        if (owner !== undefined && owner !== index) {
+          throw new Error(
+            `Heading ID ${JSON.stringify(alias)} identifies multiple headings in ${file.path ?? 'documentation page'}.`,
+          );
+        }
+        identityOwners.set(alias, index);
+      }
+      if (aliases.length > 0) {
+        heading.children ??= [];
+        heading.children.unshift(
+          ...aliases.map((alias) => ({
+            type: 'element',
+            tagName: 'span',
+            properties: { id: alias, ariaHidden: 'true' },
+            children: [],
+          })),
+        );
+      }
+    }
+  };
+}

--- a/docs/src/scripts/headingAnchors.test.ts
+++ b/docs/src/scripts/headingAnchors.test.ts
@@ -1,0 +1,850 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { pathToFileURL } from 'node:url';
+import {
+  createMarkdownProcessor,
+  parseFrontmatter,
+} from '@astrojs/markdown-remark';
+import { describe, expect, test, vi } from 'vitest';
+import { rehypeCanonicalHeadingIds } from '../plugins/rehypeCanonicalHeadingIds';
+import {
+  canonicalHeadingIds,
+  preserveCanonicalHeadingIds,
+  refreshLocalizedHeadingIds,
+  writeCanonicalHeadingCopy,
+} from './headingAnchors';
+import { translateFile } from './translate';
+
+const runTranslation = vi.hoisted(() => vi.fn());
+vi.mock('@openai/agents', () => ({
+  Agent: vi.fn(),
+  Runner: class {
+    run = runTranslation;
+  },
+  setDefaultOpenAIKey: vi.fn(),
+}));
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
+const DOCS_ROOT = path.join(REPO_ROOT, 'docs/src/content/docs');
+
+describe('canonical localized heading IDs', () => {
+  test('derives rendered English IDs and ignores fenced code', async () => {
+    const headings = await canonicalHeadingIds(`
+# Page title
+
+## Using \`Agent\` with [tools](tools.md)
+
+## [Referenced tools][tools]
+
+[tools]: /guides/tools/
+
+## Example
+
+~~~md
+## Not a heading
+~~~
+
+## Example
+`);
+
+    expect(headings).toEqual([
+      { depth: 2, id: 'using-agent-with-tools', aliases: [] },
+      { depth: 2, id: 'referenced-tools', aliases: [] },
+      { depth: 2, id: 'example', aliases: [] },
+      { depth: 2, id: 'example-1', aliases: [] },
+    ]);
+  });
+
+  test('writes idempotent metadata and rejects structural mismatches', async () => {
+    const source = `---
+title: Agents
+description: English
+---
+
+## Dynamic instructions
+`;
+    const localized = `---
+title: エージェント
+description: Japanese
+---
+
+## 動的な指示
+`;
+    const once = await preserveCanonicalHeadingIds(
+      source,
+      localized,
+      'localized fixture',
+    );
+    const twice = await preserveCanonicalHeadingIds(
+      source,
+      once,
+      'localized fixture',
+    );
+
+    expect(twice).toBe(once);
+    expect(once).toContain(`canonicalHeadingIds:
+  - depth: 2
+    id: 'dynamic-instructions'
+    aliases:
+      - '動的な指示'`);
+    await expect(
+      preserveCanonicalHeadingIds(
+        source,
+        localized.replace('## 動的な指示', '### 動的な指示'),
+        'localized fixture',
+      ),
+    ).rejects.toThrow('heading levels do not match');
+  });
+
+  test('rejects unsupported section heading representations', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      await expect(canonicalHeadingIds('Section\n-------\n')).rejects.toThrow(
+        'Only top-level H2-H6 ATX Markdown headings are supported',
+      );
+      await expect(
+        canonicalHeadingIds('> ## Quoted heading\n'),
+      ).rejects.toThrow(
+        'Only top-level H2-H6 ATX Markdown headings are supported',
+      );
+      await expect(canonicalHeadingIds('## Hello {value}\n')).rejects.toThrow(
+        'Dynamic MDX syntax is not supported',
+      );
+      await expect(canonicalHeadingIds('## `{value}`\n')).resolves.toEqual([
+        { depth: 2, id: 'value', aliases: [] },
+      ]);
+      await expect(canonicalHeadingIds('<h2>Raw heading</h2>')).rejects.toThrow(
+        'Unsupported raw or MDX H2-H6 heading',
+      );
+      expect(consoleError).toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('applies canonical IDs through the Astro heading pipeline', async () => {
+    const processor = await createMarkdownProcessor({
+      syntaxHighlight: false,
+      rehypePlugins: [[rehypeCanonicalHeadingIds, { contentRoot: DOCS_ROOT }]],
+    });
+    const result = await processor.render('## 動的な指示', {
+      frontmatter: {
+        canonicalHeadingIds: [
+          {
+            depth: 2,
+            id: 'dynamic-instructions',
+            aliases: ['以前の動的な指示'],
+          },
+        ],
+      },
+    });
+
+    expect(result.code).toContain(
+      '<h2 id="dynamic-instructions"><span id="以前の動的な指示" aria-hidden="true"></span><span id="動的な指示" aria-hidden="true"></span>',
+    );
+    expect(result.metadata.headings).toEqual([
+      { depth: 2, slug: 'dynamic-instructions', text: '動的な指示' },
+    ]);
+
+    const matchingId = await processor.render('## Stable', {
+      frontmatter: {
+        canonicalHeadingIds: [{ depth: 2, id: 'stable', aliases: [] }],
+      },
+    });
+    expect(matchingId.code).toContain('<h2 id="stable">Stable</h2>');
+    expect(matchingId.code).not.toContain('<span');
+
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      await expect(
+        processor.render('### 動的な指示', {
+          frontmatter: {
+            canonicalHeadingIds: [
+              { depth: 2, id: 'dynamic-instructions', aliases: [] },
+            ],
+          },
+        }),
+      ).rejects.toThrow('does not match the rendered headings');
+      expect(consoleError).toHaveBeenCalled();
+
+      await expect(
+        processor.render('<h2>Raw heading</h2>', {
+          frontmatter: { canonicalHeadingIds: [] },
+        }),
+      ).rejects.toThrow('Unsupported raw or MDX H2-H6 heading');
+
+      await expect(
+        processor.render('## Second\n\n## First', {
+          frontmatter: {
+            canonicalHeadingIds: [
+              { depth: 2, id: 'first', aliases: [] },
+              { depth: 2, id: 'second', aliases: [] },
+            ],
+          },
+        }),
+      ).rejects.toThrow('Heading ID "second" identifies multiple headings');
+
+      await expect(
+        processor.render('## First\n\n## Second', {
+          frontmatter: {
+            canonicalHeadingIds: [
+              { depth: 2, id: 'same', aliases: [] },
+              { depth: 2, id: 'same', aliases: [] },
+            ],
+          },
+        }),
+      ).rejects.toThrow('Heading ID "same" identifies multiple headings');
+
+      for (const metadata of [
+        { depth: 2, id: 'same', aliases: [] },
+        { depth: 2, id: 'canonical', aliases: ['same'] },
+      ]) {
+        await expect(
+          processor.render('# Same\n\n## Localized', {
+            frontmatter: { canonicalHeadingIds: [metadata] },
+          }),
+        ).rejects.toThrow('Heading ID "same" identifies multiple headings');
+      }
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test('retains every published localized alias across retranslations', async () => {
+    const source = `---
+title: Stable
+description: English
+---
+
+## Stable heading
+`;
+    const previousLocalized = `---
+title: 安定
+description: Japanese
+canonicalHeadingIds:
+  - depth: 2
+    id: 'stable-heading'
+    aliases:
+      - '最初の見出し'
+      - '二番目の見出し'
+---
+
+## 二番目の見出し
+`;
+    const thirdTranslation = await preserveCanonicalHeadingIds(
+      source,
+      `---
+title: 安定
+description: Japanese
+---
+
+## 三番目の見出し
+`,
+      'localized fixture',
+      previousLocalized,
+    );
+    const fourthTranslation = await preserveCanonicalHeadingIds(
+      source,
+      `---
+title: 安定
+description: Japanese
+---
+
+## 四番目の見出し
+`,
+      'localized fixture',
+      thirdTranslation,
+    );
+    const { content, frontmatter } = parseFrontmatter(fourthTranslation);
+
+    expect(frontmatter.canonicalHeadingIds).toEqual([
+      {
+        depth: 2,
+        id: 'stable-heading',
+        aliases: [
+          '最初の見出し',
+          '二番目の見出し',
+          '三番目の見出し',
+          '四番目の見出し',
+        ],
+      },
+    ]);
+
+    const processor = await createMarkdownProcessor({
+      syntaxHighlight: false,
+      rehypePlugins: [[rehypeCanonicalHeadingIds, { contentRoot: DOCS_ROOT }]],
+    });
+    const result = await processor.render(content, { frontmatter });
+    expect(result.code).toContain(
+      '<h2 id="stable-heading"><span id="最初の見出し" aria-hidden="true"></span><span id="二番目の見出し" aria-hidden="true"></span><span id="三番目の見出し" aria-hidden="true"></span><span id="四番目の見出し" aria-hidden="true"></span>',
+    );
+  });
+
+  test('retains aligned rename history and matches removals by canonical ID', async () => {
+    const previousLocalized = `---
+title: Previous
+description: Japanese
+canonicalHeadingIds:
+  - depth: 2
+    id: 'first'
+  - depth: 2
+    id: 'second'
+---
+
+## 最初の旧見出し
+
+## 二番目の旧見出し
+`;
+    const afterRemoval = await preserveCanonicalHeadingIds(
+      '---\ntitle: Source\ndescription: English\n---\n\n## Second\n',
+      '---\ntitle: Current\ndescription: Japanese\n---\n\n## 二番目の新見出し\n',
+      'localized fixture',
+      previousLocalized,
+    );
+    expect(
+      parseFrontmatter(afterRemoval).frontmatter.canonicalHeadingIds,
+    ).toEqual([
+      {
+        depth: 2,
+        id: 'second',
+        aliases: ['二番目の旧見出し', '二番目の新見出し'],
+      },
+    ]);
+
+    const afterCanonicalRename = await preserveCanonicalHeadingIds(
+      '---\ntitle: Source\ndescription: English\n---\n\n## Renamed\n',
+      '---\ntitle: Current\ndescription: Japanese\n---\n\n## 新しい見出し\n',
+      'localized fixture',
+      previousLocalized
+        .replace("  - depth: 2\n    id: 'second'\n", '')
+        .replace('\n## 二番目の旧見出し\n', ''),
+    );
+    expect(
+      parseFrontmatter(afterCanonicalRename).frontmatter.canonicalHeadingIds,
+    ).toEqual([
+      {
+        depth: 2,
+        id: 'renamed',
+        aliases: ['first', '最初の旧見出し', '新しい見出し'],
+      },
+    ]);
+  });
+
+  test('rejects invalid alias history before refreshing a generated file', async () => {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'heading-alias-history-'),
+    );
+    const sourcePath = path.join(temporaryDirectory, 'source.mdx');
+    const localizedPath = path.join(temporaryDirectory, 'localized.mdx');
+    const collidingLocalized = `---
+title: Localized
+canonicalHeadingIds:
+  - depth: 2
+    id: 'first'
+    aliases:
+      - 'second'
+  - depth: 2
+    id: 'second'
+    aliases: []
+---
+
+## First localized
+
+## Second localized
+`;
+    try {
+      await fs.writeFile(
+        sourcePath,
+        '---\ntitle: Source\n---\n\n## First\n\n## Second\n',
+      );
+      await fs.writeFile(localizedPath, collidingLocalized);
+
+      await expect(
+        refreshLocalizedHeadingIds(sourcePath, [localizedPath]),
+      ).rejects.toThrow('Heading ID "second" identifies multiple headings');
+      await expect(fs.readFile(localizedPath, 'utf8')).resolves.toBe(
+        collidingLocalized,
+      );
+
+      const malformedLocalized = collidingLocalized
+        .replace("    aliases:\n      - 'second'", '    aliases: invalid')
+        .replace("      - 'second'\n", '');
+      await fs.writeFile(localizedPath, malformedLocalized);
+      await expect(
+        refreshLocalizedHeadingIds(sourcePath, [localizedPath]),
+      ).rejects.toThrow('Invalid canonicalHeadingIds metadata');
+      await expect(fs.readFile(localizedPath, 'utf8')).resolves.toBe(
+        malformedLocalized,
+      );
+    } finally {
+      await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves alias history in untranslated fallback copies', async () => {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'heading-fallback-'),
+    );
+    const targetPath = path.join(temporaryDirectory, 'localized.mdx');
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const previousLocalized = `---
+title: Previous
+canonicalHeadingIds:
+  - depth: 2
+    id: 'stable-heading'
+    aliases:
+      - '最初の見出し'
+---
+
+## 二番目の見出し
+`;
+    try {
+      await fs.writeFile(targetPath, previousLocalized);
+      await expect(
+        writeCanonicalHeadingCopy(
+          'Unsupported\n-----------\n',
+          targetPath,
+          'localized fixture',
+          previousLocalized,
+        ),
+      ).rejects.toThrow(
+        'Only top-level H2-H6 ATX Markdown headings are supported',
+      );
+      await expect(fs.readFile(targetPath, 'utf8')).resolves.toBe(
+        previousLocalized,
+      );
+      expect(consoleError).toHaveBeenCalled();
+
+      const source = '---\ntitle: Fallback\n---\n\n## Stable heading\n';
+      await expect(
+        writeCanonicalHeadingCopy(
+          source,
+          targetPath,
+          'localized fixture',
+          previousLocalized,
+        ),
+      ).resolves.toBeUndefined();
+      const written = await fs.readFile(targetPath, 'utf8');
+      expect(parseFrontmatter(written).frontmatter.canonicalHeadingIds).toEqual(
+        [
+          {
+            depth: 2,
+            id: 'stable-heading',
+            aliases: ['最初の見出し', '二番目の見出し'],
+          },
+        ],
+      );
+      expect(parseFrontmatter(written).content).toContain('## Stable heading');
+
+      const malformedPrevious = previousLocalized.replace(
+        "    aliases:\n      - '最初の見出し'",
+        '    aliases: invalid',
+      );
+      await fs.writeFile(targetPath, malformedPrevious);
+      await expect(
+        writeCanonicalHeadingCopy(
+          source,
+          targetPath,
+          'localized fixture',
+          malformedPrevious,
+        ),
+      ).rejects.toThrow('Invalid canonicalHeadingIds metadata');
+      await expect(fs.readFile(targetPath, 'utf8')).resolves.toBe(
+        malformedPrevious,
+      );
+    } finally {
+      consoleError.mockRestore();
+      await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('refreshes generated metadata once and then leaves it unchanged', async () => {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'heading-anchors-'),
+    );
+    const sourcePath = path.join(temporaryDirectory, 'source.mdx');
+    const localizedPath = path.join(temporaryDirectory, 'localized.mdx');
+    try {
+      await fs.writeFile(sourcePath, '---\ntitle: Source\n---\n\n## Stable\n');
+      await fs.writeFile(
+        localizedPath,
+        '---\ntitle: Localized\n---\n\n## 翻訳済み\n',
+      );
+
+      await expect(
+        refreshLocalizedHeadingIds(sourcePath, [localizedPath]),
+      ).resolves.toEqual([localizedPath]);
+      await expect(
+        refreshLocalizedHeadingIds(sourcePath, [localizedPath]),
+      ).resolves.toEqual([]);
+
+      await fs.writeFile(
+        sourcePath,
+        '---\ntitle: Source\n---\n\n### Renamed\n',
+      );
+      await expect(
+        refreshLocalizedHeadingIds(sourcePath, [localizedPath]),
+      ).resolves.toEqual([localizedPath]);
+      const relevelled = await fs.readFile(localizedPath, 'utf8');
+      expect(
+        parseFrontmatter(relevelled).frontmatter.canonicalHeadingIds,
+      ).toEqual([{ depth: 2, id: 'renamed', aliases: ['stable', '翻訳済み'] }]);
+      expect(parseFrontmatter(relevelled).content).toContain('## 翻訳済み');
+      await expect(
+        refreshLocalizedHeadingIds(sourcePath, [localizedPath]),
+      ).resolves.toEqual([]);
+
+      await fs.writeFile(
+        sourcePath,
+        '---\ntitle: Source\n---\n\n## Added\n\n### Renamed\n',
+      );
+      await expect(
+        refreshLocalizedHeadingIds(sourcePath, [localizedPath]),
+      ).resolves.toEqual([]);
+      await expect(fs.readFile(localizedPath, 'utf8')).resolves.toBe(
+        relevelled,
+      );
+    } finally {
+      await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects known invalid inputs before translation requests and preserves legacy aliases', async () => {
+    const temporaryDirectory = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'translation-heading-inputs-'),
+    );
+    const sourcePath = path.join(temporaryDirectory, 'source.mdx');
+    const targetPath = path.join(temporaryDirectory, 'localized.mdx');
+    const source =
+      '---\ntitle: Source\ndescription: English\n---\n\n## Stable heading\n';
+    const previous =
+      '---\ntitle: Previous\ndescription: Japanese\n---\n\n## 最初の見出し\n';
+    const malformed = previous.replace(
+      'description: Japanese',
+      'description: Japanese\ncanonicalHeadingIds: invalid',
+    );
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const invalidInputs = [
+        {
+          source,
+          previous: previous + '\n# Stable heading\n',
+        },
+        {
+          source: source.replace('## Stable heading', 'Section\n-------'),
+          previous,
+        },
+        {
+          source: source.replace('## Stable heading', '## !!!'),
+          previous,
+        },
+        {
+          source,
+          previous: previous.replace('## 最初の見出し', '## !!!'),
+        },
+        {
+          source: source.replace(
+            'description: English',
+            'description: English\ncanonicalHeadingIds: invalid',
+          ),
+          previous,
+        },
+        {
+          source,
+          previous: previous.replace('## 最初の見出し', '## Hello {value}'),
+        },
+        { source, previous: malformed },
+        {
+          source,
+          previous: previous.replace(
+            'description: Japanese',
+            'description: Japanese\ncanonicalHeadingIds:\n  - depth: 2\n    id: stable-heading\n    aliases: null',
+          ),
+        },
+        {
+          source,
+          previous: previous.replace(
+            'description: Japanese',
+            'description: Japanese\ncanonicalHeadingIds:\n  - depth: 3\n    id: stable-heading\n    aliases: []',
+          ),
+        },
+      ];
+      for (const inputs of invalidInputs) {
+        runTranslation.mockReset();
+        await fs.writeFile(sourcePath, inputs.source);
+        await fs.writeFile(targetPath, inputs.previous);
+        await expect(
+          translateFile(sourcePath, targetPath, 'ja'),
+        ).rejects.toThrow();
+        expect(runTranslation).not.toHaveBeenCalled();
+        await expect(fs.readFile(targetPath, 'utf8')).resolves.toBe(
+          inputs.previous,
+        );
+      }
+
+      await fs.writeFile(sourcePath, source);
+      await fs.writeFile(targetPath, previous);
+      runTranslation.mockReset();
+      runTranslation
+        .mockResolvedValueOnce({ finalOutput: '新しいタイトル' })
+        .mockResolvedValueOnce({ finalOutput: '## 新しい見出し' });
+      await translateFile(sourcePath, targetPath, 'ja');
+      expect(runTranslation).toHaveBeenCalledTimes(2);
+      const output = await fs.readFile(targetPath, 'utf8');
+      expect(parseFrontmatter(output).frontmatter.canonicalHeadingIds).toEqual([
+        {
+          depth: 2,
+          id: 'stable-heading',
+          aliases: ['最初の見出し', '新しい見出し'],
+        },
+      ]);
+
+      // Valid translations may lag behind English additions without blocking regeneration.
+      await fs.writeFile(sourcePath, source + '\n## Added heading\n');
+      await fs.writeFile(targetPath, previous);
+      runTranslation.mockReset();
+      runTranslation
+        .mockResolvedValueOnce({ finalOutput: '新しいタイトル' })
+        .mockResolvedValueOnce({
+          finalOutput: '## 新しい見出し\n\n## 追加の見出し',
+        });
+      await translateFile(sourcePath, targetPath, 'ja');
+      expect(runTranslation).toHaveBeenCalledTimes(2);
+      expect(
+        parseFrontmatter(await fs.readFile(targetPath, 'utf8')).frontmatter
+          .canonicalHeadingIds,
+      ).toEqual([
+        { depth: 2, id: 'stable-heading', aliases: ['新しい見出し'] },
+        { depth: 2, id: 'added-heading', aliases: ['追加の見出し'] },
+      ]);
+      await fs.writeFile(sourcePath, source);
+      await fs.writeFile(targetPath, output);
+
+      for (const [translated, message] of [
+        ['### Wrong depth', 'heading levels do not match'],
+        ['## !!!', 'empty anchor ID'],
+        ['# 最初の見出し\n\n## 新しい見出し', 'identifies multiple headings'],
+      ]) {
+        runTranslation.mockReset();
+        runTranslation
+          .mockResolvedValueOnce({ finalOutput: 'タイトル' })
+          .mockResolvedValueOnce({ finalOutput: translated });
+        await expect(
+          translateFile(sourcePath, targetPath, 'ja'),
+        ).rejects.toThrow(message);
+        expect(runTranslation).toHaveBeenCalledTimes(2);
+        await expect(fs.readFile(targetPath, 'utf8')).resolves.toBe(output);
+      }
+    } finally {
+      vi.restoreAllMocks();
+      await fs.rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('derives missing metadata during rendering without modifying content files', async () => {
+    const contentRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'heading-build-'),
+    );
+    const sourcePath = path.join(contentRoot, 'guide.mdx');
+    const source = '---\ntitle: Agents\n---\n\n## Agent fundamentals\n';
+    const localized =
+      '---\ntitle: エージェント\n---\n\n## エージェントの基本\n';
+    const processor = await createMarkdownProcessor({
+      syntaxHighlight: false,
+      rehypePlugins: [[rehypeCanonicalHeadingIds, { contentRoot }]],
+    });
+    const render = (markdown: string, filePath: string) => {
+      const { content, frontmatter } = parseFrontmatter(markdown);
+      return processor.render(content, {
+        frontmatter,
+        fileURL: pathToFileURL(filePath),
+      });
+    };
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    try {
+      await fs.writeFile(sourcePath, source);
+      for (const locale of ['ja', 'ko', 'zh']) {
+        const localizedPath = path.join(contentRoot, locale, 'guide.mdx');
+        await fs.mkdir(path.dirname(localizedPath));
+        await fs.writeFile(localizedPath, localized);
+        const result = await render(localized, localizedPath);
+        expect(result.code).toContain('<h2 id="agent-fundamentals">');
+        expect(result.code).toContain(
+          '<span id="エージェントの基本" aria-hidden="true"></span>',
+        );
+        expect(result.metadata.headings).toEqual([
+          { depth: 2, slug: 'agent-fundamentals', text: 'エージェントの基本' },
+        ]);
+        await expect(fs.readFile(localizedPath, 'utf8')).resolves.toBe(
+          localized,
+        );
+      }
+      await expect(fs.readFile(sourcePath, 'utf8')).resolves.toBe(source);
+
+      for (const filePath of [
+        sourcePath,
+        path.join(contentRoot, 'openai/agents/api.md'),
+        path.join(contentRoot, '../ja/outside.md'),
+      ]) {
+        const result = await render('## Original heading', filePath);
+        expect(result.metadata.headings[0].slug).toBe('original-heading');
+      }
+      await expect(
+        render(localized, path.join(contentRoot, 'ja/missing.mdx')),
+      ).rejects.toThrow('Cannot read the English heading source');
+      await expect(
+        render(
+          localized + '\n# Agent fundamentals\n',
+          path.join(contentRoot, 'ja/guide.mdx'),
+        ),
+      ).rejects.toThrow(
+        'Heading ID "agent-fundamentals" identifies multiple headings',
+      );
+      const differentDepth = await render(
+        localized.replace('## ', '### '),
+        path.join(contentRoot, 'ja/guide.mdx'),
+      );
+      expect(differentDepth.metadata.headings[0]).toEqual({
+        depth: 3,
+        slug: 'agent-fundamentals',
+        text: 'エージェントの基本',
+      });
+      await expect(
+        render(
+          localized.replace('## エージェントの基本', '> ## Nested'),
+          path.join(contentRoot, 'ja/guide.mdx'),
+        ),
+      ).rejects.toThrow('Only top-level H2-H6 ATX Markdown headings');
+
+      // Subsequent renders must not reuse IDs from an earlier source revision.
+      await fs.writeFile(
+        sourcePath,
+        source.replace('Agent fundamentals', 'Updated fundamentals'),
+      );
+      const updated = await render(
+        localized,
+        path.join(contentRoot, 'ja/guide.mdx'),
+      );
+      expect(updated.metadata.headings[0].slug).toBe('updated-fundamentals');
+    } finally {
+      consoleError.mockRestore();
+      await fs.rm(contentRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('uses current English IDs and preserves stored targets while translations lag', async () => {
+    const contentRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'heading-drift-'),
+    );
+    const sourcePath = path.join(contentRoot, 'guide.mdx');
+    const localizedPath = path.join(contentRoot, 'ja/guide.mdx');
+    const source = '---\ntitle: Source\n---\n\n## First\n\n## Second\n';
+    const localized = '---\ntitle: 翻訳\n---\n\n## 最初\n\n## 二番目\n';
+    const withHistory = await preserveCanonicalHeadingIds(
+      source,
+      localized,
+      'fixture',
+    );
+    const processor = await createMarkdownProcessor({
+      syntaxHighlight: false,
+      rehypePlugins: [[rehypeCanonicalHeadingIds, { contentRoot }]],
+    });
+    try {
+      await fs.mkdir(path.dirname(localizedPath));
+      for (const translation of [localized, withHistory]) {
+        await fs.writeFile(localizedPath, translation);
+        const { content, frontmatter } = parseFrontmatter(translation);
+        for (const [currentSource, expectedIds] of [
+          [source.replace('## First', '### Renamed'), ['renamed', 'second']],
+          [source.replace('## First', '### First'), ['first', 'second']],
+          [
+            source.replace('## First', '## Added\n\n## First'),
+            ['最初', '二番目'],
+          ],
+          [source.replace('\n## First\n', ''), ['最初', '二番目']],
+        ] as const) {
+          await fs.writeFile(sourcePath, currentSource);
+          const result = await processor.render(content, {
+            frontmatter,
+            fileURL: pathToFileURL(localizedPath),
+          });
+          expect(result.metadata.headings).toEqual([
+            {
+              depth: 2,
+              slug: expectedIds[0],
+              text: '最初',
+            },
+            { depth: 2, slug: expectedIds[1], text: '二番目' },
+          ]);
+          for (const alias of [
+            '最初',
+            '二番目',
+            ...(translation === withHistory ? ['first', 'second'] : []),
+          ]) {
+            expect(result.code).toContain(`id="${alias}"`);
+          }
+          expect(result.code).not.toContain('id="added"');
+          await expect(fs.readFile(localizedPath, 'utf8')).resolves.toBe(
+            translation,
+          );
+        }
+      }
+    } finally {
+      await fs.rm(contentRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('renders canonical IDs from the unchanged checked-in locale corpus', async () => {
+    const processor = await createMarkdownProcessor({
+      syntaxHighlight: false,
+      rehypePlugins: [[rehypeCanonicalHeadingIds, { contentRoot: DOCS_ROOT }]],
+    });
+    const sourceFiles: string[] = [];
+    const collect = async (directory: string): Promise<void> => {
+      for (const entry of await fs.readdir(directory, {
+        withFileTypes: true,
+      })) {
+        const entryPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          await collect(entryPath);
+        } else if (/\.mdx?$/.test(entry.name)) {
+          sourceFiles.push(entryPath);
+        }
+      }
+    };
+    sourceFiles.push(path.join(DOCS_ROOT, 'index.mdx'));
+    await collect(path.join(DOCS_ROOT, 'guides'));
+    await collect(path.join(DOCS_ROOT, 'extensions'));
+
+    for (const sourcePath of sourceFiles) {
+      const relativePath = path.relative(DOCS_ROOT, sourcePath);
+      const source = await fs.readFile(sourcePath, 'utf8');
+      const sourceHeadings = await canonicalHeadingIds(source);
+      for (const locale of ['ja', 'ko', 'zh']) {
+        const localizedPath = path.join(DOCS_ROOT, locale, relativePath);
+        const localized = await fs.readFile(localizedPath, 'utf8');
+        const { content, frontmatter } = parseFrontmatter(localized);
+        const rendered = await processor.render(content, {
+          frontmatter,
+          fileURL: pathToFileURL(localizedPath),
+        });
+        expect(
+          rendered.metadata.headings
+            .filter(({ depth }) => depth >= 2 && depth <= 6)
+            .map(({ depth, slug }) => ({ depth, id: slug })),
+          `${locale}/${relativePath}`,
+        ).toEqual(sourceHeadings.map(({ depth, id }) => ({ depth, id })));
+      }
+    }
+  }, 60_000);
+});

--- a/docs/src/scripts/headingAnchors.ts
+++ b/docs/src/scripts/headingAnchors.ts
@@ -1,0 +1,514 @@
+import fs from 'fs/promises';
+import path from 'path';
+import {
+  createMarkdownProcessor,
+  parseFrontmatter,
+} from '@astrojs/markdown-remark';
+import remarkMdx from 'remark-mdx';
+
+export const CANONICAL_HEADING_IDS_FIELD = 'canonicalHeadingIds';
+
+export type CanonicalHeadingId = {
+  depth: number;
+  id: string;
+  aliases: string[];
+};
+
+type StoredHeadingId = Omit<CanonicalHeadingId, 'aliases'> & {
+  aliases?: string[];
+};
+
+type HeadingSyntaxNode = {
+  type: string;
+  depth?: number;
+  name?: string | null;
+  value?: string;
+  children?: HeadingSyntaxNode[];
+  position?: {
+    start: {
+      offset?: number;
+    };
+  };
+};
+
+type MarkdownFile = {
+  value: unknown;
+};
+
+let markdownProcessorPromise:
+  ReturnType<typeof createMarkdownProcessor> | undefined;
+
+function markdownProcessor() {
+  markdownProcessorPromise ??= createMarkdownProcessor({
+    syntaxHighlight: false,
+    remarkPlugins: [remarkMdx, remarkValidateCanonicalHeadings],
+    rehypePlugins: [rehypeRejectUnsupportedHeadings],
+  });
+  return markdownProcessorPromise;
+}
+
+function withoutFrontmatter(markdown: string): string {
+  const newline = markdown.includes('\r\n') ? '\r\n' : '\n';
+  const lines = markdown.split(/\r?\n/);
+  if (lines[0]?.trim() !== '---') {
+    return markdown;
+  }
+  const frontmatterEnd = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === '---',
+  );
+  if (frontmatterEnd < 0) {
+    throw new Error('Documentation has unterminated frontmatter.');
+  }
+  return lines.slice(frontmatterEnd + 1).join(newline);
+}
+
+function containsMdxSyntax(node: HeadingSyntaxNode): boolean {
+  if (node.type.startsWith('mdx')) {
+    return true;
+  }
+  return (node.children ?? []).some(containsMdxSyntax);
+}
+
+function remarkValidateCanonicalHeadings() {
+  return (tree: HeadingSyntaxNode, file: MarkdownFile): void => {
+    const markdown = String(file.value);
+    const visit = (
+      node: HeadingSyntaxNode,
+      parent: HeadingSyntaxNode | undefined,
+    ): void => {
+      if (
+        node.type === 'heading' &&
+        node.depth !== undefined &&
+        node.depth >= 2 &&
+        node.depth <= 6
+      ) {
+        if (parent?.type !== 'root') {
+          throw new Error(
+            'Only top-level H2-H6 ATX Markdown headings are supported in localized documentation.',
+          );
+        }
+        const offset = node.position?.start.offset;
+        const firstLine =
+          offset === undefined
+            ? ''
+            : markdown.slice(offset).split(/\r?\n/, 1)[0];
+        const marker = firstLine.match(/^ {0,3}(#{2,6})(?:[ \t]+|$)/);
+        if (!marker || marker[1].length !== node.depth) {
+          throw new Error(
+            'Only top-level H2-H6 ATX Markdown headings are supported in localized documentation.',
+          );
+        }
+        if ((node.children ?? []).some(containsMdxSyntax)) {
+          throw new Error(
+            'Dynamic MDX syntax is not supported in localized documentation headings; use static Markdown text.',
+          );
+        }
+      }
+
+      const rawHeading =
+        node.type === 'html' &&
+        typeof node.value === 'string' &&
+        /<h[2-6](?:\s|\/?>)/i.test(node.value);
+      const mdxHeading =
+        node.type.startsWith('mdxJsx') &&
+        typeof node.name === 'string' &&
+        /^h[2-6]$/i.test(node.name);
+      if (rawHeading || mdxHeading) {
+        throw new Error(
+          'Unsupported raw or MDX H2-H6 heading; use a top-level ATX Markdown heading.',
+        );
+      }
+
+      for (const child of node.children ?? []) {
+        visit(child, node);
+      }
+    };
+
+    visit(tree, undefined);
+  };
+}
+
+export function assertNoUnsupportedHeadingNodes(
+  node: HeadingSyntaxNode,
+  name: string,
+): void {
+  const rawHeading =
+    node.type === 'raw' &&
+    typeof node.value === 'string' &&
+    /<h[2-6](?:\s|\/?>)/i.test(node.value);
+  const mdxHeading =
+    node.type.startsWith('mdxJsx') &&
+    typeof node.name === 'string' &&
+    /^h[2-6]$/i.test(node.name);
+  if (rawHeading || mdxHeading) {
+    throw new Error(
+      `Unsupported raw or MDX H2-H6 heading in ${name}; use an ATX Markdown heading.`,
+    );
+  }
+  for (const child of node.children ?? []) {
+    assertNoUnsupportedHeadingNodes(child, name);
+  }
+}
+
+function rehypeRejectUnsupportedHeadings() {
+  return (tree: HeadingSyntaxNode): void => {
+    assertNoUnsupportedHeadingNodes(tree, 'documentation');
+  };
+}
+
+async function documentHeadingIds(
+  markdown: string,
+): Promise<CanonicalHeadingId[]> {
+  const body = withoutFrontmatter(markdown);
+
+  const processor = await markdownProcessor();
+  const rendered = await processor.render(body);
+  const headings = rendered.metadata.headings;
+
+  return headings.map(({ depth, slug }) => {
+    if (depth >= 2 && slug.length === 0) {
+      throw new Error(
+        'Documentation heading produces an empty anchor ID; use heading text with letters or numbers.',
+      );
+    }
+    return { depth, id: slug, aliases: [] };
+  });
+}
+
+export async function canonicalHeadingIds(
+  markdown: string,
+): Promise<CanonicalHeadingId[]> {
+  return (await documentHeadingIds(markdown)).filter(({ depth }) => depth >= 2);
+}
+
+function quoteYamlString(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function serializedHeadingIds(headings: CanonicalHeadingId[]): string[] {
+  if (headings.length === 0) {
+    return [`${CANONICAL_HEADING_IDS_FIELD}: []`];
+  }
+  return [
+    `${CANONICAL_HEADING_IDS_FIELD}:`,
+    ...headings.flatMap(({ depth, id, aliases }) => {
+      const serializedAliases =
+        aliases.length === 0
+          ? ['    aliases: []']
+          : [
+              '    aliases:',
+              ...aliases.map((alias) => `      - ${quoteYamlString(alias)}`),
+            ];
+      return [
+        `  - depth: ${depth}`,
+        `    id: ${quoteYamlString(id)}`,
+        ...serializedAliases,
+      ];
+    }),
+  ];
+}
+
+function storedHeadingIds(
+  markdown: string,
+  name: string,
+): CanonicalHeadingId[] | undefined {
+  let rawMetadata: unknown;
+  try {
+    rawMetadata =
+      parseFrontmatter(markdown).frontmatter[CANONICAL_HEADING_IDS_FIELD];
+  } catch (error) {
+    throw new Error(
+      `Cannot parse heading metadata in ${name}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (rawMetadata === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(rawMetadata)) {
+    throw new Error(
+      `Invalid ${CANONICAL_HEADING_IDS_FIELD} metadata in ${name}.`,
+    );
+  }
+
+  return rawMetadata.map((value: unknown) => {
+    if (typeof value !== 'object' || value === null) {
+      throw new Error(
+        `Invalid ${CANONICAL_HEADING_IDS_FIELD} metadata in ${name}.`,
+      );
+    }
+    const record = value as StoredHeadingId;
+    const aliases = record.aliases === undefined ? [] : record.aliases;
+    if (
+      typeof record.depth !== 'number' ||
+      !Number.isInteger(record.depth) ||
+      record.depth < 2 ||
+      record.depth > 6 ||
+      typeof record.id !== 'string' ||
+      record.id.length === 0 ||
+      !Array.isArray(aliases) ||
+      !aliases.every(
+        (alias): alias is string =>
+          typeof alias === 'string' && alias.length > 0,
+      ) ||
+      new Set(aliases).size !== aliases.length ||
+      aliases.includes(record.id)
+    ) {
+      throw new Error(
+        `Invalid ${CANONICAL_HEADING_IDS_FIELD} metadata in ${name}.`,
+      );
+    }
+    return { depth: record.depth, id: record.id, aliases };
+  });
+}
+
+function mergeAliases(canonicalId: string, ...groups: string[][]): string[] {
+  return [...new Set(groups.flat().filter((alias) => alias !== canonicalId))];
+}
+
+function assertNoHeadingIdentityCollisions(
+  headings: CanonicalHeadingId[],
+  name: string,
+  reservedIds: string[] = [],
+): void {
+  const owners = new Map(reservedIds.map((id) => [id, -1]));
+  for (const [index, heading] of headings.entries()) {
+    for (const id of [heading.id, ...heading.aliases]) {
+      const owner = owners.get(id);
+      if (owner !== undefined && owner !== index) {
+        throw new Error(
+          `Heading ID ${JSON.stringify(id)} identifies multiple headings in ${name}.`,
+        );
+      }
+      owners.set(id, index);
+    }
+  }
+}
+
+async function aliasHistoryByCanonicalId(
+  markdown: string,
+  name: string,
+  sourceHeadings?: CanonicalHeadingId[],
+): Promise<Map<string, string[]>> {
+  const allHeadings = await documentHeadingIds(markdown);
+  const localizedHeadings = allHeadings.filter(({ depth }) => depth >= 2);
+  const history = storedHeadingIds(markdown, name);
+  // Metadata-free lagging translations can be regenerated without guessing an offset.
+  const stored =
+    history ??
+    (sourceHeadings?.length === localizedHeadings.length
+      ? sourceHeadings
+      : undefined);
+  if (stored === undefined) {
+    return new Map();
+  }
+  const storedDepths = stored.map(({ depth }) => depth);
+  const localizedDepths = localizedHeadings.map(({ depth }) => depth);
+  if (
+    history !== undefined &&
+    JSON.stringify(storedDepths) !== JSON.stringify(localizedDepths)
+  ) {
+    throw new Error(
+      `Stored heading metadata does not match the localized headings in ${name}.`,
+    );
+  }
+
+  const identities = stored.map((heading, index) => {
+    const id =
+      sourceHeadings?.length === stored.length
+        ? sourceHeadings[index].id
+        : heading.id;
+    return {
+      ...heading,
+      id,
+      aliases: mergeAliases(id, [heading.id], heading.aliases, [
+        localizedHeadings[index].id,
+      ]),
+    };
+  });
+  assertNoHeadingIdentityCollisions(
+    identities,
+    name,
+    allHeadings.filter(({ depth }) => depth === 1).map(({ id }) => id),
+  );
+  return new Map(identities.map(({ id, aliases }) => [id, aliases]));
+}
+
+export async function validateTranslationHeadingInputs(
+  sourceMarkdown: string,
+  previousLocalizedMarkdown: string | undefined,
+  name: string,
+): Promise<void> {
+  const sourceHeadings = await canonicalHeadingIds(sourceMarkdown);
+  await aliasHistoryByCanonicalId(sourceMarkdown, `${name} English source`);
+  if (previousLocalizedMarkdown !== undefined) {
+    const history = await aliasHistoryByCanonicalId(
+      previousLocalizedMarkdown,
+      name,
+      sourceHeadings,
+    );
+    assertNoHeadingIdentityCollisions(
+      sourceHeadings.map((heading) => ({
+        ...heading,
+        aliases: history.get(heading.id) ?? [],
+      })),
+      name,
+    );
+  }
+}
+
+function replaceFrontmatterHeadingIds(
+  markdown: string,
+  headings: CanonicalHeadingId[],
+): string {
+  const newline = markdown.includes('\r\n') ? '\r\n' : '\n';
+  const lines = markdown.split(/\r?\n/);
+  if (lines[0]?.trim() !== '---') {
+    throw new Error('Localized documentation must start with frontmatter.');
+  }
+  const frontmatterEnd = lines.findIndex(
+    (line, index) => index > 0 && line.trim() === '---',
+  );
+  if (frontmatterEnd < 0) {
+    throw new Error('Localized documentation has unterminated frontmatter.');
+  }
+
+  const frontmatter = lines.slice(1, frontmatterEnd);
+  const fieldIndex = frontmatter.findIndex((line) =>
+    line.startsWith(`${CANONICAL_HEADING_IDS_FIELD}:`),
+  );
+  if (
+    fieldIndex >= 0 &&
+    frontmatter[fieldIndex].trim() !== `${CANONICAL_HEADING_IDS_FIELD}:` &&
+    frontmatter[fieldIndex].trim() !== `${CANONICAL_HEADING_IDS_FIELD}: []`
+  ) {
+    throw new Error(
+      `Cannot replace malformed ${CANONICAL_HEADING_IDS_FIELD} frontmatter.`,
+    );
+  }
+  if (fieldIndex >= 0) {
+    let fieldEnd = fieldIndex + 1;
+    while (
+      fieldEnd < frontmatter.length &&
+      (/^\s/.test(frontmatter[fieldEnd]) || frontmatter[fieldEnd].trim() === '')
+    ) {
+      fieldEnd += 1;
+    }
+    frontmatter.splice(fieldIndex, fieldEnd - fieldIndex);
+  }
+
+  frontmatter.push(...serializedHeadingIds(headings));
+  return [
+    '---',
+    ...frontmatter,
+    '---',
+    ...lines.slice(frontmatterEnd + 1),
+  ].join(newline);
+}
+
+export async function preserveCanonicalHeadingIds(
+  sourceMarkdown: string,
+  localizedMarkdown: string,
+  name: string,
+  previousLocalizedMarkdown?: string,
+): Promise<string> {
+  const sourceHeadings = await canonicalHeadingIds(sourceMarkdown);
+  return preserveCanonicalHeadingIdsFromSource(
+    sourceHeadings,
+    localizedMarkdown,
+    name,
+    previousLocalizedMarkdown,
+  );
+}
+
+async function preserveCanonicalHeadingIdsFromSource(
+  sourceHeadings: CanonicalHeadingId[],
+  localizedMarkdown: string,
+  name: string,
+  previousLocalizedMarkdown?: string,
+): Promise<string> {
+  const allHeadings = await documentHeadingIds(localizedMarkdown);
+  const localizedHeadings = allHeadings.filter(({ depth }) => depth >= 2);
+  const sourceDepths = sourceHeadings.map(({ depth }) => depth);
+  const localizedDepths = localizedHeadings.map(({ depth }) => depth);
+  if (JSON.stringify(sourceDepths) !== JSON.stringify(localizedDepths)) {
+    throw new Error(
+      `Cannot preserve canonical heading IDs for ${name}: heading levels do not match the English source.`,
+    );
+  }
+
+  const currentHistory = await aliasHistoryByCanonicalId(
+    localizedMarkdown,
+    name,
+    sourceHeadings,
+  );
+  const previousHistory = previousLocalizedMarkdown
+    ? await aliasHistoryByCanonicalId(
+        previousLocalizedMarkdown,
+        name,
+        sourceHeadings,
+      )
+    : new Map<string, string[]>();
+  const identities = sourceHeadings.map((heading, index) => ({
+    ...heading,
+    aliases: mergeAliases(
+      heading.id,
+      previousHistory.get(heading.id) ?? [],
+      currentHistory.get(heading.id) ?? [],
+      [localizedHeadings[index].id],
+    ),
+  }));
+  assertNoHeadingIdentityCollisions(
+    identities,
+    name,
+    allHeadings.filter(({ depth }) => depth === 1).map(({ id }) => id),
+  );
+  return replaceFrontmatterHeadingIds(localizedMarkdown, identities);
+}
+
+export async function refreshLocalizedHeadingIds(
+  sourcePath: string,
+  localizedPaths: string[],
+): Promise<string[]> {
+  const sourceMarkdown = await fs.readFile(sourcePath, 'utf8');
+  const sourceHeadings = await canonicalHeadingIds(sourceMarkdown);
+  const changed: string[] = [];
+  for (const localizedPath of localizedPaths) {
+    const localizedMarkdown = await fs.readFile(localizedPath, 'utf8');
+    const name = path.relative(process.cwd(), localizedPath);
+    const localizedHeadings = await canonicalHeadingIds(localizedMarkdown);
+    if (sourceHeadings.length !== localizedHeadings.length) {
+      // Validate available history, but keep a lagging snapshot until translation catches up.
+      await aliasHistoryByCanonicalId(localizedMarkdown, name);
+      continue;
+    }
+    const updated = await preserveCanonicalHeadingIdsFromSource(
+      sourceHeadings.map((heading, index) => ({
+        ...heading,
+        depth: localizedHeadings[index].depth,
+      })),
+      localizedMarkdown,
+      name,
+    );
+    if (updated !== localizedMarkdown) {
+      await fs.writeFile(localizedPath, updated, 'utf8');
+      changed.push(localizedPath);
+    }
+  }
+  return changed;
+}
+
+export async function writeCanonicalHeadingCopy(
+  sourceMarkdown: string,
+  targetPath: string,
+  name: string,
+  previousLocalizedMarkdown?: string,
+): Promise<void> {
+  const output = await preserveCanonicalHeadingIds(
+    sourceMarkdown,
+    sourceMarkdown,
+    name,
+    previousLocalizedMarkdown,
+  );
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await fs.writeFile(targetPath, output, 'utf8');
+}

--- a/docs/src/scripts/translate.ts
+++ b/docs/src/scripts/translate.ts
@@ -17,6 +17,12 @@ import path from 'path';
 import { spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { Agent, Runner, setDefaultOpenAIKey } from '@openai/agents';
+import {
+  preserveCanonicalHeadingIds,
+  refreshLocalizedHeadingIds,
+  validateTranslationHeadingInputs,
+  writeCanonicalHeadingCopy,
+} from './headingAnchors';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -291,6 +297,17 @@ const engToNonEngInstructions: Record<string, string[]> = {
 
 async function ensureDir(dir: string) {
   await fs.mkdir(dir, { recursive: true });
+}
+
+async function readExistingFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 function adjustLocalizedMdxImports(content: string): string {
@@ -674,15 +691,21 @@ function chunkMarkdown(content: string): {
   return { chunks, codeBlocks };
 }
 
-async function translateFile(
+export async function translateFile(
   filePath: string,
   targetPath: string,
   langCode: string,
 ): Promise<void> {
-  // Load sidebar translations for this language
+  const content = await fs.readFile(filePath, 'utf8');
+  const previousLocalizedMarkdown = await readExistingFile(targetPath);
+  await validateTranslationHeadingInputs(
+    content,
+    previousLocalizedMarkdown,
+    path.relative(REPO_ROOT, targetPath),
+  );
+  // Load sidebar translations only after validating the known inputs.
   const sidebarMap = await extractSidebarTranslations(langCode);
   console.log(`Translating ${filePath} into a different language: ${langCode}`);
-  const content = await fs.readFile(filePath, 'utf8');
 
   // Streamlined frontmatter extraction
   const lines = content.split('\n');
@@ -741,8 +764,12 @@ async function translateFile(
     mainContent = adjustLocalizedMdxImports(mainContent);
   } else {
     // If not matching, keep original English content
-    await ensureDir(path.dirname(targetPath));
-    await fs.writeFile(targetPath, content, 'utf8');
+    await writeCanonicalHeadingCopy(
+      content,
+      targetPath,
+      path.relative(REPO_ROOT, targetPath),
+      previousLocalizedMarkdown,
+    );
     return;
   }
 
@@ -770,6 +797,12 @@ async function translateFile(
   translatedText = frontmatter + '\n' + translatedText.trimStart();
   translatedText = localizeSiteLinks(translatedText, langCode);
   translatedText = normalizeTypography(translatedText);
+  translatedText = await preserveCanonicalHeadingIds(
+    content,
+    translatedText,
+    path.relative(REPO_ROOT, targetPath),
+    previousLocalizedMarkdown,
+  );
   await ensureDir(path.dirname(targetPath));
   await fs.writeFile(targetPath, translatedText, 'utf8');
 }
@@ -874,6 +907,16 @@ async function translateSingleSourceFile(
     !shouldTranslateBasedOnTranslation(filePath)
   ) {
     console.log(`Skipping ${filePath}: The translated one is up-to-date.`);
+    const rel = path.relative(sourceDir, filePath);
+    const localizedPaths = Object.keys(languages).map((langCode) =>
+      path.join(sourceDir, langCode, rel),
+    );
+    for (const changedPath of await refreshLocalizedHeadingIds(
+      filePath,
+      localizedPaths,
+    )) {
+      console.log(`Refreshing heading IDs in ${changedPath}`);
+    }
     return;
   }
   // Always compute rel as the path relative to docs/src/content/docs
@@ -1013,7 +1056,9 @@ async function main() {
   console.log('Translation completed.');
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,12 @@ importers:
         specifier: ^4.12.0
         version: 4.12.0(typedoc@0.28.19(typescript@5.9.3))
     devDependencies:
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.0
+        version: 7.2.0(supports-color@8.1.1)
+      remark-mdx:
+        specifier: ^3.1.1
+        version: 3.1.1(supports-color@8.1.1)
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -106,6 +106,7 @@ function createProjects(reviewTestProfile: boolean) {
           'scripts/released-api-contract.test.mjs',
           'scripts/run-integration-tests-managed.test.mjs',
           'scripts/workflow-contracts.test.mjs',
+          'docs/src/scripts/headingAnchors.test.ts',
         ],
       },
     },


### PR DESCRIPTION
This pull request fixes broken locale-prefixed links to translated headings by preserving Astro's canonical English heading IDs in generated Japanese, Korean, and Chinese documentation.

It derives IDs through Astro's full-document Markdown pipeline, stores and validates them in generated frontmatter, reapplies them during localized rendering, and refreshes already-up-to-date translations without another API call. Unsupported non-top-level or dynamic heading forms fail before generated output is written or published.