### PR TITLE
fix(core): preserve empty handoff descriptions

### DIFF
--- a/.changeset/preserve-empty-handoff-description.md
+++ b/.changeset/preserve-empty-handoff-description.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve explicit empty handoff tool descriptions

--- a/packages/agents-core/src/handoff.ts
+++ b/packages/agents-core/src/handoff.ts
@@ -429,7 +429,7 @@ export function handoff<
     handoff.toolName = config.toolNameOverride;
   }
 
-  if (config.toolDescriptionOverride) {
+  if (config.toolDescriptionOverride !== undefined) {
     handoff.toolDescription = config.toolDescriptionOverride;
   }
 

--- a/packages/agents-core/test/handoffEmptyDescription.test.ts
+++ b/packages/agents-core/test/handoffEmptyDescription.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, handoff } from '../src';
+
+describe('handoff description overrides', () => {
+  it('preserves an explicit empty tool description', () => {
+    const target = new Agent({
+      name: 'Specialist',
+      instructions: 'Handle specialist requests.',
+    });
+
+    const configured = handoff(target, {
+      toolDescriptionOverride: '',
+    });
+
+    expect(configured.toolDescription).toBe('');
+    expect(configured.getHandoffAsFunctionTool().description).toBe('');
+  });
+
+  it('keeps the generated description when the override is omitted', () => {
+    const target = new Agent({
+      name: 'Specialist',
+      instructions: 'Handle specialist requests.',
+    });
+
+    const configured = handoff(target);
+
+    expect(configured.toolDescription).toContain('Specialist');
+    expect(configured.getHandoffAsFunctionTool().description).toBe(
+      configured.toolDescription,
+    );
+  });
+});


### PR DESCRIPTION
### Summary

Preserve an explicit empty `toolDescriptionOverride` when creating a handoff.

`handoff()` currently applies the override only when the string is truthy, so:

```ts
handoff(agent, { toolDescriptionOverride: '' })
```

silently falls back to the generated handoff description.

That disagrees with the public optional-string override contract and with the existing `Handoff.clone({ toolDescription: '' })` and `Agent.asTool({ toolDescription: '' })` behavior, both of which preserve an explicit empty description.

This changes the check from truthiness to `undefined`, so omission still uses the generated description while `''` remains an explicit model-facing value.

### Test plan

- added public-boundary regression coverage showing an explicit empty handoff description reaches both `Handoff.toolDescription` and `getHandoffAsFunctionTool().description`
- added a guard showing an omitted override still keeps the generated handoff description
- verified the final branch is exactly one commit ahead of current upstream `main` with only the intended three files changed
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing description override parity.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
