### PR TITLE
fix: reconcile pending computer calls on stream abort

### DIFF
--- a/.changeset/stream-abort-reconcile-computer-calls.md
+++ b/.changeset/stream-abort-reconcile-computer-calls.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reconcile pending computer calls on stream abort

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -3022,7 +3022,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
                     preparedCall,
                   ),
                   conversationId: preparedCall.conversationId,
-                  modelSettings: preparedCall.modelSettings,
+                  modelSettings: {
+                    ...preparedCall.modelSettings,
+                    toolChoice: 'none',
+                  },
                   _internal: preparedCall.modelRequestInternal,
                   tools: preparedCall.serializedTools,
                   toolsExplicitlyProvided: preparedCall.toolsExplicitlyProvided,

--- a/packages/agents-core/src/runner/streamReconciliation.ts
+++ b/packages/agents-core/src/runner/streamReconciliation.ts
@@ -29,6 +29,7 @@ export type StreamAbortReconciliationState = {
   pendingShellCalls: Map<string, PendingStreamedToolCall>;
   pendingApplyPatchCalls: Map<string, PendingStreamedToolCall>;
   pendingProgramCalls: Map<string, string>;
+  pendingComputerCalls: Map<string, Pick<ComputerUseCallItem, 'callId'>>;
 };
 
 // 1x1 transparent PNG data URL used when a computer result requires an image
@@ -102,6 +103,7 @@ export function createStreamAbortReconciliationState(): StreamAbortReconciliatio
     pendingShellCalls: new Map(),
     pendingApplyPatchCalls: new Map(),
     pendingProgramCalls: new Map(),
+    pendingComputerCalls: new Map(),
   };
 }
 
@@ -114,6 +116,7 @@ export function recordStreamEventForAbortReconciliation(
     state.pendingShellCalls.clear();
     state.pendingApplyPatchCalls.clear();
     state.pendingProgramCalls.clear();
+    state.pendingComputerCalls.clear();
     state.responseId = event.response.id;
     return;
   }
@@ -176,6 +179,13 @@ export function recordStreamEventForAbortReconciliation(
     return;
   }
 
