### PR TITLE
fix(core): isolate MCP cache keys

### DIFF
--- a/.changeset/isolate-mcp-cache-keys.md
+++ b/.changeset/isolate-mcp-cache-keys.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: isolate MCP cache keys from object prototype properties

--- a/packages/agents-core/src/mcpToolCache.ts
+++ b/packages/agents-core/src/mcpToolCache.ts
@@ -1,7 +1,8 @@
 import type { MCPTool } from './mcpShared';
 
-export const cachedMcpTools: Record<string, MCPTool[]> = {};
-export const cachedMcpToolKeysByServer: Record<string, Set<string>> = {};
+export const cachedMcpTools: Record<string, MCPTool[]> = Object.create(null);
+export const cachedMcpToolKeysByServer: Record<string, Set<string>> =
+  Object.create(null);
 type ActiveServerToolsCacheListing = {
   invalidated: boolean;
 };

--- a/packages/agents-core/test/mcpCachePrototypeKeys.test.ts
+++ b/packages/agents-core/test/mcpCachePrototypeKeys.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAllMcpTools,
+  invalidateServerToolsCache,
+  type MCPServer,
+  type MCPTool,
+} from '../src/mcp';
+
+const serversToInvalidate = new Set<string>();
+
+function createCachingServer(name: string) {
+  const listTools = vi.fn(async (): Promise<MCPTool[]> => [
+    {
+      name: 'lookup',
+      description: 'Look up a value.',
+      inputSchema: { type: 'object', properties: {} },
+    },
+  ]);
+  const server = {
+    cacheToolsList: true,
+    name,
+    connect: async () => {},
+    close: async () => {},
+    listTools,
+    callTool: async () => [],
+    invalidateToolsCache: async () => {},
+  } satisfies MCPServer;
+  serversToInvalidate.add(name);
+  return { server, listTools };
+}
+
+afterEach(async () => {
+  for (const serverName of serversToInvalidate) {
+    await invalidateServerToolsCache(serverName);
+  }
+  serversToInvalidate.clear();
+});
+
+describe('MCP shared cache keys', () => {
+  it.each(['__proto__', 'constructor'])(
+    'caches a public custom key named %s without prototype collisions',
+    async (cacheKey) => {
+      const { server, listTools } = createCachingServer(`server-${cacheKey}`);
+      const options = {
+        mcpServers: [server],
+        generateMCPToolCacheKey: () => cacheKey,
+      };
+
+      await expect(getAllMcpTools(options)).resolves.toHaveLength(1);
+      await expect(getAllMcpTools(options)).resolves.toHaveLength(1);
+      expect(listTools).toHaveBeenCalledTimes(1);
+
+      await invalidateServerToolsCache(server.name);
+      await expect(getAllMcpTools(options)).resolves.toHaveLength(1);
+      expect(listTools).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('tracks a server named __proto__ without colliding with Object.prototype', async () => {
+    const { server, listTools } = createCachingServer('__proto__');
+    const options = {
+      mcpServers: [server],
+      generateMCPToolCacheKey: () => 'safe-cache-key',
+    };
+
+    await expect(getAllMcpTools(options)).resolves.toHaveLength(1);
+    await expect(getAllMcpTools(options)).resolves.toHaveLength(1);
+    expect(listTools).toHaveBeenCalledTimes(1);
+
+    await invalidateServerToolsCache(server.name);
+    await expect(getAllMcpTools(options)).resolves.toHaveLength(1);
+    expect(listTools).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Summary

Fix shared MCP tool caching for cache keys and server names that collide with JavaScript Object prototype properties.

The shared cache currently stores entries in ordinary `{}` objects. `MCPToolCacheKeyGenerator` is a public callback that may return any string, and MCP server names are also strings. Keys such as `__proto__` and `constructor` therefore resolve inherited properties before an actual cache entry exists.

For example, a first cached lookup using `__proto__` can treat `Object.prototype` as an `MCPTool[]` instead of calling `listTools()`. A server named `__proto__` can similarly collide with the per-server cache-key index and fail when the cache tries to call `.add()` on the inherited object.

Use null-prototype records for both cache tables so every string key is treated purely as data. Cache key generation, cache contents, invalidation semantics, and normal server names are unchanged.

### Test plan

- added regression coverage for public custom cache keys `__proto__` and `constructor`
- added regression coverage for a server named `__proto__`
- each regression verifies the second lookup is cached and invalidation forces a fresh `listTools()` call
- verified the branch is exactly one commit ahead of current upstream `main` with only the intended three files changed
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing shared MCP cache key handling.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
