### PR TITLE
fix: preserve approvals before handoffs and recover resumed writes

### DIFF
--- a/.changeset/preserve-approvals-before-handoffs.md
+++ b/.changeset/preserve-approvals-before-handoffs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve pending approvals before handoffs and recover resumed handoffs after Session append failures

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -1673,7 +1673,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                   validateHandoffAgent: (handoffAgent) => {
                     this.#validateModelTimeoutForAgent(handoffAgent);
                   },
-                  beforeApprovedToolResume: async () => {
+                  beforeResumedSideEffects: async () => {
                     if (
                       persistResult &&
                       options.session &&
@@ -1685,13 +1685,14 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                           state,
                         );
                     }
+                    return resumedSessionWritePreparation;
                   },
                 });
                 const checkpointDeferred =
-                  outcome.approvedToolResumed &&
+                  outcome.resumedSideEffects &&
                   outcome.nextStep.type === 'next_step_final_output' &&
                   this.#agentHasOutputGuardrail(state._currentAgent);
-                if (outcome.approvedToolResumed) {
+                if (outcome.resumedSideEffects) {
                   const approvedToolResult = new RunResult<TContext, TAgent>(
                     state,
                   );
@@ -1754,7 +1755,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                 continuingInterruptedTurn = value;
               },
             });
-            if (!shouldContinue) {
+            if (
+              !shouldContinue ||
+              interruptedOutcome.nextStep.type === 'next_step_handoff'
+            ) {
               finishRunnerSpan(currentTurnSpan);
               setRunStateTurnSpanParent(state, undefined);
               currentTurnSpan = undefined;
@@ -2702,7 +2706,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               onStepItems: (turnResult) => {
                 addStepToRunResult(result, turnResult);
               },
-              beforeApprovedToolResume: async () => {
+              onHandoff: (agent) => {
+                result._addItem(new RunAgentUpdatedStreamEvent(agent));
+              },
+              beforeResumedSideEffects: async () => {
                 if (options.session && !serverManagesConversation) {
                   resumedSessionWritePreparation =
                     await prepareResumedSessionWrite(
@@ -2710,9 +2717,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                       result.state,
                     );
                 }
+                return resumedSessionWritePreparation;
               },
             });
-            if (outcome.approvedToolResumed) {
+            if (outcome.resumedSideEffects) {
               const checkpointDeferred =
                 outcome.nextStep.type === 'next_step_final_output' &&
                 this.#agentHasOutputGuardrail(result.state._currentAgent);
@@ -2757,7 +2765,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               continuingInterruptedTurn = value;
             },
           });
