### PR TITLE
fix: preserve Chat Completions tool turns during replay

### DIFF
--- a/.changeset/soft-tools-merge.md
+++ b/.changeset/soft-tools-merge.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: merge streamed Chat Completions tool-call turns

--- a/packages/agents-openai/src/openaiChatCompletionsConverter.ts
+++ b/packages/agents-openai/src/openaiChatCompletionsConverter.ts
@@ -283,6 +283,7 @@ export function itemsToMessages(
   const result: ChatCompletionMessageParam[] = [];
   let currentAssistantMsg: ChatCompletionAssistantMessageWithReasoning | null =
     null;
+  let pendingAssistantFunctionCallProviderData: Record<string, unknown> = {};
   const flushAssistantMessage = () => {
     if (currentAssistantMsg) {
       if (
@@ -294,6 +295,7 @@ export function itemsToMessages(
       result.push(currentAssistantMsg);
       currentAssistantMsg = null;
     }
+    pendingAssistantFunctionCallProviderData = {};
   };
   const ensureAssistantMessage = () => {
     if (!currentAssistantMsg) {
@@ -325,9 +327,20 @@ export function itemsToMessages(
   for (const item of items) {
     if (isMessageItem(item)) {
       const { content, role, providerData } = item;
+      const pendingAssistantToolCallMessage =
+        role === 'assistant' &&
+        currentAssistantMsg?.content === null &&
+        currentAssistantMsg.tool_calls &&
+        currentAssistantMsg.tool_calls.length > 0
+          ? currentAssistantMsg
+          : undefined;
       const pendingReasoningMsg =
-        role === 'assistant' ? takeReasoningOnlyAssistantMessage() : undefined;
-      flushAssistantMessage();
+        role === 'assistant' && !pendingAssistantToolCallMessage
+          ? takeReasoningOnlyAssistantMessage()
+          : undefined;
+      if (!pendingAssistantToolCallMessage) {
+        flushAssistantMessage();
+      }
       if (role === 'assistant') {
         const phase = item.phase ?? providerData?.phase;
         if (typeof phase !== 'undefined' && phase !== null) {
@@ -347,8 +360,15 @@ export function itemsToMessages(
         const assistant: ChatCompletionAssistantMessageWithReasoning = {
           role: 'assistant',
           content: extractAllAssistantContent(content),
-          ...(typeof pendingReasoningMsg?.reasoning === 'string'
-            ? { reasoning: pendingReasoningMsg.reasoning }
+          ...(typeof (
+            pendingReasoningMsg?.reasoning ??
+            pendingAssistantToolCallMessage?.reasoning
+          ) === 'string'
+            ? {
+                reasoning:
+                  pendingReasoningMsg?.reasoning ??
+                  pendingAssistantToolCallMessage?.reasoning,
+              }
             : {}),
           ...getProviderDataWithoutReservedKeys(providerData, [
             'role',
@@ -369,7 +389,23 @@ export function itemsToMessages(
           }
         }
 
-        result.push(assistant);
+        if (pendingAssistantToolCallMessage) {
+          // A streamed turn may place its function calls before its assistant
+          // message. Keep the pending tool calls on the same Chat Completions
+          // assistant message instead of emitting two consecutive assistants.
+          // Reapply function-call provider data last so streamed and
+          // non-streamed orderings preserve the released message-first
+          // precedence for overlapping provider extension fields.
+          Object.assign(
+            pendingAssistantToolCallMessage,
+            assistant,
+            pendingAssistantFunctionCallProviderData,
+          );
+        } else {
+          // Keep the assistant message pending so following tool calls from the
+          // same turn can attach before the next turn boundary flushes it.
+          currentAssistantMsg = assistant;
+        }
       } else if (role === 'user') {
         result.push({
           role,
@@ -392,6 +428,12 @@ export function itemsToMessages(
         });
       }
     } else if (item.type === 'reasoning') {
+      if (currentAssistantMsg?.content !== null) {
+        // A reasoning item starts the next assistant turn. Do not let a
+        // completed content-bearing assistant message absorb its reasoning or
+        // following tool calls while waiting for a later flush boundary.
+        flushAssistantMessage();
+      }
       const asst = ensureAssistantMessage();
       // Some third-party providers support reasoning on assistant messages even
       // though it is not part of the official Chat Completions API type.
@@ -486,6 +528,10 @@ export function itemsToMessages(
         funcCall.providerData?.function,
         ['name', 'arguments'],
       );
+      const assistantProviderData = getProviderDataWithoutReservedKeys(
+        funcCall.providerData,
+        ['role', 'content', 'tool_calls', 'audio', 'id', 'type', 'function'],
+      );
       toolCalls.push({
         id: funcCall.callId,
         type: 'function',
@@ -498,17 +544,10 @@ export function itemsToMessages(
       });
       asst.tool_calls = toolCalls;
       Object.assign(
-        asst,
-        getProviderDataWithoutReservedKeys(funcCall.providerData, [
-          'role',
-          'content',
-          'tool_calls',
-          'audio',
-          'id',
-          'type',
-          'function',
-        ]),
+        pendingAssistantFunctionCallProviderData,
+        assistantProviderData,
       );
+      Object.assign(asst, assistantProviderData);
     } else if (item.type === 'function_call_result') {
       if (item.caller?.type === 'program') {
         throw new UserError(

--- a/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
+++ b/packages/agents-openai/test/openaiChatCompletionsConverter.test.ts
@@ -653,6 +653,262 @@ describe('itemsToMessages', () => {
     ]);
   });
 
+  test('converges streamed and non-streamed assistant tool turn ordering', () => {
+    const reasoning = {
+      type: 'reasoning',
+      content: [],
+      rawContent: [{ type: 'reasoning_text', text: 'why' }],
+    } as protocol.ReasoningItem;
+    const assistantMessage = {
+      id: 'msg_1',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        {
+          type: 'output_text',
+          text: 'Let me calculate.',
+          providerData: { type: 'ignored', text: 'ignored', textExtra: true },
+        },
+        {
+          type: 'refusal',
+          refusal: 'I cannot explain private reasoning.',
+          providerData: {
+            type: 'ignored',
+            refusal: 'ignored',
+            refusalExtra: true,
+          },
+        },
+        {
+          type: 'audio',
+          audio: 'encoded-audio',
+          providerData: { id: 'audio_1' },
+        },
+      ],
+      providerData: {
+        role: 'tool',
+        content: 'ignored',
+        tool_calls: [{ id: 'ignored' }],
+        audio: { id: 'ignored' },
+        messageExtra: true,
+        sharedExtra: 'message',
+      },
+    } as protocol.AssistantMessageItem;
+    const firstCall = {
+      type: 'function_call',
+      id: '1',
+      callId: 'call1',
+      name: 'first',
+      arguments: '{"value":1}',
+      status: 'completed',
+      providerData: {
+        role: 'tool',
+        content: 'ignored',
+        tool_calls: [{ id: 'ignored' }],
+        audio: { id: 'ignored' },
+        callExtra: true,
+        sharedExtra: 'call',
+      },
+    } as protocol.FunctionCallItem;
+    const secondCall = {
+      type: 'function_call',
+      id: '2',
+      callId: 'call2',
+      name: 'second',
+      arguments: '{"value":2}',
+      status: 'completed',
+    } as protocol.FunctionCallItem;
+    const results: protocol.FunctionCallResultItem[] = [
+      {
+        type: 'function_call_result',
+        id: '3',
+        callId: 'call1',
+        name: 'first',
+        status: 'completed',
+        output: 'one',
+      },
+      {
+        type: 'function_call_result',
+        id: '4',
+        callId: 'call2',
+        name: 'second',
+        status: 'completed',
+        output: 'two',
+      },
+    ];
+
+    const streamed = itemsToMessages([
+      reasoning,
+      firstCall,
+      secondCall,
+      assistantMessage,
+      ...results,
+    ]);
+    const nonStreamed = itemsToMessages([
+      reasoning,
+      assistantMessage,
+      firstCall,
+      secondCall,
+      ...results,
+    ]);
+
+    expect(streamed).toEqual(nonStreamed);
+    expect(streamed).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Let me calculate.', textExtra: true },
+          {
+            type: 'refusal',
+            refusal: 'I cannot explain private reasoning.',
+            refusalExtra: true,
+          },
+        ],
+        reasoning: 'why',
+        audio: { id: 'audio_1' },
+        messageExtra: true,
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: { name: 'first', arguments: '{"value":1}' },
+            callExtra: true,
+            sharedExtra: 'call',
+          },
+          {
+            id: 'call2',
+            type: 'function',
+            function: { name: 'second', arguments: '{"value":2}' },
+          },
+        ],
+        callExtra: true,
+        sharedExtra: 'call',
+      },
+      { role: 'tool', tool_call_id: 'call1', content: 'one' },
+      { role: 'tool', tool_call_id: 'call2', content: 'two' },
+    ]);
+  });
+
+  test('keeps an assistant message after a completed tool turn separate', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'f',
+        arguments: '{}',
+        status: 'completed',
+      } as protocol.FunctionCallItem,
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Calling the tool.' }],
+      } as protocol.AssistantMessageItem,
+      {
+        type: 'function_call_result',
+        id: '2',
+        callId: 'call1',
+        name: 'f',
+        status: 'completed',
+        output: 'result',
+      } as protocol.FunctionCallResultItem,
+      {
+        id: 'msg_2',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Done.' }],
+      } as protocol.AssistantMessageItem,
+    ];
+
+    expect(itemsToMessages(items)).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Calling the tool.' }],
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: { name: 'f', arguments: '{}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call1', content: 'result' },
+      { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+    ]);
+  });
+
+  test('keeps a later reasoning tool turn separate from prior assistant content', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        content: [{ type: 'output_text', text: 'Earlier answer.' }],
+      } as protocol.AssistantMessageItem,
+      {
+        type: 'reasoning',
+        content: [],
+        rawContent: [{ type: 'reasoning_text', text: 'new reasoning' }],
+      } as protocol.ReasoningItem,
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'f',
+        arguments: '{}',
+        status: 'completed',
+      } as protocol.FunctionCallItem,
+    ];
+
+    expect(itemsToMessages(items)).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Earlier answer.' }],
+      },
+      {
+        role: 'assistant',
+        content: null,
+        reasoning: 'new reasoning',
+        tool_calls: [
+          {
+            id: 'call1',
+            type: 'function',
+            function: { name: 'f', arguments: '{}' },
+          },
+        ],
+      },
+    ]);
+  });
+
+  test('keeps strict assistant phase validation with pending tool calls', () => {
+    const items: protocol.ModelItem[] = [
+      {
+        type: 'function_call',
+        id: '1',
+        callId: 'call1',
+        name: 'f',
+        arguments: '{}',
+        status: 'completed',
+      } as protocol.FunctionCallItem,
+      {
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        status: 'completed',
+        phase: 'commentary',
+        content: [{ type: 'output_text', text: 'Calling the tool.' }],
+      } as protocol.AssistantMessageItem,
+    ];
+
+    expect(() =>
+      itemsToMessages(items, { strictFeatureValidation: true }),
+    ).toThrow('Use the Responses API to preserve assistant message phases.');
+  });
+
   test('uses placeholder for empty structured function output by default', () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
     const items: protocol.ModelItem[] = [


### PR DESCRIPTION
This pull request fixes replay of normalized model turns when function calls precede their assistant message. Both item orderings now produce one assistant message containing the same-turn content, refusals, and tool calls.
It preserves reasoning, audio, filtered provider data, call ordering, validation, and later-turn separation.