### PR TITLE
feat(ai-sdk): add OrcaRouter provider example

### DIFF
--- a/examples/ai-sdk/README.md
+++ b/examples/ai-sdk/README.md
@@ -7,6 +7,7 @@ These examples show how to wrap models from the [AI SDK](https://www.npmjs.com/p
 | Script | Command | Provider | Description |
 | --- | --- | --- | --- |
 | [index.ts](./index.ts) | `pnpm -F ai-sdk start` | OpenRouter (`OPENROUTER_API_KEY`) | Runs a parent agent that hands off a weather question to a child agent equipped with a `get_weather` tool. |
+| [orca-router.ts](./orca-router.ts) | `pnpm -F ai-sdk start:orca-router` | OrcaRouter (`ORCAROUTER_API_KEY`) | Runs the same handoff workflow as `index.ts` against an OrcaRouter-backed model. |
 | [gpt-5.ts](./gpt-5.ts) | `pnpm -F ai-sdk start:gpt-5` | OpenAI (`OPENAI_API_KEY`) | Shows a single agent that must call the `get_weather` tool using `gpt-5.4` with custom provider options. |
 | [retry.ts](./retry.ts) | `pnpm -F ai-sdk start:retry` | OpenAI (`OPENAI_API_KEY`) | Configures opt-in model retries for an AI SDK-backed agent and logs retry decisions when transient failures occur. |
 | [stream.ts](./stream.ts) | `pnpm -F ai-sdk start:stream` | OpenAI (`OPENAI_API_KEY`) | Demonstrates streaming text output from an AI SDK model wrapped with `aisdk()`. |

--- a/examples/ai-sdk/orca-router.ts
+++ b/examples/ai-sdk/orca-router.ts
@@ -1,0 +1,92 @@
+import { Agent, ModelSettings, Runner, tool } from '@openai/agents';
+import { aisdk, AiSdkModel } from '@openai/agents-extensions/ai-sdk';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { z } from 'zod';
+
+// OrcaRouter is an OpenAI-compatible AI gateway, so the standard AI SDK
+// openai-compatible provider is all we need to expose its models as named,
+// first-class providers in the Agents SDK.
+const orcaRouter = createOpenAICompatible({
+  name: 'orcarouter',
+  baseURL: 'https://api.orcarouter.ai/v1',
+  apiKey: process.env.ORCAROUTER_API_KEY,
+});
+
+export async function runAgents(
+  model: AiSdkModel,
+  modelSettings: ModelSettings,
+) {
+  const lookedUpCities: string[] = [];
+
+  const getWeatherTool = tool({
+    name: 'get_weather',
+    description: 'Get the weather for one or more cities.',
+    parameters: z.object({
+      cities: z.array(z.string()).min(1),
+    }),
+    execute: ({ cities }) => {
+      lookedUpCities.push(...cities);
+      return cities.map((city) => `${city}: sunny`).join('\n');
+    },
+  });
+
+  const dataAgent = new Agent({
+    name: 'Weather Data Agent',
+    instructions: 'You answer weather questions.',
+    handoffDescription: 'Looks up weather for one or more cities.',
+    tools: [getWeatherTool],
+    toolUseBehavior: 'stop_on_first_tool',
+    model, // Using the OrcaRouter-backed AI SDK model for this agent
+    modelSettings: {
+      ...modelSettings,
+      toolChoice: 'required',
+    },
+  });
+
+  const agent = new Agent({
+    name: 'Helpful Assistant',
+    instructions: 'Delegate weather requests to the available specialist.',
+    handoffs: [dataAgent],
+    model, // Using the OrcaRouter-backed AI SDK model for this agent
+    modelSettings: {
+      ...modelSettings,
+      toolChoice: 'required',
+    },
+  });
+
+  const runner = new Runner({
+    traceMetadata: {
+      userId: 'u_123',
+      chatType: 'support',
+    },
+  });
+  const result = await runner.run(
+    agent,
+    'What is the weather in San Francisco and Oakland?',
+  );
+
+  if (!result.newItems.some((item) => item.type === 'handoff_call_item')) {
+    throw new Error('Expected the weather request to be handed off.');
+  }
+
+  const normalizedCities = lookedUpCities.map((city) =>
+    city.trim().toLowerCase(),
+  );
+  if (
+    !normalizedCities.includes('san francisco') ||
+    !normalizedCities.includes('oakland')
+  ) {
+    throw new Error(
+      `Expected weather lookups for San Francisco and Oakland, saw: ${lookedUpCities.join(', ')}.`,
+    );
+  }
+
+  console.log(`[workflow] cities=${lookedUpCities.join(',')}`);
+  console.log(result.finalOutput);
+}
+
+(async function () {
+  // Switch the model to use for testing, e.g. `orcarouter('deepseek/deepseek-v4-flash')`.
+  const model = aisdk(orcaRouter('orcarouter/fusion'));
+  await runAgents(model, {});
+})();

--- a/examples/ai-sdk/package.json
+++ b/examples/ai-sdk/package.json
@@ -5,6 +5,7 @@
     "@ai-sdk/anthropic": "^3.0.9",
     "@ai-sdk/google": "^3.0.6",
     "@ai-sdk/openai": "^3.0.7",
+    "@ai-sdk/openai-compatible": "2.0.65",
     "@openai/agents": "workspace:*",
     "@openai/agents-extensions": "workspace:*",
     "@openrouter/ai-sdk-provider": "^2.9.0",
@@ -13,6 +14,7 @@
   "scripts": {
     "build-check": "tsc --noEmit",
     "start": "tsx index.ts",
+    "start:orca-router": "tsx orca-router.ts",
     "start:gpt-5": "tsx gpt-5.ts",
     "start:retry": "tsx retry.ts",
     "start:stream": "tsx stream.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@ai-sdk/openai':
         specifier: ^3.0.7
         version: 3.0.7(zod@4.3.5)
+      '@ai-sdk/openai-compatible':
+        specifier: 2.0.65
+        version: 2.0.65(zod@4.3.5)
       '@openai/agents':
         specifier: workspace:*
         version: link:../../packages/agents
@@ -879,6 +882,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/openai-compatible@2.0.65':
+    resolution: {integrity: sha512-OEQDO8zp8z51RdNJp/5gqqfG7lkHwJhN/AT6kKDA7MWdbz5/25+VkWLK4+OtOqbACPCG3Q34BMUwCBSmE/006A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@1.3.24':
     resolution: {integrity: sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==}
     engines: {node: '>=18'}
@@ -921,6 +930,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.43':
+    resolution: {integrity: sha512-UBM3ZblJl0bObISlh/tB1G2ZO5jdU5KQykVXLgKQJ0ZEIwV0AheU6fEjVOyz3CDZA6EMnajbDpHCXucJ8ypcAA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.8':
     resolution: {integrity: sha512-ns9gN7MmpI8vTRandzgz+KK/zNMLzhrriiKECMt4euLtQFSBgNfydtagPOX4j4pS1/3KvHF6RivhT3gNQgBZsg==}
     engines: {node: '>=18'}
@@ -933,6 +948,10 @@ packages:
 
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.2':
@@ -2499,6 +2518,10 @@ packages:
 
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@fastify/error@4.2.0':
     resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
@@ -4585,10 +4608,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -5765,6 +5790,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5845,6 +5871,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -9272,6 +9302,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -9870,6 +9904,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.4(zod@4.3.5)
       zod: 4.3.5
 
+  '@ai-sdk/openai-compatible@2.0.65(zod@4.3.5)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.43(zod@4.3.5)
+      zod: 4.3.5
+
   '@ai-sdk/openai@1.3.24(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
@@ -9916,6 +9956,14 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.3.5
 
+  '@ai-sdk/provider-utils@4.0.43(zod@4.3.5)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.1
+      undici: 5.29.0
+      zod: 4.3.5
+
   '@ai-sdk/provider-utils@4.0.8(zod@4.3.5)':
     dependencies:
       '@ai-sdk/provider': 3.0.4
@@ -9928,6 +9976,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.14':
     dependencies:
       json-schema: 0.4.0
 
@@ -12112,6 +12164,8 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       fast-uri: 3.1.0
+
+  '@fastify/busboy@2.1.1': {}
 
   '@fastify/error@4.2.0': {}
 
@@ -16020,6 +16074,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.1: {}
 
   eventsource@3.0.7:
     dependencies:
@@ -20344,6 +20400,10 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   undici@7.25.0: {}
 


### PR DESCRIPTION
### Summary

The Agents SDK describes itself as "provider-agnostic, supporting OpenAI APIs and more" — and for the "and more" part, the AI SDK integration in `examples/ai-sdk/` is where people discover named third-party providers, with OpenRouter shown as a first-class example in `index.ts`.

This PR adds [OrcaRouter](https://www.orcarouter.ai) as another named provider right beside it. OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

Because OrcaRouter speaks the OpenAI-compatible protocol, the example builds the provider with the official `createOpenAICompatible()` helper from `@ai-sdk/openai-compatible` (the same pattern AI SDK recommends for any named OpenAI-compatible provider) and wraps it with the existing `aisdk()` adapter — the same wiring `examples/ai-sdk/index.ts` uses for OpenRouter. No changes to the SDK runtime are required.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What's included

- `examples/ai-sdk/orca-router.ts` — a new runnable example that mirrors the OpenRouter handoff workflow from `index.ts`, using an OrcaRouter-backed model (`orcarouter/fusion`).
- `examples/ai-sdk/package.json` — adds `@ai-sdk/openai-compatible` and a `start:orca-router` script.
- `examples/ai-sdk/README.md` — adds the example to the available-scripts table.
- `pnpm-lock.yaml` — dependency lockfile update.

### Test plan

- `pnpm build` — passes.
- `pnpm -F ai-sdk build-check` — passes.
- `pnpm test` — 208 files / 6443 tests pass.
- `pnpm test:examples` — all examples build-check pass.
- `pnpm lint` and `pnpm format:check:changed` — pass.
- Live run: `ORCAROUTER_API_KEY=... pnpm -F ai-sdk start:orca-router` successfully ran the full handoff workflow (parent agent → handoff to weather specialist → `get_weather` tool calls for San Francisco and Oakland → final output), confirming the OrcaRouter provider path returns 200 responses end-to-end.

### Issue number

N/A

### Checks

- [x] I've run `pnpm test` and `pnpm test:examples`
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass

Note: no changeset is added because this change touches only `examples/ai-sdk/` (a private example) and does not modify any published package under `packages/`.

---

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
