### PR TITLE
fix(openai): preserve empty hosted MCP outputs

### DIFF
--- a/.changeset/preserve-empty-mcp-output.md
+++ b/.changeset/preserve-empty-mcp-output.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: preserve empty hosted MCP tool outputs during Responses conversion

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -3163,7 +3163,7 @@ function convertToOutputItem(
         id: item.id!,
         name: item.type,
         status: 'completed',
-        output: outputData || undefined,
+        output: outputData ?? undefined,
         ...(caller ? { caller } : {}),
         providerData,
       };

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -2449,6 +2449,28 @@ describe('convertToOutputItem', () => {
     expect(output.providerData).not.toHaveProperty('caller');
   });
 
+  it('preserves empty hosted MCP outputs', () => {
+    const [output] = convertToOutputItem([
+      {
+        type: 'mcp_call',
+        id: 'mcp_1',
+        name: 'lookup',
+        arguments: '{}',
+        server_label: 'server',
+        status: 'completed',
+        output: '',
+      },
+    ] as any);
+
+    expect(output).toMatchObject({
+      type: 'hosted_tool_call',
+      id: 'mcp_1',
+      name: 'mcp_call',
+      output: '',
+    });
+    expect(output.providerData).not.toHaveProperty('output');
+  });
+
   it('converts Programmatic Tool Calling items and caller linkage', () => {
     const out = convertToOutputItem([
       {


### PR DESCRIPTION
### Summary

This pull request fixes hosted MCP response conversion so an explicit empty-string output remains `""` instead of being collapsed to `undefined`.

The nullish fallback preserves the existing handling of null and omitted outputs. It also adds focused regression coverage and a patch changeset for `@openai/agents-openai`.

### Test plan

- `pnpm exec vitest run packages/agents-openai/test/openaiResponsesModel.helpers.test.ts --mode full`
- `.agents/skills/code-change-verification/scripts/run.sh`
- `pnpm changeset:validate-result`

### Issue number

N/A

### Checks

- [x] I've added new tests
- [x] Documentation is not required for this focused conversion fix
- [x] I've run `pnpm test` and the examples build checks
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've completed the Codex implementation review
- [x] I've added a changeset
