### PR TITLE
fix(realtime): validate guardrail debounce length

### DIFF
--- a/.changeset/validate-realtime-guardrail-debounce.md
+++ b/.changeset/validate-realtime-guardrail-debounce.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: validate realtime output guardrail debounce lengths

--- a/packages/agents-realtime/src/guardrail.ts
+++ b/packages/agents-realtime/src/guardrail.ts
@@ -5,6 +5,7 @@ import {
   OutputGuardrailDefinition,
   OutputGuardrailMetadata,
   OutputGuardrailFunctionArgs,
+  UserError,
 } from '@openai/agents-core';
 
 export interface RealtimeOutputGuardrailSettings {
@@ -22,9 +23,17 @@ export interface RealtimeOutputGuardrailSettings {
 export function getRealtimeGuardrailSettings(
   settings: Partial<RealtimeOutputGuardrailSettings>,
 ): RealtimeOutputGuardrailSettings {
-  return {
-    debounceTextLength: settings.debounceTextLength ?? 100,
-  };
+  const debounceTextLength = settings.debounceTextLength ?? 100;
+  if (
+    debounceTextLength !== -1 &&
+    (!Number.isFinite(debounceTextLength) || debounceTextLength <= 0)
+  ) {
+    throw new UserError(
+      'Realtime output guardrail debounceTextLength must be a positive finite number or -1.',
+    );
+  }
+
+  return { debounceTextLength };
 }
 
 export interface RealtimeOutputGuardrail extends OutputGuardrail {

--- a/packages/agents-realtime/test/guardrail.test.ts
+++ b/packages/agents-realtime/test/guardrail.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { RunContext } from '@openai/agents-core';
+import { RunContext, UserError } from '@openai/agents-core';
 
 import {
   defineRealtimeOutputGuardrail,
@@ -9,14 +9,30 @@ import {
 } from '../src/guardrail';
 
 describe('realtime guardrail helpers', () => {
-  it('provides default settings and honors overrides', () => {
+  it('provides default settings and honors supported overrides', () => {
     expect(getRealtimeGuardrailSettings({})).toEqual({
       debounceTextLength: 100,
     });
     expect(getRealtimeGuardrailSettings({ debounceTextLength: 12 })).toEqual({
       debounceTextLength: 12,
     });
+    expect(getRealtimeGuardrailSettings({ debounceTextLength: -1 })).toEqual({
+      debounceTextLength: -1,
+    });
   });
+
+  it.each([0, -2, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    'rejects invalid debounceTextLength %s',
+    (debounceTextLength) => {
+      expect(() =>
+        getRealtimeGuardrailSettings({ debounceTextLength }),
+      ).toThrow(
+        new UserError(
+          'Realtime output guardrail debounceTextLength must be a positive finite number or -1.',
+        ),
+      );
+    },
+  );
 
   it('propagates policyHint and generates feedback text', async () => {
     const context = new RunContext({});


### PR DESCRIPTION
### Summary

Validate `outputGuardrailSettings.debounceTextLength` before Realtime guardrails use it for transcript debounce math.

The public setting documents a positive character interval, with `-1` as the only special value for running guardrails only when the complete transcript is available. Other values currently produce broken or misleading behavior:

- `0` divides by zero, causing the first debounce index to become `Infinity` and suppressing later incremental runs
- negative values other than `-1` silently behave like the final-transcript-only sentinel
- `NaN` can make the debounce comparison fail open on every delta
- infinities can suppress incremental execution

Reject invalid values at configuration time with `UserError`. Positive finite values, the default of `100`, and the documented `-1` sentinel are unchanged.

### Test plan

- extended `guardrail.test.ts` to preserve the default and a positive override
- added coverage for the documented `-1` sentinel
- added rejection coverage for `0`, `-2`, `NaN`, positive infinity, and negative infinity
- verified the final branch is exactly one commit ahead of current upstream `main` with only the intended runtime, test, and changeset files changed
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing Realtime guardrail configuration boundaries.

### Checks

- [x] I've added new tests (if relevant)
- [x] No documentation update is required; the existing public JSDoc already documents the supported values
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
