### PR TITLE
fix(core): honor EOF hunks for newline-terminated files

### DIFF
--- a/.changeset/honor-eof-newline-hunks.md
+++ b/.changeset/honor-eof-newline-hunks.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: honor end-of-file hunks when the file ends in a newline

--- a/packages/agents-core/src/utils/applyDiff.ts
+++ b/packages/agents-core/src/utils/applyDiff.ts
@@ -325,10 +325,18 @@ function findContext(
   eof: boolean,
 ): { newIndex: number; fuzz: number } {
   if (eof) {
-    const endStart = Math.max(0, lines.length - context.length);
-    const endMatch = findContextCore(lines, context, endStart);
+    const searchLines =
+      lines.length > 1 && lines[lines.length - 1] === ''
+        ? lines.slice(0, -1)
+        : lines;
+    const endStart = Math.max(0, searchLines.length - context.length);
+    const endMatch = findContextCore(searchLines, context, endStart);
     if (endMatch.newIndex !== -1) return endMatch;
-    const fallback = findContextCore(lines, context, start);
+    const fallback = findContextCore(
+      searchLines,
+      context,
+      Math.min(start, searchLines.length),
+    );
     return { newIndex: fallback.newIndex, fuzz: fallback.fuzz + 10000 };
   }
   return findContextCore(lines, context, start);

--- a/packages/agents-core/test/utils/applyDiff.test.ts
+++ b/packages/agents-core/test/utils/applyDiff.test.ts
@@ -55,6 +55,35 @@ describe('applyDiff', () => {
     expect(result).toBe(['keep', 'stay'].join('\n') + '\n');
   });
 
+  it('appends EOF hunks without changing the trailing newline state', () => {
+    const diff = ['@@', '+c', '*** End of File'].join('\n');
+
+    expect(applyDiff('a\nb\n', diff)).toBe('a\nb\nc\n');
+    expect(applyDiff('a\nb', diff)).toBe('a\nb\nc');
+  });
+
+  it('matches EOF context at the final occurrence across multiple hunks', () => {
+    const input = 'start\nx\nfoo\ny\nfoo\n';
+    const diff = [
+      '@@',
+      '-start',
+      '+updated',
+      '@@',
+      ' foo',
+      '+added',
+      '*** End of File',
+    ].join('\n');
+
+    expect(applyDiff(input, diff)).toBe('updated\nx\nfoo\ny\nfoo\nadded\n');
+  });
+
+  it('preserves an intentional blank line before an EOF append', () => {
+    const input = 'a\n\n';
+    const diff = ['@@', '+b', '*** End of File'].join('\n');
+
+    expect(applyDiff(input, diff)).toBe('a\n\nb\n');
+  });
+
   it('applies V4A context marker diffs (class method rename)', () => {
     const input =
       [


### PR DESCRIPTION
This pull request fixes `*** End of File` hunk placement when an existing file ends with a newline. EOF context matching now excludes only the synthetic trailing split element, allowing content to be appended after the last real line while preserving the original trailing-newline state.

Regression coverage includes inputs with and without trailing newlines, repeated final context across multiple hunks, and intentional blank lines before EOF.