### PR TITLE
fix(agents-core): await in-flight parallel guardrails in throwIfError

### DIFF
--- a/.changeset/fix-guardrail-throw-if-error.md
+++ b/.changeset/fix-guardrail-throw-if-error.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: await in-flight parallel guardrails in throwIfError before checking for errors

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -67,10 +67,10 @@ export const createGuardrailTracker = (): GuardrailTracker => {
   };
 
   const throwIfError = async () => {
+    if (promise) {
+      await promise;
+    }
     if (error) {
-      if (promise) {
-        await promise;
-      }
       throw error;
     }
   };

--- a/packages/agents-core/test/runner/guardrails.test.ts
+++ b/packages/agents-core/test/runner/guardrails.test.ts
@@ -5,6 +5,7 @@ import { withTrace } from '../../src';
 import { Agent, AgentOutputType } from '../../src/agent';
 import {
   buildInputGuardrailDefinitions,
+  createGuardrailTracker,
   runInputGuardrails,
   runOutputGuardrails,
   splitInputGuardrails,
@@ -88,6 +89,24 @@ describe('splitInputGuardrails', () => {
 
     expect(blockingResult.map((g) => g.name)).toEqual(['block']);
     expect(parallelResult.map((g) => g.name)).toEqual(['parallel']);
+  });
+});
+
+describe('createGuardrailTracker', () => {
+  it('throwIfError awaits in-flight parallel guardrails before surfacing errors', async () => {
+    const tracker = createGuardrailTracker();
+    const guardrailError = new Error('parallel guardrail failed');
+    let rejectGuardrail!: (err: Error) => void;
+    const pendingGuardrail = new Promise<never>((_, reject) => {
+      rejectGuardrail = reject;
+    });
+    tracker.setPromise(pendingGuardrail);
+
+    const throwPromise = tracker.throwIfError();
+
+    rejectGuardrail(guardrailError);
+
+    await expect(throwPromise).rejects.toBe(guardrailError);
   });
 });
 


### PR DESCRIPTION
## Problem

`GuardrailTracker.throwIfError()` checked the `error` flag **before** awaiting the pending guardrail `promise`. When input guardrails run in parallel (`runInParallel: true`), the promise is still resolving when `throwIfError()` is called at admission checkpoints (`run.ts` lines 1875, 2894, 3115). At that point `error` is `undefined` — the `.catch` handler that calls `setError` hasn't run yet — so `throwIfError()` returns immediately without throwing. The admission checkpoint is bypassed and in-flight guardrail failures/tripwires are never surfaced.

## Root cause

```ts
// Before (buggy)
const throwIfError = async () => {
  if (error) {          // ← checked BEFORE await
    if (promise) {
      await promise;
    }
    throw error;
  }
};
```

## Fix

Await `promise` first, then check `error` — the same order already used by `awaitCompletion` (line 78–84):

```ts
// After (fixed)
const throwIfError = async () => {
  if (promise) {
    await promise;      // ← await FIRST so .catch → setError runs
  }
  if (error) {
    throw error;
  }
};
```

## Test

Added `throwIfError awaits in-flight parallel guardrails before surfacing errors`: creates a tracker, sets a pending promise that rejects, calls `throwIfError()` while the promise is still in-flight, then rejects the promise and asserts `throwIfError` throws the guardrail error.

- **RED** on old code: `throwIfError` resolves `undefined` (checkpoint bypassed)
- **GREEN** after fix: `throwIfError` awaits the promise and throws the error

All 16 tests in `guardrails.test.ts` pass; `tsc --noEmit` and ESLint clean.

Fixes #1770