### PR TITLE
fix(core): reject malformed persisted sandbox base64

### DIFF
--- a/.changeset/strict-sandbox-base64.md
+++ b/.changeset/strict-sandbox-base64.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reject malformed base64 in persisted sandbox files consistently

--- a/packages/agents-core/src/utils/base64.ts
+++ b/packages/agents-core/src/utils/base64.ts
@@ -49,6 +49,18 @@ export function encodeUint8ArrayToBase64(data: Uint8Array): string {
   return result;
 }
 
+function normalizeBase64ForDecoding(value: string): string {
+  const normalized = value.replace(/[\t\n\f\r ]/g, '');
+  if (
+    normalized.length % 4 === 1 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/u.test(normalized) ||
+    (normalized.includes('=') && normalized.length % 4 !== 0)
+  ) {
+    throw new TypeError('Invalid base64 string.');
+  }
+  return normalized;
+}
+
 /**
  * Decode a base64 string into a Uint8Array in both Node and browser environments.
  */
@@ -57,17 +69,18 @@ export function decodeBase64ToUint8Array(value: string): Uint8Array {
     return new Uint8Array();
   }
 
+  const normalized = normalizeBase64ForDecoding(value);
   const globalBuffer =
     typeof globalThis !== 'undefined' && (globalThis as any).Buffer
       ? (globalThis as any).Buffer
       : undefined;
 
   if (globalBuffer) {
-    return Uint8Array.from(globalBuffer.from(value, 'base64'));
+    return Uint8Array.from(globalBuffer.from(normalized, 'base64'));
   }
 
   if (typeof (globalThis as any).atob === 'function') {
-    const binary = (globalThis as any).atob(value);
+    const binary = (globalThis as any).atob(normalized);
     const bytes = new Uint8Array(binary.length);
     for (let index = 0; index < binary.length; index += 1) {
       bytes[index] = binary.charCodeAt(index);
@@ -77,11 +90,6 @@ export function decodeBase64ToUint8Array(value: string): Uint8Array {
 
   const chars =
     'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-  const normalized = value.replace(/[\t\n\f\r ]/g, '');
-  if (normalized.length % 4 === 1) {
-    throw new TypeError('Invalid base64 string.');
-  }
-
   const padded = normalized.padEnd(
     normalized.length + ((4 - (normalized.length % 4)) % 4),
     '=',

--- a/packages/agents-core/test/sandboxManifestBase64.test.ts
+++ b/packages/agents-core/test/sandboxManifestBase64.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { Manifest, file } from '../src/sandbox';
+import {
+  deserializeManifest,
+  serializeManifestRecord,
+} from '../src/sandbox/internal';
+
+describe('sandbox manifest binary persistence', () => {
+  it('rejects malformed persisted base64 file content', () => {
+    const serialized = serializeManifestRecord(
+      new Manifest({
+        entries: {
+          'payload.bin': file({ content: Uint8Array.from([1, 2, 3]) }),
+        },
+      }),
+    );
+    const entries = serialized.entries as Record<string, any>;
+    entries['payload.bin'].content = {
+      type: 'base64',
+      data: '!!!!',
+    };
+
+    expect(() => deserializeManifest(serialized)).toThrow(
+      'Invalid base64 string.',
+    );
+  });
+});

--- a/packages/agents-core/test/utils/base64.test.ts
+++ b/packages/agents-core/test/utils/base64.test.ts
@@ -82,6 +82,38 @@ describe('decodeBase64ToUint8Array', () => {
     );
   });
 
+  it('accepts ASCII whitespace and omitted padding across decoder paths', () => {
+    const value = 'A Q I\n';
+    const expected = new Uint8Array([1, 2]);
+
+    expect(decodeBase64ToUint8Array(value)).toEqual(expected);
+
+    (globalThis as any).Buffer = undefined;
+    expect(decodeBase64ToUint8Array(value)).toEqual(expected);
+
+    (globalThis as any).atob = undefined;
+    expect(decodeBase64ToUint8Array(value)).toEqual(expected);
+  });
+
+  it.each(['!!!!', 'AA=', 'AAAA=', 'AA-_'])(
+    'rejects malformed base64 %j across decoder paths',
+    (value) => {
+      expect(() => decodeBase64ToUint8Array(value)).toThrow(
+        'Invalid base64 string.',
+      );
+
+      (globalThis as any).Buffer = undefined;
+      expect(() => decodeBase64ToUint8Array(value)).toThrow(
+        'Invalid base64 string.',
+      );
+
+      (globalThis as any).atob = undefined;
+      expect(() => decodeBase64ToUint8Array(value)).toThrow(
+        'Invalid base64 string.',
+      );
+    },
+  );
+
   it('uses atob when Buffer is unavailable', () => {
     (globalThis as any).Buffer = undefined;
     const atobSpy = vi.fn((input: string) =>


### PR DESCRIPTION
### Summary

Sandbox manifests persist binary file content as base64. On Node, `Buffer.from(value, 'base64')` accepts malformed inputs that browser `atob` rejects, so corrupted or tampered persisted state can silently resume with empty or altered file bytes instead of failing.

Validate standard base64 before decoding so Buffer, `atob`, and the manual fallback reject malformed data consistently. Valid padded and unpadded base64 and ASCII whitespace remain supported; serialization and the persisted manifest format are unchanged.

### Test plan

- added cross-runtime decoder regression coverage for valid whitespace/unpadded input and malformed characters, padding, and base64url input
- added a sandbox manifest persistence regression proving malformed persisted binary content is rejected
- verified the final branch is exactly one commit ahead of current upstream `main` with only the intended four files changed
- full monorepo verification is left to GitHub Actions

### Issue number

N/A. Found while auditing sandbox persistence/resume handling.

### Checks

- [x] I've added new tests
- [x] No documentation change is required; the public API and persisted format are unchanged
- [ ] I've run `pnpm test` and `pnpm test:examples`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all repository verification steps pass
- [x] I've added a patch changeset for `@openai/agents-core`
