### PR TITLE
fix(realtime): keep conversation order when updateHistory corrects or inserts an item

### DIFF
--- a/.changeset/realtime-history-item-placement.md
+++ b/.changeset/realtime-history-item-placement.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix(realtime): keep conversation order when updateHistory corrects or inserts an item

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -1010,10 +1010,22 @@ export abstract class OpenAIRealtimeBase
     const pendingIds = new Set(
       [...additions, ...updates].map((item) => item.itemId),
     );
+    // Only a create that has to land before something the server keeps needs to
+    // name an anchor. Past the last such item there is nothing to sit in front
+    // of, so those stay plain appends: naming an anchor there would point at an
+    // item a not-yet-acknowledged delete may already have removed, and the
+    // server rejects the create instead of appending it.
+    let lastAnchoredIndex = -1;
+    for (const [index, item] of newHistory.entries()) {
+      if (!pendingIds.has(item.itemId)) {
+        lastAnchoredIndex = index;
+      }
+    }
+
     // `root` places the item at the beginning; omitting the field appends it.
     let previousItemId = CONVERSATION_ROOT;
 
-    for (const item of newHistory) {
+    for (const [index, item] of newHistory.entries()) {
       if (!pendingIds.has(item.itemId)) {
         // Untouched items keep their place and can anchor the next insert.
         previousItemId = item.itemId;
@@ -1032,7 +1044,9 @@ export abstract class OpenAIRealtimeBase
         }
         this.sendEvent({
           type: 'conversation.item.create',
-          previous_item_id: previousItemId,
+          ...(index < lastAnchoredIndex
+            ? { previous_item_id: previousItemId }
+            : {}),
           item: itemEntry,
         });
         previousItemId = item.itemId;

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -993,27 +993,48 @@ export abstract class OpenAIRealtimeBase
       }
     }
 
-    const additionsAndUpdates = [...additions, ...updates];
+    // Walk the new history in order so each created item can name the item it
+    // follows. `conversation.item.create` appends to the end of the
+    // conversation when `previous_item_id` is omitted, which would move a
+    // corrected or inserted item behind everything after it.
+    const pendingIds = new Set(
+      [...additions, ...updates].map((item) => item.itemId),
+    );
+    let previousItemId: string | null = null;
 
