### PR TITLE
fix(openai): restrict redacted response IDs to official endpoints

### DIFF
--- a/.changeset/redacted-response-id-endpoints.md
+++ b/.changeset/redacted-response-id-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: restrict redacted trace response IDs to official OpenAI endpoints

--- a/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
+++ b/packages/agents-openai/src/experimental/hostedMultiAgent/model.ts
@@ -94,6 +94,10 @@ type HostedWebSocketCreationOptions = {
   headers: Record<string, string>;
 };
 
+type HostedResponseEndpointMetadata = {
+  requestURL?: string;
+};
+
 class HostedMultiAgentWebSocketClosedError extends Error {
   constructor(
     message: string,
@@ -248,6 +252,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
   #webSocket?: ResponsesWebSocketLike;
   #webSocketIterator?: AsyncIterator<Record<string, any>>;
   #webSocketConnectionKey?: string;
+  #webSocketConnectionURL?: string;
   #webSocketTransportOverridesKey?: string;
   #activeResponse?: ActiveHostedResponse;
   #normalizedResponses = new WeakMap<
@@ -295,6 +300,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     const webSocket = this.#webSocket;
     this.#webSocket = undefined;
     this.#webSocketConnectionKey = undefined;
+    this.#webSocketConnectionURL = undefined;
     this.#webSocketTransportOverridesKey = undefined;
     webSocket?.close();
   }
@@ -403,19 +409,22 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
   protected override async _fetchResponse(
     request: ModelRequest,
     stream: true,
+    endpointMetadata?: HostedResponseEndpointMetadata,
   ): Promise<AsyncIterable<OpenAI.Responses.ResponseStreamEvent>>;
   protected override async _fetchResponse(
     request: ModelRequest,
     stream: false,
+    endpointMetadata?: HostedResponseEndpointMetadata,
   ): Promise<OpenAI.Responses.Response>;
   protected override async _fetchResponse(
     request: ModelRequest,
     stream: boolean,
+    endpointMetadata?: HostedResponseEndpointMetadata,
   ): Promise<
     | AsyncIterable<OpenAI.Responses.ResponseStreamEvent>
     | OpenAI.Responses.Response
   > {
-    const events = this.#runWebSocketTurn(request);
+    const events = this.#runWebSocketTurn(request, endpointMetadata);
     if (stream) {
       return events as AsyncIterable<OpenAI.Responses.ResponseStreamEvent>;
     }
@@ -436,6 +445,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
 
   async *#runWebSocketTurn(
     request: ModelRequest,
+    endpointMetadata?: HostedResponseEndpointMetadata,
   ): AsyncIterable<Record<string, any>> {
     if (this.#requestInProgress) {
       throw new UserError(
@@ -480,6 +490,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
         Boolean(this.#activeResponse),
         builtRequest.signal,
         requestTimeoutDeadline,
+        endpointMetadata,
       );
       let pendingInjections = 0;
       const injectingCallIds = new Set<string>();
@@ -860,6 +871,7 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
     activeResponse: boolean,
     signal: AbortSignal | undefined,
     requestTimeoutDeadline: WebSocketRequestTimeoutDeadline | undefined,
+    endpointMetadata: HostedResponseEndpointMetadata | undefined,
   ): Promise<ResponsesWebSocketLike> {
     if (signal?.aborted) {
       throw new OpenAI.APIUserAbortError();
@@ -876,6 +888,9 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       }
       if (this.#webSocket) {
         if (isReusableWebSocket(this.#webSocket)) {
+          if (endpointMetadata) {
+            endpointMetadata.requestURL = this.#webSocketConnectionURL;
+          }
           return this.#webSocket;
         }
         this.#dropWebSocketConnection();
@@ -914,8 +929,12 @@ export class OpenAIHostedMultiAgentModel extends OpenAIResponsesModel {
       this.#webSocket = this._createResponsesWebSocket(creationOptions);
       this.#webSocketIterator = this.#webSocket[Symbol.asyncIterator]();
       this.#webSocketConnectionKey = connectionKey;
+      this.#webSocketConnectionURL = connectionURL;
     }
     this.#webSocketTransportOverridesKey = transportOverridesKey;
+    if (endpointMetadata) {
+      endpointMetadata.requestURL = this.#webSocketConnectionURL;
+    }
     return this.#webSocket;
   }
 

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -89,6 +89,32 @@ import { FAKE_ID } from './openaiItemIds';
 
 type ModelTracingParent = Parameters<typeof createResponseSpan>[1];
 
+type ResponsesEndpointTransport = 'http' | 'websocket';
+
+function isOfficialOpenAIEndpoint(
+  baseURL: string | URL | undefined,
+  transport: ResponsesEndpointTransport,
+): boolean {
+  if (!baseURL) {
+    return false;
+  }
+
+  try {
+    const parsedURL = new URL(baseURL);
+    if (parsedURL.hostname !== 'api.openai.com' || parsedURL.port.length > 0) {
+      return false;
+    }
+
+    if (transport === 'http') {
+      return parsedURL.protocol === 'https:';
+    }
+
+    return parsedURL.protocol === 'https:' || parsedURL.protocol === 'wss:';
+  } catch {
+    return false;
+  }
+}
+
 function getModelTracingParent(request: ModelRequest): ModelTracingParent {
   return (
     request as ModelRequest & {
@@ -3306,9 +3332,22 @@ type ResponseStreamWithRequestID =
   AsyncIterable<OpenAI.Responses.ResponseStreamEvent> & {
     withResponse?: () => Promise<{
       data: AsyncIterable<OpenAI.Responses.ResponseStreamEvent>;
+      response?: Response;
       request_id: string | null;
     }>;
   };
+
+type ResponsePromiseWithRequestMetadata<T> = Promise<T> & {
+  withResponse?: () => Promise<{
+    data: T;
+    response?: Response;
+    request_id: string | null;
+  }>;
+};
+
+type ResponseEndpointMetadata = {
+  requestURL?: string;
+};
 
 function getOpenAIResponseRequestId(
   response: object | undefined,
@@ -3377,6 +3416,22 @@ export class OpenAIResponsesModel implements Model {
 
   getRetryAdvice(args: ModelRetryAdviceRequest): ModelRetryAdvice | undefined {
     return getOpenAIRetryAdvice(args);
+  }
+
+  /**
+   * @internal
+   */
+  protected _isOfficialOpenAIEndpoint(
+    baseURL: string | URL | undefined,
+  ): boolean {
+    return isOfficialOpenAIEndpoint(baseURL, 'http');
+  }
+
+  /**
+   * @internal
+   */
+  protected _usesOfficialOpenAIEndpoint(): boolean {
+    return this._isOfficialOpenAIEndpoint(this._client.baseURL);
   }
 
   /**
@@ -3474,14 +3529,17 @@ export class OpenAIResponsesModel implements Model {
   protected async _fetchResponse(
     request: ModelRequest,
     stream: true,
+    endpointMetadata?: ResponseEndpointMetadata,
   ): Promise<AsyncIterable<OpenAI.Responses.ResponseStreamEvent>>;
   protected async _fetchResponse(
     request: ModelRequest,
     stream: false,
+    endpointMetadata?: ResponseEndpointMetadata,
   ): Promise<OpenAI.Responses.Response>;
   protected async _fetchResponse(
     request: ModelRequest,
     stream: boolean,
+    endpointMetadata?: ResponseEndpointMetadata,
   ): Promise<
     | AsyncIterable<OpenAI.Responses.ResponseStreamEvent>
     | OpenAI.Responses.Response
@@ -3521,6 +3579,9 @@ export class OpenAIResponsesModel implements Model {
         .withResponse;
       if (typeof withResponse === 'function') {
         const streamedResponse = await withResponse.call(responsePromise);
+        if (endpointMetadata) {
+          endpointMetadata.requestURL = streamedResponse.response?.url;
+        }
         response = withAttachedResponseRequestId(
           streamedResponse.data,
           streamedResponse.request_id ?? undefined,
@@ -3530,7 +3591,16 @@ export class OpenAIResponsesModel implements Model {
           (await responsePromise) as AsyncIterable<OpenAI.Responses.ResponseStreamEvent>;
       }
     } else {
-      response = (await responsePromise) as OpenAI.Responses.Response;
+      const responseWithMetadata =
+        responsePromise as ResponsePromiseWithRequestMetadata<OpenAI.Responses.Response>;
+      const withResponse = responseWithMetadata.withResponse;
+      if (endpointMetadata && typeof withResponse === 'function') {
+        const receivedResponse = await withResponse.call(responsePromise);
+        endpointMetadata.requestURL = receivedResponse.response?.url;
+        response = receivedResponse.data;
+      } else {
+        response = (await responsePromise) as OpenAI.Responses.Response;
+      }
     }
 
     if (logger.dontLogModelData) {
@@ -3720,7 +3790,16 @@ export class OpenAIResponsesModel implements Model {
   async getResponse(request: ModelRequest): Promise<ModelResponse> {
     const { response, rawUsage, preservedUsage } = await withResponseSpan(
       async (span) => {
-        const response = await this._fetchResponse(request, false);
+        const redactedResponseIdEndpointWasTrusted =
+          request.tracing === 'enabled_without_data' &&
+          this._usesOfficialOpenAIEndpoint();
+        const endpointMetadata: ResponseEndpointMetadata | undefined =
+          request.tracing === 'enabled_without_data' ? {} : undefined;
+        const response = await this._fetchResponse(
+          request,
+          false,
+          endpointMetadata,
+        );
         const rawUsage =
           request.modelSettings.preserveRawUsage === true
             ? snapshotRawUsage(response.usage)
@@ -3731,7 +3810,14 @@ export class OpenAIResponsesModel implements Model {
           this._getUnsuccessfulResponseTerminalType(response);
 
         if (request.tracing) {
-          span.spanData.response_id = response.id;
+          if (
+            request.tracing === true ||
+            (redactedResponseIdEndpointWasTrusted &&
+              this._isOfficialOpenAIEndpoint(endpointMetadata?.requestURL) &&
+              this._usesOfficialOpenAIEndpoint())
+          ) {
+            span.spanData.response_id = response.id;
+          }
           if (request.tracing === true || !terminalType) {
             span.spanData._input = request.input;
             span.spanData._response = response;
@@ -3787,7 +3873,16 @@ export class OpenAIResponsesModel implements Model {
           span.spanData._input = request.input;
         }
       }
-      const response = await this._fetchResponse(request, true);
+      const redactedResponseIdEndpointWasTrusted =
+        request.tracing === 'enabled_without_data' &&
+        this._usesOfficialOpenAIEndpoint();
+      const endpointMetadata: ResponseEndpointMetadata | undefined =
+        request.tracing === 'enabled_without_data' ? {} : undefined;
+      const response = await this._fetchResponse(
+        request,
+        true,
+        endpointMetadata,
+      );
 
       let finalResponse: OpenAI.Responses.Response | undefined;
       const outputItemsByIndex = new Map<number, Record<string, any>>();
@@ -3829,6 +3924,16 @@ export class OpenAIResponsesModel implements Model {
               terminalResponse,
               eventType,
             );
+          if (
+            span &&
+            terminalResponse &&
+            request.tracing === 'enabled_without_data' &&
+            redactedResponseIdEndpointWasTrusted &&
+            this._isOfficialOpenAIEndpoint(endpointMetadata?.requestURL) &&
+            this._usesOfficialOpenAIEndpoint()
+          ) {
+            span.spanData.response_id = terminalResponse.id;
+          }
           if (unsuccessfulTerminalType) {
             terminalError = createUnsuccessfulResponseError(
               unsuccessfulTerminalType,
@@ -3841,8 +3946,8 @@ export class OpenAIResponsesModel implements Model {
               finalResponse = terminalResponse;
             }
             if (span && terminalResponse) {
-              span.spanData.response_id = terminalResponse.id;
               if (request.tracing === true) {
+                span.spanData.response_id = terminalResponse.id;
                 span.spanData._response = terminalResponse;
               }
             }
@@ -3920,7 +4025,9 @@ export class OpenAIResponsesModel implements Model {
       }
 
       if (request.tracing && span && finalResponse) {
-        span.spanData.response_id = finalResponse.id;
+        if (request.tracing === true) {
+          span.spanData.response_id = finalResponse.id;
+        }
         if (request.tracing === true || !terminalError) {
           span.spanData._response = finalResponse;
         }
@@ -3990,6 +4097,24 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
     );
   }
 
+  /**
+   * @internal
+   */
+  protected override _isOfficialOpenAIEndpoint(
+    baseURL: string | URL | undefined,
+  ): boolean {
+    return isOfficialOpenAIEndpoint(baseURL, 'websocket');
+  }
+
+  /**
+   * @internal
+   */
+  protected override _usesOfficialOpenAIEndpoint(): boolean {
+    return this._isOfficialOpenAIEndpoint(
+      this.#websocketBaseURL ?? this._client.baseURL,
+    );
+  }
+
   override getRetryAdvice(
     args: ModelRetryAdviceRequest,
   ): ModelRetryAdvice | undefined {
@@ -4028,14 +4153,17 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
   protected async _fetchResponse(
     request: ModelRequest,
     stream: true,
+    endpointMetadata?: ResponseEndpointMetadata,
   ): Promise<AsyncIterable<OpenAI.Responses.ResponseStreamEvent>>;
   protected async _fetchResponse(
     request: ModelRequest,
     stream: false,
+    endpointMetadata?: ResponseEndpointMetadata,
   ): Promise<OpenAI.Responses.Response>;
   protected async _fetchResponse(
     request: ModelRequest,
     stream: boolean,
+    endpointMetadata?: ResponseEndpointMetadata,
   ): Promise<
     | AsyncIterable<OpenAI.Responses.ResponseStreamEvent>
     | OpenAI.Responses.Response
@@ -4045,7 +4173,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
     const builtRequest = this._buildResponsesCreateRequest(request, true);
 
     if (stream) {
-      return this.#iterWebSocketResponseEvents(builtRequest);
+      return this.#iterWebSocketResponseEvents(builtRequest, endpointMetadata);
     }
 
     let receivedResponseEvent = false;
@@ -4053,6 +4181,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
       let finalResponse: OpenAI.Responses.Response | undefined;
       for await (const event of this.#iterWebSocketResponseEvents(
         builtRequest,
+        endpointMetadata,
       )) {
         receivedResponseEvent = true;
         const eventType = (event as { type?: string }).type;
@@ -4096,6 +4225,7 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
 
   async *#iterWebSocketResponseEvents(
     builtRequest: BuiltResponsesCreateRequest,
+    endpointMetadata?: ResponseEndpointMetadata,
   ): AsyncIterable<OpenAI.Responses.ResponseStreamEvent> {
     const requestTimeoutDeadline =
       this.#createWebSocketRequestTimeoutDeadline();
@@ -4113,6 +4243,9 @@ export class OpenAIResponsesWSModel extends OpenAIResponsesModel {
         builtRequest,
         requestTimeoutDeadline,
       );
+      if (endpointMetadata) {
+        endpointMetadata.requestURL = wsURL;
+      }
       throwIfAborted(builtRequest.signal);
       let connection = await this.#ensureWebSocketConnection(
         wsURL,

--- a/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
+++ b/packages/agents-openai/test/experimental/hostedMultiAgent.test.ts
@@ -1,10 +1,12 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import OpenAI from 'openai';
 import {
+  setTraceProcessors,
   setTracingDisabled,
   UserError,
   withTrace,
   type ResponseStreamEvent,
+  type Span,
 } from '@openai/agents-core';
 import { OpenAIResponsesModel } from '../../src/openaiResponsesModel';
 import {
@@ -131,6 +133,30 @@ function withTestTrace<T>(fn: () => Promise<T>): Promise<T> {
   return withTrace('hosted-multi-agent-test', fn);
 }
 
+function captureResponseSpans(): Span<any>[] {
+  const responseSpans: Span<any>[] = [];
+  setTracingDisabled(false);
+  setTraceProcessors([
+    {
+      async onTraceStart() {},
+      async onTraceEnd() {},
+      async onSpanStart() {},
+      async onSpanEnd(span: Span<any>) {
+        if (span.spanData.type === 'response') {
+          responseSpans.push(span);
+        }
+      },
+      async shutdown() {},
+      async forceFlush() {},
+    },
+  ]);
+  return responseSpans;
+}
+
+function getSerializedResponseSpanData(span: Span<any>): Record<string, any> {
+  return (span.toJSON() as { span_data: Record<string, any> }).span_data;
+}
+
 async function getTestResponse(
   model: TestHostedMultiAgentModel,
   modelRequest: ReturnType<typeof request>,
@@ -158,6 +184,53 @@ describe('OpenAIHostedMultiAgentModel', () => {
   beforeAll(() => {
     setTracingDisabled(true);
   });
+
+  it.each([
+    ['non-streaming', false, 'https://api.openai.com/v1', 'resp_hosted'],
+    ['streaming', true, 'https://api.openai.com/v1', 'resp_hosted'],
+    [
+      'non-streaming custom',
+      false,
+      'https://provider.example.test/v1',
+      undefined,
+    ],
+    ['streaming custom', true, 'https://provider.example.test/v1', undefined],
+  ] as const)(
+    'gates redacted response IDs for hosted %s requests',
+    async (_label, stream, baseURL, expectedResponseId) => {
+      const responseSpans = captureResponseSpans();
+      const fakeWebSocket = new FakeResponsesWebSocket([
+        { type: 'response.created', response: emptyResponse('resp_hosted') },
+        {
+          type: 'response.completed',
+          response: emptyResponse('resp_hosted'),
+        },
+      ]);
+      const model = new TestHostedMultiAgentModel(
+        fakeWebSocket,
+        undefined,
+        new OpenAI({ apiKey: 'test-key', baseURL }),
+      );
+
+      try {
+        const response = await getTestResponse(
+          model,
+          request({ tracing: 'enabled_without_data' }),
+          stream,
+        );
+
+        expect(response.responseId ?? response.id).toBe('resp_hosted');
+        expect(responseSpans).toHaveLength(1);
+        expect(
+          getSerializedResponseSpanData(responseSpans[0]!).response_id,
+        ).toBe(expectedResponseId);
+      } finally {
+        await model.close();
+        setTraceProcessors([]);
+        setTracingDisabled(true);
+      }
+    },
+  );
 
   it('uses response.create over WebSocket with the hosted configuration', async () => {
     const fakeWebSocket = new FakeResponsesWebSocket([

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -30,6 +30,72 @@ class TestableOpenAIResponsesModel extends OpenAIResponsesModel {
   }
 }
 
+function captureResponseSpans(): Span<any>[] {
+  const responseSpans: Span<any>[] = [];
+  setTracingDisabled(false);
+  setTraceProcessors([
+    {
+      async onTraceStart() {},
+      async onTraceEnd() {},
+      async onSpanStart() {},
+      async onSpanEnd(span: Span<any>) {
+        if (span.spanData.type === 'response') {
+          responseSpans.push(span);
+        }
+      },
+      async shutdown() {},
+      async forceFlush() {},
+    },
+  ]);
+  return responseSpans;
+}
+
+function getSerializedResponseSpanData(span: Span<any>): Record<string, any> {
+  return (span.toJSON() as { span_data: Record<string, any> }).span_data;
+}
+
+function createResponsePromiseWithURL<T>(
+  data: T,
+  url: string,
+  beforeResolve?: () => void,
+): Promise<T> & {
+  withResponse: () => Promise<{
+    data: T;
+    response: Response;
+    request_id: null;
+  }>;
+} {
+  return Object.assign(Promise.resolve(data), {
+    withResponse: async () => {
+      beforeResolve?.();
+      return {
+        data,
+        response: { url } as Response,
+        request_id: null,
+      };
+    },
+  });
+}
+
+function createResponseStreamWithURL<T extends AsyncIterable<unknown>>(
+  data: T,
+  url: string,
+): T & {
+  withResponse: () => Promise<{
+    data: T;
+    response: Response;
+    request_id: null;
+  }>;
+} {
+  return Object.assign(data, {
+    withResponse: async () => ({
+      data,
+      response: { url } as Response,
+      request_id: null,
+    }),
+  });
+}
+
 const serializedFunctionTool = {
   type: 'function',
   name: 'lookup',
@@ -660,14 +726,20 @@ describe('OpenAIResponsesModel', () => {
     const sensitiveDetail = 'sensitive-no-data-response';
     const model = new OpenAIResponsesModel(
       {
+        baseURL: 'https://api.openai.com/v1',
         responses: {
-          create: vi.fn().mockResolvedValue({
-            id: 'resp_no_data_incomplete',
-            status: 'incomplete',
-            usage: {},
-            output: [],
-            incomplete_details: { reason: sensitiveDetail },
-          }),
+          create: vi.fn().mockReturnValue(
+            createResponsePromiseWithURL(
+              {
+                id: 'resp_no_data_incomplete',
+                status: 'incomplete',
+                usage: {},
+                output: [],
+                incomplete_details: { reason: sensitiveDetail },
+              },
+              'https://api.openai.com/v1/responses',
+            ),
+          ),
         },
       } as unknown as OpenAI,
       'gpt-test',
@@ -692,6 +764,187 @@ describe('OpenAIResponsesModel', () => {
     expect(responseSpan?.spanData._input).toBeUndefined();
     expect(responseSpan?.spanData._response).toBeUndefined();
     expect(JSON.stringify(responseSpan?.error)).not.toContain(sensitiveDetail);
+  });
+
+  it.each([
+    {
+      label: 'official endpoint',
+      before: 'https://api.openai.com/v1',
+      requestURL: 'https://api.openai.com/v1/responses',
+      after: 'https://api.openai.com/v1',
+      expectedResponseId: 'resp_redacted_endpoint',
+    },
+    {
+      label: 'custom endpoint',
+      before: 'https://provider.example.test/v1',
+      requestURL: 'https://provider.example.test/v1/responses',
+      after: 'https://provider.example.test/v1',
+      expectedResponseId: undefined,
+    },
+    {
+      label: 'custom endpoint changed to official',
+      before: 'https://provider.example.test/v1',
+      requestURL: 'https://api.openai.com/v1/responses',
+      after: 'https://api.openai.com/v1',
+      expectedResponseId: undefined,
+    },
+    {
+      label: 'official endpoint changed to custom',
+      before: 'https://api.openai.com/v1',
+      requestURL: 'https://provider.example.test/v1/responses',
+      after: 'https://provider.example.test/v1',
+      expectedResponseId: undefined,
+    },
+    {
+      label: 'insecure official host',
+      before: 'http://api.openai.com/v1',
+      requestURL: 'http://api.openai.com/v1/responses',
+      after: 'http://api.openai.com/v1',
+      expectedResponseId: undefined,
+    },
+    {
+      label: 'lookalike host',
+      before: 'https://api.openai.com.example.test/v1',
+      requestURL: 'https://api.openai.com.example.test/v1/responses',
+      after: 'https://api.openai.com.example.test/v1',
+      expectedResponseId: undefined,
+    },
+    {
+      label: 'nonstandard port',
+      before: 'https://api.openai.com:8443/v1',
+      requestURL: 'https://api.openai.com:8443/v1/responses',
+      after: 'https://api.openai.com:8443/v1',
+      expectedResponseId: undefined,
+    },
+    {
+      label: 'official endpoint routed through custom endpoint and restored',
+      before: 'https://api.openai.com/v1',
+      requestURL: 'https://provider.example.test/v1/responses',
+      after: 'https://api.openai.com/v1',
+      expectedResponseId: undefined,
+    },
+  ])(
+    'gates redacted non-streaming response IDs for $label',
+    async ({ before, requestURL, after, expectedResponseId }) => {
+      const responseSpans = captureResponseSpans();
+      const response = {
+        id: 'resp_redacted_endpoint',
+        status: 'completed',
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+        output: [],
+        _request_id: 'req_redacted_endpoint',
+      };
+      const client = {
+        baseURL: before,
+        responses: {
+          create: vi.fn(() =>
+            createResponsePromiseWithURL(response, requestURL, () => {
+              client.baseURL = after;
+            }),
+          ),
+        },
+      } as unknown as OpenAI;
+      const model = new OpenAIResponsesModel(client, 'gpt-test');
+
+      const result = await withTrace('test', () =>
+        model.getResponse({
+          systemInstructions: undefined,
+          input: 'hello',
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: 'enabled_without_data',
+          signal: undefined,
+        } as any),
+      );
+
+      expect(result.responseId).toBe('resp_redacted_endpoint');
+      expect(result.requestId).toBe('req_redacted_endpoint');
+      expect(result.usage).toMatchObject({
+        inputTokens: 1,
+        outputTokens: 2,
+        totalTokens: 3,
+      });
+      expect(responseSpans).toHaveLength(1);
+      const spanData = getSerializedResponseSpanData(responseSpans[0]!);
+      expect(spanData.response_id).toBe(expectedResponseId);
+      expect(spanData).not.toHaveProperty('_input');
+      expect(spanData).not.toHaveProperty('_response');
+    },
+  );
+
+  it('preserves a custom endpoint response ID for full-data tracing', async () => {
+    const responseSpans = captureResponseSpans();
+    const model = new OpenAIResponsesModel(
+      {
+        baseURL: 'https://provider.example.test/v1',
+        responses: {
+          create: vi.fn().mockResolvedValue({
+            id: 'resp_full_data_custom',
+            status: 'completed',
+            usage: {},
+            output: [],
+          }),
+        },
+      } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    const result = await withTrace('test', () =>
+      model.getResponse({
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: true,
+        signal: undefined,
+      } as any),
+    );
+
+    expect(result.responseId).toBe('resp_full_data_custom');
+    expect(responseSpans).toHaveLength(1);
+    expect(getSerializedResponseSpanData(responseSpans[0]!).response_id).toBe(
+      'resp_full_data_custom',
+    );
+    expect(responseSpans[0]?.spanData._response).toBeDefined();
+  });
+
+  it('does not create a response span when tracing is disabled', async () => {
+    const responseSpans = captureResponseSpans();
+    setTracingDisabled(true);
+    const model = new OpenAIResponsesModel(
+      {
+        baseURL: 'https://api.openai.com/v1',
+        responses: {
+          create: vi.fn().mockResolvedValue({
+            id: 'resp_tracing_disabled',
+            status: 'completed',
+            usage: {},
+            output: [],
+          }),
+        },
+      } as unknown as OpenAI,
+      'gpt-test',
+    );
+
+    const result = await withTrace('test', () =>
+      model.getResponse({
+        systemInstructions: undefined,
+        input: 'hello',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+        signal: undefined,
+      } as any),
+    );
+
+    expect(result.responseId).toBe('resp_tracing_disabled');
+    expect(responseSpans).toEqual([]);
   });
 
   it('does not persist an unsuccessful non-streaming response as a successful turn', async () => {
@@ -5455,8 +5708,14 @@ describe('OpenAIResponsesModel', () => {
     }
     const model = new OpenAIResponsesModel(
       {
+        baseURL: 'https://api.openai.com/v1',
         responses: {
-          create: vi.fn().mockImplementation(async () => fakeStream()),
+          create: vi.fn(() =>
+            createResponseStreamWithURL(
+              fakeStream(),
+              'https://api.openai.com/v1/responses',
+            ),
+          ),
         },
       } as unknown as OpenAI,
       'model-stream',
@@ -5868,7 +6127,15 @@ describe('OpenAIResponsesModel', () => {
     }
     const model = new OpenAIResponsesModel(
       {
-        responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+        baseURL: 'https://api.openai.com/v1',
+        responses: {
+          create: vi.fn(() =>
+            createResponseStreamWithURL(
+              fakeStream(),
+              'https://api.openai.com/v1/responses',
+            ),
+          ),
+        },
       } as unknown as OpenAI,
       'model-stream',
     );
@@ -5901,6 +6168,134 @@ describe('OpenAIResponsesModel', () => {
     expect(responseSpan?.spanData._response).toBeUndefined();
     expect(JSON.stringify(responseSpan?.error)).not.toContain(sensitiveDetail);
   });
+
+  it.each([
+    ['response.incomplete', 'incomplete'],
+    ['response.failed', 'failed'],
+  ] as const)(
+    'omits a custom endpoint response ID for redacted terminal event %s',
+    async (eventType, status) => {
+      const responseSpans = captureResponseSpans();
+      async function* fakeStream() {
+        yield {
+          type: eventType,
+          response: {
+            id: 'tenant-customer-response-id',
+            status,
+            output: [],
+            usage: {},
+          },
+          sequence_number: 0,
+        } as unknown as OpenAIResponseStreamEvent;
+      }
+      const model = new OpenAIResponsesModel(
+        {
+          baseURL: 'https://provider.example.test/v1',
+          responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+        } as unknown as OpenAI,
+        'model-stream',
+      );
+      const received: ResponseStreamEvent[] = [];
+
+      const error = await withTrace('test', async () => {
+        try {
+          for await (const event of model.getStreamedResponse({
+            systemInstructions: undefined,
+            input: 'data',
+            modelSettings: {},
+            tools: [],
+            outputType: 'text',
+            handoffs: [],
+            tracing: 'enabled_without_data',
+            signal: undefined,
+          } as any)) {
+            received.push(event);
+          }
+        } catch (caught) {
+          return caught;
+        }
+      });
+
+      expect(error).toBeInstanceOf(ModelBehaviorError);
+      expect(
+        received.some(
+          (event) => event.type === 'model' && event.event.type === eventType,
+        ),
+      ).toBe(true);
+      expect(responseSpans).toHaveLength(1);
+      expect(
+        getSerializedResponseSpanData(responseSpans[0]!).response_id,
+      ).toBeUndefined();
+    },
+  );
+
+  it.each([
+    ['https://api.openai.com/v1', 'resp_redacted_stream'],
+    ['https://provider.example.test/v1', undefined],
+  ] as const)(
+    'records a redacted streamed response ID only for a trusted endpoint (%s)',
+    async (baseURL, expectedResponseId) => {
+      const responseSpans = captureResponseSpans();
+      const completedEvent: OpenAIResponseStreamEvent = {
+        type: 'response.completed',
+        response: {
+          id: 'resp_redacted_stream',
+          status: 'completed',
+          output: [],
+          usage: { input_tokens: 2, output_tokens: 3, total_tokens: 5 },
+          _request_id: 'req_redacted_stream',
+        } as any,
+        sequence_number: 0,
+      };
+      async function* fakeStream() {
+        yield completedEvent;
+      }
+      const model = new OpenAIResponsesModel(
+        {
+          baseURL,
+          responses: {
+            create: vi.fn(() =>
+              createResponseStreamWithURL(fakeStream(), `${baseURL}/responses`),
+            ),
+          },
+        } as unknown as OpenAI,
+        'model-stream',
+      );
+      await withTrace('test', async () => {
+        const iterator = model
+          .getStreamedResponse({
+            systemInstructions: undefined,
+            input: 'data',
+            modelSettings: {},
+            tools: [],
+            outputType: 'text',
+            handoffs: [],
+            tracing: 'enabled_without_data',
+            signal: undefined,
+          } as any)
+          [Symbol.asyncIterator]();
+
+        const first = await iterator.next();
+        expect(first).toMatchObject({
+          done: false,
+          value: {
+            type: 'response_done',
+            response: {
+              id: 'resp_redacted_stream',
+              requestId: 'req_redacted_stream',
+              usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+            },
+          },
+        });
+        await iterator.return?.();
+      });
+
+      expect(responseSpans).toHaveLength(1);
+      expect(getSerializedResponseSpanData(responseSpans[0]!).response_id).toBe(
+        expectedResponseId,
+      );
+    },
+  );
 
   it('prevents extra_body from overriding streamed request mode', async () => {
     await withTrace('test', async () => {

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -11,7 +11,9 @@ import type OpenAI from 'openai';
 import type { ResponseStreamEvent as OpenAIResponseStreamEvent } from 'openai/resources/responses/responses';
 import {
   ModelBehaviorError,
+  setTraceProcessors,
   setTracingDisabled,
+  type Span,
   type ResponseStreamEvent,
   withTrace,
 } from '@openai/agents-core';
@@ -140,6 +142,30 @@ function createFakeClient(): OpenAI & {
   } as unknown as OpenAI & { _callApiKey: ReturnType<typeof vi.fn> };
 }
 
+function captureResponseSpans(): Span<any>[] {
+  const responseSpans: Span<any>[] = [];
+  setTracingDisabled(false);
+  setTraceProcessors([
+    {
+      async onTraceStart() {},
+      async onTraceEnd() {},
+      async onSpanStart() {},
+      async onSpanEnd(span: Span<any>) {
+        if (span.spanData.type === 'response') {
+          responseSpans.push(span);
+        }
+      },
+      async shutdown() {},
+      async forceFlush() {},
+    },
+  ]);
+  return responseSpans;
+}
+
+function getSerializedResponseSpanData(span: Span<any>): Record<string, any> {
+  return (span.toJSON() as { span_data: Record<string, any> }).span_data;
+}
+
 describe('OpenAIResponsesWSModel', () => {
   const originalWebSocket = (globalThis as any).WebSocket;
 
@@ -153,6 +179,8 @@ describe('OpenAIResponsesWSModel', () => {
   });
 
   afterEach(() => {
+    setTracingDisabled(true);
+    setTraceProcessors([]);
     if (typeof originalWebSocket === 'undefined') {
       delete (globalThis as any).WebSocket;
     } else {
@@ -1052,6 +1080,164 @@ describe('OpenAIResponsesWSModel', () => {
     expect(TestWebSocket.instances[0]?.url).toBe(
       'wss://proxy.example.test/v1/responses?base_param=1&tenant=acme',
     );
+  });
+
+  it.each([
+    {
+      label: 'official HTTPS base URL',
+      websocketBaseURL: 'https://api.openai.com/v1',
+      expectedURL: 'wss://api.openai.com/v1/responses',
+      expectedResponseId: 'resp_ws_redacted',
+    },
+    {
+      label: 'official WSS base URL',
+      websocketBaseURL: 'wss://api.openai.com/v1',
+      expectedURL: 'wss://api.openai.com/v1/responses',
+      expectedResponseId: 'resp_ws_redacted',
+    },
+    {
+      label: 'custom WSS base URL',
+      websocketBaseURL: 'wss://provider.example.test/v1',
+      expectedURL: 'wss://provider.example.test/v1/responses',
+      expectedResponseId: undefined,
+    },
+  ])(
+    'gates redacted response IDs for an explicit $label',
+    async ({ websocketBaseURL, expectedURL, expectedResponseId }) => {
+      const responseSpans = captureResponseSpans();
+      const fakeClient = createFakeClient();
+      TestWebSocket.onCreate = (socket) => {
+        socket.onSend(() => {
+          socket.queueJSON({
+            type: 'response.completed',
+            response: {
+              id: 'resp_ws_redacted',
+              status: 'completed',
+              output: [],
+              usage: {},
+            },
+            sequence_number: 0,
+          });
+        });
+      };
+      const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
+        websocketBaseURL,
+      });
+
+      const result = await withTrace('test', () =>
+        model.getResponse({
+          systemInstructions: undefined,
+          input: 'ping',
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: 'enabled_without_data',
+          signal: undefined,
+        } as any),
+      );
+
+      expect(result.responseId).toBe('resp_ws_redacted');
+      expect(TestWebSocket.instances[0]?.url).toBe(expectedURL);
+      expect(responseSpans).toHaveLength(1);
+      expect(getSerializedResponseSpanData(responseSpans[0]!).response_id).toBe(
+        expectedResponseId,
+      );
+      await model.close();
+    },
+  );
+
+  it('omits a redacted websocket response ID when the client endpoint changes during the request', async () => {
+    const responseSpans = captureResponseSpans();
+    const fakeClient = createFakeClient();
+    fakeClient.baseURL = 'https://api.openai.com/v1';
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        fakeClient.baseURL = 'https://provider.example.test/v1';
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'resp_ws_mutated',
+            status: 'completed',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 0,
+        });
+      });
+    };
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+
+    const result = await withTrace('test', () =>
+      model.getResponse({
+        systemInstructions: undefined,
+        input: 'ping',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: 'enabled_without_data',
+        signal: undefined,
+      } as any),
+    );
+
+    expect(result.responseId).toBe('resp_ws_mutated');
+    expect(TestWebSocket.instances[0]?.url).toBe(
+      'wss://api.openai.com/v1/responses',
+    );
+    expect(responseSpans).toHaveLength(1);
+    expect(
+      getSerializedResponseSpanData(responseSpans[0]!).response_id,
+    ).toBeUndefined();
+    await model.close();
+  });
+
+  it('binds redacted websocket response ID trust to the URL used for the request', async () => {
+    const responseSpans = captureResponseSpans();
+    const fakeClient = createFakeClient();
+    fakeClient.baseURL = 'https://api.openai.com/v1';
+    TestWebSocket.onCreate = (socket) => {
+      socket.onSend(() => {
+        fakeClient.baseURL = 'https://api.openai.com/v1';
+        socket.queueJSON({
+          type: 'response.completed',
+          response: {
+            id: 'tenant-customer-response-id',
+            status: 'completed',
+            output: [],
+            usage: {},
+          },
+          sequence_number: 0,
+        });
+      });
+    };
+    const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws');
+
+    const resultPromise = withTrace('test', () =>
+      model.getResponse({
+        systemInstructions: undefined,
+        input: 'ping',
+        modelSettings: {},
+        tools: [],
+        outputType: 'text',
+        handoffs: [],
+        tracing: 'enabled_without_data',
+        signal: undefined,
+      } as any),
+    );
+    fakeClient.baseURL = 'https://provider.example.test/v1';
+    const result = await resultPromise;
+
+    expect(result.responseId).toBe('tenant-customer-response-id');
+    expect(TestWebSocket.instances[0]?.url).toBe(
+      'wss://provider.example.test/v1/responses',
+    );
+    expect(fakeClient.baseURL).toBe('https://api.openai.com/v1');
+    expect(responseSpans).toHaveLength(1);
+    expect(
+      getSerializedResponseSpanData(responseSpans[0]!).response_id,
+    ).toBeUndefined();
+    await model.close();
   });
 
   it.each([


### PR DESCRIPTION
This pull request fixes redacted Responses tracing so `response_id` is exported only when the request uses the official OpenAI endpoint before dispatch, for the actual HTTP or WebSocket request, and when the ID is recorded.

Custom and proxy endpoints now omit the ID from `enabled_without_data` spans, while full-data tracing and caller-visible response IDs, continuation behavior, usage, errors, and request IDs remain unchanged. The fix also covers the released hosted multi-agent WebSocket transport and adds regression coverage for endpoint mutation, unsuccessful terminal events, and early iterator close.