### PR TITLE
fix(examples) avoid deprecated Windows shell spawning

### DIFF
--- a/examples/tools/image-generation.ts
+++ b/examples/tools/image-generation.ts
@@ -3,15 +3,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { spawnSync } from 'node:child_process';
+import { getFileOpenInvocation } from './open-file';
 
 function openFile(filePath: string): void {
-  if (process.platform === 'darwin') {
-    spawnSync('open', [filePath], { stdio: 'inherit' });
-  } else if (process.platform === 'win32') {
-    spawnSync('cmd', ['/c', 'start', '', filePath], { shell: true });
-  } else {
-    spawnSync('xdg-open', [filePath], { stdio: 'inherit' });
-  }
+  const invocation = getFileOpenInvocation(filePath);
+  spawnSync(invocation.command, invocation.args, { stdio: 'inherit' });
 }
 
 async function main() {

--- a/examples/tools/open-file.ts
+++ b/examples/tools/open-file.ts
@@ -1,0 +1,23 @@
+export type FileOpenInvocation = {
+  command: string;
+  args: string[];
+};
+
+export function getFileOpenInvocation(
+  filePath: string,
+  platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): FileOpenInvocation {
+  if (platform === 'darwin') {
+    return { command: 'open', args: [filePath] };
+  }
+
+  if (platform === 'win32') {
+    return {
+      command: env.ComSpec || 'cmd.exe',
+      args: ['/d', '/s', '/c', 'start', '', filePath],
+    };
+  }
+
+  return { command: 'xdg-open', args: [filePath] };
+}

--- a/helpers/vitest/imageGenerationFileOpen.test.ts
+++ b/helpers/vitest/imageGenerationFileOpen.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { getFileOpenInvocation } from '../../examples/tools/open-file';
+
+describe('image generation file opening', () => {
+  it('opens files directly with the platform helper on macOS', () => {
+    expect(getFileOpenInvocation('/tmp/image file.png', 'darwin', {})).toEqual({
+      command: 'open',
+      args: ['/tmp/image file.png'],
+    });
+  });
+
+  it('opens files through cmd.exe without shell:true on Windows', () => {
+    const filePath = 'C:\\Users\\Example User\\AppData\\Local\\Temp\\image file.png';
+    expect(getFileOpenInvocation(filePath, 'win32', {})).toEqual({
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', 'start', '', filePath],
+    });
+  });
+
+  it('honors ComSpec on Windows', () => {
+    expect(
+      getFileOpenInvocation('C:\\Temp\\image.png', 'win32', {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+      }),
+    ).toMatchObject({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+    });
+  });
+
+  it('uses xdg-open on other platforms', () => {
+    expect(getFileOpenInvocation('/tmp/image.png', 'linux', {})).toEqual({
+      command: 'xdg-open',
+      args: ['/tmp/image.png'],
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -99,6 +99,7 @@ function createProjects(reviewTestProfile: boolean) {
         include: [
           'helpers/tests/consoleGuard.test.ts',
           'helpers/vitest/codeChangeVerificationPolicy.test.ts',
+          'helpers/vitest/imageGenerationFileOpen.test.ts',
           'helpers/vitest/reviewTestProfile.test.ts',
           'helpers/vitest/testConcurrency.test.ts',
           'helpers/vitest/workspacePackageAliases.test.ts',


### PR DESCRIPTION
### Summary

Fix the Windows file-opening path in the image-generation example.

`examples/tools/image-generation.ts` currently launches `cmd` with an argument array and `shell: true`. Current Node versions deprecate passing `args` when `shell: true`, and the extra shell layer makes Windows path handling unnecessarily fragile.

This changes the example to spawn `%ComSpec%` / `cmd.exe` directly on Windows while keeping the existing `start` behavior. macOS continues to use `open`, and Linux continues to use `xdg-open`.

### Changes

- remove the deprecated `shell: true` argument-spawning pattern on Windows
- invoke `%ComSpec%` / `cmd.exe` directly with the file path kept as a separate argument
- preserve existing macOS and Linux behavior
- add focused regression coverage for Windows, macOS, Linux, and custom `ComSpec`

### Test plan

- added focused platform-invocation tests under the workspace Vitest project
- verified the branch is one commit ahead of current upstream `main`
- no published package code changed, so no changeset is required

### Issue

Closes #1782
