### PR TITLE
fix(openai): keep Conversations history limits local

### DIFF
--- a/.changeset/local-conversation-history-limit.md
+++ b/.changeset/local-conversation-history-limit.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: keep Conversations session history limits local

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -160,7 +160,6 @@ export class OpenAIConversationsSession
     const itemGroups: AgentInputItem[][] = [];
     let total = 0;
     const iterator = this.#client.conversations.items.list(conversationId, {
-      limit,
       order: 'desc' as const,
     });
 

--- a/packages/agents-openai/src/memory/openaiConversationsSession.ts
+++ b/packages/agents-openai/src/memory/openaiConversationsSession.ts
@@ -160,6 +160,7 @@ export class OpenAIConversationsSession
     const itemGroups: AgentInputItem[][] = [];
     let total = 0;
     const iterator = this.#client.conversations.items.list(conversationId, {
+      limit: Math.min(limit, 100),
       order: 'desc' as const,
     });
 

--- a/packages/agents-openai/test/openaiConversationsSession.pagination.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.pagination.test.ts
@@ -1,0 +1,85 @@
+import { ConversationCursorPage } from 'openai/core/pagination';
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAIConversationsSession } from '../src';
+
+function userMessage(id: number) {
+  return {
+    id: `user-${id}`,
+    type: 'message' as const,
+    role: 'user' as const,
+    content: [{ type: 'input_text' as const, text: `message ${id}` }],
+  };
+}
+
+describe('OpenAIConversationsSession pagination', () => {
+  it('caps provider pages at 100 while keeping the total history limit local', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) =>
+      userMessage(199 - index),
+    );
+    const secondPage = Array.from({ length: 100 }, (_, index) =>
+      userMessage(99 - index),
+    );
+    const nextPageQueries: Array<Record<string, unknown>> = [];
+    const paginationClient: any = {};
+    paginationClient.requestAPIList = vi.fn(
+      async (_Page: unknown, options: any) => {
+        nextPageQueries.push(options.query);
+        return new ConversationCursorPage(
+          paginationClient,
+          new Response(),
+          {
+            data: secondPage,
+            has_more: false,
+            last_id: 'user-0',
+          },
+          options,
+        );
+      },
+    );
+
+    const list = vi.fn((_conversationId: string, query: any) =>
+      new ConversationCursorPage(
+        paginationClient,
+        new Response(),
+        {
+          data: firstPage,
+          has_more: true,
+          last_id: 'user-100',
+        },
+        {
+          method: 'get',
+          path: '/conversations/conv-123/items',
+          query,
+        } as any,
+      ),
+    );
+    const session = new OpenAIConversationsSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    const result = await session.getItems(150);
+
+    expect(list).toHaveBeenCalledWith('conv-123', {
+      limit: 100,
+      order: 'desc',
+    });
+    expect(paginationClient.requestAPIList).toHaveBeenCalledTimes(1);
+    expect(nextPageQueries).toEqual([
+      { limit: 100, order: 'desc', after: 'user-100' },
+    ]);
+    expect(result).toHaveLength(150);
+    expect(result[0]?.id).toBe('user-50');
+    expect(result[result.length - 1]?.id).toBe('user-199');
+  });
+});

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -175,7 +175,7 @@ describe('OpenAIConversationsSession', () => {
 
     const result = await session.getItems(1);
 
-    expect(list).toHaveBeenCalledWith('conv-123', { limit: 1, order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
     expect(convertToOutputItemMock).not.toHaveBeenCalled();
     expect(result).toEqual([
       {
@@ -185,6 +185,51 @@ describe('OpenAIConversationsSession', () => {
         content: 'User info (session context): premium account',
       },
     ]);
+  });
+
+  it('keeps large history limits local while preserving newest-item order', async () => {
+    const items = Array.from({ length: 200 }, (_, index) => {
+      const itemNumber = 199 - index;
+      return {
+        id: `user-${itemNumber}`,
+        type: 'message',
+        role: 'user',
+        content: [
+          {
+            type: 'input_text',
+            text: `message ${itemNumber}`,
+          },
+        ],
+      };
+    });
+    const list = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        for (const item of items) {
+          yield item as any;
+        }
+      },
+    }));
+    const session = createSession({
+      client: {
+        conversations: {
+          items: {
+            list,
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+          create: vi.fn(),
+          delete: vi.fn(),
+        },
+      } as any,
+      conversationId: 'conv-123',
+    });
+
+    const result = await session.getItems(150);
+
+    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
+    expect(result).toHaveLength(150);
+    expect(result[0]?.id).toBe('user-50');
+    expect(result[result.length - 1]?.id).toBe('user-199');
   });
 
   it('wraps string function_call_output payloads before converting', async () => {
@@ -372,7 +417,7 @@ describe('OpenAIConversationsSession', () => {
 
     const result = await session.getItems(2);
 
-    expect(list).toHaveBeenCalledWith('conv-123', { limit: 2, order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
     expect(convertToOutputItemMock).toHaveBeenCalledTimes(1);
     expect(result).toHaveLength(2);
     expect(result.map((item: any) => item.id)).toEqual([
@@ -439,7 +484,7 @@ describe('OpenAIConversationsSession', () => {
 
     const popped = await session.popItem();
 
-    expect(list).toHaveBeenCalledWith('conv-123', { limit: 1, order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
     expect(deleteMock).toHaveBeenCalledWith('resp-1-msg-3', {
       conversation_id: 'conv-123',
     });
@@ -1733,7 +1778,7 @@ describe('OpenAIConversationsSession', () => {
     });
 
     const popped = await session.popItem();
-    expect(list).toHaveBeenCalledWith('conv-new', { limit: 1, order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-new', { order: 'desc' });
     expect(deleteItem).toHaveBeenCalledWith('assistant-3', {
       conversation_id: 'conv-new',
     });

--- a/packages/agents-openai/test/openaiConversationsSession.test.ts
+++ b/packages/agents-openai/test/openaiConversationsSession.test.ts
@@ -175,7 +175,7 @@ describe('OpenAIConversationsSession', () => {
 
     const result = await session.getItems(1);
 
-    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-123', { limit: 1, order: 'desc' });
     expect(convertToOutputItemMock).not.toHaveBeenCalled();
     expect(result).toEqual([
       {
@@ -185,51 +185,6 @@ describe('OpenAIConversationsSession', () => {
         content: 'User info (session context): premium account',
       },
     ]);
-  });
-
-  it('keeps large history limits local while preserving newest-item order', async () => {
-    const items = Array.from({ length: 200 }, (_, index) => {
-      const itemNumber = 199 - index;
-      return {
-        id: `user-${itemNumber}`,
-        type: 'message',
-        role: 'user',
-        content: [
-          {
-            type: 'input_text',
-            text: `message ${itemNumber}`,
-          },
-        ],
-      };
-    });
-    const list = vi.fn(() => ({
-      async *[Symbol.asyncIterator]() {
-        for (const item of items) {
-          yield item as any;
-        }
-      },
-    }));
-    const session = createSession({
-      client: {
-        conversations: {
-          items: {
-            list,
-            create: vi.fn(),
-            delete: vi.fn(),
-          },
-          create: vi.fn(),
-          delete: vi.fn(),
-        },
-      } as any,
-      conversationId: 'conv-123',
-    });
-
-    const result = await session.getItems(150);
-
-    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
-    expect(result).toHaveLength(150);
-    expect(result[0]?.id).toBe('user-50');
-    expect(result[result.length - 1]?.id).toBe('user-199');
   });
 
   it('wraps string function_call_output payloads before converting', async () => {
@@ -417,7 +372,7 @@ describe('OpenAIConversationsSession', () => {
 
     const result = await session.getItems(2);
 
-    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-123', { limit: 2, order: 'desc' });
     expect(convertToOutputItemMock).toHaveBeenCalledTimes(1);
     expect(result).toHaveLength(2);
     expect(result.map((item: any) => item.id)).toEqual([
@@ -484,7 +439,7 @@ describe('OpenAIConversationsSession', () => {
 
     const popped = await session.popItem();
 
-    expect(list).toHaveBeenCalledWith('conv-123', { order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-123', { limit: 1, order: 'desc' });
     expect(deleteMock).toHaveBeenCalledWith('resp-1-msg-3', {
       conversation_id: 'conv-123',
     });
@@ -1778,7 +1733,7 @@ describe('OpenAIConversationsSession', () => {
     });
 
     const popped = await session.popItem();
-    expect(list).toHaveBeenCalledWith('conv-new', { order: 'desc' });
+    expect(list).toHaveBeenCalledWith('conv-new', { limit: 1, order: 'desc' });
     expect(deleteItem).toHaveBeenCalledWith('assistant-3', {
       conversation_id: 'conv-new',
     });


### PR DESCRIPTION
### Summary

`OpenAIConversationsSession.getItems(limit)` uses the SDK history limit as a total item cap, while the Conversations API `limit` is a per-page size. Passing large SDK limits through unchanged can exceed the provider's page-size bound.

Keep the total limit local while retaining an efficient provider page size:

- omitted SDK limits preserve the existing ascending-history request without a provider `limit`;
- finite positive limits request descending pages with `limit: Math.min(limit, 100)`;
- client pagination continues across page boundaries until enough Agent SDK items have been collected;
- the existing reverse/trim logic still returns the newest requested items in chronological order, including when one provider item expands into multiple Agent items.

### Test plan

- restored the existing focused Conversations session tests from current `main`, so small finite limits continue to verify the existing provider request shape;
- added a pagination regression using the OpenAI client's `ConversationCursorPage` implementation rather than a flat async iterator;
- the regression requests 150 history items from two 100-item descending provider pages, verifies the first page is capped at 100, verifies the second request carries the `after` cursor and the same page size, and verifies the SDK returns exactly `user-50` through `user-199` in chronological order;
- pushed-head CI is currently waiting at `action_required` for fork workflow approval.

### Issue number

N/A. Found while auditing Conversations session pagination parity.

### Checks

- [x] I've added new tests
- [x] Documentation change is not required; this preserves the existing `Session.getItems(limit)` contract
- [ ] Pushed-head CI is awaiting workflow approval
- [x] I've added a changeset using `pnpm changeset` to indicate my changes