### PR TITLE
feat: add server-wide MCP tool guardrails

### DIFF
--- a/.changeset/mcp-server-tool-guardrails.md
+++ b/.changeset/mcp-server-tool-guardrails.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+feat: add server-wide MCP tool guardrails

--- a/packages/agents-core/src/mcp.ts
+++ b/packages/agents-core/src/mcp.ts
@@ -1,4 +1,10 @@
-import { FunctionTool, tool, Tool, type ToolCallDetails } from './tool';
+import {
+  FunctionTool,
+  tool,
+  Tool,
+  type FunctionToolCustomDataContext,
+  type ToolCallDetails,
+} from './tool';
 import { UserError } from './errors';
 import {
   MCPServerStdio as UnderlyingMCPServerStdio,
@@ -51,6 +57,10 @@ import {
   assertOpenAIStrictToolSchemaPreservesOpenObjects,
   isJsonSchemaDepthError,
 } from './utils/strictToolSchema';
+import type {
+  ToolInputGuardrailDefinition,
+  ToolOutputGuardrailDefinition,
+} from './toolGuardrail';
 
 export {
   BaseMCPServerSSE,
@@ -162,6 +172,10 @@ export interface MCPServer {
   toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   toolMetaResolver?: MCPToolMetaResolver;
   customDataExtractor?: MCPToolCustomDataExtractor;
+  /** Guardrails applied before every tool on this server is invoked. */
+  toolInputGuardrails?: ToolInputGuardrailDefinition<any>[];
+  /** Guardrails applied after every tool on this server returns. */
+  toolOutputGuardrails?: ToolOutputGuardrailDefinition<any>[];
   /**
    * Whether to use MCP `structuredContent` as the model-visible tool output when available.
    * Defaults to false to preserve the existing content-based output behavior.
@@ -1151,6 +1165,12 @@ export function mcpToFunctionTool(
   options: MCPFunctionToolConversionOptions = {},
 ) {
   const toolName = options.toolNameOverride ?? mcpTool.name;
+  const inputGuardrails = server.toolInputGuardrails
+    ? [...server.toolInputGuardrails]
+    : undefined;
+  const outputGuardrails = server.toolOutputGuardrails
+    ? [...server.toolOutputGuardrails]
+    : undefined;
   const customDataByCall = new WeakMap<
     RunContext<any>,
     Map<string, MCPToolCustomDataContext<any>>
@@ -1243,6 +1263,22 @@ export function mcpToFunctionTool(
     return toolOutput;
   }
 
+  async function extractCustomData(
+    context: FunctionToolCustomDataContext<any>,
+  ) {
+    const mcpContext = getMcpCustomDataContext(
+      customDataByCall,
+      context.runContext,
+      context.toolCall.callId,
+    );
+    return mcpContext
+      ? maybeExtractToolOutputCustomData(server.customDataExtractor, {
+          ...mcpContext,
+          toolOutput: context.output,
+        })
+      : undefined;
+  }
+
   const inputSchema = mcpTool.inputSchema ?? {};
   const inputSchemaIsEmpty = Object.keys(inputSchema).length === 0;
   const schema = {
@@ -1266,19 +1302,9 @@ export function mcpToFunctionTool(
         strict: true,
         execute: invoke,
         errorFunction,
-        customDataExtractor: async (context) => {
-          const mcpContext = getMcpCustomDataContext(
-            customDataByCall,
-            context.runContext,
-            context.toolCall.callId,
-          );
-          return mcpContext
-            ? maybeExtractToolOutputCustomData(
-                server.customDataExtractor,
-                mcpContext,
-              )
-            : undefined;
-        },
+        inputGuardrails,
+        outputGuardrails,
+        customDataExtractor: extractCustomData,
       });
     } catch (e) {
       if (convertSchemasToStrict && isJsonSchemaDepthError(e)) {
@@ -1307,19 +1333,9 @@ export function mcpToFunctionTool(
     strict: false,
     execute: invoke,
     errorFunction,
-    customDataExtractor: async (context) => {
-      const mcpContext = getMcpCustomDataContext(
-        customDataByCall,
-        context.runContext,
-        context.toolCall.callId,
-      );
-      return mcpContext
-        ? maybeExtractToolOutputCustomData(
-            server.customDataExtractor,
-            mcpContext,
-          )
-        : undefined;
-    },
+    inputGuardrails,
+    outputGuardrails,
+    customDataExtractor: extractCustomData,
   });
 }
 
@@ -1374,6 +1390,10 @@ export interface BaseMCPServerStdioOptions {
    * Optional callback that attaches SDK-only custom data to local MCP tool output items.
    */
   customDataExtractor?: MCPToolCustomDataExtractor;
+  /** Guardrails applied before every tool on this server is invoked. */
+  toolInputGuardrails?: ToolInputGuardrailDefinition<any>[];
+  /** Guardrails applied after every tool on this server returns. */
+  toolOutputGuardrails?: ToolOutputGuardrailDefinition<any>[];
   /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
@@ -1411,6 +1431,10 @@ export interface MCPServerStreamableHttpOptions {
    * Optional callback that attaches SDK-only custom data to local MCP tool output items.
    */
   customDataExtractor?: MCPToolCustomDataExtractor;
+  /** Guardrails applied before every tool on this server is invoked. */
+  toolInputGuardrails?: ToolInputGuardrailDefinition<any>[];
+  /** Guardrails applied after every tool on this server returns. */
+  toolOutputGuardrails?: ToolOutputGuardrailDefinition<any>[];
   /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.
@@ -1453,6 +1477,10 @@ export interface MCPServerSSEOptions {
    * Optional callback that attaches SDK-only custom data to local MCP tool output items.
    */
   customDataExtractor?: MCPToolCustomDataExtractor;
+  /** Guardrails applied before every tool on this server is invoked. */
+  toolInputGuardrails?: ToolInputGuardrailDefinition<any>[];
+  /** Guardrails applied after every tool on this server returns. */
+  toolOutputGuardrails?: ToolOutputGuardrailDefinition<any>[];
   /**
    * Optional function to convert MCP tool failures into model-visible messages.
    * Set to null to rethrow errors instead of converting them.

--- a/packages/agents-core/src/mcpShared.ts
+++ b/packages/agents-core/src/mcpShared.ts
@@ -21,6 +21,10 @@ import type {
   MCPToolFilterStatic,
   MCPToolMetaResolver,
 } from './mcpUtil';
+import type {
+  ToolInputGuardrailDefinition,
+  ToolOutputGuardrailDefinition,
+} from './toolGuardrail';
 
 export const DEFAULT_STDIO_MCP_CLIENT_LOGGER_NAME =
   'openai-agents:stdio-mcp-client';
@@ -37,6 +41,8 @@ export abstract class BaseMCPServerStdio implements MCPServer {
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
   public customDataExtractor?: MCPToolCustomDataExtractor;
+  public toolInputGuardrails?: ToolInputGuardrailDefinition<any>[];
+  public toolOutputGuardrails?: ToolOutputGuardrailDefinition<any>[];
   public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
@@ -48,6 +54,8 @@ export abstract class BaseMCPServerStdio implements MCPServer {
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
     this.customDataExtractor = options.customDataExtractor;
+    this.toolInputGuardrails = options.toolInputGuardrails;
+    this.toolOutputGuardrails = options.toolOutputGuardrails;
     this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
@@ -93,6 +101,8 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
   public customDataExtractor?: MCPToolCustomDataExtractor;
+  public toolInputGuardrails?: ToolInputGuardrailDefinition<any>[];
+  public toolOutputGuardrails?: ToolOutputGuardrailDefinition<any>[];
   public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
@@ -105,6 +115,8 @@ export abstract class BaseMCPServerStreamableHttp implements MCPServer {
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
     this.customDataExtractor = options.customDataExtractor;
+    this.toolInputGuardrails = options.toolInputGuardrails;
+    this.toolOutputGuardrails = options.toolOutputGuardrails;
     this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }
@@ -151,6 +163,8 @@ export abstract class BaseMCPServerSSE implements MCPServer {
   public toolFilter?: MCPToolFilterCallable | MCPToolFilterStatic;
   public toolMetaResolver?: MCPToolMetaResolver;
   public customDataExtractor?: MCPToolCustomDataExtractor;
+  public toolInputGuardrails?: ToolInputGuardrailDefinition<any>[];
+  public toolOutputGuardrails?: ToolOutputGuardrailDefinition<any>[];
   public useStructuredContent?: boolean;
   public errorFunction?: MCPToolErrorFunction | null;
 
@@ -162,6 +176,8 @@ export abstract class BaseMCPServerSSE implements MCPServer {
     this.toolFilter = options.toolFilter;
     this.toolMetaResolver = options.toolMetaResolver;
     this.customDataExtractor = options.customDataExtractor;
+    this.toolInputGuardrails = options.toolInputGuardrails;
+    this.toolOutputGuardrails = options.toolOutputGuardrails;
     this.useStructuredContent = options.useStructuredContent;
     this.errorFunction = options.errorFunction;
   }

--- a/packages/agents-core/test/mcp.test.ts
+++ b/packages/agents-core/test/mcp.test.ts
@@ -1,5 +1,12 @@
 import { describe, test, expect } from 'vitest';
-import { MCPServerStdio } from '../src';
+import {
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  MCPServerSSE,
+  MCPServerStdio,
+  MCPServerStreamableHttp,
+  ToolGuardrailFunctionOutputFactory,
+} from '../src';
 
 describe('MCPServerStdio', () => {
   test('should be available', () => {
@@ -11,5 +18,45 @@ describe('MCPServerStdio', () => {
     expect(server).toBeDefined();
     expect(server.name).toBe('test');
     expect(server.cacheToolsList).toBe(true);
+  });
+
+  test('transport constructors retain server-wide tool guardrails', () => {
+    const inputGuardrails = [
+      defineToolInputGuardrail({
+        name: 'server-input',
+        run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+      }),
+    ];
+    const outputGuardrails = [
+      defineToolOutputGuardrail({
+        name: 'server-output',
+        run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+      }),
+    ];
+    const servers = [
+      new MCPServerStdio({
+        name: 'stdio',
+        fullCommand: 'test',
+        toolInputGuardrails: inputGuardrails,
+        toolOutputGuardrails: outputGuardrails,
+      }),
+      new MCPServerStreamableHttp({
+        name: 'streamable-http',
+        url: 'https://example.test/mcp',
+        toolInputGuardrails: inputGuardrails,
+        toolOutputGuardrails: outputGuardrails,
+      }),
+      new MCPServerSSE({
+        name: 'sse',
+        url: 'https://example.test/sse',
+        toolInputGuardrails: inputGuardrails,
+        toolOutputGuardrails: outputGuardrails,
+      }),
+    ];
+
+    for (const server of servers) {
+      expect(server.toolInputGuardrails).toBe(inputGuardrails);
+      expect(server.toolOutputGuardrails).toBe(outputGuardrails);
+    }
   });
 });

--- a/packages/agents-core/test/mcpCache.test.ts
+++ b/packages/agents-core/test/mcpCache.test.ts
@@ -16,6 +16,11 @@ import { Agent } from '../src/agent';
 import { handoff } from '../src/handoff';
 import { z } from 'zod';
 import logger from '../src/logger';
+import {
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  ToolGuardrailFunctionOutputFactory,
+} from '../src/toolGuardrail';
 
 class StubServer extends NodeMCPServerStdio {
   public toolList: any[];
@@ -534,6 +539,52 @@ describe('MCP tools uniqueness', () => {
         'mcp_calendar__update',
       ]);
     });
+  });
+
+  it('keeps server guardrails isolated through filtering, caching, and name prefixing', async () => {
+    const inputGuardrail = defineToolInputGuardrail({
+      name: 'guarded-input',
+      run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+    });
+    const outputGuardrail = defineToolOutputGuardrail({
+      name: 'guarded-output',
+      run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+    });
+    const guardedServer = new StubServer('guarded', [
+      toolNamed('allowed'),
+      toolNamed('filtered'),
+    ]);
+    guardedServer.toolFilter = { allowedToolNames: ['allowed'] };
+    guardedServer.toolInputGuardrails = [inputGuardrail];
+    guardedServer.toolOutputGuardrails = [outputGuardrail];
+    const unguardedServer = new StubServer('unguarded', [toolNamed('plain')]);
+    const options = {
+      mcpServers: [guardedServer, unguardedServer],
+      runContext: new RunContext({}),
+      agent: new Agent({ name: 'GuardrailIsolationAgent' }),
+      includeServerInToolNames: true,
+    };
+
+    const first = (await getAllMcpTools(options)) as FunctionTool[];
+    const second = (await getAllMcpTools(options)) as FunctionTool[];
+
+    expect(first.map((tool) => tool.name)).toEqual([
+      'mcp_guarded__allowed',
+      'mcp_unguarded__plain',
+    ]);
+    expect(first[0].inputGuardrails).toEqual([inputGuardrail]);
+    expect(first[0].outputGuardrails).toEqual([outputGuardrail]);
+    expect(first[1].inputGuardrails).toEqual([]);
+    expect(first[1].outputGuardrails).toEqual([]);
+    expect(second[0].inputGuardrails).not.toBe(first[0].inputGuardrails);
+    expect(second[0].outputGuardrails).not.toBe(first[0].outputGuardrails);
+
+    first[0].inputGuardrails?.splice(0);
+    first[0].outputGuardrails?.splice(0);
+    expect(guardedServer.toolInputGuardrails).toEqual([inputGuardrail]);
+    expect(guardedServer.toolOutputGuardrails).toEqual([outputGuardrail]);
+    expect(second[0].inputGuardrails).toEqual([inputGuardrail]);
+    expect(second[0].outputGuardrails).toEqual([outputGuardrail]);
   });
 
   it('redacts URL credentials from prefixed tool names while dispatching the original tool name', async () => {

--- a/packages/agents-core/test/mcpToFunctionTool.test.ts
+++ b/packages/agents-core/test/mcpToFunctionTool.test.ts
@@ -8,6 +8,11 @@ import { withTrace } from '../src/tracing';
 import { withCustomSpan } from '../src/tracing/createSpans';
 import { getCurrentSpan } from '../src/tracing';
 import { UserError } from '../src/errors';
+import {
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  ToolGuardrailFunctionOutputFactory,
+} from '../src/toolGuardrail';
 
 const SCHEMA_DEPTH_ERROR =
   'JSON schema is too deeply nested to process safely. Simplify or flatten the schema, or disable strict mode.';
@@ -126,6 +131,58 @@ function convertExpectingStrictFallback(
 }
 
 describe('mcpToFunctionTool', () => {
+  it.each([false, true])(
+    'attaches isolated server guardrail arrays with strict conversion=$convertSchemasToStrict',
+    (convertSchemasToStrict) => {
+      const inputGuardrail = defineToolInputGuardrail({
+        name: 'server-input',
+        run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+      });
+      const outputGuardrail = defineToolOutputGuardrail({
+        name: 'server-output',
+        run: async () => ToolGuardrailFunctionOutputFactory.allow(),
+      });
+      const server: MCPServer = {
+        name: 'guarded-server',
+        cacheToolsList: false,
+        toolInputGuardrails: [inputGuardrail],
+        toolOutputGuardrails: [outputGuardrail],
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [],
+        callTool: async () => [],
+        invalidateToolsCache: async () => {},
+      };
+      const mcpTool = {
+        name: 'guarded-tool',
+        description: '',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      };
+
+      const first = mcpToFunctionTool(mcpTool, server, convertSchemasToStrict);
+      const second = mcpToFunctionTool(mcpTool, server, convertSchemasToStrict);
+
+      expect(first.inputGuardrails).toEqual([inputGuardrail]);
+      expect(first.outputGuardrails).toEqual([outputGuardrail]);
+      expect(first.inputGuardrails).not.toBe(server.toolInputGuardrails);
+      expect(first.outputGuardrails).not.toBe(server.toolOutputGuardrails);
+      expect(second.inputGuardrails).not.toBe(first.inputGuardrails);
+      expect(second.outputGuardrails).not.toBe(first.outputGuardrails);
+
+      first.inputGuardrails?.splice(0);
+      first.outputGuardrails?.splice(0);
+      expect(server.toolInputGuardrails).toEqual([inputGuardrail]);
+      expect(server.toolOutputGuardrails).toEqual([outputGuardrail]);
+      expect(second.inputGuardrails).toEqual([inputGuardrail]);
+      expect(second.outputGuardrails).toEqual([outputGuardrail]);
+    },
+  );
+
   it('preserves non-strict behavior when schema conversion is disabled', () => {
     const server: MCPServer = {
       name: 'stub',

--- a/packages/agents-core/test/mcpToolGuardrails.test.ts
+++ b/packages/agents-core/test/mcpToolGuardrails.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  Agent,
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  RunState,
+  RunToolCallOutputItem,
+  run,
+  ToolGuardrailFunctionOutputFactory,
+} from '../src';
+import type { MCPServer, MCPTool } from '../src/mcp';
+import { getAllMcpTools } from '../src/mcp';
+import { ScriptedModel } from '../src/testing';
+import type * as protocol from '../src/types/protocol';
+
+function functionToolCall(
+  name: string,
+  args: string,
+  callId = 'mcp-call',
+): protocol.FunctionCallItem {
+  return {
+    id: `fc_${callId}`,
+    type: 'function_call',
+    name,
+    callId,
+    status: 'completed',
+    arguments: args,
+    providerData: {},
+  };
+}
+
+function textMessage(text: string): protocol.AssistantMessageItem {
+  return {
+    type: 'message',
+    role: 'assistant',
+    status: 'completed',
+    content: [
+      {
+        type: 'output_text',
+        text,
+        providerData: { annotations: [] },
+      },
+    ],
+    providerData: {},
+  };
+}
+
+function mcpTool(name: string): MCPTool {
+  return {
+    name,
+    description: '',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+      additionalProperties: false,
+    },
+  };
+}
+
+async function runInMode(
+  agent: Agent<any, any>,
+  input: string | RunState<any, any>,
+  stream: boolean,
+  preApprovalInputGuardrails = false,
+): Promise<any> {
+  const options = {
+    tracingDisabled: true,
+    toolExecution: { preApprovalInputGuardrails },
+  };
+  if (stream) {
+    const result = await run(agent, input, { ...options, stream: true });
+    await result.completed;
+    return result;
+  }
+  return run(agent, input, options);
+}
+
+describe('MCP server tool guardrails', () => {
+  it.each([false, true])(
+    'blocks MCP input before the server call with stream=$stream',
+    async (stream) => {
+      const callTool = vi.fn(async () => [
+        { type: 'text', text: 'unexpected output' },
+      ]);
+      const inputGuardrail = defineToolInputGuardrail({
+        name: 'block-sensitive-input',
+        run: async ({ toolCall }) => {
+          expect(toolCall.name).toBe('sensitive');
+          expect(toolCall.arguments).toBe('{"secret":"value"}');
+          return ToolGuardrailFunctionOutputFactory.rejectContent(
+            'blocked MCP input',
+          );
+        },
+      });
+      const server: MCPServer = {
+        name: 'input-guarded-server',
+        cacheToolsList: false,
+        toolInputGuardrails: [inputGuardrail],
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [mcpTool('sensitive')],
+        callTool,
+        invalidateToolsCache: async () => {},
+      };
+      const model = new ScriptedModel([
+        [functionToolCall('sensitive', '{"secret":"value"}')],
+        [textMessage('done')],
+      ]);
+      const agent = new Agent({
+        name: 'InputGuardedMcpAgent',
+        model,
+        mcpServers: [server],
+      });
+
+      const result = await runInMode(agent, 'call the tool', stream);
+
+      expect(result.finalOutput).toBe('done');
+      expect(callTool).not.toHaveBeenCalled();
+      expect(result.toolInputGuardrailResults).toHaveLength(1);
+      expect(JSON.stringify(model.lastCall?.request.input)).toContain(
+        'blocked MCP input',
+      );
+      expect(JSON.stringify(model.lastCall?.request.input)).not.toContain(
+        'unexpected output',
+      );
+    },
+  );
+
+  it.each([false, true])(
+    'replaces MCP output before the next model input with stream=$stream',
+    async (stream) => {
+      const sensitiveOutput = 'sensitive MCP output';
+      const replacementOutput = 'blocked MCP output';
+      const callTool = vi.fn(async () => {
+        throw new Error('callTool should not run when customData is enabled.');
+      });
+      const callToolResult = vi.fn(async () => ({
+        content: [{ type: 'text' as const, text: sensitiveOutput }],
+      }));
+      const outputGuardrail = defineToolOutputGuardrail({
+        name: 'block-sensitive-output',
+        run: async ({ output }) => {
+          expect(output).toEqual({ type: 'text', text: sensitiveOutput });
+          return ToolGuardrailFunctionOutputFactory.rejectContent(
+            replacementOutput,
+          );
+        },
+      });
+      const server: MCPServer = {
+        name: 'output-guarded-server',
+        cacheToolsList: false,
+        toolOutputGuardrails: [outputGuardrail],
+        customDataExtractor: ({ toolOutput }) => ({ output: toolOutput }),
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [mcpTool('lookup')],
+        callTool,
+        callToolResult,
+        invalidateToolsCache: async () => {},
+      };
+      const model = new ScriptedModel([
+        [functionToolCall('lookup', '{}')],
+        [textMessage('done')],
+      ]);
+      const agent = new Agent({
+        name: 'OutputGuardedMcpAgent',
+        model,
+        mcpServers: [server],
+      });
+
+      const result = await runInMode(agent, 'call the tool', stream);
+
+      expect(result.finalOutput).toBe('done');
+      expect(callTool).not.toHaveBeenCalled();
+      expect(callToolResult).toHaveBeenCalledTimes(1);
+      expect(result.toolOutputGuardrailResults).toHaveLength(1);
+      expect(JSON.stringify(model.lastCall?.request.input)).toContain(
+        replacementOutput,
+      );
+      expect(JSON.stringify(model.lastCall?.request.input)).not.toContain(
+        sensitiveOutput,
+      );
+
+      const outputItem = result.newItems.find(
+        (item: unknown) => item instanceof RunToolCallOutputItem,
+      ) as RunToolCallOutputItem | undefined;
+      expect(outputItem?.customData).toEqual({ output: replacementOutput });
+      const serializedState = result.state.toString();
+      expect(serializedState).toContain(replacementOutput);
+      expect(serializedState).not.toContain(sensitiveOutput);
+      const restored = await RunState.fromString(agent, serializedState);
+      const restoredOutputItem = restored._generatedItems.find(
+        (item) => item instanceof RunToolCallOutputItem,
+      ) as RunToolCallOutputItem | undefined;
+      expect(restoredOutputItem?.customData).toEqual({
+        output: replacementOutput,
+      });
+    },
+  );
+
+  it.each([false, true])(
+    'preserves approval and serialized resume ordering with stream=$stream',
+    async (stream) => {
+      const inputGuardrailRun = vi.fn(async () =>
+        ToolGuardrailFunctionOutputFactory.allow(),
+      );
+      const server: MCPServer = {
+        name: 'approval-guarded-server',
+        cacheToolsList: false,
+        toolInputGuardrails: [
+          defineToolInputGuardrail({
+            name: 'time-sensitive-check',
+            run: inputGuardrailRun,
+          }),
+        ],
+        connect: async () => {},
+        close: async () => {},
+        listTools: async () => [mcpTool('approved')],
+        callTool: vi.fn(async () => [{ type: 'text', text: 'approved' }]),
+        invalidateToolsCache: async () => {},
+      };
+      const [convertedTool] = await getAllMcpTools([server]);
+      if (!convertedTool || convertedTool.type !== 'function') {
+        throw new Error('Expected a converted MCP function tool.');
+      }
+      convertedTool.needsApproval = async () => true;
+      const model = new ScriptedModel([
+        [functionToolCall('approved', '{}', 'approval-call')],
+      ]);
+      const agent = new Agent({
+        name: 'ApprovalGuardedMcpAgent',
+        model,
+        tools: [convertedTool],
+        toolUseBehavior: 'stop_on_first_tool',
+      });
+
+      const first = await runInMode(agent, 'call the tool', stream, true);
+
+      expect(first.interruptions).toHaveLength(1);
+      expect(inputGuardrailRun).toHaveBeenCalledTimes(1);
+      expect(server.callTool).not.toHaveBeenCalled();
+
+      const restored = await RunState.fromString(agent, first.state.toString());
+      restored.approve(restored.getInterruptions()[0]);
+      const resumed = await runInMode(agent, restored, stream, true);
+
+      expect(resumed.interruptions).toHaveLength(0);
+      expect(inputGuardrailRun).toHaveBeenCalledTimes(2);
+      expect(server.callTool).toHaveBeenCalledTimes(1);
+      expect(model.calls).toHaveLength(1);
+    },
+  );
+});


### PR DESCRIPTION
This pull request adds optional server-wide input and output guardrails to local MCP servers. Each converted tool receives isolated guardrail arrays and continues through the existing FunctionTool lifecycle across filtering, caching, name prefixing, streaming, approval, and serialized resume paths.

MCP custom data extraction now receives the post-guardrail output, preventing rejected tool content from being retained in `customData` or serialized RunState.