### PR TITLE
fix(agents-core): prevent duplicate computer screenshots and reconcile aborted computer calls

### DIFF
--- a/.changeset/dedupe-computer-screenshot-and-reconcile-abort.md
+++ b/.changeset/dedupe-computer-screenshot-and-reconcile-abort.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: prevent duplicate screenshot captures for explicit screenshot actions and reconcile aborted computer calls

--- a/packages/agents-core/src/runner/streamReconciliation.ts
+++ b/packages/agents-core/src/runner/streamReconciliation.ts
@@ -28,6 +28,7 @@ export type StreamAbortReconciliationState = {
   pendingFunctionCalls: Map<string, PendingStreamedFunctionCall>;
   pendingShellCalls: Map<string, PendingStreamedToolCall>;
   pendingApplyPatchCalls: Map<string, PendingStreamedToolCall>;
+  pendingComputerCalls: Map<string, PendingStreamedToolCall>;
   pendingProgramCalls: Map<string, string>;
 };
 
@@ -101,6 +102,7 @@ export function createStreamAbortReconciliationState(): StreamAbortReconciliatio
     pendingFunctionCalls: new Map(),
     pendingShellCalls: new Map(),
     pendingApplyPatchCalls: new Map(),
+    pendingComputerCalls: new Map(),
     pendingProgramCalls: new Map(),
   };
 }