-          if (!shouldContinue) {
+          if (
+            !shouldContinue ||
+            interruptedOutcome.nextStep.type === 'next_step_handoff'
+          ) {
             finishRunnerSpan(currentTurnSpan);
             setRunStateTurnSpanParent(result.state, undefined);
             currentTurnSpan = undefined;

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -173,7 +173,8 @@ import {
  * - 1.20: Adds sandbox session-state envelope version 5 so Docker labels cannot be
  *   consumed by older SDKs that would drop them during container replacement, preserves
  *   exact current-response ownership for serialized approval resumes, and checkpoints
- *   unacknowledged ordinary Session appends completed during approval resume.
+ *   unacknowledged ordinary Session appends completed during approval resume, including
+ *   filtered handoff input held until its source append settles.
  */
 export const CURRENT_SCHEMA_VERSION = '1.20' as const;
 export const SUPPORTED_SCHEMA_VERSIONS = [
@@ -265,6 +266,8 @@ const pendingSessionWriteBaseSchema = {
   alreadyPersistedCount: z.number().int().min(0),
   persistedItemCount: z.number().int().min(1),
   reasoningItemIdPolicy: z.enum(['preserve', 'omit']),
+  // Kept separately from canonical append items until the source turn is durable.
+  handoffInput: z.lazy(() => handoffInputSnapshotSchema).optional(),
   terminalToolFinalization: z
     .object({
       behavior: z.enum([
@@ -1628,6 +1631,11 @@ const sandboxStateSchema = z.object({
   sessionsByAgent: z.record(z.string(), sandboxSessionEntrySchema),
 });
 
+const handoffInputSnapshotSchema = z.object({
+  originalInput: z.string().or(z.array(protocol.ModelItem)),
+  generatedItems: z.array(itemSchema),
+});
+
 const serializedProcessedResponseSchema = z.object({
   newItems: z.array(itemSchema),
   toolsUsed: z.array(z.string()),
@@ -1864,7 +1872,7 @@ export const SerializedRunState = z.object({
     .default({}),
   lastProcessedResponse: serializedProcessedResponseSchema.optional(),
   currentTurnPersistedItemCount: z.number().int().min(0).optional(),
-  currentTurnSessionWriteCompactedItemCount: z.number().int().min(1).optional(),
+  currentTurnSessionWriteCompactedItemCount: z.number().int().min(0).optional(),
   currentTurnDeferredSessionItemIndexes: z
     .array(z.number().int().min(0))
     .optional(),
@@ -2716,6 +2724,35 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
    */
   _replaceGeneratedItems(generatedItems: RunItem[]): void {
     this._generatedItems = generatedItems;
+  }
+
+  /** @internal Captures an input view without retaining mutable filter-owned items. */
+  _captureHandoffInput(
+    originalInput: string | AgentInputItem[],
+    generatedItems: RunItem[],
+  ): NonNullable<PendingSessionWrite['handoffInput']> {
+    const identities = buildAgentIdentityMap(this.#startingAgent);
+    return structuredClone(
+      handoffInputSnapshotSchema.parse({
+        originalInput,
+        generatedItems: generatedItems.map((item) =>
+          serializeRunItem(item, identities.byAgent),
+        ),
+      }),
+    );
+  }
+
+  /** @internal Reuses ordinary RunState item reconstruction for the accepted input view. */
+  _deserializeHandoffInput(
+    input: NonNullable<PendingSessionWrite['handoffInput']>,
+  ): { originalInput: string | AgentInputItem[]; generatedItems: RunItem[] } {
+    const identities = buildAgentIdentityMap(this.#startingAgent);
+    return {
+      originalInput: structuredClone(input.originalInput),
+      generatedItems: input.generatedItems.map((item) =>
+        deserializeItem(item, identities.byIdentity),
+      ),
+    };
   }
 
   private getOrCreateToolSearchRuntimeToolState(
@@ -3868,6 +3905,21 @@ export function assertPendingSessionWriteOwnership(
   }
 
   getPendingSessionWriteAppendItems(state, pending);
+  if (pending.handoffInput) {
+    if (
+      state._currentStep?.type !== 'next_step_run_again' ||
+      !state._noActiveAgentRun ||
+      state._currentTurnInProgress ||
+      !state._generatedItems.some(
+        (item) =>
+          item instanceof RunHandoffOutputItem &&
+          item.targetAgent === state._currentAgent,
+      )
+    ) {
+      throw new UserError('RunState pending handoff input is invalid.');
+    }
+    state._deserializeHandoffInput(pending.handoffInput);
+  }
 }
 
 function getPendingSessionWriteBehaviorKind(

--- a/packages/agents-core/src/runner/runLoop.ts
+++ b/packages/agents-core/src/runner/runLoop.ts
@@ -1,10 +1,12 @@
 import type { Agent, AgentOutputType } from '../agent';
 import { UserError } from '../errors';
+import { resetCurrentSpan } from '../tracing/context';
 import type { RunState } from '../runState';
 import type { RunConfig, Runner, ToolErrorFormatter } from '../run';
 import { getFunctionToolStateKeyForCall } from '../toolIdentity';
 import type { SingleStepResult } from './steps';
 import type { ProcessedResponse } from './types';
+import type { ResumedSessionWritePreparation } from './sessionPersistence';
 import { getServerConversationOwner } from './conversation';
 import {
   preflightToolInvocations,
@@ -184,7 +186,7 @@ export async function resumeAcceptedModelResponse<
 export type InterruptedTurnOutcome = {
   nextStep: SingleStepResult['nextStep'];
   action: 'return_interruption' | 'rerun_turn' | 'advance_step';
-  approvedToolResumed: boolean;
+  resumedSideEffects: boolean;
 };
 
 export type InterruptedTurnControl = {
@@ -249,7 +251,10 @@ export async function resumeInterruptedTurn<
   signal?: AbortSignal;
   onStepItems?: (turnResult: SingleStepResult) => void;
   validateHandoffAgent?: (agent: Agent<any, any>) => void;
-  beforeApprovedToolResume?: () => Promise<void>;
+  beforeResumedSideEffects?: () => Promise<
+    ResumedSessionWritePreparation | undefined
+  >;
+  onHandoff?: (agent: TAgent) => void;
 }): Promise<InterruptedTurnOutcome> {
   const {
     state,
@@ -259,7 +264,8 @@ export async function resumeInterruptedTurn<
     signal,
     onStepItems,
     validateHandoffAgent,
-    beforeApprovedToolResume,
+    beforeResumedSideEffects,
+    onHandoff,
   } = options;
   const approvedToolWillResume = state.getInterruptions().some((item) => {
     const rawItem = item.rawItem;
@@ -287,9 +293,12 @@ export async function resumeInterruptedTurn<
       ) === true
     );
   });
-  if (approvedToolWillResume) {
-    await beforeApprovedToolResume?.();
-  }
+  const preparation =
+    approvedToolWillResume ||
+    (state._lastProcessedResponse?.handoffs.length ?? 0) > 0
+      ? await beforeResumedSideEffects?.()
+      : undefined;
+  let unfilteredHandoffInput: ResumedSessionWritePreparation['handoffInput'];
   const turnResult = await resolveInterruptedTurn<TContext>(
     state._currentAgent,
     state._originalInput,
@@ -302,10 +311,35 @@ export async function resumeInterruptedTurn<
     agentToolParentRunConfig,
     signal,
     validateHandoffAgent,
+    preparation
+      ? (input) => {
+          unfilteredHandoffInput = state._captureHandoffInput(
+            input.inputHistory,
+            [...input.preHandoffItems, ...input.newItems],
+          );
+        }
+      : undefined,
   );
-  const approvedToolResumed =
-    approvedToolWillResume &&
-    turnResult.generatedItems.length > state._currentTurnPersistedItemCount;
+  const resumedSideEffects =
+    turnResult.nextStep.type === 'next_step_handoff' ||
+    (approvedToolWillResume &&
+      turnResult.generatedItems.length > state._currentTurnPersistedItemCount);
+
+  if (preparation && unfilteredHandoffInput) {
+    preparation.handoffInput = state._captureHandoffInput(
+      turnResult.originalInput,
+      turnResult.generatedItems,
+    );
+    const canonicalInput = state._deserializeHandoffInput(
+      unfilteredHandoffInput,
+    );
+    // Streaming observes the accepted filtered step, while persistence keeps the source pairs.
+    onStepItems?.(turnResult);
+    turnResult.originalInput = canonicalInput.originalInput;
+    turnResult.preStepItems = [];
+    turnResult.newStepItems = canonicalInput.generatedItems;
+    turnResult.toolInvocationCommitItems = canonicalInput.generatedItems;
+  }
 
   applyTurnResult({
     state,
@@ -313,8 +347,34 @@ export async function resumeInterruptedTurn<
     agent: state._currentAgent,
     toolsUsed: state._lastProcessedResponse?.toolsUsed ?? [],
     resetTurnPersistence: false,
-    onStepItems,
+    onStepItems: unfilteredHandoffInput ? undefined : onStepItems,
   });
+
+  if (turnResult.nextStep.type === 'next_step_handoff') {
+    // The transfer and tool effects have completed. Persist their continuation before
+    // the caller attempts the fallible resumed Session append.
+    state.setCurrentAgent(turnResult.nextStep.newAgent as TAgent);
+    state._currentStep = { type: 'next_step_run_again' };
+    state._noActiveAgentRun = true;
+    state._currentTurnInProgress = false;
+    if (state._currentAgentSpan) {
+      state._currentAgentSpan.end();
+      resetCurrentSpan();
+      state.setCurrentAgentSpan(undefined);
+    }
+    if (
+      !getServerConversationOwner(
+        state._conversationId,
+        state._previousResponseId,
+      )
+    ) {
+      // Local history owns the completed source-agent results. Retaining its execution
+      // plan would try to rehydrate source tools against the target agent on restore.
+      // Server-managed continuation still needs the plan for ignored handoff outputs.
+      state._lastProcessedResponse = undefined;
+    }
+    onHandoff?.(state._currentAgent);
+  }
 
   // Map next-step outcomes to interruption flow control for the outer run loop.
   // return_interruption: still waiting on approvals. rerun_turn: same turn rerun without increment.
@@ -323,20 +383,20 @@ export async function resumeInterruptedTurn<
     return {
       nextStep: turnResult.nextStep,
       action: 'return_interruption',
-      approvedToolResumed,
+      resumedSideEffects,
     };
   }
   if (turnResult.nextStep.type === 'next_step_run_again') {
     return {
       nextStep: turnResult.nextStep,
       action: 'rerun_turn',
-      approvedToolResumed,
+      resumedSideEffects,
     };
   }
   return {
     nextStep: turnResult.nextStep,
     action: 'advance_step',
-    approvedToolResumed,
+    resumedSideEffects,
   };
 }
 
@@ -361,6 +421,10 @@ export function handleInterruptedOutcome<
       return { shouldReturn: false, shouldContinue: true };
     case 'advance_step':
       setContinuingInterruptedTurn(false);
+      if (outcome.nextStep.type === 'next_step_handoff') {
+        // The transfer, lifecycle notification and durable continuation are already published.
+        return { shouldReturn: false, shouldContinue: true };
+      }
       state._currentStep = outcome.nextStep;
       return { shouldReturn: false, shouldContinue: false };
     default: {

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -75,6 +75,7 @@ export type ResumedSessionWritePreparation = {
   readonly state: RunState<any, any>;
   readonly sessionId: string;
   readonly reasoningItemIdPolicy: ReasoningItemIdPolicy;
+  handoffInput?: PendingSessionWrite['handoffInput'];
 };
 
 const SESSION_LIMIT_UNSET = Symbol('sessionLimitUnset');
@@ -382,6 +383,7 @@ function checkpointPreparedResumedSessionWrite(options: {
   const pending: Extract<PendingSessionWrite, { phase: 'prepared' }> = {
     phase: 'prepared',
     ...pendingItems,
+    handoffInput: preparation.handoffInput,
     terminalToolFinalization:
       capturePendingSessionWriteTerminalFinalization(state),
   };
@@ -757,7 +759,16 @@ function commitApprovedToolInputCompaction(
   state: RunState<any, any>,
   persistedItemCount: number,
 ): void {
-  state._currentTurnSessionWriteCompactedItemCount = persistedItemCount;
+  const handoffInput = state._pendingSessionWrite?.handoffInput;
+  if (handoffInput) {
+    const input = state._deserializeHandoffInput(handoffInput);
+    state._originalInput = input.originalInput;
+    state._replaceGeneratedItems(input.generatedItems);
+    state._currentTurnPersistedItemCount = input.generatedItems.length;
+  }
+  state._currentTurnSessionWriteCompactedItemCount = handoffInput
+    ? state._generatedItems.length
+    : persistedItemCount;
   state._pendingSessionWrite = undefined;
   clearPendingSessionWriteTerminalProducer(state);
 }

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -2543,6 +2543,7 @@ export async function executeHandoffCalls<
   runContext: RunContext<TContext>,
   parent?: Span<any>,
   validateHandoffAgent?: (agent: Agent<any, any>) => void,
+  beforeInputFilter?: (input: HandoffInputData) => void,
 ): Promise<import('./steps').SingleStepResult> {
   newStepItems = [...newStepItems];
 
@@ -2638,6 +2639,7 @@ export async function executeHandoffCalls<
           runContext,
         };
 
+        beforeInputFilter?.(handoffInputData);
         const filtered = inputFilter(handoffInputData);
         invalidateOutputItemNormalization([
           ...handoffInputData.preHandoffItems,

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { Agent } from '../agent';
 import { getAgentToolSourceAgent } from '../agentToolSourceRegistry';
-import type { Handoff } from '../handoff';
+import type { Handoff, HandoffInputData } from '../handoff';
 import { ModelBehaviorError, ModelRefusalError } from '../errors';
 import {
   RunHandoffCallItem,
@@ -991,12 +991,19 @@ export async function resolveInterruptedTurn<TContext>(
   agentToolParentRunConfig?: Partial<RunConfig>,
   signal?: AbortSignal,
   validateHandoffAgent?: (agent: Agent<any, any>) => void,
+  beforeHandoffInputFilter?: (input: HandoffInputData) => void,
 ): Promise<SingleStepResult> {
   const suppressedToolCalls = preflightToolInvocations(
     agent,
     state,
     processedResponse as ProcessedResponse<TContext>,
   );
+  const handoffRuns = processedResponse.handoffs.filter(
+    (run) => !suppressedToolCalls.has(run.toolCall),
+  );
+  if (handoffRuns.length > 0) {
+    validateHandoffAgent?.(handoffRuns[0].handoff.agent);
+  }
   // call_ids for function tools
   const functionCallIds = originalPreStepItems
     .filter(
@@ -1303,6 +1310,25 @@ export async function resolveInterruptedTurn<TContext>(
     state.rewindTurnPersistence(removedApprovalCount);
   }
 
+  const handoffStep = await resolveHandoffAfterTools({
+    agent,
+    originalInput,
+    preStepItems,
+    newItems,
+    newResponse,
+    handoffRuns,
+    functionResults,
+    additionalInterruptions,
+    runner,
+    state,
+    signal,
+    validateHandoffAgent,
+    beforeHandoffInputFilter,
+  });
+  if (handoffStep) {
+    return handoffStep;
+  }
+
   const completedStep = await maybeCompleteTurnFromToolResults({
     agent,
     runner,
@@ -1510,27 +1536,22 @@ export async function resolveTurnAfterModelResponse<
     });
   }
 
-  // process handoffs
-  if (handoffRuns.length > 0) {
-    if (signal?.aborted) {
-      for (const { toolCall } of handoffRuns) {
-        const rawItem = buildFunctionAbortResult(toolCall);
-        appendIfNew(new RunToolCallOutputItem(rawItem, agent, rawItem.output));
-      }
-    } else {
-      return await executeHandoffCalls(
-        agent,
-        originalInput,
-        preStepItems,
-        newItems,
-        newResponse,
-        handoffRuns as ToolRunHandoff[],
-        runner,
-        state._context,
-        getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
-        validateHandoffAgent,
-      );
-    }
+  const handoffStep = await resolveHandoffAfterTools({
+    agent,
+    originalInput,
+    preStepItems,
+    newItems,
+    newResponse,
+    handoffRuns,
+    functionResults,
+    additionalInterruptions,
+    runner,
+    state,
+    signal,
+    validateHandoffAgent,
+  });
+  if (handoffStep) {
+    return handoffStep;
   }
 
   const completedStep = await maybeCompleteTurnFromToolResults({
@@ -1761,6 +1782,76 @@ type TurnFinalizationParams<TContext> = {
   newItems: RunItem[];
   additionalInterruptions?: RunToolApprovalItem[];
 };
+
+// Handoffs retain precedence over terminal tool behavior, but cannot discard pending approvals.
+async function resolveHandoffAfterTools<TContext>(
+  options: TurnFinalizationParams<TContext> & {
+    handoffRuns: ToolRunHandoff[];
+    signal?: AbortSignal;
+    validateHandoffAgent?: (agent: Agent<any, any>) => void;
+    beforeHandoffInputFilter?: (input: HandoffInputData) => void;
+  },
+): Promise<SingleStepResult | undefined> {
+  const {
+    agent,
+    originalInput,
+    preStepItems,
+    newItems,
+    newResponse,
+    handoffRuns,
+    functionResults,
+    additionalInterruptions,
+    runner,
+    state,
+    signal,
+    validateHandoffAgent,
+    beforeHandoffInputFilter,
+  } = options;
+  if (handoffRuns.length === 0) {
+    return undefined;
+  }
+  if (signal?.aborted) {
+    const appendContext = buildAppendContext([...preStepItems, ...newItems]);
+    for (const { toolCall } of handoffRuns) {
+      const rawItem = buildFunctionAbortResult(toolCall);
+      appendRunItemIfNew(
+        new RunToolCallOutputItem(rawItem, agent, rawItem.output),
+        newItems,
+        appendContext,
+      );
+    }
+    return undefined;
+  }
+  const interruptions = collectInterruptions(
+    functionResults,
+    additionalInterruptions,
+  );
+  if (interruptions.length > 0) {
+    return new SingleStepResult(
+      originalInput,
+      newResponse,
+      preStepItems,
+      newItems,
+      {
+        type: 'next_step_interruption',
+        data: { interruptions },
+      },
+    );
+  }
+  return executeHandoffCalls(
+    agent,
+    originalInput,
+    preStepItems,
+    newItems,
+    newResponse,
+    handoffRuns,
+    runner,
+    state._context,
+    getRunStateTurnSpanParent(state) ?? state._currentAgentSpan,
+    validateHandoffAgent,
+    beforeHandoffInputFilter,
+  );
+}
 
 // Consolidates the logic that determines whether tool results yielded a final answer,
 // triggered an interruption, or require the agent loop to continue running.

--- a/packages/agents-core/test/run.sessionWriteRecovery.test.ts
+++ b/packages/agents-core/test/run.sessionWriteRecovery.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import {
   Agent,
   RunState,
+  ToolGuardrailFunctionOutputFactory,
   Usage,
   UserError,
   run,
@@ -17,6 +18,8 @@ import {
   type ToolToFinalOutputFunction,
   type ToolUseBehavior,
 } from '../src';
+import { handoff, type HandoffInputData } from '../src/handoff';
+import { removeAllTools } from '../src/extensions/handoffFilters';
 import * as protocol from '../src/types/protocol';
 import { attachClientToolSearchExecutor } from '../src/tool';
 import { ScriptedModel, modelResponder } from '../src/testing';
@@ -300,6 +303,82 @@ function createApprovalRun(
   return { agent, execute, model };
 }
 
+function createApprovalHandoffRun(
+  options: {
+    calls?: number;
+    needsApproval?: boolean;
+    toolUseBehavior?: ToolUseBehavior;
+    inputFilter?: (data: HandoffInputData) => HandoffInputData;
+  } = {},
+) {
+  const execute = vi.fn(async () => 'approved-result');
+  const inputGuardrail = vi.fn(async () =>
+    ToolGuardrailFunctionOutputFactory.allow('input-checked'),
+  );
+  const outputGuardrail = vi.fn(async () =>
+    ToolGuardrailFunctionOutputFactory.allow('output-checked'),
+  );
+  const approvalTool = tool({
+    name: 'approval_tool',
+    description: 'Returns a result after approval.',
+    parameters: z.object({}),
+    needsApproval: options.needsApproval ?? true,
+    inputGuardrails: [{ name: 'input check', run: inputGuardrail }],
+    outputGuardrails: [{ name: 'output check', run: outputGuardrail }],
+    execute,
+  });
+  const targetModel = new ScriptedModel([
+    modelResponder(() => ({
+      output: [fakeModelMessage('target done')],
+      usage: new Usage(),
+    })),
+  ]);
+  const target = new Agent({ name: 'Handoff target', model: targetModel });
+  const onHandoff = vi.fn();
+  const inputFilter = vi.fn(
+    options.inputFilter ?? ((data: HandoffInputData) => data),
+  );
+  const transfer = handoff(target, { onHandoff, inputFilter });
+  const sourceModel = new ScriptedModel([
+    modelResponder(() => ({
+      output: [
+        ...Array.from({ length: options.calls ?? 1 }, (_, index) =>
+          functionToolCall(`approval-${index}`),
+        ),
+        { ...functionToolCall('handoff'), name: transfer.toolName },
+      ],
+      usage: new Usage(),
+    })),
+  ]);
+  const agent = new Agent({
+    name: 'Handoff source',
+    model: sourceModel,
+    tools: [approvalTool],
+    handoffs: [transfer],
+    toolUseBehavior: options.toolUseBehavior,
+  });
+  const toolStart = vi.fn();
+  const toolEnd = vi.fn();
+  const targetStart = vi.fn();
+  agent.on('agent_tool_start', toolStart);
+  agent.on('agent_tool_end', toolEnd);
+  target.on('agent_start', targetStart);
+  return {
+    agent,
+    target,
+    sourceModel,
+    targetModel,
+    execute,
+    inputGuardrail,
+    outputGuardrail,
+    onHandoff,
+    inputFilter,
+    toolStart,
+    toolEnd,
+    targetStart,
+  };
+}
+
 function createApprovalRunWithToolSearch(
   toolUseBehavior: 'run_llm_again' | 'stop_on_first_tool' = 'run_llm_again',
 ) {
@@ -365,6 +444,417 @@ function createApprovalRunWithToolSearch(
 describe('resumed Session write recovery', () => {
   beforeAll(() => {
     setTracingDisabled(true);
+  });
+
+  it.each(
+    (['non_streamed', 'streamed'] as const).flatMap((failingMode) =>
+      (['non_streamed', 'streamed'] as const).flatMap((retryMode) =>
+        (['before', 'after'] as const).flatMap((failure) =>
+          [false, true].map((roundTrip) => ({
+            failingMode,
+            retryMode,
+            failure,
+            roundTrip,
+          })),
+        ),
+      ),
+    ),
+  )(
+    'recovers a resumed handoff: $failingMode/$retryMode, $failure commit, roundTrip=$roundTrip',
+    async ({ failingMode, retryMode, failure, roundTrip }) => {
+      const fixture = createApprovalHandoffRun();
+      const { agent, target, targetModel, sourceModel, execute, onHandoff } =
+        fixture;
+      const session = new UncertainAppendSession();
+      const paused = await runOnce(
+        failingMode,
+        agent,
+        'Approve then transfer.',
+        session,
+      );
+      expect(paused.interruptions).toHaveLength(1);
+      expect(onHandoff).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+      expect(targetModel.calls).toHaveLength(0);
+      // Restore the interruption as well as the failed append to cover both durable boundaries.
+      const state = roundTrip
+        ? await RunState.fromString(agent, paused.state.toString())
+        : paused.state;
+      state.approve(state.getInterruptions()[0]!);
+      session.failNextAppend(failure);
+      const appendError =
+        failure === 'before' ? /before commit/ : /acknowledgement lost/;
+      if (failingMode === 'streamed') {
+        const failed = await run(agent, state, { session, stream: true });
+        await expect(failed.completed).rejects.toThrow(appendError);
+        expect(failed.lastAgent).toBe(target);
+      } else {
+        await expect(
+          runOnce(failingMode, agent, state, session),
+        ).rejects.toThrow(appendError);
+      }
+      expect(state.currentAgent).toBe(target);
+      expect(state._currentStep).toEqual({ type: 'next_step_run_again' });
+      expect(state._noActiveAgentRun).toBe(true);
+      expect(state._currentTurnInProgress).toBe(false);
+      expect(state._pendingSessionWrite?.phase).toBe('append_ready');
+      expect(targetModel.calls).toHaveLength(0);
+      expect(fixture.targetStart).not.toHaveBeenCalled();
+      expect(
+        state._toolInputGuardrailResults.map((r) => r.output.outputInfo),
+      ).toEqual(['input-checked']);
+      expect(
+        state._toolOutputGuardrailResults.map((r) => r.output.outputInfo),
+      ).toEqual(['output-checked']);
+
+      const retryState = roundTrip
+        ? await RunState.fromString(agent, state.toString())
+        : state;
+      const completed = await runOnce(retryMode, agent, retryState, session);
+      expect(completed.finalOutput).toBe('target done');
+      expect(completed.lastAgent).toBe(target);
+      expect(completed.state._currentTurn).toBe(2);
+      expect(completed.state._pendingSessionWrite).toBeUndefined();
+      for (const effect of [
+        execute,
+        onHandoff,
+        fixture.inputFilter,
+        fixture.inputGuardrail,
+        fixture.outputGuardrail,
+        fixture.toolStart,
+        fixture.toolEnd,
+        fixture.targetStart,
+      ]) {
+        expect(effect).toHaveBeenCalledTimes(1);
+      }
+      expect(sourceModel.calls).toHaveLength(1);
+      expect(targetModel.calls).toHaveLength(1);
+      expect(
+        completed.toolInputGuardrailResults.map((r) => r.output.outputInfo),
+      ).toEqual(['input-checked']);
+      expect(
+        completed.toolOutputGuardrailResults.map((r) => r.output.outputInfo),
+      ).toEqual(['output-checked']);
+      for (const items of [await session.getItems(), completed.history]) {
+        for (const callId of ['approval-0', 'handoff']) {
+          expect(
+            items
+              .filter((item) => 'callId' in item && item.callId === callId)
+              .map((item) => item.type),
+          ).toEqual(['function_call', 'function_call_result']);
+        }
+      }
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'waits for every approval before a %s handoff, including rejection',
+    async (mode) => {
+      const { agent, execute, onHandoff, target } = createApprovalHandoffRun({
+        calls: 2,
+      });
+      const session = new UncertainAppendSession();
+      const paused = await runOnce(
+        mode,
+        agent,
+        'Approve then transfer.',
+        session,
+      );
+      expect(paused.interruptions).toHaveLength(2);
+      paused.state.approve(paused.interruptions[0]!);
+      const partiallyApproved = await runOnce(
+        mode,
+        agent,
+        paused.state,
+        session,
+      );
+      expect(partiallyApproved.interruptions).toHaveLength(1);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(onHandoff).not.toHaveBeenCalled();
+      const restored = await RunState.fromString(
+        agent,
+        partiallyApproved.state.toString(),
+      );
+      restored.reject(restored.getInterruptions()[0]!);
+      session.failNextAppend('before');
+      await expect(runOnce(mode, agent, restored, session)).rejects.toThrow(
+        /before commit/,
+      );
+      expect(restored._pendingSessionWrite?.phase).toBe('append_ready');
+      const retry = await RunState.fromString(agent, restored.toString());
+      const completed = await runOnce(mode, agent, retry, session);
+      expect(completed.finalOutput).toBe('target done');
+      expect(completed.lastAgent).toBe(target);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(onHandoff).toHaveBeenCalledTimes(1);
+      expect(
+        completed.history.filter(
+          (item) =>
+            item.type === 'function_call_result' &&
+            item.callId === 'approval-1',
+        ),
+      ).toHaveLength(1);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'preserves %s handoff precedence over terminal tool behavior without pending approvals',
+    async (mode) => {
+      const { agent, target, execute, onHandoff } = createApprovalHandoffRun({
+        needsApproval: false,
+        toolUseBehavior: 'stop_on_first_tool',
+      });
+      const completed = await runOnce(
+        mode,
+        agent,
+        'Transfer.',
+        new UncertainAppendSession(),
+      );
+      expect(completed.finalOutput).toBe('target done');
+      expect(completed.lastAgent).toBe(target);
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(onHandoff).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'resumes a %s handoff after input compaction fails without repeating the transfer',
+    async (mode) => {
+      const { agent, target, execute, onHandoff } = createApprovalHandoffRun();
+      const session = new UncertainAppendSession();
+      const paused = await runOnce(
+        mode,
+        agent,
+        'Approve then transfer.',
+        session,
+      );
+      paused.state.approve(paused.interruptions[0]!);
+      session.failNextCompaction();
+      await expect(runOnce(mode, agent, paused.state, session)).rejects.toThrow(
+        'input compaction rejected',
+      );
+      expect(paused.state._pendingSessionWrite?.phase).toBe(
+        'compaction_pending',
+      );
+      const restored = await RunState.fromString(
+        agent,
+        paused.state.toString(),
+      );
+      const completed = await runOnce(mode, agent, restored, session);
+      expect(completed.lastAgent).toBe(target);
+      expect(completed.finalOutput).toBe('target done');
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(onHandoff).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('emits one target update on a streamed approved handoff without a Session', async () => {
+    const { agent, target, execute, onHandoff, targetStart } =
+      createApprovalHandoffRun({
+        toolUseBehavior: 'stop_on_first_tool',
+      });
+    const paused = await run(agent, 'Approve then transfer.', { stream: true });
+    await paused.completed;
+    expect(paused.interruptions).toHaveLength(1);
+    paused.state.approve(paused.interruptions[0]!);
+    const completed = await run(agent, paused.state, { stream: true });
+    const updates = [];
+    for await (const event of completed.toStream()) {
+      if (event.type === 'agent_updated_stream_event') {
+        updates.push(event.agent);
+      }
+    }
+    await completed.completed;
+    expect(updates).toEqual([target]);
+    expect(completed.finalOutput).toBe('target done');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(onHandoff).toHaveBeenCalledTimes(1);
+    expect(targetStart).toHaveBeenCalledTimes(1);
+  });
+
+  it.each<RunMode>(['non_streamed', 'streamed'])(
+    'recovers a %s handoff after rejecting every tool',
+    async (mode) => {
+      const { agent, target, execute, onHandoff, targetModel } =
+        createApprovalHandoffRun();
+      const session = new UncertainAppendSession();
+      const paused = await runOnce(
+        mode,
+        agent,
+        'Reject then transfer.',
+        session,
+      );
+      paused.state.reject(paused.interruptions[0]!);
+      session.failNextAppend('after');
+      await expect(runOnce(mode, agent, paused.state, session)).rejects.toThrow(
+        /acknowledgement lost/,
+      );
+      expect(paused.state._pendingSessionWrite?.phase).toBe('append_ready');
+      expect(targetModel.calls).toHaveLength(0);
+      const restored = await RunState.fromString(
+        agent,
+        paused.state.toString(),
+      );
+      const completed = await runOnce(mode, agent, restored, session);
+      expect(completed.lastAgent).toBe(target);
+      expect(completed.finalOutput).toBe('target done');
+      expect(execute).not.toHaveBeenCalled();
+      expect(onHandoff).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    { mode: 'non_streamed' as const, failure: 'before' as const },
+    { mode: 'streamed' as const, failure: 'after' as const },
+    { mode: 'non_streamed' as const, failure: 'compaction' as const },
+  ])(
+    'settles source pairs before restoring filtered handoff input: $mode/$failure',
+    async ({ mode, failure }) => {
+      const fixture = createApprovalHandoffRun({ inputFilter: removeAllTools });
+      const { agent, target, targetModel, execute, onHandoff, inputFilter } =
+        fixture;
+      const session = new UncertainAppendSession();
+      const paused = await runOnce(
+        mode,
+        agent,
+        'Approve then transfer.',
+        session,
+      );
+      paused.state.approve(paused.interruptions[0]!);
+      if (failure === 'compaction') session.failNextCompaction();
+      else session.failNextAppend(failure);
+      await expect(
+        runOnce(mode, agent, paused.state, session),
+      ).rejects.toThrow();
+      expect(targetModel.calls).toHaveLength(0);
+      expect(
+        paused.state._pendingSessionWrite?.handoffInput?.generatedItems,
+      ).toEqual([]);
+      const restored = await RunState.fromString(
+        agent,
+        paused.state.toString(),
+      );
+      const completed = await runOnce(mode, agent, restored, session);
+      expect(completed.lastAgent).toBe(target);
+      expect(completed.finalOutput).toBe('target done');
+      expect(completed.history.map((item) => item.type)).toEqual([
+        'message',
+        'message',
+      ]);
+      expect(completed.newItems.map((item) => item.type)).toEqual([
+        'message_output_item',
+      ]);
+      expect(targetModel.calls[0]?.request.input).toEqual([
+        { type: 'message', role: 'user', content: 'Approve then transfer.' },
+      ]);
+      for (const effect of [
+        execute,
+        onHandoff,
+        inputFilter,
+        fixture.inputGuardrail,
+        fixture.outputGuardrail,
+      ])
+        expect(effect).toHaveBeenCalledTimes(1);
+      const stored = await session.getItems();
+      for (const callId of ['approval-0', 'handoff']) {
+        expect(
+          stored
+            .filter((item) => 'callId' in item && item.callId === callId)
+            .map((item) => item.type),
+        ).toEqual(['function_call', 'function_call_result']);
+      }
+    },
+  );
+
+  it('freezes source append items before a mutating handoff filter and rejects unknown snapshot agents', async () => {
+    const fixture = createApprovalHandoffRun({
+      inputFilter: (data) => {
+        const output = data.newItems.find(
+          (item) => item.type === 'tool_call_output_item',
+        );
+        if (output?.rawItem.type === 'function_call_result')
+          output.rawItem.output = 'filtered-output';
+        return data;
+      },
+    });
+    const { agent } = fixture;
+    const session = new UncertainAppendSession();
+    const paused = await runOnce(
+      'non_streamed',
+      agent,
+      'Approve then transfer.',
+      session,
+    );
+    paused.state.approve(paused.interruptions[0]!);
+    session.failNextAppend('before');
+    await expect(
+      runOnce('non_streamed', agent, paused.state, session),
+    ).rejects.toThrow(/before commit/);
+    const serialized = paused.state.toJSON() as any;
+    const filteredItem =
+      serialized.pendingSessionWrite.handoffInput.generatedItems.find(
+        (item: { type: string }) => item.type === 'tool_call_output_item',
+      );
+    const validAgent = filteredItem.agent;
+    filteredItem.agent = {
+      name: 'Unknown snapshot agent',
+      identity: 'not-configured',
+    };
+    await expect(
+      RunState.fromString(agent, JSON.stringify(serialized)),
+    ).rejects.toThrow();
+    filteredItem.agent = validAgent;
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    const completed = await runOnce('non_streamed', agent, restored, session);
+    expect(
+      (await session.getItems()).find(
+        (item) =>
+          item.type === 'function_call_result' && item.callId === 'approval-0',
+      ),
+    ).toMatchObject({ output: { type: 'text', text: 'approved-result' } });
+    expect(
+      completed.history.find(
+        (item) =>
+          item.type === 'function_call_result' && item.callId === 'approval-0',
+      ),
+    ).toMatchObject({ output: 'filtered-output' });
+    expect(fixture.execute).toHaveBeenCalledTimes(1);
+    expect(fixture.inputFilter).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits the target update before a streamed append fails, without replaying it on retry', async () => {
+    const { agent, target, onHandoff } = createApprovalHandoffRun();
+    const session = new UncertainAppendSession();
+    const paused = await runOnce(
+      'streamed',
+      agent,
+      'Approve then transfer.',
+      session,
+    );
+    paused.state.approve(paused.interruptions[0]!);
+    session.failNextAppend('before');
+    const failed = await run(agent, paused.state, { session, stream: true });
+    const updates: Agent[] = [];
+    const consume = async () => {
+      for await (const event of failed.toStream())
+        if (event.type === 'agent_updated_stream_event')
+          updates.push(event.agent);
+    };
+    await expect(consume()).rejects.toThrow(/before commit/);
+    await expect(failed.completed).rejects.toThrow(/before commit/);
+    expect(updates).toEqual([target]);
+    const restored = await RunState.fromString(agent, failed.state.toString());
+    const completed = await run(agent, restored, { session, stream: true });
+    for await (const event of completed.toStream())
+      if (event.type === 'agent_updated_stream_event')
+        updates.push(event.agent);
+    await completed.completed;
+    expect(updates).toEqual([target]);
+    expect(completed.lastAgent).toBe(target);
+    expect(onHandoff).toHaveBeenCalledTimes(1);
   });
 
   it.each([


### PR DESCRIPTION
This pull request fixes approval-gated tools being skipped when a model response also requests a handoff. Pending approvals now interrupt first, and the transfer follows settled approval or rejection decisions.

Existing Session recovery preserves the target agent, completed source results, filtered target input and stream notification across append failures and serialized retries without repeating side effects. An optional snapshot extends unreleased RunState schema 1.20 without introducing another recovery state machine or schema version.