### PR TITLE
docs: clarify capability visibility and authorization

### DIFF
--- a/docs/src/content/docs/guides/context.mdx
+++ b/docs/src/content/docs/guides/context.mdx
@@ -36,6 +36,18 @@ Use local context for things like:
 
 Within a single run, derived contexts share the same underlying app context, approvals, and usage tracking. Nested `agent.asTool()` runs may attach a different `toolInput`, but they do not get an isolated copy of your app state by default.
 
+### Use local context for capability visibility
+
+When function tools, local MCP tools, and handoffs depend on the same request policy, keep the policy inputs or helper on your application context. Each SDK surface exposes the current run context through its own callback:
+
+- A function tool created with `tool()` receives an object whose `runContext` property is the current `RunContext` in its `isEnabled` predicate.
+- A handoff `isEnabled` predicate receives an object whose `runContext` property is the current `RunContext`.
+- A callable MCP [`toolFilter`](/openai-agents-js/guides/mcp#tool-filtering) receives `MCPToolFilterContext`, whose `runContext` property is the current `RunContext`.
+
+Adapt the shared application policy to these callbacks instead of maintaining separate capability lists. The callbacks control which capabilities the SDK includes in the model-visible set for the current turn; they run before the model produces tool or handoff arguments, so they cannot authorize a model-generated argument or resource selection. For function tools, enforce those decisions inside `execute`, or add [tool input guardrails](/openai-agents-js/guides/guardrails#tool-guardrails) and [approvals](/openai-agents-js/guides/human-in-the-loop) when appropriate. MCP servers must authorize their own protected operations. For a handoff with `inputType`, check the parsed input at the start of `onHandoff`, before application side effects, and throw when authorization fails. Returning successfully from `onHandoff` continues the transfer, and tool input guardrails do not run for handoffs. See [Handoff inputs](/openai-agents-js/guides/handoffs#handoff-inputs) for the callback lifecycle.
+
+If a callable MCP `toolFilter` depends on request context, keep `cacheToolsList` disabled for the agent-managed server. Cached entries contain the already-filtered tool list, while the default callable-filter cache key is not request-context-specific. Code that calls `getAllMcpTools(...)` directly can instead provide a `generateMCPToolCacheKey` that includes the relevant policy identity. See the [MCP caching guidance](/openai-agents-js/guides/mcp#other-things-to-know).
+
 ### What `RunContext` exposes
 
 `RunContext<T>` is a wrapper around your app-defined context object. In practice you will most often use:

--- a/docs/src/content/docs/guides/handoffs.mdx
+++ b/docs/src/content/docs/guides/handoffs.mdx
@@ -54,6 +54,8 @@ Sometimes you want the model to attach a small structured payload when it choose
 
 `inputType` describes the arguments for the handoff tool call itself. The SDK exposes that schema to the model as the handoff tool's `parameters`, parses the returned arguments locally, and passes the parsed value to `onHandoff`.
 
+`isEnabled` is evaluated while the SDK prepares the handoffs available to the model, before the model returns handoff arguments, so it cannot authorize values inside an argument-bearing handoff. When authorization depends on the parsed fields, perform the check at the start of `onHandoff`, before any application side effects. If authorization fails, throw instead of returning; the SDK continues the transfer after `onHandoff` returns successfully. Tool input guardrails apply to function tools, not handoffs.
+
 It does not replace the next agent's main input, and it does not choose a different destination. The `handoff()` helper still transfers to the specific agent you wrapped, and the receiving agent still sees the conversation history unless you change it with an `inputFilter`.
 
 `inputType` is also separate from `RunContext`. Use it for metadata the model decides at handoff time, not for application state or dependencies you already have locally.

--- a/docs/src/content/docs/guides/tools.mdx
+++ b/docs/src/content/docs/guides/tools.mdx
@@ -160,6 +160,12 @@ You can turn **any** function into a tool with the `tool()` helper.
 | `inputGuardrails` | No | Guardrails that run before the tool executes; can reject or throw. See [Guardrails](/openai-agents-js/guides/guardrails#tool-guardrails). |
 | `outputGuardrails` | No | Guardrails that run after the tool executes; can reject or throw. See [Guardrails](/openai-agents-js/guides/guardrails#tool-guardrails). |
 
+#### Conditional tool availability
+
+Use `isEnabled` for request-scoped capability visibility, environment-specific availability, feature flags, or experiments. The runner evaluates the predicate while preparing the model-visible tool set for the current turn.
+
+`isEnabled` does not replace authorization that depends on the tool arguments or the resource being accessed, because the predicate runs before the model produces those arguments. Enforce argument- and resource-level authorization inside `execute`, or add [tool input guardrails](/openai-agents-js/guides/guardrails#tool-guardrails) and [approvals](/openai-agents-js/guides/human-in-the-loop) when appropriate. MCP servers must authorize their own protected operations. See [Context management](/openai-agents-js/guides/context#use-local-context-for-capability-visibility) for a pattern that applies one application policy across function tools, local MCP tools, and handoffs.
+
 Supported Standard Schema parameters are converted to JSON Schema for the model and validated locally before `execute` runs. The validation output type, including library transforms and defaults, becomes the inferred `execute` argument type. See [Schema validation](/openai-agents-js/guides/schemas) for a Valibot example and current limitations.
 
 #### SDK-only custom data


### PR DESCRIPTION
This pull request updates the context, tools, and handoff guides to show how one request-scoped application policy can drive function-tool, handoff, and local MCP visibility.

It clarifies that `isEnabled` and `toolFilter` shape the model-visible capability set, while argument- and resource-level authorization belongs at invocation boundaries. It also documents parsed handoff checks in `onHandoff` and the cache-key requirement for request-dependent MCP filters.