### PR TITLE
fix(examples): run Prisma setup on Windows

### DIFF
--- a/examples/memory/prisma-command.ts
+++ b/examples/memory/prisma-command.ts
@@ -1,0 +1,30 @@
+export type PrismaCommand = 'db-push' | 'generate';
+
+type PrismaInvocation = {
+  command: string;
+  args: string[];
+  windowsVerbatimArguments?: boolean;
+};
+
+const PRISMA_COMMAND_ARGS = {
+  'db-push': ['prisma', 'db', 'push', '--schema', './prisma/schema.prisma'],
+  generate: ['prisma', 'generate', '--schema', './prisma/schema.prisma'],
+} as const satisfies Record<PrismaCommand, readonly string[]>;
+
+export function getPrismaInvocation(
+  command: PrismaCommand,
+  platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): PrismaInvocation {
+  const args = [...PRISMA_COMMAND_ARGS[command]];
+
+  if (platform !== 'win32') {
+    return { command: 'pnpm', args };
+  }
+
+  return {
+    command: env.ComSpec || 'cmd.exe',
+    args: ['/d', '/s', '/c', `"pnpm.cmd ${args.join(' ')}"`],
+    windowsVerbatimArguments: true,
+  };
+}

--- a/examples/memory/start-prisma.ts
+++ b/examples/memory/start-prisma.ts
@@ -1,13 +1,16 @@
 import { spawnSync } from 'node:child_process';
+import {
+  getPrismaInvocation,
+  type PrismaCommand,
+} from './prisma-command';
 
-const prismaSchemaPath = './prisma/schema.prisma';
-const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
-
-function runPrismaCommand(args: string[]) {
-  const result = spawnSync(pnpmCommand, ['prisma', ...args], {
+function runPrismaCommand(command: PrismaCommand) {
+  const invocation = getPrismaInvocation(command);
+  const result = spawnSync(invocation.command, invocation.args, {
     cwd: __dirname,
     env: process.env,
     stdio: 'inherit',
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
 
   if (result.error) {
@@ -31,8 +34,8 @@ async function main() {
     );
   }
 
-  runPrismaCommand(['db', 'push', '--schema', prismaSchemaPath]);
-  runPrismaCommand(['generate', '--schema', prismaSchemaPath]);
+  runPrismaCommand('db-push');
+  runPrismaCommand('generate');
 
   await import('./prisma');
 }

--- a/helpers/vitest/prismaMemoryExample.test.ts
+++ b/helpers/vitest/prismaMemoryExample.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getPrismaInvocation } from '../../examples/memory/prisma-command';
+
+describe('Prisma memory example command invocation', () => {
+  it('spawns pnpm directly off Windows', () => {
+    expect(getPrismaInvocation('db-push', 'linux', {})).toEqual({
+      command: 'pnpm',
+      args: ['prisma', 'db', 'push', '--schema', './prisma/schema.prisma'],
+    });
+  });
+
+  it('runs the pnpm.cmd shim through cmd.exe on Windows', () => {
+    expect(getPrismaInvocation('generate', 'win32', {})).toEqual({
+      command: 'cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        '"pnpm.cmd prisma generate --schema ./prisma/schema.prisma"',
+      ],
+      windowsVerbatimArguments: true,
+    });
+  });
+
+  it('honors ComSpec on Windows', () => {
+    expect(
+      getPrismaInvocation('db-push', 'win32', {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+      }),
+    ).toMatchObject({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -99,6 +99,7 @@ function createProjects(reviewTestProfile: boolean) {
         include: [
           'helpers/tests/consoleGuard.test.ts',
           'helpers/vitest/codeChangeVerificationPolicy.test.ts',
+          'helpers/vitest/prismaMemoryExample.test.ts',
           'helpers/vitest/reviewTestProfile.test.ts',
           'helpers/vitest/testConcurrency.test.ts',
           'helpers/vitest/workspacePackageAliases.test.ts',


### PR DESCRIPTION
### Summary

Fix the Prisma memory example on Windows under current Node versions.

`examples/memory/start-prisma.ts` selects `pnpm.cmd` on Windows and passes it directly to `spawnSync`. Node 20.12.2 and newer reject direct `.cmd`/`.bat` spawning, so `pnpm -F memory start:prisma` can fail before Prisma runs.

This is a remaining occurrence of the Windows shim pattern reported in #1775. The open #1776 fix covers the verification runner and `scripts/prettier-changed.mjs`, but does not cover the Prisma memory example.

### Changes

- route Prisma commands through `ComSpec` / `cmd.exe` on Windows
- keep direct `pnpm` spawning on non-Windows platforms
- preserve the existing Prisma arguments, working directory, environment, exit-code, and signal handling
- add focused regression coverage for Windows, non-Windows, and custom `ComSpec` invocation

### Test plan

- added focused invocation tests under the workspace Vitest project
- verified the branch is one commit ahead of current upstream `main`
- full Windows runtime execution is left to CI/reviewer validation

### Issue number

No separate issue. Found while checking the remaining Windows `.cmd` spawn sites after #1775.

### Checks

- [x] Added focused regression coverage
- [x] No published package code changed, so no changeset is required
