### PR TITLE
fix(core): reject malformed Base64 consistently

### DIFF
--- a/.changeset/tidy-base64-decoders.md
+++ b/.changeset/tidy-base64-decoders.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reject malformed Base64 consistently across runtime decoders

--- a/packages/agents-core/src/utils/base64.ts
+++ b/packages/agents-core/src/utils/base64.ts
@@ -57,17 +57,19 @@ export function decodeBase64ToUint8Array(value: string): Uint8Array {
     return new Uint8Array();
   }
 
+  const padded = normalizeBase64(value);
+
   const globalBuffer =
     typeof globalThis !== 'undefined' && (globalThis as any).Buffer
       ? (globalThis as any).Buffer
       : undefined;
 
   if (globalBuffer) {
-    return Uint8Array.from(globalBuffer.from(value, 'base64'));
+    return Uint8Array.from(globalBuffer.from(padded, 'base64'));
   }
 
   if (typeof (globalThis as any).atob === 'function') {
-    const binary = (globalThis as any).atob(value);
+    const binary = (globalThis as any).atob(padded);
     const bytes = new Uint8Array(binary.length);
     for (let index = 0; index < binary.length; index += 1) {
       bytes[index] = binary.charCodeAt(index);
@@ -77,15 +79,6 @@ export function decodeBase64ToUint8Array(value: string): Uint8Array {
 
   const chars =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-  const normalized = value.replace(/[\t\n\f\r ]/g, '');
-  if (normalized.length % 4 === 1) {
-    throw new TypeError('Invalid base64 string.');
-  }
-
-  const padded = normalized.padEnd(
-    normalized.length + ((4 - (normalized.length % 4)) % 4),
-    '=',
-  );
   const padding = padded.endsWith('==') ? 2 : padded.endsWith('=') ? 1 : 0;
   const bytes = new Uint8Array((padded.length / 4) * 3 - padding);
   let outputIndex = 0;
@@ -120,4 +113,31 @@ export function decodeBase64ToUint8Array(value: string): Uint8Array {
   }
 
   return bytes;
+}
+
+function normalizeBase64(value: string): string {
+  const normalized = value.replace(/[\t\n\f\r ]/g, '');
+
+  if (normalized.includes('=')) {
+    const isValidPaddedBase64 =
+      normalized.length % 4 === 0 &&
+      /^(?:[a-zA-Z0-9+/]{4})*(?:[a-zA-Z0-9+/]{2}==|[a-zA-Z0-9+/]{3}=)?$/u.test(
+        normalized,
+      );
+
+    if (!isValidPaddedBase64) {
+      throw new TypeError('Invalid base64 string.');
+    }
+
+    return normalized;
+  }
+
+  if (normalized.length % 4 === 1 || !/^[a-zA-Z0-9+/]*$/u.test(normalized)) {
+    throw new TypeError('Invalid base64 string.');
+  }
+
+  return normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    '=',
+  );
 }

--- a/packages/agents-core/test/sandboxShared.test.ts
+++ b/packages/agents-core/test/sandboxShared.test.ts
@@ -602,6 +602,21 @@ describe('sandbox shared helpers', () => {
     expect((restored.entries['payload.bin'] as any).content).toEqual(bytes);
   });
 
+  it('rejects malformed persisted binary manifest content', () => {
+    const serialized = serializeManifestRecord(
+      new Manifest({
+        entries: {
+          'payload.bin': file({ content: Uint8Array.from([1, 2]) }),
+        },
+      }),
+    );
+    ((serialized.entries as any)['payload.bin'].content as any).data = 'AQI!';
+
+    expect(() => deserializeManifest(serialized)).toThrow(
+      new TypeError('Invalid base64 string.'),
+    );
+  });
+
   it('materializes manifest environment values and preserves runtime overrides', async () => {
     const previous = new Manifest({
       environment: {

--- a/packages/agents-core/test/utils/base64.test.ts
+++ b/packages/agents-core/test/utils/base64.test.ts
@@ -110,4 +110,41 @@ describe('decodeBase64ToUint8Array', () => {
       expect(decodeBase64ToUint8Array(value)).toEqual(new Uint8Array(expected));
     }
   });
+
+  it('accepts whitespace and omitted padding consistently', () => {
+    const backends = [
+      { Buffer: originalBuffer, atob: originalAtob },
+      { Buffer: undefined, atob: originalAtob },
+      { Buffer: undefined, atob: undefined },
+    ];
+
+    for (const backend of backends) {
+      (globalThis as any).Buffer = backend.Buffer;
+      (globalThis as any).atob = backend.atob;
+
+      expect(decodeBase64ToUint8Array(' A Q I \n')).toEqual(
+        new Uint8Array([1, 2]),
+      );
+    }
+  });
+
+  it('rejects malformed input consistently', () => {
+    const backends = [
+      { Buffer: originalBuffer, atob: originalAtob },
+      { Buffer: undefined, atob: originalAtob },
+      { Buffer: undefined, atob: undefined },
+    ];
+    const malformedValues = ['AQI!', 'AQI-', 'A', 'AA=', 'AA=A', 'A==='];
+
+    for (const backend of backends) {
+      (globalThis as any).Buffer = backend.Buffer;
+      (globalThis as any).atob = backend.atob;
+
+      for (const value of malformedValues) {
+        expect(() => decodeBase64ToUint8Array(value)).toThrow(
+          new TypeError('Invalid base64 string.'),
+        );
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary

This fixes runtime-dependent Base64 validation in `@openai/agents-core`.

Node's permissive `Buffer` decoder silently accepted malformed inputs such as `AQI!` and `AQI-`, while the browser `atob` and manual decoding paths rejected them. This caused identical input to behave differently depending on the runtime.

The decoder now:

* Validates and normalizes standard Base64 before selecting a runtime backend.
* Preserves support for ASCII whitespace and omitted padding.
* Rejects invalid characters, malformed padding, impossible lengths, and non-standard Base64URL alphabet input with a consistent `TypeError`.
* Adds regression coverage across the `Buffer`, `atob`, and manual decoder paths.
* Adds caller-level coverage for malformed persisted binary manifest content.

## Test plan

* `pnpm test packages/agents-core/test/utils/base64.test.ts packages/agents-core/test/sandboxShared.test.ts`

  * 69 tests passed.
* Full code-change verification under Node.js 22.23.2:

  * Build, build-check, dist-check, lint, and formatting passed.
  * 206 test files passed.
  * 6,277 tests passed and 2 skipped.
* TruffleHog scanned the staged changes with zero verified or unverified secrets.

## Changeset

Included a patch changeset for `@openai/agents-core`.
