### PR TITLE
fix(extensions): decode PTY output incrementally

### DIFF
--- a/.changeset/pty-utf8-frame-split.md
+++ b/.changeset/pty-utf8-frame-split.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+Decode sandbox PTY output with a streaming decoder so multi-byte UTF-8 characters split across WebSocket frames are no longer corrupted

--- a/packages/agents-extensions/src/sandbox/shared/pty.ts
+++ b/packages/agents-extensions/src/sandbox/shared/pty.ts
@@ -22,6 +22,15 @@ export type PtyProcessEntry = {
   waiters: Set<() => void>;
   sendInput?: (chars: string) => Promise<void>;
   terminate?: () => Promise<void>;
+  /** Carries partial UTF-8 sequences across chunk boundaries. */
+  decoder?: PtyTextDecoder;
+};
+
+type PtyTextDecoder = {
+  decode(
+    input?: Uint8Array | ArrayBuffer,
+    options?: { stream?: boolean },
+  ): string;
 };
 
 export type PtyWebSocket = {
@@ -64,9 +73,16 @@ export function appendPtyOutput(
   chunk: string | Uint8Array | ArrayBuffer,
 ): void {
   if (typeof chunk === 'string') {
+    // Emit any bytes still buffered by the decoder before the string so the
+    // PTY output stays in the order the process produced it.
+    entry.output += flushPtyDecoder(entry);
     entry.output += chunk;
   } else {
-    entry.output += new TextDecoder().decode(chunk);
+    // A PTY chunk is an arbitrary slice of the byte stream, so a multi-byte
+    // UTF-8 sequence can straddle two chunks. Reuse one streaming decoder per
+    // process entry instead of decoding each chunk in isolation.
+    entry.decoder ??= new TextDecoder();
+    entry.output += entry.decoder.decode(chunk, { stream: true });
   }
   notifyPtyWaiters(entry);
 }
@@ -75,6 +91,7 @@ export function markPtyDone(
   entry: PtyProcessEntry,
   exitCode: number | null = null,
 ): void {
+  entry.output += flushPtyDecoder(entry);
   entry.done = true;
   entry.exitCode = exitCode;
   notifyPtyWaiters(entry);
@@ -470,6 +487,15 @@ function allocatePtyProcessId(processes: Map<number, PtyProcessEntry>): number {
       return processId;
     }
   }
+}
+
+function flushPtyDecoder(entry: PtyProcessEntry): string {
+  if (!entry.decoder) {
+    return '';
+  }
+  const rest = entry.decoder.decode();
+  entry.decoder = undefined;
+  return rest;
 }
 
 function consumePtyOutput(entry: PtyProcessEntry): string {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -4697,6 +4697,49 @@ describe('remote sandbox path helpers', () => {
     });
   });
 
+  test('decodes UTF-8 sequences split across PTY frames', async () => {
+    const text = 'caf\u00e9 \u2014 \ud83c\udf89 \u5b8c\u4e86';
+    const bytes = new TextEncoder().encode(text);
+
+    // A remote PTY can end a WebSocket frame in the middle of a multi-byte
+    // UTF-8 sequence, so every possible split has to round-trip.
+    for (let splitAt = 1; splitAt < bytes.length; splitAt++) {
+      const entry = createPtyProcessEntry({});
+      const pendingOutput = collectPtyOutput({ entry, yieldTimeMs: 1_000 });
+
+      appendPtyOutput(entry, bytes.slice(0, splitAt));
+      appendPtyOutput(entry, bytes.slice(splitAt));
+      markPtyDone(entry, 0);
+
+      await expect(pendingOutput).resolves.toEqual({ text });
+    }
+  });
+
+  test('keeps ordering when string chunks follow partial UTF-8 bytes', async () => {
+    const entry = createPtyProcessEntry({});
+    const pendingOutput = collectPtyOutput({ entry, yieldTimeMs: 1_000 });
+
+    const bytes = new TextEncoder().encode('\u5b8c\u4e86');
+    appendPtyOutput(entry, bytes.slice(0, 4));
+    appendPtyOutput(entry, bytes.slice(4));
+    appendPtyOutput(entry, ' done');
+    markPtyDone(entry, 0);
+
+    await expect(pendingOutput).resolves.toEqual({
+      text: '\u5b8c\u4e86 done',
+    });
+  });
+
+  test('flushes dangling incomplete UTF-8 bytes when the PTY completes', async () => {
+    const entry = createPtyProcessEntry({});
+    const pendingOutput = collectPtyOutput({ entry, yieldTimeMs: 1_000 });
+
+    appendPtyOutput(entry, new Uint8Array([0x68, 0x69, 0xf0, 0x9f]));
+    markPtyDone(entry, 0);
+
+    await expect(pendingOutput).resolves.toEqual({ text: 'hi\uFFFD' });
+  });
+
   test('writes PTY stdin, finalizes completed sessions, and reports missing sessions', async () => {
     const sendInput = vi.fn(async (chars: string) => {
       expect(chars).toBe('continue\n');

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -4721,12 +4721,11 @@ describe('remote sandbox path helpers', () => {
 
     const bytes = new TextEncoder().encode('\u5b8c\u4e86');
     appendPtyOutput(entry, bytes.slice(0, 4));
-    appendPtyOutput(entry, bytes.slice(4));
     appendPtyOutput(entry, ' done');
     markPtyDone(entry, 0);
 
     await expect(pendingOutput).resolves.toEqual({
-      text: '\u5b8c\u4e86 done',
+      text: '\u5b8c\uFFFD done',
     });
   });
 


### PR DESCRIPTION
### Summary

`appendPtyOutput()` decoded every PTY chunk with a fresh `TextDecoder`, so a multi-byte UTF-8 character that straddled two WebSocket frames was turned into replacement characters — `café` arrived as `caf��`. PTY chunks are arbitrary slices of a remote process byte stream, so the split happens in practice (the Cloudflare provider forwards raw binary frames without reassembling them).

This keeps one streaming decoder per PTY process entry, decodes with `{ stream: true }` so partial sequences carry over, and flushes the decoder when the process completes. String chunks flush any pending bytes first so output ordering matches what the process produced.

`appendPtyOutput()` is the shared PTY path, so this covers the Cloudflare, Daytona, E2B and Blaxel sandbox providers at once.

### Test plan

Added three tests to `packages/agents-extensions/test/sandbox/shared.test.ts`:

- `decodes UTF-8 sequences split across PTY frames` — splits `café — 🎉 完了` at every byte offset and asserts each split round-trips. Fails on `main` with `caf�� — 🎉 完了`.
- `keeps ordering when string chunks follow partial UTF-8 bytes` — a string chunk arriving after buffered bytes must not reorder output.
- `flushes dangling incomplete UTF-8 bytes when the PTY completes` — guards the flush-on-completion path.

The `@openai/agents-extensions` project goes from 1044 to 1047 tests, all passing — the three added above, no regressions. `.agents/skills/code-change-verification/scripts/run.sh` passes (206 files, 6279 tests), along with `build-check`, `dist:check` and `prettier --check`.

### Issue number

N/A

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