+  if (item.type === 'computer_call' && typeof item.call_id === 'string') {
+    state.pendingComputerCalls.set(item.call_id, {
+      callId: item.call_id,
+    });
+    return;
+  }
+
   if (
     item.type === 'shell_call' &&
     typeof item.call_id === 'string' &&
@@ -204,6 +214,14 @@ export function recordStreamEventForAbortReconciliation(
     return;
   }
 
+  if (
+    item.type === 'computer_call_output' &&
+    typeof item.call_id === 'string'
+  ) {
+    state.pendingComputerCalls.delete(item.call_id);
+    return;
+  }
+
   if (item.type === 'shell_call_output' && typeof item.call_id === 'string') {
     state.pendingShellCalls.delete(item.call_id);
     return;
@@ -221,6 +239,7 @@ export function buildAbortReconciliationInput(
   state: StreamAbortReconciliationState,
 ): (
   | FunctionCallResultItem
+  | ComputerCallResultItem
   | ShellCallResultItem
   | ApplyPatchCallResultItem
   | ProgramCallResultItem
@@ -228,6 +247,10 @@ export function buildAbortReconciliationInput(
   const functionOutputs = Array.from(
     state.pendingFunctionCalls.values(),
     buildFunctionAbortResult,
+  );
+  const computerOutputs = Array.from(
+    state.pendingComputerCalls.values(),
+    buildComputerAbortResult,
   );
   const shellOutputs = Array.from(
     state.pendingShellCalls.values(),
@@ -250,6 +273,7 @@ export function buildAbortReconciliationInput(
 
   return [
     ...functionOutputs,
+    ...computerOutputs,
     ...shellOutputs,
     ...applyPatchOutputs,
     ...programOutputs,
@@ -271,6 +295,7 @@ export function shouldReconcileStreamAbort(
 ): boolean {
   return (
     state.pendingFunctionCalls.size > 0 ||
+    state.pendingComputerCalls.size > 0 ||
     state.pendingProgramCalls.size > 0 ||
     state.pendingShellCalls.size > 0 ||
     state.pendingApplyPatchCalls.size > 0
@@ -282,6 +307,7 @@ export function markAbortReconciliationComplete(
   response: ModelResponse | undefined,
 ): void {
   state.pendingFunctionCalls.clear();
+  state.pendingComputerCalls.clear();
   state.pendingShellCalls.clear();
   state.pendingApplyPatchCalls.clear();
   state.pendingProgramCalls.clear();

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -2022,6 +2022,75 @@ describe('Runner.run', () => {
       ).toHaveLength(1);
     });
 
+    it('reconciles streamed pending computer calls using toolChoice none under required tool choice', async () => {
+      const controller = new AbortController();
+      const abortReason = new Error('abort stream');
+      const computer = new FakeComputer();
+
+      const model = new ScriptedModel([
+        {
+          type: 'stream_responder',
+          respond: async function* () {
+            yield {
+              type: 'model',
+              event: {
+                type: 'response.created',
+                response: { id: 'resp_initial' },
+              },
+            };
+            yield {
+              type: 'model',
+              event: {
+                type: 'response.output_item.done',
+                item: {
+                  type: 'computer_call',
+                  id: 'comp_1',
+                  call_id: 'call_comp_1',
+                  status: 'completed',
+                  action: { type: 'screenshot' },
+                },
+              },
+            };
+            controller.abort(abortReason);
+            const abortError = new Error('stream aborted');
+            abortError.name = 'AbortError';
+            throw abortError;
+          },
+        },
+        modelResponse({
+          output: [fakeModelMessage('reconciled response')],
+          usage: new Usage(),
+        }),
+      ]);
+
+      const agent = new Agent({
+        name: 'ComputerStreamAbortAgent',
+        model,
+        tools: [computerTool({ computer })],
+        modelSettings: { toolChoice: 'required' },
+      });
+
+      const result = await run(agent, 'start', {
+        stream: true,
+        conversationId: 'conv_123',
+        signal: controller.signal,
+      });
+
+      await result.completed;
+
+      expect(model.calls).toHaveLength(2);
+      expect(model.calls[0]?.request.modelSettings.toolChoice).toBe('required');
+      expect(model.calls[1]?.request.modelSettings.toolChoice).toBe('none');
+      expect(model.calls[1]?.request.input).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'computer_call_result',
+            callId: 'call_comp_1',
+          }),
+        ]),
+      );
+    });
+
     it('accepts public tool not found behavior config', () => {
       const toolNotFoundBehavior =
         'return_error_to_model' satisfies ToolNotFoundBehavior;

--- a/packages/agents-core/test/runner/streamReconciliation.test.ts
+++ b/packages/agents-core/test/runner/streamReconciliation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildAbortReconciliationInput,
+  COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
   createStreamAbortReconciliationState,
   recordStreamEventForAbortReconciliation,
   shouldReconcileStreamAbort,
@@ -251,6 +252,70 @@ describe('stream abort reconciliation', () => {
         call_id: 'call_prog_1',
         result: 'done',
         status: 'completed',
+      },
+    ]) {
+      recordStreamEventForAbortReconciliation(state, {
+        type: 'model',
+        event: {
+          type: 'response.output_item.done',
+          item,
+        },
+      });
+    }
+
+    expect(shouldReconcileStreamAbort(state)).toBe(false);
+    expect(buildAbortReconciliationInput(state)).toEqual([]);
+  });
+
+  it('reconciles pending computer calls', () => {
+    const state = createStreamAbortReconciliationState();
+
+    recordStreamEventForAbortReconciliation(state, {
+      type: 'model',
+      event: {
+        type: 'response.output_item.done',
+        item: {
+          type: 'computer_call',
+          id: 'computer_1',
+          call_id: 'call_comp_1',
+          status: 'completed',
+          action: { type: 'screenshot' },
+        },
+      },
+    });
+
+    expect(shouldReconcileStreamAbort(state)).toBe(true);
+    expect(buildAbortReconciliationInput(state)).toEqual([
+      {
+        type: 'computer_call_result',
+        callId: 'call_comp_1',
+        output: {
+          type: 'computer_screenshot',
+          data: COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
+        },
+        providerData: { status: 'incomplete' },
+      },
+    ]);
+  });
+
+  it('does not reconcile computer calls that have outputs', () => {
+    const state = createStreamAbortReconciliationState();
+
+    for (const item of [
+      {
+        type: 'computer_call',
+        id: 'computer_1',
+        call_id: 'call_comp_1',
+        status: 'completed',
+        action: { type: 'screenshot' },
+      },
+      {
+        type: 'computer_call_output',
+        call_id: 'call_comp_1',
+        output: {
+          type: 'computer_screenshot',
+          data: 'data:image/png;base64,abc',
+        },
       },
     ]) {
       recordStreamEventForAbortReconciliation(state, {


### PR DESCRIPTION
### Summary

When a stream aborts, the runner synthesizes results for in-flight tool calls to prevent execution deadlocks. Previously, the `StreamAbortReconciliationState` omitted tracking for `computer_call`, which would cause the runner to hang if a computer call was in-flight when the abort happened. 

This update adds `pendingComputerCalls` to the reconciliation state and provides fallback screenshot generation, bringing computer calls to parity with functions, shell calls, and other streaming tools.

### Test plan

Added unit tests in `streamReconciliation.test.ts` to verify that `computer_call` stream aborts are properly tracked and synthesized into a fallback 1x1 screenshot result. Verified all tests, typechecking, linting, and build pass locally using the full code change verification stack.

### Issue number

Closes #1770 

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [x] I've run `pnpm test` and `pnpm test:examples`
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
