### PR TITLE
fix(agents-extensions): decode sandbox stream output incrementally

### DIFF
--- a/.changeset/cloudflare-sandbox-utf8-chunk-split.md
+++ b/.changeset/cloudflare-sandbox-utf8-chunk-split.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: preserve multi-byte characters split across Cloudflare sandbox output chunks

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -840,6 +840,11 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     }
 
     const decoder = new TextDecoder();
+    // The worker splits stdout/stderr into base64 chunks at arbitrary byte
+    // offsets, so a multi-byte character can straddle two events. Keep one
+    // streaming decoder per stream so those sequences survive the split.
+    const stdoutDecoder = new TextDecoder();
+    const stderrDecoder = new TextDecoder();
     const reader = response.body.getReader();
     let buffer = '';
     let rawStream = '';
@@ -848,11 +853,15 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     let exitCode: number | undefined;
     const processEvent = (event: { event: string; data: string }): void => {
       if (event.event === 'stdout') {
-        stdout += decodeBase64Text(event.data);
+        stdout += stdoutDecoder.decode(decodeBase64Bytes(event.data), {
+          stream: true,
+        });
         return;
       }
       if (event.event === 'stderr') {
-        stderr += decodeBase64Text(event.data);
+        stderr += stderrDecoder.decode(decodeBase64Bytes(event.data), {
+          stream: true,
+        });
         return;
       }
       if (event.event === 'exit') {
@@ -908,6 +917,8 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
         processEvent(event);
       }
     }
+    stdout += stdoutDecoder.decode();
+    stderr += stderrDecoder.decode();
     if (exitCode === undefined && !stdout && !stderr && rawStream.trim()) {
       throw new SandboxProviderError(
         'CloudflareSandboxClient failed to execute command.',
@@ -1772,10 +1783,6 @@ function collectSseEvents(text: string): string[] {
     events.push(remaining);
   }
   return events;
-}
-
-function decodeBase64Text(value: string): string {
-  return new TextDecoder().decode(decodeBase64Bytes(value));
 }
 
 const STREAMED_PAYLOAD_SSE_SNIFF_BYTES = 256;

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -457,6 +457,43 @@ describe('CloudflareSandboxClient', () => {
     expect(output).toContain('lost exit');
   });
 
+  test('preserves multi-byte characters split across streamed output chunks', async () => {
+    const client = new CloudflareSandboxClient();
+    const session = await client.create(new Manifest(), {
+      workerUrl: 'https://worker.example.com',
+    });
+    const stdoutText = 'café \u{1f680} 日本語\n';
+    const stdoutBytes = Buffer.from(stdoutText, 'utf8');
+    const stderrText = '✓ fertig\n';
+    const stderrBytes = Buffer.from(stderrText, 'utf8');
+    // Split in the middle of the multi-byte sequences the worker streams back.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      sseExecResponse([
+        {
+          event: 'stdout',
+          data: stdoutBytes.subarray(0, 4).toString('base64'),
+        },
+        {
+          event: 'stdout',
+          data: stdoutBytes.subarray(4, 9).toString('base64'),
+        },
+        { event: 'stdout', data: stdoutBytes.subarray(9).toString('base64') },
+        {
+          event: 'stderr',
+          data: stderrBytes.subarray(0, 2).toString('base64'),
+        },
+        { event: 'stderr', data: stderrBytes.subarray(2).toString('base64') },
+        { event: 'exit', data: JSON.stringify({ exit_code: 0 }) },
+      ]),
+    );
+
+    const output = await session.execCommand({ cmd: 'emit-unicode' });
+
+    expect(output).toContain(stdoutText.trimEnd());
+    expect(output).toContain(stderrText.trimEnd());
+    expect(output).not.toContain('�');
+  });
+
   test('applies provider timeout bundles to Cloudflare requests', async () => {
     const client = new CloudflareSandboxClient({
       workerUrl: 'https://worker.example.com',


### PR DESCRIPTION
### Summary

`execCommand` decoded each streamed `stdout`/`stderr` SSE event with its own `new TextDecoder().decode(...)` call. The Cloudflare worker splits command output into base64 chunks at arbitrary byte offsets, so any multi-byte character straddling two events was decoded as U+FFFD replacement characters, and the corruption persisted in the string returned to the caller.

This keeps one streaming decoder per stream (`{ stream: true }`) and flushes both once every event has been processed, so split sequences are reassembled.

The command output is produced by a remote sandbox and reaches the model as tool output, so the split points are not under the caller's control.

### Test plan

Added `preserves multi-byte characters split across streamed output chunks` to `packages/agents-extensions/test/sandbox/cloudflare.test.ts`, splitting UTF-8 sequences mid-character across events. It fails on `main` (`caf�� �� 日本語`) and passes with this change.

`cloudflare.test.ts`: 65/65. Full `agents-extensions` suite: 1045/1045. `pnpm lint` and `pnpm build` clean.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