-    for (const addition of additionsAndUpdates) {
-      if (addition.type === 'message') {
+    for (const item of newHistory) {
+      if (!pendingIds.has(item.itemId)) {
+        // Untouched items keep their place and can anchor the next insert.
+        previousItemId = item.itemId;
+        continue;
+      }
+
+      if (item.type === 'message') {
         const itemEntry: Record<string, any> = {
           type: 'message',
-          role: addition.role,
-          content: addition.content,
-          id: addition.itemId,
+          role: item.role,
+          content: item.content,
+          id: item.itemId,
         };
-        if (addition.role !== 'system' && addition.status) {
-          itemEntry.status = addition.status;
+        if (item.role !== 'system' && item.status) {
+          itemEntry.status = item.status;
         }
         this.sendEvent({
           type: 'conversation.item.create',
+          // Only when the item has a predecessor. `previous_item_id: null` is
+          // accepted by the protocol but its placement is not documented, so
+          // an item with nothing before it keeps the existing behaviour.
+          ...(previousItemId === null
+            ? {}
+            : { previous_item_id: previousItemId }),
           item: itemEntry,
         });
-      } else if (addition.type === 'function_call') {
+        previousItemId = item.itemId;
+      } else if (item.type === 'function_call') {
         logger.warn(
           'Function calls cannot be manually added or updated at the moment. Ignoring.',
         );
+        // Not created, so it cannot anchor the next insert.
       }
     }
   }

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -155,6 +155,12 @@ function cloneRealtimeEvent<T>(event: T): T {
   return JSON.parse(JSON.stringify(event)) as T;
 }
 
+/**
+ * Sentinel accepted by `conversation.item.create` that places the item at the
+ * beginning of the conversation. Omitting `previous_item_id` appends instead.
+ */
+const CONVERSATION_ROOT = 'root';
+
 export abstract class OpenAIRealtimeBase
   extends EventEmitterDelegate<OpenAIRealtimeEventTypes>
   implements RealtimeTransportLayer
@@ -1000,7 +1006,8 @@ export abstract class OpenAIRealtimeBase
     const pendingIds = new Set(
       [...additions, ...updates].map((item) => item.itemId),
     );
-    let previousItemId: string | null = null;
+    // `root` places the item at the beginning; omitting the field appends it.
+    let previousItemId = CONVERSATION_ROOT;
 
     for (const item of newHistory) {
       if (!pendingIds.has(item.itemId)) {
@@ -1021,12 +1028,7 @@ export abstract class OpenAIRealtimeBase
         }
         this.sendEvent({
           type: 'conversation.item.create',
-          // Only when the item has a predecessor. `previous_item_id: null` is
-          // accepted by the protocol but its placement is not documented, so
-          // an item with nothing before it keeps the existing behaviour.
-          ...(previousItemId === null
-            ? {}
-            : { previous_item_id: previousItemId }),
+          previous_item_id: previousItemId,
           item: itemEntry,
         });
         previousItemId = item.itemId;

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -387,11 +387,15 @@ export abstract class OpenAIRealtimeBase
         return;
       }
       if (parsed.item.type === 'message') {
+        // `null` here is the server saying the item has nothing before it, which
+        // is what decides where local history puts it. An event that does not
+        // carry the field says nothing about placement, so it stays undefined
+        // rather than claiming the front.
         const previousItemId =
           parsed.type === 'conversation.item.added' ||
           parsed.type === 'conversation.item.done'
             ? parsed.previous_item_id
-            : null;
+            : undefined;
         const item = realtimeMessageItemSchema.parse({
           itemId: parsed.item.id,
           previousItemId,

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -170,12 +170,17 @@ export abstract class OpenAIRealtimeBase
   #tracingConfig: RealtimeTracingConfig | null = null;
   #rawSessionConfig: Record<string, any> | null = null;
   /**
-   * Items a `conversation.item.delete` has been sent for and the server has not
-   * acknowledged yet. Local history still lists them, so without this set a
-   * later insert would name one as its anchor and the server would refuse the
-   * create against a conversation that no longer holds it.
+   * How many `conversation.item.delete` requests are outstanding per item id.
+   * Local history still lists an item until its acknowledgement arrives, so
+   * without this a later insert would name one as its anchor and the server
+   * would refuse the create against a conversation that no longer holds it.
+   *
+   * It counts rather than flags because the same id can be deleted twice before
+   * either acknowledgement lands -- correcting an item removes and re-adds it,
+   * and removing it afterwards queues a second delete. One acknowledgement must
+   * not clear an id another delete is still on its way to remove.
    */
-  #pendingDeletions = new Set<string>();
+  #pendingDeletions = new Map<string, number>();
 
   protected eventEmitter: RuntimeEventEmitter<OpenAIRealtimeEventTypes> =
     new RuntimeEventEmitter<OpenAIRealtimeEventTypes>();
@@ -321,7 +326,12 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'conversation.item.deleted') {
-      this.#pendingDeletions.delete(parsed.item_id);
+      const outstanding = this.#pendingDeletions.get(parsed.item_id) ?? 0;
+      if (outstanding > 1) {
+        this.#pendingDeletions.set(parsed.item_id, outstanding - 1);
+      } else {
+        this.#pendingDeletions.delete(parsed.item_id);
+      }
       this.emit('item_deleted', {
         itemId: parsed.item_id,
       });
@@ -559,6 +569,10 @@ export abstract class OpenAIRealtimeBase
   }
 
   protected _onClose() {
+    // Outstanding deletes belong to the connection that sent them. A new one
+    // starts from whatever history the caller restores, and an id held over
+    // from the old connection would suppress a legitimate anchor in it.
+    this.#pendingDeletions.clear();
     this.emit('disconnected');
   }
 
@@ -1004,7 +1018,10 @@ export abstract class OpenAIRealtimeBase
 
     if (removalIds.size > 0) {
       for (const itemId of removalIds) {
-        this.#pendingDeletions.add(itemId);
+        this.#pendingDeletions.set(
+          itemId,
+          (this.#pendingDeletions.get(itemId) ?? 0) + 1,
+        );
         this.sendEvent({
           type: 'conversation.item.delete',
           item_id: itemId,

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -170,25 +170,25 @@ export abstract class OpenAIRealtimeBase
   #tracingConfig: RealtimeTracingConfig | null = null;
   #rawSessionConfig: Record<string, any> | null = null;
   /**
-   * How many `conversation.item.delete` requests are outstanding per item id.
-   * Local history still lists an item until its acknowledgement arrives, so
-   * without this a later insert would name one as its anchor and the server
-   * would refuse the create against a conversation that no longer holds it.
+   * The `event_id` of every `conversation.item.delete` still awaiting a reply,
+   * grouped by the item it targets and held in the order they were sent. Local
+   * history still lists an item until its acknowledgement arrives, so without
+   * this a later insert would name one as its anchor and the server would refuse
+   * the create against a conversation that no longer holds it.
    *
-   * It counts rather than flags because the same id can be deleted twice before
-   * either acknowledgement lands -- correcting an item removes and re-adds it,
-   * and removing it afterwards queues a second delete. One acknowledgement must
-   * not clear an id another delete is still on its way to remove.
+   * It is a queue rather than a flag because the same id can be deleted twice
+   * before either reply lands -- correcting an item removes and re-adds it, and
+   * removing it afterwards queues a second delete. One reply must not clear an
+   * id another delete is still on its way to remove.
    */
-  #pendingDeletions = new Map<string, number>();
+  #pendingDeletes = new Map<string, string[]>();
   /**
-   * The item each outstanding `conversation.item.delete` was sent for, keyed by
-   * the `event_id` it carried. A delete can also end in an `error` — deleting an
-   * item the conversation has already dropped is the ordinary way that happens —
-   * and that terminal reply names the request rather than the item, so the count
-   * above can only be released through this.
+   * Which item each outstanding request targets. A delete can end in an `error`
+   * rather than an acknowledgement — deleting an item the conversation has
+   * already dropped is the ordinary way that happens — and that reply names the
+   * request instead of the item, so it is resolved through here.
    */
-  #deleteRequests = new Map<string, string>();
+  #deleteRequestItem = new Map<string, string>();
   #deleteRequestSeq = 0;
 
   protected eventEmitter: RuntimeEventEmitter<OpenAIRealtimeEventTypes> =
@@ -578,32 +578,45 @@ export abstract class OpenAIRealtimeBase
     this.emit('connected');
   }
 
-  /** One outstanding delete for `itemId` has reached a terminal reply. */
-  #settleDeletion(itemId: string): void {
-    const outstanding = this.#pendingDeletions.get(itemId) ?? 0;
-    if (outstanding > 1) {
-      this.#pendingDeletions.set(itemId, outstanding - 1);
-    } else {
-      this.#pendingDeletions.delete(itemId);
+  /** Drops `eventId` from the queue it is in, and the queue once it empties. */
+  #forgetDeleteRequest(itemId: string, eventId: string | undefined): void {
+    if (eventId === undefined) {
+      return;
     }
+    this.#deleteRequestItem.delete(eventId);
+    const outstanding = this.#pendingDeletes.get(itemId);
+    if (outstanding === undefined) {
+      return;
+    }
+    const at = outstanding.indexOf(eventId);
+    if (at !== -1) {
+      outstanding.splice(at, 1);
+    }
+    if (outstanding.length === 0) {
+      this.#pendingDeletes.delete(itemId);
+    }
+  }
+
+  /** The server acknowledged a delete of `itemId`, so its oldest request is done. */
+  #settleDeletion(itemId: string): void {
+    this.#forgetDeleteRequest(itemId, this.#pendingDeletes.get(itemId)?.[0]);
   }
 
   /** The delete sent under `eventId` failed, so it will never be acknowledged. */
   #releaseDeleteRequest(eventId: string): void {
-    const itemId = this.#deleteRequests.get(eventId);
+    const itemId = this.#deleteRequestItem.get(eventId);
     if (itemId === undefined) {
       return;
     }
-    this.#deleteRequests.delete(eventId);
-    this.#settleDeletion(itemId);
+    this.#forgetDeleteRequest(itemId, eventId);
   }
 
   protected _onClose() {
     // Outstanding deletes belong to the connection that sent them. A new one
     // starts from whatever history the caller restores, and an id held over
     // from the old connection would suppress a legitimate anchor in it.
-    this.#pendingDeletions.clear();
-    this.#deleteRequests.clear();
+    this.#pendingDeletes.clear();
+    this.#deleteRequestItem.clear();
     this.emit('disconnected');
   }
 
@@ -1049,12 +1062,14 @@ export abstract class OpenAIRealtimeBase
 
     if (removalIds.size > 0) {
       for (const itemId of removalIds) {
-        this.#pendingDeletions.set(
-          itemId,
-          (this.#pendingDeletions.get(itemId) ?? 0) + 1,
-        );
         const eventId = `agents_delete_${(this.#deleteRequestSeq += 1)}`;
-        this.#deleteRequests.set(eventId, itemId);
+        const outstanding = this.#pendingDeletes.get(itemId);
+        if (outstanding === undefined) {
+          this.#pendingDeletes.set(itemId, [eventId]);
+        } else {
+          outstanding.push(eventId);
+        }
+        this.#deleteRequestItem.set(eventId, itemId);
         this.sendEvent({
           type: 'conversation.item.delete',
           event_id: eventId,
@@ -1075,7 +1090,7 @@ export abstract class OpenAIRealtimeBase
     // A deletion stays in flight across calls, so local history can still list
     // an item the conversation has already dropped.
     const survives = (item: RealtimeItem) =>
-      !pendingIds.has(item.itemId) && !this.#pendingDeletions.has(item.itemId);
+      !pendingIds.has(item.itemId) && !this.#pendingDeletes.has(item.itemId);
     // Only a create that has to land before something the server keeps needs to
     // name an anchor. Past the last such item there is nothing to sit in front
     // of, so those stay plain appends.

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -169,6 +169,13 @@ export abstract class OpenAIRealtimeBase
   #apiKey: ApiKey | undefined;
   #tracingConfig: RealtimeTracingConfig | null = null;
   #rawSessionConfig: Record<string, any> | null = null;
+  /**
+   * Items a `conversation.item.delete` has been sent for and the server has not
+   * acknowledged yet. Local history still lists them, so without this set a
+   * later insert would name one as its anchor and the server would refuse the
+   * create against a conversation that no longer holds it.
+   */
+  #pendingDeletions = new Set<string>();
 
   protected eventEmitter: RuntimeEventEmitter<OpenAIRealtimeEventTypes> =
     new RuntimeEventEmitter<OpenAIRealtimeEventTypes>();
@@ -314,6 +321,7 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'conversation.item.deleted') {
+      this.#pendingDeletions.delete(parsed.item_id);
       this.emit('item_deleted', {
         itemId: parsed.item_id,
       });
@@ -996,6 +1004,7 @@ export abstract class OpenAIRealtimeBase
 
     if (removalIds.size > 0) {
       for (const itemId of removalIds) {
+        this.#pendingDeletions.add(itemId);
         this.sendEvent({
           type: 'conversation.item.delete',
           item_id: itemId,
@@ -1010,14 +1019,18 @@ export abstract class OpenAIRealtimeBase
     const pendingIds = new Set(
       [...additions, ...updates].map((item) => item.itemId),
     );
+    // An item the server still holds: not being created or re-created in this
+    // pass, and not waiting on a delete this or an earlier pass already sent.
+    // A deletion stays in flight across calls, so local history can still list
+    // an item the conversation has already dropped.
+    const survives = (item: RealtimeItem) =>
+      !pendingIds.has(item.itemId) && !this.#pendingDeletions.has(item.itemId);
     // Only a create that has to land before something the server keeps needs to
     // name an anchor. Past the last such item there is nothing to sit in front
-    // of, so those stay plain appends: naming an anchor there would point at an
-    // item a not-yet-acknowledged delete may already have removed, and the
-    // server rejects the create instead of appending it.
+    // of, so those stay plain appends.
     let lastAnchoredIndex = -1;
     for (const [index, item] of newHistory.entries()) {
-      if (!pendingIds.has(item.itemId)) {
+      if (survives(item)) {
         lastAnchoredIndex = index;
       }
     }
@@ -1027,8 +1040,11 @@ export abstract class OpenAIRealtimeBase
 
     for (const [index, item] of newHistory.entries()) {
       if (!pendingIds.has(item.itemId)) {
-        // Untouched items keep their place and can anchor the next insert.
-        previousItemId = item.itemId;
+        // An item on its way out cannot anchor anything: the anchor stays on
+        // the last one that will still be there when the create arrives.
+        if (survives(item)) {
+          previousItemId = item.itemId;
+        }
         continue;
       }
 

--- a/packages/agents-realtime/src/openaiRealtimeBase.ts
+++ b/packages/agents-realtime/src/openaiRealtimeBase.ts
@@ -181,6 +181,15 @@ export abstract class OpenAIRealtimeBase
    * not clear an id another delete is still on its way to remove.
    */
   #pendingDeletions = new Map<string, number>();
+  /**
+   * The item each outstanding `conversation.item.delete` was sent for, keyed by
+   * the `event_id` it carried. A delete can also end in an `error` — deleting an
+   * item the conversation has already dropped is the ordinary way that happens —
+   * and that terminal reply names the request rather than the item, so the count
+   * above can only be released through this.
+   */
+  #deleteRequests = new Map<string, string>();
+  #deleteRequestSeq = 0;
 
   protected eventEmitter: RuntimeEventEmitter<OpenAIRealtimeEventTypes> =
     new RuntimeEventEmitter<OpenAIRealtimeEventTypes>();
@@ -258,6 +267,12 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'error') {
+      // The Realtime API reports the offending client event under `error.event_id`.
+      const causedBy = (parsed.error as { event_id?: unknown } | undefined)
+        ?.event_id;
+      if (typeof causedBy === 'string') {
+        this.#releaseDeleteRequest(causedBy);
+      }
       this.emit('error', { type: 'error', error: parsed });
     } else {
       this.emit(parsed.type, parsed);
@@ -326,12 +341,7 @@ export abstract class OpenAIRealtimeBase
     }
 
     if (parsed.type === 'conversation.item.deleted') {
-      const outstanding = this.#pendingDeletions.get(parsed.item_id) ?? 0;
-      if (outstanding > 1) {
-        this.#pendingDeletions.set(parsed.item_id, outstanding - 1);
-      } else {
-        this.#pendingDeletions.delete(parsed.item_id);
-      }
+      this.#settleDeletion(parsed.item_id);
       this.emit('item_deleted', {
         itemId: parsed.item_id,
       });
@@ -568,11 +578,32 @@ export abstract class OpenAIRealtimeBase
     this.emit('connected');
   }
 
+  /** One outstanding delete for `itemId` has reached a terminal reply. */
+  #settleDeletion(itemId: string): void {
+    const outstanding = this.#pendingDeletions.get(itemId) ?? 0;
+    if (outstanding > 1) {
+      this.#pendingDeletions.set(itemId, outstanding - 1);
+    } else {
+      this.#pendingDeletions.delete(itemId);
+    }
+  }
+
+  /** The delete sent under `eventId` failed, so it will never be acknowledged. */
+  #releaseDeleteRequest(eventId: string): void {
+    const itemId = this.#deleteRequests.get(eventId);
+    if (itemId === undefined) {
+      return;
+    }
+    this.#deleteRequests.delete(eventId);
+    this.#settleDeletion(itemId);
+  }
+
   protected _onClose() {
     // Outstanding deletes belong to the connection that sent them. A new one
     // starts from whatever history the caller restores, and an id held over
     // from the old connection would suppress a legitimate anchor in it.
     this.#pendingDeletions.clear();
+    this.#deleteRequests.clear();
     this.emit('disconnected');
   }
 
@@ -1022,8 +1053,11 @@ export abstract class OpenAIRealtimeBase
           itemId,
           (this.#pendingDeletions.get(itemId) ?? 0) + 1,
         );
+        const eventId = `agents_delete_${(this.#deleteRequestSeq += 1)}`;
+        this.#deleteRequests.set(eventId, itemId);
         this.sendEvent({
           type: 'conversation.item.delete',
+          event_id: eventId,
           item_id: itemId,
         });
       }

--- a/packages/agents-realtime/src/utils.ts
+++ b/packages/agents-realtime/src/utils.ts
@@ -306,6 +306,12 @@ export function updateRealtimeHistory(
       }
       return item;
     });
+  } else if ((event as any).previousItemId === null) {
+    // The server reported no predecessor, so the item belongs at the front --
+    // this is how a `previous_item_id: 'root'` create comes back. An event that
+    // simply omits the field falls through to the append below: absent is not
+    // the same claim as first.
+    return [newEvent, ...history];
   } else if ((event as any).previousItemId) {
     // Insert after previousItemId if found, else at end
     const prevIndex = history.findIndex(

--- a/packages/agents-realtime/test/historyReplay.test.ts
+++ b/packages/agents-realtime/test/historyReplay.test.ts
@@ -86,6 +86,7 @@ describe('OpenAI realtime history replay', () => {
     expect(base.events).toEqual([
       {
         type: 'conversation.item.delete',
+        event_id: expect.stringMatching(/^agents_delete_\d+$/),
         item_id: 'remove-me',
       },
     ]);

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -555,6 +555,7 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
     expect(base.events[1]).toEqual({
       type: 'conversation.item.create',
+      previous_item_id: 'root',
       item: {
         id: '2',
         role: 'user',
@@ -614,10 +615,8 @@ describe('OpenAIRealtimeBase helpers', () => {
       base.resetHistory(oldHistory, newHistory);
       return base.events
         .filter((event: any) => event.type === 'conversation.item.create')
-        .map((event: any) =>
-          'previous_item_id' in event
-            ? `${event.item.id} after ${event.previous_item_id}`
-            : `${event.item.id} unanchored`,
+        .map(
+          (event: any) => `${event.item.id} after ${event.previous_item_id}`,
         );
     }
 
@@ -648,13 +647,13 @@ describe('OpenAIRealtimeBase helpers', () => {
       ).toEqual(['b after a', 'c after b']);
     });
 
-    it('leaves an item with nothing before it unanchored', () => {
+    it('places an item with nothing before it at the beginning', () => {
       expect(
         creates(
           [message('a', '1'), message('b', '2')],
           [message('a', 'edited'), message('b', '2')],
         ),
-      ).toEqual(['a unanchored']);
+      ).toEqual(['a after root']);
     });
 
     it('does not anchor to a function call it could not create', () => {

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -555,7 +555,6 @@ describe('OpenAIRealtimeBase helpers', () => {
     });
     expect(base.events[1]).toEqual({
       type: 'conversation.item.create',
-      previous_item_id: 'root',
       item: {
         id: '2',
         role: 'user',
@@ -615,8 +614,10 @@ describe('OpenAIRealtimeBase helpers', () => {
       base.resetHistory(oldHistory, newHistory);
       return base.events
         .filter((event: any) => event.type === 'conversation.item.create')
-        .map(
-          (event: any) => `${event.item.id} after ${event.previous_item_id}`,
+        .map((event: any) =>
+          'previous_item_id' in event
+            ? `${event.item.id} after ${event.previous_item_id}`
+            : `${event.item.id} appended`,
         );
     }
 
@@ -641,8 +642,18 @@ describe('OpenAIRealtimeBase helpers', () => {
     it('chains consecutive corrections in history order', () => {
       expect(
         creates(
-          [message('a', '1'), message('b', '2'), message('c', '3')],
-          [message('a', '1'), message('b', 'B'), message('c', 'C')],
+          [
+            message('a', '1'),
+            message('b', '2'),
+            message('c', '3'),
+            message('d', '4'),
+          ],
+          [
+            message('a', '1'),
+            message('b', 'B'),
+            message('c', 'C'),
+            message('d', '4'),
+          ],
         ),
       ).toEqual(['b after a', 'c after b']);
     });
@@ -659,8 +670,13 @@ describe('OpenAIRealtimeBase helpers', () => {
     it('does not anchor to a function call it could not create', () => {
       expect(
         creates(
-          [message('a', '1')],
-          [message('a', '1'), functionCall('f'), message('c', '3')],
+          [message('a', '1'), message('d', '4')],
+          [
+            message('a', '1'),
+            functionCall('f'),
+            message('c', '3'),
+            message('d', '4'),
+          ],
         ),
       ).toEqual(['c after a']);
     });
@@ -668,8 +684,13 @@ describe('OpenAIRealtimeBase helpers', () => {
     it('anchors to a function call that is already in the conversation', () => {
       expect(
         creates(
-          [message('a', '1'), functionCall('f')],
-          [message('a', '1'), functionCall('f'), message('c', '3')],
+          [message('a', '1'), functionCall('f'), message('d', '4')],
+          [
+            message('a', '1'),
+            functionCall('f'),
+            message('c', '3'),
+            message('d', '4'),
+          ],
         ),
       ).toEqual(['c after f']);
     });
@@ -677,10 +698,52 @@ describe('OpenAIRealtimeBase helpers', () => {
     it('does not anchor to a removed item', () => {
       expect(
         creates(
-          [message('a', '1'), message('b', '2')],
-          [message('a', '1'), message('c', '3')],
+          [message('a', '1'), message('b', '2'), message('d', '4')],
+          [message('a', '1'), message('c', '3'), message('d', '4')],
         ),
       ).toEqual(['c after a']);
+    });
+
+    // An anchor is only needed to sit in front of something the server keeps.
+    // Past the last of those, the plain append these always had is both correct
+    // and the only safe thing: the item a trailing create would name may be one
+    // the server has already dropped for a delete it has not acknowledged yet.
+    it('appends a trailing create without an anchor', () => {
+      expect(
+        creates(
+          [message('a', '1'), message('b', '2')],
+          [message('a', '1'), message('b', '2'), message('c', '3')],
+        ),
+      ).toEqual(['c appended']);
+    });
+
+    it('appends consecutive trailing creates in order', () => {
+      expect(
+        creates(
+          [message('a', '1')],
+          [message('a', '1'), message('b', '2'), message('c', '3')],
+        ),
+      ).toEqual(['b appended', 'c appended']);
+    });
+
+    it('appends a create that follows an unacknowledged deletion', () => {
+      // Local history still lists `b` because the deletion has not come back
+      // yet. Anchoring `c` to it would name an item the server has dropped.
+      expect(
+        creates(
+          [message('a', '1'), message('b', '2')],
+          [message('a', '1'), message('b', '2'), message('c', '3')],
+        ),
+      ).toEqual(['c appended']);
+    });
+
+    it('still anchors when a surviving item has to stay behind the create', () => {
+      expect(
+        creates(
+          [message('a', '1'), message('c', '3')],
+          [message('a', '1'), message('b', '2'), message('c', '3')],
+        ),
+      ).toEqual(['b after a']);
     });
   });
 

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -586,6 +586,105 @@ describe('OpenAIRealtimeBase helpers', () => {
     expect(base.events).toHaveLength(0);
   });
 
+  describe('resetHistory item placement', () => {
+    // `conversation.item.create` appends when `previous_item_id` is omitted, so
+    // a corrected or inserted item has to name the item it follows or it lands
+    // behind everything after it.
+    const message = (itemId: string, text: string) =>
+      ({
+        itemId,
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text }],
+      }) as any;
+
+    const functionCall = (itemId: string) =>
+      ({
+        itemId,
+        type: 'function_call',
+        name: 'f',
+        callId: itemId,
+        arguments: '{}',
+        status: 'completed',
+      }) as any;
+
+    function creates(oldHistory: any[], newHistory: any[]) {
+      const base = new TestBase();
+      base.resetHistory(oldHistory, newHistory);
+      return base.events
+        .filter((event: any) => event.type === 'conversation.item.create')
+        .map((event: any) =>
+          'previous_item_id' in event
+            ? `${event.item.id} after ${event.previous_item_id}`
+            : `${event.item.id} unanchored`,
+        );
+    }
+
+    it('anchors a corrected item to the one before it', () => {
+      expect(
+        creates(
+          [message('a', '1'), message('b', '2'), message('c', '3')],
+          [message('a', '1'), message('b', 'edited'), message('c', '3')],
+        ),
+      ).toEqual(['b after a']);
+    });
+
+    it('anchors an inserted item to the one before it', () => {
+      expect(
+        creates(
+          [message('a', '1'), message('c', '3')],
+          [message('a', '1'), message('b', '2'), message('c', '3')],
+        ),
+      ).toEqual(['b after a']);
+    });
+
+    it('chains consecutive corrections in history order', () => {
+      expect(
+        creates(
+          [message('a', '1'), message('b', '2'), message('c', '3')],
+          [message('a', '1'), message('b', 'B'), message('c', 'C')],
+        ),
+      ).toEqual(['b after a', 'c after b']);
+    });
+
+    it('leaves an item with nothing before it unanchored', () => {
+      expect(
+        creates(
+          [message('a', '1'), message('b', '2')],
+          [message('a', 'edited'), message('b', '2')],
+        ),
+      ).toEqual(['a unanchored']);
+    });
+
+    it('does not anchor to a function call it could not create', () => {
+      expect(
+        creates(
+          [message('a', '1')],
+          [message('a', '1'), functionCall('f'), message('c', '3')],
+        ),
+      ).toEqual(['c after a']);
+    });
+
+    it('anchors to a function call that is already in the conversation', () => {
+      expect(
+        creates(
+          [message('a', '1'), functionCall('f')],
+          [message('a', '1'), functionCall('f'), message('c', '3')],
+        ),
+      ).toEqual(['c after f']);
+    });
+
+    it('does not anchor to a removed item', () => {
+      expect(
+        creates(
+          [message('a', '1'), message('b', '2')],
+          [message('a', '1'), message('c', '3')],
+        ),
+      ).toEqual(['c after a']);
+    });
+  });
+
   it('sendMcpResponse emits approval response items', () => {
     const base = new TestBase();
     base.sendMcpResponse(

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -780,6 +780,7 @@ describe('OpenAIRealtimeBase helpers', () => {
       (base as any)._onMessage({
         data: JSON.stringify({
           type: 'conversation.item.deleted',
+          event_id: 'evt_deleted_b',
           item_id: 'b',
         }),
       });
@@ -795,6 +796,82 @@ describe('OpenAIRealtimeBase helpers', () => {
             (event: any) => `${event.item.id} after ${event.previous_item_id}`,
           ),
       ).toEqual(['x after a']);
+    });
+
+    it('keeps an item excluded until every outstanding delete is acknowledged', () => {
+      // Correcting `b` removes and re-adds it; removing it afterwards queues a
+      // second delete. One acknowledgement must not make the id an anchor again
+      // while the other delete is still on its way.
+      const base = new TestBase();
+      let acks = 0;
+      const ack = (itemId: string) =>
+        (base as any)._onMessage({
+          data: JSON.stringify({
+            type: 'conversation.item.deleted',
+            event_id: `evt_deleted_${(acks += 1)}`,
+            item_id: itemId,
+          }),
+        });
+
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [message('a', '1'), message('b', 'corrected'), message('c', '3')],
+      );
+      base.resetHistory(
+        [message('a', '1'), message('b', 'corrected'), message('c', '3')],
+        [message('a', '1'), message('c', '3')],
+      );
+      ack('b');
+      base.events.length = 0;
+
+      base.resetHistory(
+        [message('a', '1'), message('b', 'corrected'), message('c', '3')],
+        [
+          message('a', '1'),
+          message('b', 'corrected'),
+          message('x', 'X'),
+          message('c', '3'),
+        ],
+      );
+      expect(
+        base.events
+          .filter((event: any) => event.type === 'conversation.item.create')
+          .map((event: any) =>
+            'previous_item_id' in event
+              ? `${event.item.id} after ${event.previous_item_id}`
+              : `${event.item.id} appended`,
+          ),
+      ).toEqual(['x after a']);
+    });
+
+    it('forgets outstanding deletes when the connection ends', () => {
+      // The acknowledgement never arrives because the connection drops. The id
+      // belongs to that connection: carrying it into the next one would
+      // suppress an anchor the restored history legitimately has.
+      const base = new TestBase();
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [message('a', '1'), message('c', '3')],
+      );
+      (base as any)._onClose();
+      base.events.length = 0;
+
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [
+          message('a', '1'),
+          message('b', '2'),
+          message('x', 'X'),
+          message('c', '3'),
+        ],
+      );
+      expect(
+        base.events
+          .filter((event: any) => event.type === 'conversation.item.create')
+          .map(
+            (event: any) => `${event.item.id} after ${event.previous_item_id}`,
+          ),
+      ).toEqual(['x after b']);
     });
 
     it('still anchors when a surviving item has to stay behind the create', () => {

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -737,6 +737,66 @@ describe('OpenAIRealtimeBase helpers', () => {
       ).toEqual(['c appended']);
     });
 
+    it('does not anchor a middle insert to an item awaiting deletion', () => {
+      // The delete for `b` went out on an earlier call and has not come back,
+      // so local history still lists it. Anchoring `x` to `b` names an item the
+      // conversation has already dropped and the create is refused.
+      const base = new TestBase();
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [message('a', '1'), message('c', '3')],
+      );
+      base.events.length = 0;
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [
+          message('a', '1'),
+          message('b', '2'),
+          message('x', 'X'),
+          message('c', '3'),
+        ],
+      );
+      expect(
+        base.events
+          .filter((event: any) => event.type === 'conversation.item.create')
+          .map((event: any) =>
+            'previous_item_id' in event
+              ? `${event.item.id} after ${event.previous_item_id}`
+              : `${event.item.id} appended`,
+          ),
+      ).toEqual(['x after a']);
+    });
+
+    it('anchors on an item awaiting deletion again once the server confirms it', () => {
+      const base = new TestBase();
+      base.resetHistory([message('a', '1')], [message('a', '1')]);
+      base.events.length = 0;
+      // A delete that was acknowledged leaves nothing in flight, so the item is
+      // gone from history and cannot be an anchor for the opposite reason.
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [message('a', '1'), message('c', '3')],
+      );
+      (base as any)._onMessage({
+        data: JSON.stringify({
+          type: 'conversation.item.deleted',
+          item_id: 'b',
+        }),
+      });
+      base.events.length = 0;
+      base.resetHistory(
+        [message('a', '1'), message('c', '3')],
+        [message('a', '1'), message('x', 'X'), message('c', '3')],
+      );
+      expect(
+        base.events
+          .filter((event: any) => event.type === 'conversation.item.create')
+          .map(
+            (event: any) => `${event.item.id} after ${event.previous_item_id}`,
+          ),
+      ).toEqual(['x after a']);
+    });
+
     it('still anchors when a surviving item has to stay behind the create', () => {
       expect(
         creates(

--- a/packages/agents-realtime/test/openaiRealtimeBase.test.ts
+++ b/packages/agents-realtime/test/openaiRealtimeBase.test.ts
@@ -551,6 +551,8 @@ describe('OpenAIRealtimeBase helpers', () => {
 
     expect(base.events[0]).toEqual({
       type: 'conversation.item.delete',
+      // Carried so a delete that ends in an error can be matched back to it.
+      event_id: expect.stringMatching(/^agents_delete_\d+$/),
       item_id: '1',
     });
     expect(base.events[1]).toEqual({
@@ -842,6 +844,71 @@ describe('OpenAIRealtimeBase helpers', () => {
               : `${event.item.id} appended`,
           ),
       ).toEqual(['x after a']);
+    });
+
+    it('releases a delete that failed instead of being acknowledged', () => {
+      // Deleting an item the conversation has already dropped comes back as an
+      // error naming the request, not as conversation.item.deleted. Without
+      // that reply releasing the count, the id stays excluded as an anchor for
+      // the rest of the connection.
+      const base = new TestBase();
+      const errors: unknown[] = [];
+      base.on('error', (event) => errors.push(event));
+      const deleteIds = () =>
+        base.events
+          .filter((event: any) => event.type === 'conversation.item.delete')
+          .map((event: any) => event.event_id);
+
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [message('a', '1'), message('b', 'corrected'), message('c', '3')],
+      );
+      base.resetHistory(
+        [message('a', '1'), message('b', 'corrected'), message('c', '3')],
+        [message('a', '1'), message('c', '3')],
+      );
+      const [firstDelete, secondDelete] = deleteIds();
+      expect(firstDelete).toBeDefined();
+      expect(secondDelete).toBeDefined();
+
+      (base as any)._onMessage({
+        data: JSON.stringify({
+          type: 'conversation.item.deleted',
+          event_id: 'evt_deleted_b',
+          item_id: 'b',
+        }),
+      });
+      (base as any)._onMessage({
+        data: JSON.stringify({
+          type: 'error',
+          event_id: 'evt_error',
+          error: {
+            type: 'invalid_request_error',
+            code: 'item_not_found',
+            event_id: secondDelete,
+          },
+        }),
+      });
+      expect(errors).toHaveLength(1);
+      base.events.length = 0;
+
+      // `b` is restored, so it is a legitimate anchor again.
+      base.resetHistory(
+        [message('a', '1'), message('b', '2'), message('c', '3')],
+        [
+          message('a', '1'),
+          message('b', '2'),
+          message('x', 'X'),
+          message('c', '3'),
+        ],
+      );
+      expect(
+        base.events
+          .filter((event: any) => event.type === 'conversation.item.create')
+          .map(
+            (event: any) => `${event.item.id} after ${event.previous_item_id}`,
+          ),
+      ).toEqual(['x after b']);
     });
 
     it('forgets outstanding deletes when the connection ends', () => {

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -386,6 +386,124 @@ describe('RealtimeSession', () => {
     });
   });
 
+  it('keeps a trailing append alive while a deletion is unacknowledged', async () => {
+    // The server drops an item the moment the delete reaches it but answers
+    // later, so local history still lists it when the next append goes out.
+    // A trailing create that named it would be rejected against a conversation
+    // that no longer holds it.
+    class ServerBackedTransport extends OpenAIRealtimeBase {
+      status = 'connected' as const;
+      serverHistory: string[] = [];
+      pendingDeletionAcks: string[] = [];
+      connect = vi.fn(async () => {});
+      mute = vi.fn();
+      close = vi.fn();
+      interrupt = vi.fn();
+      get muted() {
+        return false;
+      }
+
+      seed(itemId: string, previousItemId: string | null) {
+        this.serverHistory.push(itemId);
+        this.#announce(itemId, previousItemId);
+      }
+
+      flushDeletionAcks() {
+        for (const itemId of this.pendingDeletionAcks.splice(0)) {
+          this.emit('item_deleted', { itemId } as any);
+        }
+      }
+
+      #announce(itemId: string, previousItemId: string | null) {
+        this.emit('item_update', {
+          itemId,
+          previousItemId,
+          type: 'message',
+          role: 'user',
+          status: 'completed',
+          content: [{ type: 'input_text', text: itemId }],
+        } as any);
+      }
+
+      sendEvent(event: any): void {
+        if (event.type === 'conversation.item.delete') {
+          this.serverHistory = this.serverHistory.filter(
+            (id) => id !== event.item_id,
+          );
+          this.pendingDeletionAcks.push(event.item_id);
+          return;
+        }
+        if (event.type !== 'conversation.item.create') {
+          return;
+        }
+        const anchor = event.previous_item_id;
+        if (anchor === undefined) {
+          this.serverHistory.push(event.item.id);
+          this.#announce(
+            event.item.id,
+            this.serverHistory[this.serverHistory.length - 2] ?? null,
+          );
+          return;
+        }
+        if (anchor === 'root') {
+          this.serverHistory.unshift(event.item.id);
+          this.#announce(event.item.id, null);
+          return;
+        }
+        const at = this.serverHistory.indexOf(anchor);
+        if (at === -1) {
+          // The conversation has no such item, so the server refuses the create.
+          return;
+        }
+        this.serverHistory.splice(at + 1, 0, event.item.id);
+        this.#announce(event.item.id, anchor);
+      }
+    }
+
+    const serverTransport = new ServerBackedTransport();
+    const serverSession = new RealtimeSession(
+      new RealtimeAgent({ name: 'A' }),
+      {
+        transport: serverTransport,
+      },
+    );
+    await serverSession.connect({ apiKey: 'test' });
+
+    serverTransport.seed('a', null);
+    serverTransport.seed('b', 'a');
+    await vi.waitFor(() => {
+      expect(serverSession.history.map((item) => item.itemId)).toEqual([
+        'a',
+        'b',
+      ]);
+    });
+
+    serverSession.updateHistory((history) =>
+      history.filter((item) => item.itemId !== 'b'),
+    );
+    // The delete has reached the server; the acknowledgment has not come back,
+    // so local history is still [a, b].
+    expect(serverTransport.serverHistory).toEqual(['a']);
+    expect(serverSession.history.map((item) => item.itemId)).toEqual([
+      'a',
+      'b',
+    ]);
+
+    serverSession.updateHistory((history) => [
+      ...history,
+      createMessage('c', 'three'),
+    ]);
+    serverTransport.flushDeletionAcks();
+
+    expect(serverTransport.serverHistory).toEqual(['a', 'c']);
+    await vi.waitFor(() => {
+      expect(serverSession.history.map((item) => item.itemId)).toEqual([
+        'a',
+        'c',
+      ]);
+    });
+  });
+
   it('calls transport.resetHistory with correct arguments', () => {
     const item = createMessage('1', 'hi');
     session.updateHistory([item]);

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -349,6 +349,43 @@ describe('RealtimeSession', () => {
     expect(execute).toHaveBeenCalledTimes(1);
   });
 
+  it('places a server-confirmed first item at the front of local history', async () => {
+    // A corrected first item is re-created with `previous_item_id: 'root'`, and
+    // the server answers with no predecessor. Local history has to agree with
+    // the conversation the server now holds.
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(new RealtimeAgent({ name: 'A' }), {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+
+    const message = (
+      itemId: string,
+      text: string,
+      previousItemId?: string | null,
+    ) =>
+      ({
+        itemId,
+        type: 'message',
+        role: 'user',
+        status: 'completed',
+        content: [{ type: 'input_text', text }],
+        ...(previousItemId === undefined ? {} : { previousItemId }),
+      }) as any;
+
+    localTransport.emit('item_update', message('a', 'one'));
+    localTransport.emit('item_update', message('b', 'two', 'a'));
+    localTransport.emit('item_deleted', { itemId: 'a' } as any);
+    localTransport.emit('item_update', message('a', 'one corrected', null));
+
+    await vi.waitFor(() => {
+      expect(localSession.history.map((item) => item.itemId)).toEqual([
+        'a',
+        'b',
+      ]);
+    });
+  });
+
   it('calls transport.resetHistory with correct arguments', () => {
     const item = createMessage('1', 'hi');
     session.updateHistory([item]);


### PR DESCRIPTION
### Summary

`resetHistory()` creates every item without `previous_item_id`. The protocol says an item created that way is appended:

> The ID of the preceding item after which the new item will be inserted. If not set, the new item will be appended to the end of the conversation.

So correcting an item in the middle of the history moves it behind everything that followed it, and inserting one puts it at the end instead of where it was placed. The voice agent guide recommends `updateHistory()` for exactly this ("update it when you need to correct or remove items"), and the documented limitations do not mention reordering.

Emitted events before this change, for `[a, b, c]` with `b` edited:

```
conversation.item.delete  b
conversation.item.create  b        // no previous_item_id -> appended
```

The server conversation becomes `[a, c, b]`. Inserting `b` into `[a, c]` lands it at the end the same way.

After:

```
conversation.item.delete  b
conversation.item.create  b        previous_item_id: "a"
```

### What changed

`additions` and `updates` were concatenated and sent in that order, which is not history order and carries no anchor. They are now walked in new-history order so each created item can name the item it follows. Because the walk is in order, an anchor always exists by the time it is used.

Anchors have to be items the conversation actually has, since "if the ID cannot be found, an error will be returned and the item will not be added":

- untouched items keep their place and can anchor the next insert
- a function call that could not be created does not become an anchor
- a removed item does not become an anchor

An item with nothing before it is still created without `previous_item_id`, exactly as before. The protocol documents `previous_item_id: "root"` for inserting at the beginning, which would also fix front-insertion, but I could not verify `root` against a live session and a rejected anchor drops the item entirely — worse than today's append. Happy to add it if you can confirm the deployed behaviour.

All transports inherit this from `OpenAIRealtimeBase`, so WebSocket, WebRTC, SIP and the Cloudflare layer are covered by the one change.

### Test plan

- `pnpm test` — 6412 passed, 0 failed
- `.agents/skills/code-change-verification/scripts/run.sh` — `code-change-verification: all commands passed.`
- `pnpm changeset:validate-lite` — `Package changes detected with 1 changeset file(s)`
- 7 tests added to `packages/agents-realtime/test/openaiRealtimeBase.test.ts`, covering the corrected item, the inserted item, consecutive corrections chaining in order, an item with nothing before it, and the three anchor cases above. No existing test needed changing.

### Issue number

N/A

### Checks

- [x] I've added new tests
- [x] Documentation is not required; this restores the behaviour the voice agent guide already describes
- [x] I've run `pnpm test` and the examples build checks
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've added a changeset