@@ -113,6 +115,7 @@ export function recordStreamEventForAbortReconciliation(
     state.pendingFunctionCalls.clear();
     state.pendingShellCalls.clear();
     state.pendingApplyPatchCalls.clear();
+    state.pendingComputerCalls.clear();
     state.pendingProgramCalls.clear();
     state.responseId = event.response.id;
     return;
@@ -196,6 +199,14 @@ export function recordStreamEventForAbortReconciliation(
     return;
   }
 
+  if (item.type === 'computer_call' && typeof item.call_id === 'string') {
+    state.pendingComputerCalls.set(item.call_id, {
+      callId: item.call_id,
+      ...(caller ? { caller } : {}),
+    });
+    return;
+  }
+
   if (
     item.type === 'function_call_output' &&
     typeof item.call_id === 'string'
@@ -214,6 +225,14 @@ export function recordStreamEventForAbortReconciliation(
     typeof item.call_id === 'string'
   ) {
     state.pendingApplyPatchCalls.delete(item.call_id);
+    return;
+  }
+
+  if (
+    item.type === 'computer_call_output' &&
+    typeof item.call_id === 'string'
+  ) {
+    state.pendingComputerCalls.delete(item.call_id);
   }
 }
 
@@ -223,6 +242,7 @@ export function buildAbortReconciliationInput(
   | FunctionCallResultItem
   | ShellCallResultItem
   | ApplyPatchCallResultItem
+  | ComputerCallResultItem
   | ProgramCallResultItem
 )[] {
   const functionOutputs = Array.from(
@@ -236,6 +256,10 @@ export function buildAbortReconciliationInput(
   const applyPatchOutputs = Array.from(
     state.pendingApplyPatchCalls.values(),
     buildApplyPatchAbortResult,
+  );
+  const computerOutputs = Array.from(
+    state.pendingComputerCalls.values(),
+    buildComputerAbortResult,
   );
   const programOutputs = Array.from(
     state.pendingProgramCalls,
@@ -252,6 +276,7 @@ export function buildAbortReconciliationInput(
     ...functionOutputs,
     ...shellOutputs,
     ...applyPatchOutputs,
+    ...computerOutputs,
     ...programOutputs,
   ];
 }
@@ -273,7 +298,8 @@ export function shouldReconcileStreamAbort(
     state.pendingFunctionCalls.size > 0 ||
     state.pendingProgramCalls.size > 0 ||
     state.pendingShellCalls.size > 0 ||
-    state.pendingApplyPatchCalls.size > 0
+    state.pendingApplyPatchCalls.size > 0 ||
+    state.pendingComputerCalls.size > 0
   );
 }
 
@@ -284,6 +310,7 @@ export function markAbortReconciliationComplete(
   state.pendingFunctionCalls.clear();
   state.pendingShellCalls.clear();
   state.pendingApplyPatchCalls.clear();
+  state.pendingComputerCalls.clear();
   state.pendingProgramCalls.clear();
   if (response?.responseId) {
     state.responseId = response.responseId;

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1520,7 +1520,10 @@ async function _runComputerActionAndScreenshot(
   runContext: RunContext,
   signal?: AbortSignal,
 ): Promise<{ type: 'completed'; output: string } | { type: 'cancelled' }> {
-  for (const action of getComputerToolActions(toolCall)) {
+  const actions = getComputerToolActions(toolCall);
+  let lastScreenshot: string | undefined;
+
+  for (const action of actions) {
     if (signal?.aborted) {
       return { type: 'cancelled' };
     }
@@ -1544,7 +1547,7 @@ async function _runComputerActionAndScreenshot(
         await computer.move(action.x, action.y, runContext);
         break;
       case 'screenshot':
-        await computer.screenshot(runContext);
+        lastScreenshot = await computer.screenshot(runContext);
         break;
       case 'scroll':
         await computer.scroll(
@@ -1573,6 +1576,12 @@ async function _runComputerActionAndScreenshot(
   if (signal?.aborted) {
     return { type: 'cancelled' };
   }
+
+  // If the last action was an explicit screenshot, reuse its result rather than capturing twice
+  if (actions.length > 0 && actions[actions.length - 1].type === 'screenshot' && typeof lastScreenshot !== 'undefined') {
+    return { type: 'completed', output: lastScreenshot };
+  }
+
   if (typeof computer.screenshot === 'function') {
     const screenshot = await computer.screenshot(runContext);
     if (signal?.aborted) {

--- a/packages/agents-core/test/runner/streamReconciliation.test.ts
+++ b/packages/agents-core/test/runner/streamReconciliation.test.ts
@@ -265,4 +265,51 @@ describe('stream abort reconciliation', () => {
     expect(shouldReconcileStreamAbort(state)).toBe(false);
     expect(buildAbortReconciliationInput(state)).toEqual([]);
   });
+
+  it('tracks pending computer calls and reconciles with fallback screenshot on abort (Issue #1737)', () => {
+    const state = createStreamAbortReconciliationState();
+
+    recordStreamEventForAbortReconciliation(state, {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'computer_call',
+          id: 'comp_1',
+          call_id: 'call_comp_1',
+          status: 'completed',
+          action: { type: 'screenshot' },
+        },
+      },
+    });
+
+    expect(shouldReconcileStreamAbort(state)).toBe(true);
+    expect(buildAbortReconciliationInput(state)).toEqual([
+      {
+        type: 'computer_call_result',
+        callId: 'call_comp_1',
+        output: {
+          type: 'computer_screenshot',
+          data: expect.stringMatching(/^data:image\/png;base64,/),
+        },
+        providerData: { status: 'incomplete' },
+      },
+    ]);
+
+    // Output clears pending computer call
+    recordStreamEventForAbortReconciliation(state, {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'computer_call_output',
+          id: 'comp_out_1',
+          call_id: 'call_comp_1',
+        },
+      },
+    });
+
+    expect(shouldReconcileStreamAbort(state)).toBe(false);
+    expect(buildAbortReconciliationInput(state)).toEqual([]);
+  });
 });

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -988,7 +988,7 @@ describe('AgentToolUseTracker', () => {
 });
 
 describe('executeComputerActions', () => {
-  it('runs action and returns screenshot output', async () => {
+  it('runs action and returns screenshot output without duplicate capture on explicit screenshot (Issue #1735)', async () => {
     setDefaultModelProvider(new ScriptedModelProvider());
     const fakeComputer = {
       environment: 'mac',
@@ -1019,6 +1019,7 @@ describe('executeComputerActions', () => {
     );
     expect(items).toHaveLength(1);
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('does not start an action after cancellation', async () => {
@@ -2034,7 +2035,7 @@ describe('executeComputerActions', () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]).toBeInstanceOf(ToolCallOutputItem);
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('passes RunContext to computer actions', async () => {
@@ -2248,7 +2249,7 @@ describe('executeComputerActions', () => {
     expect(items).toHaveLength(1);
     expect(items[0]).toBeInstanceOf(ToolCallOutputItem);
     expect(needsApproval).not.toHaveBeenCalled();
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

1. **Avoids duplicate screenshot capture on explicit screenshot actions (Fixes #1735)**: In `_runComputerActionAndScreenshot()`, when the last action in a `computer_call` is an explicit `screenshot` action, the runner now reuses its captured screenshot rather than capturing twice unconditionally.
2. **Tracks pending computer calls in streamed abort reconciliation (Fixes #1737)**: `recordStreamEventForAbortReconciliation()` now tracks pending `computer_call` items, and `buildAbortReconciliationInput()` synthesizes a completed/fallback `computer_call_result` using `buildComputerAbortResult()` on cancellation.

---

## Changes

- **`packages/agents-core/src/runner/toolExecution.ts`**:
  - Reuses explicit screenshot result from `computer.screenshot()` if `action.type === 'screenshot'`.
- **`packages/agents-core/src/runner/streamReconciliation.ts`**:
  - Added `pendingComputerCalls: Map<string, PendingStreamedToolCall>` to `StreamAbortReconciliationState`.
  - Included `computer_call` event tracking and abort result synthesis.
- **`packages/agents-core/test/runner/streamReconciliation.test.ts`**:
  - Added unit test verifying pending `computer_call` abort reconciliation and fallback screenshot synthesis.
- **`packages/agents-core/test/runner/toolExecution.test.ts`**:
  - Updated assertions confirming `fakeComputer.screenshot` is invoked exactly once for explicit screenshot action calls.

---

## Verification

- `pnpm exec vitest run packages/agents-core/test/runner/streamReconciliation.test.ts packages/agents-core/test/runner/toolExecution.test.ts` passed: 267/267 tests passing.
