### PR TITLE
fix: preserve serialized approval resume ownership

### DIFF
--- a/.changeset/preserve-approval-resume-ownership.md
+++ b/.changeset/preserve-approval-resume-ownership.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve serialized approval resume ownership

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -31,7 +31,11 @@ import { getServerConversationOwner } from './runner/conversation';
 import { AgentToolUseTracker } from './runner/toolUseTracker';
 import { nextStepSchema, NextStep } from './runner/steps';
 import { createToolRunFunction, type ProcessedResponse } from './runner/types';
-import { hasBlockedOutputExecutionEffect } from './runner/blockedOutputPersistence';
+import {
+  getCurrentResponseToolOutputGuardrailResultStart,
+  hasBlockedOutputExecutionEffect,
+  restoreCurrentResponseToolOutputGuardrailResultStart,
+} from './runner/blockedOutputPersistence';
 import type { AgentSpanData, Span } from './tracing/spans';
 import { ModelBehaviorError, SystemError, UserError } from './errors';
 import { getGlobalTraceProvider } from './tracing/provider';
@@ -162,7 +166,8 @@ import {
  *   so Docker network-isolation state cannot be consumed by older SDKs that would drop it
  *   during container replacement.
  * - 1.20: Adds sandbox session-state envelope version 5 so Docker labels cannot be
- *   consumed by older SDKs that would drop them during container replacement.
+ *   consumed by older SDKs that would drop them during container replacement, and
+ *   preserves exact current-response ownership for serialized approval resumes.
  */
 export const CURRENT_SCHEMA_VERSION = '1.20' as const;
 export const SUPPORTED_SCHEMA_VERSIONS = [
@@ -1573,6 +1578,19 @@ const serializedProcessedResponseSchema = z.object({
     .optional(),
 });
 
+const currentResponseGeneratedItemOwnershipSchema = z
+  .object({
+    generatedItemStartIndex: z.number().int().min(0),
+    generatedItemEndIndexExclusive: z.number().int().min(0),
+    interruptionGeneratedItemIndexes: z.array(z.number().int().min(0)),
+    toolOutputGuardrailResultStartIndex: z.number().int().min(0),
+  })
+  .strict();
+
+type CurrentResponseGeneratedItemOwnership = z.infer<
+  typeof currentResponseGeneratedItemOwnershipSchema
+>;
+
 const guardrailFunctionOutputSchema = z.object({
   tripwireTriggered: z.boolean(),
   outputInfo: z.any(),
@@ -1714,6 +1732,8 @@ export const SerializedRunState = z.object({
   currentStep: nextStepSchema.optional(),
   lastModelResponse: modelResponseSchema.optional(),
   generatedItems: z.array(itemSchema),
+  currentResponseGeneratedItemOwnership:
+    currentResponseGeneratedItemOwnershipSchema.optional(),
   pendingAgentToolRuns: z.record(z.string(), z.string()).optional().default({}),
   pendingAgentToolRunAliases: z
     .record(z.string(), z.string())
@@ -1763,6 +1783,244 @@ export const SerializedRunState = z.object({
   trace: serializedTraceSchema.nullable(),
   sandbox: sandboxStateSchema.optional(),
 });
+
+function findUniqueContiguousIdentityStart(
+  items: readonly RunItem[],
+  sequence: readonly RunItem[],
+): number | undefined {
+  if (sequence.length === 0 || sequence.length > items.length) {
+    return undefined;
+  }
+  let match: number | undefined;
+  for (let start = 0; start <= items.length - sequence.length; start += 1) {
+    if (
+      !sequence.every((item, offset) => {
+        const candidate = items[start + offset];
+        if (candidate === item) {
+          return true;
+        }
+        try {
+          return (
+            candidate !== undefined &&
+            candidate.type === item.type &&
+            'rawItem' in candidate &&
+            'rawItem' in item &&
+            candidate.rawItem === item.rawItem
+          );
+        } catch {
+          return false;
+        }
+      })
+    ) {
+      continue;
+    }
+    if (match !== undefined) {
+      return undefined;
+    }
+    match = start;
+  }
+  return match;
+}
+
+function captureCurrentResponseGeneratedItemOwnership(
+  state: RunState<any, any>,
+): CurrentResponseGeneratedItemOwnership | undefined {
+  if (state._currentStep?.type !== 'next_step_interruption') {
+    return undefined;
+  }
+  const processedItems = state._lastProcessedResponse?.newItems ?? [];
+  const interruptions = state._currentStep.data.interruptions;
+  if (processedItems.length === 0 || interruptions.length === 0) {
+    return undefined;
+  }
+  const generatedItemStartIndex = findUniqueContiguousIdentityStart(
+    state._generatedItems,
+    processedItems,
+  );
+  if (generatedItemStartIndex === undefined) {
+    return undefined;
+  }
+  const processedEndIndex = generatedItemStartIndex + processedItems.length;
+  const interruptionGeneratedItemIndexes: number[] = [];
+  for (const interruption of interruptions) {
+    const matchingIndexes = state._generatedItems.flatMap((item, index) => {
+      if (index < processedEndIndex) {
+        return [];
+      }
+      if (item === interruption) {
+        return [index];
+      }
+      try {
+        if ('rawItem' in item && item.rawItem === interruption.rawItem) {
+          return [index];
+        }
+        // A partial live resume can recreate the remaining approval wrapper. In that case,
+        // use the existing canonical invocation identity, but only inside the already-proven
+        // terminal current-response range and only when it selects one candidate.
+        return item instanceof RunToolApprovalItem &&
+          item.agent === interruption.agent &&
+          getToolInvocationCallId(item.rawItem) ===
+            getToolInvocationCallId(interruption.rawItem) &&
+          getToolInvocationFingerprint(
+            item.functionToolStateKey ?? item.name ?? '',
+            item.rawItem,
+          ) ===
+            getToolInvocationFingerprint(
+              interruption.functionToolStateKey ?? interruption.name ?? '',
+              interruption.rawItem,
+            )
+          ? [index]
+          : [];
+      } catch {
+        return [];
+      }
+    });
+    if (
+      matchingIndexes.length !== 1 ||
+      matchingIndexes[0] < processedEndIndex
+    ) {
+      return undefined;
+    }
+    interruptionGeneratedItemIndexes.push(matchingIndexes[0]);
+  }
+  if (
+    interruptionGeneratedItemIndexes.some(
+      (index, offset) =>
+        offset > 0 && index <= interruptionGeneratedItemIndexes[offset - 1],
+    )
+  ) {
+    return undefined;
+  }
+  const lastModelResponseIndex = state._modelResponses.lastIndexOf(
+    state._lastTurnResponse!,
+  );
+  if (
+    state._lastTurnResponse === undefined ||
+    lastModelResponseIndex !== state._modelResponses.length - 1 ||
+    state._modelResponses.indexOf(state._lastTurnResponse) !==
+      lastModelResponseIndex
+  ) {
+    return undefined;
+  }
+  const toolOutputGuardrailResultStartIndex =
+    getCurrentResponseToolOutputGuardrailResultStart(state);
+  if (
+    toolOutputGuardrailResultStartIndex === undefined ||
+    toolOutputGuardrailResultStartIndex >
+      state._toolOutputGuardrailResults.length
+  ) {
+    return undefined;
+  }
+  return {
+    generatedItemStartIndex,
+    generatedItemEndIndexExclusive: state._generatedItems.length,
+    interruptionGeneratedItemIndexes,
+    toolOutputGuardrailResultStartIndex,
+  };
+}
+
+function serializedValuesEqual(left: unknown, right: unknown): boolean {
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
+
+function throwCurrentResponseOwnershipError(
+  reason = 'invalid boundary',
+): never {
+  throw new UserError(
+    `RunState current-response generated-item ownership has an ${reason}. Start a new run from safe input.`,
+  );
+}
+
+function validateCurrentResponseGeneratedItemOwnership(
+  stateJson: z.infer<typeof SerializedRunState>,
+  ownership: CurrentResponseGeneratedItemOwnership,
+): void {
+  // Validate only serialized values here, before tool rehydration or caller-owned context work.
+  // Deserialized object identity is restored only after the complete terminal boundary is proven.
+  const processedItems = stateJson.lastProcessedResponse?.newItems;
+  const serializedInterruptions =
+    stateJson.currentStep?.type === 'next_step_interruption' &&
+    Array.isArray(stateJson.currentStep.data?.interruptions)
+      ? stateJson.currentStep.data.interruptions
+      : undefined;
+  const generatedEnd = ownership.generatedItemEndIndexExclusive;
+  const processedEnd =
+    ownership.generatedItemStartIndex + (processedItems?.length ?? 0);
+  if (
+    !processedItems ||
+    processedItems.length === 0 ||
+    !serializedInterruptions ||
+    serializedInterruptions.length === 0 ||
+    !stateJson.lastModelResponse ||
+    stateJson.modelResponses.length === 0 ||
+    generatedEnd !== stateJson.generatedItems.length ||
+    ownership.generatedItemStartIndex >= generatedEnd ||
+    processedEnd > generatedEnd ||
+    ownership.interruptionGeneratedItemIndexes.length !==
+      serializedInterruptions.length ||
+    ownership.toolOutputGuardrailResultStartIndex >
+      stateJson.toolOutputGuardrailResults.length ||
+    !serializedValuesEqual(
+      stateJson.lastModelResponse,
+      stateJson.modelResponses.at(-1),
+    )
+  ) {
+    throwCurrentResponseOwnershipError();
+  }
+  for (const [offset, processedItem] of processedItems.entries()) {
+    if (
+      !serializedValuesEqual(
+        processedItem,
+        stateJson.generatedItems[ownership.generatedItemStartIndex + offset],
+      )
+    ) {
+      throwCurrentResponseOwnershipError();
+    }
+  }
+  const interruptionIndexes = new Set<number>();
+  for (const [
+    offset,
+    interruptionIndex,
+  ] of ownership.interruptionGeneratedItemIndexes.entries()) {
+    const parsedInterruption = itemSchema.safeParse(
+      serializedInterruptions[offset],
+    );
+    const mismatch = !serializedValuesEqual(
+      parsedInterruption.success ? parsedInterruption.data : undefined,
+      stateJson.generatedItems[interruptionIndex],
+    );
+    if (
+      !parsedInterruption.success ||
+      parsedInterruption.data.type !== 'tool_approval_item' ||
+      interruptionIndexes.has(interruptionIndex) ||
+      interruptionIndex < processedEnd ||
+      interruptionIndex >= generatedEnd ||
+      (offset > 0 &&
+        interruptionIndex <=
+          ownership.interruptionGeneratedItemIndexes[offset - 1]) ||
+      mismatch
+    ) {
+      throwCurrentResponseOwnershipError(
+        mismatch ? 'interruption content mismatch' : 'interruption index error',
+      );
+    }
+    interruptionIndexes.add(interruptionIndex);
+  }
+  const unownedApproval = stateJson.generatedItems
+    .slice(processedEnd, generatedEnd)
+    .some(
+      (item, offset) =>
+        item.type === 'tool_approval_item' &&
+        !interruptionIndexes.has(processedEnd + offset),
+    );
+  if (unownedApproval) {
+    throwCurrentResponseOwnershipError();
+  }
+}
 
 export type FinalOutputSource =
   'error_handler' | 'turn_resolution' | 'tool_result';
@@ -2769,6 +3027,8 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
 
     const includeTracingApiKey = options.includeTracingApiKey === true;
     const contextJson = this._context._toJSONForRunState(agentIdentity.byAgent);
+    const currentResponseGeneratedItemOwnership =
+      captureCurrentResponseGeneratedItemOwnership(this);
     const output = {
       $schemaVersion: CURRENT_SCHEMA_VERSION,
       currentTurn: this._currentTurn,
@@ -2833,6 +3093,7 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
       generatedItems: this._generatedItems.map(
         (item) => serializeRunItem(item, agentIdentity.byAgent) as any,
       ),
+      currentResponseGeneratedItemOwnership,
       pendingAgentToolRuns: Object.fromEntries(
         this._pendingAgentToolRuns.entries(),
       ),
@@ -3008,6 +3269,10 @@ async function buildRunStateFromString<
     stateJson,
   );
   assertSchemaVersionSupportsOutputGuardrailSessionPersistence(
+    currentSchemaVersion as SupportedSchemaVersion,
+    stateJson,
+  );
+  assertSchemaVersionSupportsCurrentResponseGeneratedItemOwnership(
     currentSchemaVersion as SupportedSchemaVersion,
     stateJson,
   );
@@ -3307,6 +3572,22 @@ function assertSchemaVersionSupportsOutputGuardrailSessionPersistence(
   throw new UserError(
     `Run state schema version ${schemaVersion} does not support output guardrail session persistence state. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
   );
+}
+
+function assertSchemaVersionSupportsCurrentResponseGeneratedItemOwnership(
+  schemaVersion: SupportedSchemaVersion,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  const ownership = stateJson.currentResponseGeneratedItemOwnership;
+  if (ownership === undefined) {
+    return;
+  }
+  if (!schemaVersionSupportsV120State(schemaVersion)) {
+    throw new UserError(
+      `Run state schema version ${schemaVersion} does not support current-response generated-item ownership. Please reserialize the run state with schema ${CURRENT_SCHEMA_VERSION}.`,
+    );
+  }
+  validateCurrentResponseGeneratedItemOwnership(stateJson, ownership);
 }
 
 function assertSchemaVersionSupportsPendingInput(
@@ -5369,6 +5650,45 @@ async function rehydrateToolSearchRuntimeTools<
   return capabilitySnapshotsByAgent;
 }
 
+function restoreCurrentResponseProcessedOwnership(
+  state: RunState<any, any>,
+  stateJson: z.infer<typeof SerializedRunState>,
+): void {
+  const ownership = stateJson.currentResponseGeneratedItemOwnership;
+  if (!ownership || !state._lastProcessedResponse) {
+    return;
+  }
+  const processedItemCount =
+    stateJson.lastProcessedResponse?.newItems.length ?? 0;
+  state._lastProcessedResponse.newItems = state._generatedItems.slice(
+    ownership.generatedItemStartIndex,
+    ownership.generatedItemStartIndex + processedItemCount,
+  );
+  state._lastTurnResponse = state._modelResponses.at(-1);
+  restoreCurrentResponseToolOutputGuardrailResultStart(
+    state,
+    ownership.toolOutputGuardrailResultStartIndex,
+  );
+}
+
+function restoreCurrentResponseInterruptionOwnership(
+  stateJson: z.infer<typeof SerializedRunState>,
+  generatedItems: readonly RunItem[],
+  interruptions: RunToolApprovalItem[],
+): RunToolApprovalItem[] {
+  const ownership = stateJson.currentResponseGeneratedItemOwnership;
+  if (!ownership) {
+    return interruptions;
+  }
+  return ownership.interruptionGeneratedItemIndexes.map((index) => {
+    const interruption = generatedItems[index];
+    if (!(interruption instanceof RunToolApprovalItem)) {
+      throwCurrentResponseOwnershipError();
+    }
+    return interruption;
+  });
+}
+
 async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
   initialAgent: TAgent,
   stateJson: z.infer<typeof SerializedRunState>,
@@ -5661,6 +5981,7 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
         },
       )
     : undefined;
+  restoreCurrentResponseProcessedOwnership(state, stateJson);
   restorePendingAgentToolRunAliases(
     state,
     stateJson.pendingAgentToolRunAliases ?? {},
@@ -5674,10 +5995,14 @@ async function buildRunStateFromJson<TContext, TAgent extends Agent<any, any>>(
       ) as TAgent,
     };
   } else if (stateJson.currentStep?.type === 'next_step_interruption') {
-    const interruptions = deserializeInterruptions(
-      stateJson.currentStep.data?.interruptions,
-      agentMap,
-      state._currentAgent,
+    const interruptions = restoreCurrentResponseInterruptionOwnership(
+      stateJson,
+      generatedItems,
+      deserializeInterruptions(
+        stateJson.currentStep.data?.interruptions,
+        agentMap,
+        state._currentAgent,
+      ),
     );
     rebindInterruptionFunctionToolStateKeys(
       interruptions,

--- a/packages/agents-core/src/runner/blockedOutputPersistence.ts
+++ b/packages/agents-core/src/runner/blockedOutputPersistence.ts
@@ -3,6 +3,7 @@ import type { OutputGuardrailResult } from '../guardrail';
 import {
   RunHandoffOutputItem,
   RunItem,
+  RunToolApprovalItem,
   RunToolCallItem,
   RunToolCallOutputItem,
   RunToolSearchCallItem,
@@ -64,6 +65,19 @@ export function captureCurrentResponseToolOutputGuardrailResultStart(
       state._toolOutputGuardrailResults.length,
     );
   }
+}
+
+export function getCurrentResponseToolOutputGuardrailResultStart(
+  state: RunState<any, any>,
+): number | undefined {
+  return currentResponseToolOutputGuardrailResultStarts.get(state);
+}
+
+export function restoreCurrentResponseToolOutputGuardrailResultStart(
+  state: RunState<any, any>,
+  startIndex: number,
+): void {
+  currentResponseToolOutputGuardrailResultStarts.set(state, startIndex);
 }
 
 function currentCompletedToolRuns(state: RunState<any, any>) {
@@ -283,17 +297,32 @@ export function assertResumedSessionOutputGuardrailSafety(
     state,
     hasOutputGuardrail,
   );
+  let restoredSelection: CurrentRunItemSelection | undefined;
   if (state._serializedCurrentStep !== undefined && shouldDefer) {
     const responseOutput = getResponseOutput(currentResponse(state));
+    restoredSelection = responseOutput
+      ? currentRunItemSelection(state, responseOutput)
+      : undefined;
     if (
-      session !== undefined ||
-      state._toolOutputGuardrailResults.length > 0 ||
       !responseOutput ||
       responseOutput.some((item) => item.type !== 'function_call') ||
-      !currentRunItemSelection(state, responseOutput).proven
+      !restoredSelection?.proven ||
+      getCurrentResponseToolOutputGuardrailResultStart(state) === undefined
     ) {
+      const reasons = [
+        !responseOutput ? 'missing response output' : undefined,
+        responseOutput?.some((item) => item.type !== 'function_call')
+          ? 'non-function response item'
+          : undefined,
+        !restoredSelection?.proven
+          ? 'unproven generated-item range'
+          : undefined,
+        getCurrentResponseToolOutputGuardrailResultStart(state) === undefined
+          ? 'missing guardrail-result boundary'
+          : undefined,
+      ].filter((reason): reason is string => reason !== undefined);
       throw new UserError(
-        'Cannot resume this serialized output-bearing approval checkpoint because current-response provenance was not preserved. Start a new run from safe input.',
+        `Cannot resume this serialized output-bearing approval checkpoint because current-response provenance was not preserved (${reasons.join(', ')}). Start a new run from safe input.`,
       );
     }
   }
@@ -311,12 +340,14 @@ export function assertResumedSessionOutputGuardrailSafety(
       (run) => run.toolCall.callId,
     ),
   );
-  const currentStart = state._generatedItems.findIndex(
-    (item) =>
-      item instanceof RunToolCallItem &&
-      item.rawItem.type === 'function_call' &&
-      currentCallIds.has(item.rawItem.callId),
-  );
+  const currentStart = restoredSelection
+    ? state._generatedItems.length - restoredSelection.primary.length
+    : state._generatedItems.findIndex(
+        (item) =>
+          item instanceof RunToolCallItem &&
+          item.rawItem.type === 'function_call' &&
+          currentCallIds.has(item.rawItem.callId),
+      );
   const firstOutputIndex = state._generatedItems.findIndex(
     (item, index) =>
       index >= currentStart && item instanceof RunToolCallOutputItem,
@@ -1270,10 +1301,88 @@ function boundedCurrentFunctionResponseStart(
   return start;
 }
 
+function restoredCurrentRunItemSelection(
+  state: RunState<any, any>,
+  responseOutput: AgentInputItem[],
+): CurrentRunItemSelection | undefined {
+  if (
+    state._serializedCurrentStep !== state._currentStep ||
+    state._currentStep?.type !== 'next_step_interruption'
+  ) {
+    return undefined;
+  }
+  const generated = state._generatedItems;
+  const processed = state._lastProcessedResponse?.newItems ?? [];
+  // A valid schema 1.20 restore relinks these wrappers. Do not fall back to structural
+  // equality for an approval checkpoint whose serialized ownership was absent or invalid.
+  const responseKeys = responseOutput.map(functionCallKey);
+  if (
+    getCurrentResponseToolOutputGuardrailResultStart(state) === undefined ||
+    processed.length === 0 ||
+    processed.length !== responseKeys.length ||
+    responseKeys.some((key) => key === undefined) ||
+    processed.some(
+      (item, index) =>
+        !(item instanceof RunToolCallItem) ||
+        item.rawItem.type !== 'function_call' ||
+        functionCallKey(item.rawItem) !== responseKeys[index],
+    )
+  ) {
+    const fallbackStart = Math.min(
+      state._currentTurnPersistedItemCount,
+      generated.length,
+    );
+    const fallback = generated.slice(fallbackStart);
+    return { primary: fallback, aliases: fallback, proven: false };
+  }
+  const matchingStarts: number[] = [];
+  for (
+    let start = 0;
+    start <= generated.length - processed.length;
+    start += 1
+  ) {
+    if (processed.every((item, offset) => generated[start + offset] === item)) {
+      matchingStarts.push(start);
+    }
+  }
+  const start = matchingStarts.length === 1 ? matchingStarts[0] : undefined;
+  const processedEnd =
+    start === undefined ? undefined : start + processed.length;
+  const interruptionIndexes = state._currentStep.data.interruptions.map(
+    (interruption: RunToolApprovalItem) =>
+      generated.flatMap((item, index) =>
+        item === interruption ? [index] : [],
+      ),
+  );
+  if (
+    start === undefined ||
+    interruptionIndexes.some(
+      (indexes: number[]) =>
+        indexes.length !== 1 || indexes[0] < (processedEnd ?? Infinity),
+    )
+  ) {
+    const fallbackStart = Math.min(
+      state._currentTurnPersistedItemCount,
+      generated.length,
+    );
+    const fallback = generated.slice(fallbackStart);
+    return { primary: fallback, aliases: fallback, proven: false };
+  }
+  const primary = generated.slice(start);
+  return { primary, aliases: primary, proven: true };
+}
+
 function currentRunItemSelection(
   state: RunState<any, any>,
   responseOutput: AgentInputItem[],
 ): CurrentRunItemSelection {
+  const restoredSelection = restoredCurrentRunItemSelection(
+    state,
+    responseOutput,
+  );
+  if (restoredSelection) {
+    return restoredSelection;
+  }
   const generated = state._generatedItems.slice();
   const responseObjects = new Set(responseOutput);
   const processed = state._lastProcessedResponse?.newItems ?? [];
@@ -1348,64 +1457,6 @@ function currentRunItemSelection(
       }
     }
     return { primary, aliases, proven: true };
-  }
-
-  if (
-    state._currentStep?.type === 'next_step_interruption' &&
-    processed.length > 0 &&
-    processed.length === responseOutput.length &&
-    processed.length * 2 <= generated.length &&
-    processed.every(
-      (item, index) =>
-        item instanceof RunToolCallItem &&
-        item.rawItem.type === 'function_call' &&
-        functionCallKey(item.rawItem) ===
-          functionCallKey(responseOutput[index]!),
-    )
-  ) {
-    const interruptionCount = state._currentStep.data.interruptions.length;
-    const currentSuffix = generated.slice(-processed.length * 2);
-    const callItems = currentSuffix.slice(0, processed.length);
-    const outcomeItems = currentSuffix.slice(processed.length);
-    const responseKeys = new Set(responseOutput.map(functionCallKey));
-    const outcomeKeys = new Set<string>();
-    let approvalCount = 0;
-    const outcomesAreBounded = outcomeItems.every((item) => {
-      if (item.type === 'tool_approval_item') {
-        if (!('rawItem' in item) || item.rawItem.type !== 'function_call') {
-          return false;
-        }
-        approvalCount += 1;
-        const key = functionCallKey(item.rawItem);
-        if (!key || !responseKeys.has(key) || outcomeKeys.has(key))
-          return false;
-        outcomeKeys.add(key);
-        return true;
-      }
-      if (
-        !(item instanceof RunToolCallOutputItem) ||
-        item.rawItem.type !== 'function_call_result'
-      ) {
-        return false;
-      }
-      const key = functionResultKey(item.rawItem);
-      if (!key || !responseKeys.has(key) || outcomeKeys.has(key)) return false;
-      outcomeKeys.add(key);
-      return true;
-    });
-    if (
-      responseKeys.size === responseOutput.length &&
-      outcomeKeys.size === responseOutput.length &&
-      approvalCount === interruptionCount &&
-      outcomesAreBounded &&
-      functionRunItemSequenceIsPrefix(callItems, processed)
-    ) {
-      return {
-        primary: currentSuffix,
-        aliases: [...currentSuffix, ...processed],
-        proven: true,
-      };
-    }
   }
 
   if (state._currentTurnBlockedSessionStartIndex !== undefined) {
@@ -1699,6 +1750,7 @@ function replaceCurrentResponse(
     !replacedResponse &&
     state._serializedCurrentStep !== undefined &&
     state._serializedCurrentStep === state._currentStep &&
+    state._currentStep?.type === 'next_step_final_output' &&
     state._modelResponses.length > 0
   ) {
     const archivedResponse = state._modelResponses.at(-1);

--- a/packages/agents-core/test/agentScenarios.test.ts
+++ b/packages/agents-core/test/agentScenarios.test.ts
@@ -546,6 +546,7 @@ describe('Agent scenarios (examples and docs patterns)', () => {
       const serialized = first.state.toJSON() as any;
       const downgradeToLegacy = (value: any) => {
         value.$schemaVersion = '1.15';
+        delete value.currentResponseGeneratedItemOwnership;
         delete value.context.functionApprovals;
         delete value.context.legacyFunctionApprovals;
         delete value.pendingAgentToolRunAliases;

--- a/packages/agents-core/test/fixtures/run-state/README.md
+++ b/packages/agents-core/test/fixtures/run-state/README.md
@@ -10,7 +10,7 @@ This directory is immutable compatibility evidence for released `RunState` write
 
 Each historical fixture records its package version, release tag, full source commit, npm integrity, scenario, path, and SHA-256 in `sources.json`. The published package and npm integrity identify the primary writer artifact; the tag and commit are supplementary source provenance. Minimal fixtures prove the writer format for every published schema. Feature and resume fixtures are intentionally limited to durable boundaries that need more than an empty state to exercise compatibility.
 
-The released `1.17` sandbox format predates the mount-credential redaction boundary added by schema `1.18`. The `v0.16.0` writer fixtures establish the released `1.18` boundary, including canonical per-call approval identity. The `v0.17.0` writer fixture establishes the released `1.19` boundary for exact-call approval precedence and Docker network-isolation state. Current schema `1.20` adds the next sandbox envelope version for Docker labels. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
+The released `1.17` sandbox format predates the mount-credential redaction boundary added by schema `1.18`. The `v0.16.0` writer fixtures establish the released `1.18` boundary, including canonical per-call approval identity. The `v0.17.0` writer fixture establishes the released `1.19` boundary for exact-call approval precedence and Docker network-isolation state. Current schema `1.20` adds the next sandbox envelope version for Docker labels and exact current-response ownership for serialized approval resumes. The prototype-key negative fixture uses the obvious non-secret sentinel `sentinel-not-a-secret`.
 
 ## Regeneration
 

--- a/packages/agents-core/test/fixtures/run-state/sources.json
+++ b/packages/agents-core/test/fixtures/run-state/sources.json
@@ -333,7 +333,7 @@
     {
       "schemaVersion": "1.20",
       "status": "current_unreleased",
-      "reason": "Supported on main but not emitted by the latest released package v0.17.0; adds sandbox envelope version 5 for Docker labels."
+      "reason": "Supported on main but not emitted by the latest released package v0.17.0; adds sandbox envelope version 5 for Docker labels and exact current-response ownership for serialized approval resumes."
     }
   ],
   "expectedNormalizedFixtures": [

--- a/packages/agents-core/test/run.outputGuardrailReplaySession.test.ts
+++ b/packages/agents-core/test/run.outputGuardrailReplaySession.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import {
   Agent,
+  GuardrailExecutionError,
   MemorySession,
   OutputGuardrailTripwireTriggered,
   RunContext,
@@ -12,6 +13,7 @@ import {
   ToolGuardrailFunctionOutputFactory,
   Usage,
   defineToolOutputGuardrail,
+  handoff,
   run,
   tool,
   toolNamespace,
@@ -536,7 +538,11 @@ describe('output guardrails with Session persistence', () => {
         'completed nonterminal sibling',
       );
       expect(first.state._currentTurnPersistedItemCount).toBeGreaterThan(0);
-      first.state.approve(first.interruptions[0]!);
+      const resumeState =
+        behavior === 'run_llm_again'
+          ? await RunState.fromString(agent, first.state.toString())
+          : first.state;
+      resumeState.approve(resumeState.getInterruptions()[0]!);
 
       if (behavior !== 'run_llm_again') {
         agent.toolUseBehavior =
@@ -552,7 +558,7 @@ describe('output guardrails with Session persistence', () => {
                       ?.output,
                   ),
                 });
-        await expect(runOnce(first.state)).rejects.toThrow(
+        await expect(runOnce(resumeState)).rejects.toThrow(
           'persisted response ownership cannot be proven',
         );
         expect(approveExecute).not.toHaveBeenCalled();
@@ -562,7 +568,7 @@ describe('output guardrails with Session persistence', () => {
         return;
       }
 
-      const resumed = await runOnce(first.state);
+      const resumed = await runOnce(resumeState);
       expect(resumed.finalOutput).toBe('approved sibling continuation');
       expect(approveExecute).toHaveBeenCalledTimes(1);
       expect(siblingExecute).toHaveBeenCalledTimes(1);
@@ -586,9 +592,13 @@ describe('output guardrails with Session persistence', () => {
     },
   );
 
-  it.each<RunMode>(['non_streamed', 'streamed'])(
-    'resumes a later call-only approval after an earlier $mode tool result',
-    async (mode) => {
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      ([false, true] as const).map((trip) => ({ mode, trip })),
+    ),
+  )(
+    'resumes a later call-only approval after an earlier $mode tool result with trip=$trip',
+    async ({ mode, trip }) => {
       const historicalExecute = vi.fn(async () => 'accepted earlier result');
       const approvedExecute = vi.fn(async () => 'approved later result');
       const historicalTool = tool({
@@ -630,22 +640,18 @@ describe('output guardrails with Session persistence', () => {
           ],
           usage: new Usage(),
         }),
-        modelResponse({
-          output: [assistantMessage('approved continuation complete')],
-          usage: new Usage(),
-        }),
       ]);
       const agent = new Agent({
         name: 'Historical result before approval agent',
         model,
         tools: [historicalTool, approvalTool],
-        toolUseBehavior: 'run_llm_again',
+        toolUseBehavior: { stopAtToolNames: ['later_approval_tool'] },
         outputGuardrails: [
           {
             name: 'passing approval output guardrail',
             execute: async () => ({
               outputInfo: undefined,
-              tripwireTriggered: false,
+              tripwireTriggered: trip,
             }),
           },
         ],
@@ -667,7 +673,7 @@ describe('output guardrails with Session persistence', () => {
         return run(agent, input, options);
       };
 
-      const first = await runOnce('Run both tools.', false);
+      const first = await runOnce('Run both tools.');
       expect(first.interruptions).toHaveLength(1);
       expect(historicalExecute).toHaveBeenCalledTimes(1);
       expect(approvedExecute).not.toHaveBeenCalled();
@@ -677,14 +683,43 @@ describe('output guardrails with Session persistence', () => {
 
       const restored = await RunState.fromString(agent, first.state.toString());
       restored.approve(restored.getInterruptions()[0]!);
+      if (trip) {
+        let tripwire: OutputGuardrailTripwireTriggered<any> | undefined;
+        try {
+          await runOnce(restored);
+        } catch (error) {
+          expect(error).toBeInstanceOf(OutputGuardrailTripwireTriggered);
+          tripwire = error as OutputGuardrailTripwireTriggered<any>;
+        }
+        expect(tripwire).toBeDefined();
+        const blockedState = tripwire!.state!;
+        expect(JSON.stringify(blockedState._generatedItems)).toContain(
+          'accepted earlier result',
+        );
+        expect(JSON.stringify(blockedState._generatedItems)).not.toContain(
+          'approved later result',
+        );
+        expect(
+          blockedState._toolOutputGuardrailResults[0]?.output.outputInfo,
+        ).toBe('accepted historical guardrail metadata');
+        const stored = JSON.stringify(await session.getItems());
+        expect(stored).toContain('accepted earlier result');
+        expect(stored).not.toContain('approved later result');
+        expect(historicalExecute).toHaveBeenCalledTimes(1);
+        expect(approvedExecute).toHaveBeenCalledTimes(1);
+        expect(model.calls).toHaveLength(2);
+        return;
+      }
+
       const resumed = await runOnce(restored);
 
-      expect(resumed.finalOutput).toBe('approved continuation complete');
+      expect(resumed.finalOutput).toBe('approved later result');
       expect(historicalExecute).toHaveBeenCalledTimes(1);
       expect(approvedExecute).toHaveBeenCalledTimes(1);
       expect(
         resumed.state._toolOutputGuardrailResults[0]?.output.outputInfo,
       ).toBe('accepted historical guardrail metadata');
+      expect(model.calls).toHaveLength(2);
       const stored = JSON.stringify(await session.getItems());
       expect(stored).toContain('accepted earlier result');
       expect(stored).toContain('approved later result');
@@ -692,8 +727,111 @@ describe('output guardrails with Session persistence', () => {
   );
 
   it.each<RunMode>(['non_streamed', 'streamed'])(
-    'rejects a legacy persisted partial approval before $mode resume side effects',
+    'resumes a serialized $mode approval after a handoff filter clears the generated prefix',
     async (mode) => {
+      const execute = vi.fn(async () => 'handoff approval output');
+      const approvalTool = tool({
+        name: 'handoff_approval_tool',
+        description: 'Requires approval after the handoff.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute,
+      });
+      const targetModel = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              'handoff_approval_tool',
+              {},
+              { callId: 'handoff-approval-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const targetAgent = new Agent({
+        name: 'Filtered handoff approval target',
+        model: targetModel,
+        tools: [approvalTool],
+        toolUseBehavior: 'stop_on_first_tool',
+        outputGuardrails: [
+          {
+            name: 'passing handoff approval guardrail',
+            execute: async () => ({
+              outputInfo: undefined,
+              tripwireTriggered: false,
+            }),
+          },
+        ],
+      });
+      const filteredHandoff = handoff(targetAgent, {
+        inputFilter: ({ runContext }) => ({
+          inputHistory: [],
+          preHandoffItems: [],
+          newItems: [],
+          runContext,
+        }),
+      });
+      const sourceModel = new ScriptedModel([
+        modelResponse({
+          output: [
+            functionCall(
+              filteredHandoff.toolName,
+              {},
+              { callId: 'filtered-handoff-call' },
+            ),
+          ],
+          usage: new Usage(),
+        }),
+      ]);
+      const sourceAgent = new Agent({
+        name: 'Filtered handoff approval source',
+        model: sourceModel,
+        handoffs: [filteredHandoff],
+      });
+      const runOnce = async (
+        input: string | RunState<unknown, typeof sourceAgent>,
+      ) => {
+        if (mode === 'streamed') {
+          const result = await run(sourceAgent, input, { stream: true });
+          await result.completed;
+          return result;
+        }
+        return run(sourceAgent, input);
+      };
+
+      const first = await runOnce('Transfer and request approval.');
+      expect(first.interruptions).toHaveLength(1);
+      const serialized = first.state.toJSON();
+      expect(
+        serialized.currentResponseGeneratedItemOwnership
+          ?.generatedItemStartIndex,
+      ).toBe(0);
+
+      const restored = await RunState.fromString(
+        sourceAgent,
+        JSON.stringify(serialized),
+      );
+      restored.approve(restored.getInterruptions()[0]!);
+      const completed = await runOnce(restored);
+
+      expect(completed.finalOutput).toBe('handoff approval output');
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(sourceModel.calls).toHaveLength(1);
+      expect(targetModel.calls).toHaveLength(1);
+    },
+  );
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((mode) =>
+      (['1.20', '1.19', '1.18'] as const).map((schemaVersion) => ({
+        mode,
+        schemaVersion,
+      })),
+    ),
+  )(
+    'rejects a schema $schemaVersion partial approval without ownership before $mode resume side effects',
+    async ({ mode, schemaVersion }) => {
       const firstExecute = vi.fn(async () => 'legacy first secret');
       const secondExecute = vi.fn(async () => 'legacy second secret');
       const firstTool = tool({
@@ -766,9 +904,16 @@ describe('output guardrails with Session persistence', () => {
       expect(firstExecute).toHaveBeenCalledTimes(1);
       expect(secondExecute).not.toHaveBeenCalled();
 
-      partial.state._currentTurnPersistedItemCount = 1;
-      partial.state.approve(partial.interruptions[0]);
-      partial.state.setReasoningItemIdPolicy('preserve');
+      const serialized = partial.state.toJSON();
+      serialized.$schemaVersion = schemaVersion;
+      delete serialized.currentResponseGeneratedItemOwnership;
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      restored._currentTurnPersistedItemCount = 1;
+      restored.approve(restored.getInterruptions()[0]);
+      restored.setReasoningItemIdPolicy('preserve');
       const sessionBefore = structuredClone(await session.getItems());
       const modelCallCount = model.calls.length;
       const callback = vi.fn(
@@ -778,15 +923,15 @@ describe('output guardrails with Session persistence', () => {
         ],
       );
 
-      await expect(runOnce(partial.state, callback, 'omit')).rejects.toThrow(
-        'persisted response ownership cannot be proven',
+      await expect(runOnce(restored, callback, 'omit')).rejects.toThrow(
+        'current-response provenance was not preserved',
       );
       expect(firstExecute).toHaveBeenCalledTimes(1);
       expect(secondExecute).not.toHaveBeenCalled();
       expect(model.calls).toHaveLength(modelCallCount);
       expect(callback).not.toHaveBeenCalled();
       expect(await session.getItems()).toEqual(sessionBefore);
-      expect(partial.state._reasoningItemIdPolicy).toBe('preserve');
+      expect(restored._reasoningItemIdPolicy).toBe('preserve');
     },
   );
 
@@ -1012,6 +1157,7 @@ describe('output guardrails with Session persistence', () => {
         [
           'pass',
           'trip',
+          'error',
           'ambiguous',
           'namespace_mismatch',
           'session',
@@ -1057,6 +1203,7 @@ describe('output guardrails with Session persistence', () => {
         description: 'Namespaced approval tools.',
         tools: [firstTool, secondTool],
       });
+      const guardrailError = new Error('serialized approval guardrail error');
       const model = new ScriptedModel([
         modelResponse({
           output: [
@@ -1082,10 +1229,15 @@ describe('output guardrails with Session persistence', () => {
         outputGuardrails: [
           {
             name: 'passing portable approval guardrail',
-            execute: async () => ({
-              outputInfo: undefined,
-              tripwireTriggered: verdict === 'trip',
-            }),
+            execute: async () => {
+              if (verdict === 'error') {
+                throw guardrailError;
+              }
+              return {
+                outputInfo: undefined,
+                tripwireTriggered: verdict === 'trip',
+              };
+            },
           },
         ],
       });
@@ -1108,9 +1260,13 @@ describe('output guardrails with Session persistence', () => {
       const partial = await runOnce(first.state, session);
       expect(partial.state._currentTurnPersistedItemCount).toBeGreaterThan(0);
       const historicalSessionItems = await session.getItems();
-      const restored = await RunState.fromString(
+      const onceRestored = await RunState.fromString(
         agent,
         partial.state.toString(),
+      );
+      const restored = await RunState.fromString(
+        agent,
+        onceRestored.toString(),
       );
       restored.approve(restored.getInterruptions()[0]!);
 
@@ -1123,23 +1279,29 @@ describe('output guardrails with Session persistence', () => {
           responseCall.namespace = 'billing';
         }
       }
-      if (
-        verdict === 'ambiguous' ||
-        verdict === 'namespace_mismatch' ||
-        verdict === 'session' ||
-        verdict === 'prior_tool_guardrail'
-      ) {
-        await expect(
-          runOnce(restored, verdict === 'session' ? session : undefined),
-        ).rejects.toThrow('current-response provenance was not preserved');
+      if (verdict === 'ambiguous' || verdict === 'namespace_mismatch') {
+        await expect(runOnce(restored)).rejects.toThrow(
+          'current-response provenance was not preserved',
+        );
         expect(secondExecute).not.toHaveBeenCalled();
         expect(model.calls).toHaveLength(1);
         expect(await session.getItems()).toEqual(historicalSessionItems);
-        if (verdict === 'prior_tool_guardrail') {
-          expect(
-            restored._toolOutputGuardrailResults[0]?.output.outputInfo,
-          ).toBe('pre-serialization approval guardrail secret');
+        return;
+      }
+
+      if (verdict === 'error') {
+        let executionError: GuardrailExecutionError | undefined;
+        try {
+          await runOnce(restored);
+        } catch (error) {
+          expect(error).toBeInstanceOf(GuardrailExecutionError);
+          executionError = error as GuardrailExecutionError;
         }
+        expect(executionError?.error).toBe(guardrailError);
+        expect(firstExecute).toHaveBeenCalledTimes(1);
+        expect(secondExecute).toHaveBeenCalledTimes(1);
+        expect(model.calls).toHaveLength(1);
+        expect(await session.getItems()).toEqual(historicalSessionItems);
         return;
       }
 
@@ -1181,14 +1343,44 @@ describe('output guardrails with Session persistence', () => {
         return;
       }
 
-      const completed = await runOnce(restored);
+      const completed = await runOnce(
+        restored,
+        verdict === 'session' ? session : undefined,
+      );
 
       expect(completed.finalOutput).toBe('accepted second approval output');
       expect(firstExecute).toHaveBeenCalledTimes(1);
       expect(secondExecute).toHaveBeenCalledTimes(1);
       expect(model.calls).toHaveLength(1);
-      expect(restored._currentTurnPersistedItemCount).toBe(0);
-      expect(await session.getItems()).toEqual(historicalSessionItems);
+      if (verdict === 'session') {
+        expect(restored._currentTurnPersistedItemCount).toBe(
+          restored._generatedItems.length,
+        );
+      } else {
+        expect(restored._currentTurnPersistedItemCount).toBe(0);
+      }
+      if (verdict === 'session') {
+        const stored = await session.getItems();
+        for (const callId of ['portable-first-call', 'portable-second-call']) {
+          expect(
+            stored
+              .filter(
+                (item) =>
+                  (item.type === 'function_call' ||
+                    item.type === 'function_call_result') &&
+                  item.callId === callId,
+              )
+              .map((item) => item.type),
+          ).toEqual(['function_call', 'function_call_result']);
+        }
+      } else {
+        expect(await session.getItems()).toEqual(historicalSessionItems);
+      }
+      if (verdict === 'prior_tool_guardrail') {
+        expect(restored._toolOutputGuardrailResults[0]?.output.outputInfo).toBe(
+          'pre-serialization approval guardrail secret',
+        );
+      }
     },
   );
 

--- a/packages/agents-core/test/runState.cases.ts
+++ b/packages/agents-core/test/runState.cases.ts
@@ -60,10 +60,91 @@ import {
   getFunctionToolStateKey,
   getFunctionToolStateKeyForCall,
 } from '../src/toolIdentity';
+import {
+  captureCurrentResponseToolOutputGuardrailResultStart,
+  getCurrentResponseToolOutputGuardrailResultStart,
+} from '../src/runner/blockedOutputPersistence';
 import { z, ZodError } from 'zod';
 
 const REDACTED_TOOL_NAME_COLLISION_WARNING =
   'Tool name collision detected. Assign unique routed tool names or enable tool data logging for details. Only the current dispatch winner will be exposed.';
+
+function buildCurrentResponseOwnershipState() {
+  const approvalTool = tool({
+    name: 'serialized_ownership_tool',
+    description: 'Requires approval for serialized ownership tests.',
+    parameters: z.object({ value: z.string() }),
+    needsApproval: true,
+    execute: async ({ value }) => value,
+  });
+  const agent = new Agent({
+    name: 'Serialized ownership agent',
+    tools: [approvalTool as Tool],
+  });
+  const currentCall = {
+    type: 'function_call',
+    name: approvalTool.name,
+    callId: 'reused-ownership-call',
+    status: 'completed',
+    arguments: '{"value":"same"}',
+  } satisfies protocol.FunctionCallItem;
+  const historicalCall = structuredClone(currentCall);
+  const historicalCallItem = new RunToolCallItem(historicalCall, agent);
+  const historicalApprovalItem = new ToolApprovalItem(
+    historicalCall,
+    agent,
+    approvalTool.name,
+    getFunctionToolStateKey(approvalTool),
+  );
+  const currentCallItem = new RunToolCallItem(currentCall, agent);
+  const currentApprovalItem = new ToolApprovalItem(
+    currentCall,
+    agent,
+    approvalTool.name,
+    getFunctionToolStateKey(approvalTool),
+  );
+  const response: ModelResponse = {
+    output: [currentCall],
+    usage: new Usage(),
+    responseId: 'serialized-ownership-response',
+  };
+  const state = new RunState(new RunContext(), 'input', agent, 2);
+  state._generatedItems = [
+    historicalCallItem,
+    historicalApprovalItem,
+    currentCallItem,
+    currentApprovalItem,
+  ];
+  state._lastProcessedResponse = {
+    newItems: [currentCallItem],
+    toolsUsed: [approvalTool.name],
+    handoffs: [],
+    functions: [{ toolCall: currentCall, tool: approvalTool as any }],
+    functionToolsNotFound: [],
+    computerActions: [],
+    shellActions: [],
+    applyPatchActions: [],
+    mcpApprovalRequests: [],
+    hasToolsOrApprovalsToRun: () => true,
+  };
+  state._currentStep = {
+    type: 'next_step_interruption',
+    data: { interruptions: [currentApprovalItem] },
+  };
+  state._modelResponses = [response];
+  state._lastTurnResponse = response;
+  state._toolOutputGuardrailResults = [
+    {
+      guardrail: { type: 'tool_output', name: 'accepted earlier guardrail' },
+      output: {
+        outputInfo: 'accepted earlier metadata',
+        behavior: { type: 'allow' },
+      },
+    },
+  ];
+  captureCurrentResponseToolOutputGuardrailResultStart(state, true);
+  return { agent, state };
+}
 
 async function expectToolNameCollisionWarnings<T>(
   expectedCount: number,
@@ -215,6 +296,135 @@ export function registerRunStateCoreTests(): void {
 
       const restored = await RunState.fromString(agent, state.toString());
       expect(restored.history).toEqual(state.history);
+    });
+
+    it('restores exact current-response ownership across repeated round trips', async () => {
+      const { agent, state } = buildCurrentResponseOwnershipState();
+      const serialized = state.toJSON();
+
+      expect(serialized.currentResponseGeneratedItemOwnership).toEqual({
+        generatedItemStartIndex: 2,
+        generatedItemEndIndexExclusive: 4,
+        interruptionGeneratedItemIndexes: [3],
+        toolOutputGuardrailResultStartIndex: 1,
+      });
+
+      const onceRestored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+      expect(onceRestored._lastProcessedResponse?.newItems[0]).toBe(
+        onceRestored._generatedItems[2],
+      );
+      expect(
+        onceRestored._currentStep?.type === 'next_step_interruption'
+          ? onceRestored._currentStep.data.interruptions[0]
+          : undefined,
+      ).toBe(onceRestored._generatedItems[3]);
+      expect(onceRestored._lastTurnResponse).toBe(
+        onceRestored._modelResponses.at(-1),
+      );
+      expect(
+        getCurrentResponseToolOutputGuardrailResultStart(onceRestored),
+      ).toBe(1);
+      expect(onceRestored._generatedItems[0]).not.toBe(
+        onceRestored._lastProcessedResponse?.newItems[0],
+      );
+
+      const twiceSerialized = onceRestored.toJSON();
+      expect(twiceSerialized.currentResponseGeneratedItemOwnership).toEqual(
+        serialized.currentResponseGeneratedItemOwnership,
+      );
+      const twiceRestored = await RunState.fromString(
+        agent,
+        JSON.stringify(twiceSerialized),
+      );
+      expect(twiceRestored._lastProcessedResponse?.newItems[0]).toBe(
+        twiceRestored._generatedItems[2],
+      );
+      expect(
+        twiceRestored._currentStep?.type === 'next_step_interruption'
+          ? twiceRestored._currentStep.data.interruptions[0]
+          : undefined,
+      ).toBe(twiceRestored._generatedItems[3]);
+    });
+
+    it.each([
+      {
+        name: 'a non-integer start index',
+        mutate: (serialized: any) => {
+          serialized.currentResponseGeneratedItemOwnership.generatedItemStartIndex = 1.5;
+        },
+      },
+      {
+        name: 'a non-terminal end index',
+        mutate: (serialized: any) => {
+          serialized.currentResponseGeneratedItemOwnership.generatedItemEndIndexExclusive =
+            serialized.generatedItems.length - 1;
+        },
+      },
+      {
+        name: 'an interruption index inside the processed prefix',
+        mutate: (serialized: any) => {
+          serialized.currentResponseGeneratedItemOwnership.interruptionGeneratedItemIndexes =
+            [2];
+        },
+      },
+      {
+        name: 'duplicate interruption indexes',
+        mutate: (serialized: any) => {
+          serialized.currentResponseGeneratedItemOwnership.interruptionGeneratedItemIndexes =
+            [3, 3];
+        },
+      },
+      {
+        name: 'mismatched processed item content',
+        mutate: (serialized: any) => {
+          serialized.lastProcessedResponse.newItems[0].rawItem.arguments =
+            '{"value":"different"}';
+        },
+      },
+      {
+        name: 'an out-of-range guardrail-result boundary',
+        mutate: (serialized: any) => {
+          serialized.currentResponseGeneratedItemOwnership.toolOutputGuardrailResultStartIndex =
+            serialized.toolOutputGuardrailResults.length + 1;
+        },
+      },
+      {
+        name: 'ownership data on released schema 1.19',
+        mutate: (serialized: any) => {
+          serialized.$schemaVersion = '1.19';
+        },
+      },
+    ])('rejects $name before returning a RunState', async ({ mutate }) => {
+      const { agent, state } = buildCurrentResponseOwnershipState();
+      const serialized = JSON.parse(state.toString());
+      mutate(serialized);
+
+      await expect(
+        RunState.fromString(agent, JSON.stringify(serialized)),
+      ).rejects.toThrow();
+    });
+
+    it('keeps a released 1.19 snapshot readable without claiming current-response ownership', async () => {
+      const { agent, state } = buildCurrentResponseOwnershipState();
+      const serialized = JSON.parse(state.toString());
+      serialized.$schemaVersion = '1.19';
+      delete serialized.currentResponseGeneratedItemOwnership;
+
+      const restored = await RunState.fromString(
+        agent,
+        JSON.stringify(serialized),
+      );
+
+      expect(restored.getInterruptions()).toHaveLength(1);
+      expect(restored._lastProcessedResponse?.newItems[0]).not.toBe(
+        restored._generatedItems[2],
+      );
+      expect(
+        getCurrentResponseToolOutputGuardrailResultStart(restored),
+      ).toBeUndefined();
     });
 
     it.each(['commentary', 'final_answer'] as const)(

--- a/packages/agents-core/test/toolInvocationReplay.test.ts
+++ b/packages/agents-core/test/toolInvocationReplay.test.ts
@@ -849,6 +849,7 @@ describe('tool invocation replay binding', () => {
       ).toBeTypeOf('string');
       if (legacySchemaVersion) {
         serialized.$schemaVersion = legacySchemaVersion;
+        delete serialized.currentResponseGeneratedItemOwnership;
         delete serialized.context.approvalInvocations;
         delete serialized.completedToolInvocations;
         delete serialized.completedToolInvocationEvidence;
@@ -1357,6 +1358,7 @@ describe('tool invocation replay binding', () => {
     expect(shell.calls).toEqual([{ commands: ['echo once'] }]);
     const serialized = interrupted.state.toJSON() as any;
     serialized.$schemaVersion = '1.17';
+    delete serialized.currentResponseGeneratedItemOwnership;
     for (const item of serialized.generatedItems) {
       if (item.type === 'tool_call_output_item') {
         item.output = JSON.stringify(item.output);
@@ -1467,6 +1469,7 @@ describe('tool invocation replay binding', () => {
     expect(screenshot).toHaveBeenCalledTimes(2);
     const serialized = interrupted.state.toJSON() as any;
     serialized.$schemaVersion = '1.17';
+    delete serialized.currentResponseGeneratedItemOwnership;
     delete serialized.context.approvalInvocations;
     delete serialized.completedToolInvocations;
 
@@ -1511,6 +1514,7 @@ describe('tool invocation replay binding', () => {
     expect(editor.operations).toHaveLength(1);
     const serialized = interrupted.state.toJSON() as any;
     serialized.$schemaVersion = '1.17';
+    delete serialized.currentResponseGeneratedItemOwnership;
     delete serialized.context.approvalInvocations;
     delete serialized.completedToolInvocations;
 


### PR DESCRIPTION
This pull request fixes serialized `RunState` approval resumes that could lose current-response ownership after deserialization. It records a strict generated-item range, interruption indexes, and tool-output-guardrail boundary in unreleased schema 1.20, validates them before rehydration, and relinks canonical identities only when the complete boundary is provable.

It preserves accepted-prefix outputs across later turns and allows valid streaming and non-streaming resumes with or without a `Session`. Malformed, ambiguous, and legacy snapshots that cannot prove ownership continue to fail before tool execution or Session mutation, while synthetic legacy fixtures omit the new schema 1.20-only field.