### PR TITLE
fix(openai): bound websocket keepalive timers

### DIFF
--- a/.changeset/calm-ws-timers.md
+++ b/.changeset/calm-ws-timers.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+Reject Responses WebSocket keepalive durations that exceed Node's maximum timer delay.

--- a/packages/agents-openai/src/responsesWebSocketConnection.ts
+++ b/packages/agents-openai/src/responsesWebSocketConnection.ts
@@ -1,6 +1,8 @@
 import { UserError } from '@openai/agents-core';
 import OpenAI from 'openai';
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 export type WebSocketMessageValue =
   | string
   | Blob
@@ -10,12 +12,14 @@ export type WebSocketMessageValue =
 export type ResponsesWebSocketKeepAliveOptions = {
   /**
    * Time in milliseconds between keepalive pings sent by the client.
+   * Must be greater than 0 and no greater than 2147483647 when provided.
    *
    * Set to null to disable client keepalive pings.
    */
   pingIntervalMs?: number | null;
   /**
    * Time in milliseconds to wait for a pong response before closing the socket.
+   * Must be greater than 0 and no greater than 2147483647 when provided.
    *
    * Set to null to keep pings enabled but disable heartbeat timeouts.
    */
@@ -202,12 +206,16 @@ function normalizeKeepAliveDurationMs(
   if (value == null) {
     return undefined;
   }
-  if (Number.isFinite(value) && value > 0) {
+  if (
+    Number.isFinite(value) &&
+    value > 0 &&
+    value <= MAX_TIMER_DELAY_MS
+  ) {
     return value;
   }
 
   throw new UserError(
-    `Responses websocket ${fieldName} must be a positive number of milliseconds or null.`,
+    `Responses websocket ${fieldName} must be a positive finite number no greater than ${MAX_TIMER_DELAY_MS}, or null.`,
   );
 }
 

--- a/packages/agents-openai/test/responsesWebSocketConnection.test.ts
+++ b/packages/agents-openai/test/responsesWebSocketConnection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { ResponsesWebSocketConnection } from '../src/responsesWebSocketConnection';
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+const createSocketStub = (): WebSocket =>
+  ({
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as unknown as WebSocket;
+
+describe('ResponsesWebSocketConnection keepalive timer bounds', () => {
+  it.each(['pingIntervalMs', 'pingTimeoutMs'] as const)(
+    'accepts %s at the maximum Node timer delay',
+    (fieldName) => {
+      expect(
+        () =>
+          new ResponsesWebSocketConnection(createSocketStub(), {
+            [fieldName]: MAX_TIMER_DELAY_MS,
+          }),
+      ).not.toThrow();
+    },
+  );
+
+  it.each(['pingIntervalMs', 'pingTimeoutMs'] as const)(
+    'rejects %s above the maximum Node timer delay',
+    (fieldName) => {
+      expect(
+        () =>
+          new ResponsesWebSocketConnection(createSocketStub(), {
+            [fieldName]: MAX_TIMER_DELAY_MS + 1,
+          }),
+      ).toThrow(
+        `Responses websocket ${fieldName} must be a positive finite number no greater than ${MAX_TIMER_DELAY_MS}, or null.`,
+      );
+    },
+  );
+});


### PR DESCRIPTION
### Summary

Reject Responses WebSocket keepalive durations that exceed Node's maximum timer delay.

`pingIntervalMs` and `pingTimeoutMs` currently accept any positive finite number, then pass it to `setInterval`/`setTimeout`. Node timers support delays up to 2,147,483,647 ms; larger values overflow and can turn an intended long keepalive interval or pong timeout into almost immediate activity or failure.

### Changes

- cap both keepalive durations at 2,147,483,647 ms
- keep `null`/`undefined` behavior unchanged
- document the bound in the public option JSDoc
- add regression coverage for the maximum accepted value and maximum + 1 rejection
- add a patch changeset for `@openai/agents-openai`

### Test plan

- focused unit coverage in `responsesWebSocketConnection.test.ts`
- verified the branch is one commit ahead of current upstream `main`
- full repository execution is left to GitHub Actions

### Issue number

None. Found while auditing Responses WebSocket timer handling.

### Checks

- [x] Added regression tests
- [x] Added a changeset
- [x] No public API signature changes