### PR TITLE
fix(openai): preserve response span data on early stream close

### DIFF
--- a/.changeset/streamed-response-span-data.md
+++ b/.changeset/streamed-response-span-data.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: preserve full tracing data when streamed response consumers stop at completion

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -3958,6 +3958,10 @@ export class OpenAIResponsesModel implements Model {
             }
           } else if (terminalResponse) {
             finalResponse = terminalResponse;
+            if (span && request.tracing === true) {
+              span.spanData.response_id = terminalResponse.id;
+              span.spanData._response = terminalResponse;
+            }
             const { response: _response, ...remainingEvent } = terminalEvent;
             const {
               output: _output,

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -6297,6 +6297,62 @@ describe('OpenAIResponsesModel', () => {
     },
   );
 
+  it('records full tracing data before a response_done consumer closes the stream', async () => {
+    const responseSpans = captureResponseSpans();
+    const input = 'full tracing stream input';
+    const terminalResponse = {
+      id: 'resp_full_data_stream',
+      status: 'completed',
+      output: [],
+      usage: { input_tokens: 2, output_tokens: 3, total_tokens: 5 },
+    };
+    async function* fakeStream() {
+      yield {
+        type: 'response.completed',
+        response: terminalResponse,
+        sequence_number: 0,
+      } as unknown as OpenAIResponseStreamEvent;
+    }
+    const model = new OpenAIResponsesModel(
+      {
+        responses: { create: vi.fn().mockResolvedValue(fakeStream()) },
+      } as unknown as OpenAI,
+      'model-stream',
+    );
+
+    await withTrace('test', async () => {
+      const iterator = model
+        .getStreamedResponse({
+          systemInstructions: undefined,
+          input,
+          modelSettings: {},
+          tools: [],
+          outputType: 'text',
+          handoffs: [],
+          tracing: true,
+          signal: undefined,
+        } as any)
+        [Symbol.asyncIterator]();
+
+      expect(await iterator.next()).toMatchObject({
+        done: false,
+        value: {
+          type: 'response_done',
+          response: { id: 'resp_full_data_stream' },
+        },
+      });
+      await iterator.return?.();
+    });
+
+    expect(responseSpans).toHaveLength(1);
+    expect(responseSpans[0]?.endedAt).not.toBeNull();
+    expect(responseSpans[0]?.spanData._input).toBe(input);
+    expect(responseSpans[0]?.spanData._response).toBe(terminalResponse);
+    expect(getSerializedResponseSpanData(responseSpans[0]!).response_id).toBe(
+      'resp_full_data_stream',
+    );
+  });
+
   it('prevents extra_body from overriding streamed request mode', async () => {
     await withTrace('test', async () => {
       const createdEvent: OpenAIResponseStreamEvent = {


### PR DESCRIPTION
This pull request fixes missing response span data when a streamed Responses consumer closes the iterator immediately after receiving `response_done`. Previously, closing the generator skipped the post-loop assignments, leaving the ended span without its terminal response and full-data response ID.

Record those fields before yielding `response_done`, preserving tracing redaction, endpoint ID rules, terminal errors, and event ordering.