### PR TITLE
fix(openai): preserve websocket session callback errors

### DIFF
--- a/.changeset/preserve-websocket-session-callback-error.md
+++ b/.changeset/preserve-websocket-session-callback-error.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: preserve callback failures when websocket session cleanup metadata cannot be attached

--- a/packages/agents-openai/src/responsesWebSocketSession.ts
+++ b/packages/agents-openai/src/responsesWebSocketSession.ts
@@ -27,21 +27,25 @@ function attachCleanupErrorToThrownError(
   callbackError: unknown,
   cleanupError: unknown,
 ): void {
-  if (!(callbackError instanceof Error)) {
-    return;
+  try {
+    if (!(callbackError instanceof Error)) {
+      return;
+    }
+
+    const callbackErrorWithMetadata = callbackError as Error & {
+      cause?: unknown;
+      cleanupError?: unknown;
+    };
+
+    if (typeof callbackErrorWithMetadata.cause === 'undefined') {
+      callbackErrorWithMetadata.cause = cleanupError;
+      return;
+    }
+
+    callbackErrorWithMetadata.cleanupError = cleanupError;
+  } catch {
+    // Cleanup metadata is best-effort and must not replace the callback failure.
   }
-
-  const callbackErrorWithMetadata = callbackError as Error & {
-    cause?: unknown;
-    cleanupError?: unknown;
-  };
-
-  if (typeof callbackErrorWithMetadata.cause === 'undefined') {
-    callbackErrorWithMetadata.cause = cleanupError;
-    return;
-  }
-
-  callbackErrorWithMetadata.cleanupError = cleanupError;
 }
 
 /**

--- a/packages/agents-openai/test/responsesWebSocketSessionCleanup.test.ts
+++ b/packages/agents-openai/test/responsesWebSocketSessionCleanup.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OpenAIProvider } from '../src/openaiProvider';
+import { withResponsesWebSocketSession } from '../src/responsesWebSocketSession';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('withResponsesWebSocketSession cleanup failures', () => {
+  it('attaches cleanup failure metadata to a mutable callback error', async () => {
+    const callbackError = new Error('callback failed');
+    const cleanupError = new Error('cleanup failed');
+    vi.spyOn(OpenAIProvider.prototype, 'close').mockRejectedValue(cleanupError);
+
+    await expect(
+      withResponsesWebSocketSession(() => {
+        throw callbackError;
+      }),
+    ).rejects.toBe(callbackError);
+
+    expect((callbackError as Error & { cause?: unknown }).cause).toBe(
+      cleanupError,
+    );
+  });
+
+  it('preserves a frozen callback error when cleanup metadata cannot be attached', async () => {
+    const callbackError = Object.freeze(new Error('callback failed'));
+    const cleanupError = new Error('cleanup failed');
+    vi.spyOn(OpenAIProvider.prototype, 'close').mockRejectedValue(cleanupError);
+
+    await expect(
+      withResponsesWebSocketSession(() => {
+        throw callbackError;
+      }),
+    ).rejects.toBe(callbackError);
+  });
+});


### PR DESCRIPTION
### Summary

Preserve the callback failure when both a `withResponsesWebSocketSession(...)` callback and provider cleanup fail, even if the callback `Error` cannot accept cleanup metadata.

The helper already treats the callback failure as primary and tries to attach the cleanup failure as `cause` or `cleanupError`. For a frozen or otherwise non-extensible `Error`, assigning that metadata throws a `TypeError`, which currently replaces the original application error.

Make cleanup-error metadata attachment best-effort. Mutable errors still receive the cleanup failure as metadata; frozen errors remain the original rejection. Successful callback and cleanup behavior is unchanged.

### Test plan

- added regression coverage showing mutable callback errors still receive the cleanup error as `cause`
- added regression coverage showing a frozen callback error remains the thrown value when provider cleanup also fails
- verified the branch is exactly one commit ahead of current upstream `main` with only the intended three files changed
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing Responses WebSocket session cleanup failure handling.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
