### PR TITLE
fix(openai): validate default mode settings

### DIFF
--- a/.changeset/validate-openai-default-modes.md
+++ b/.changeset/validate-openai-default-modes.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: validate default OpenAI API and Responses transport modes

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -1,3 +1,4 @@
+import { UserError } from '@openai/agents-core';
 import { loadEnv } from '@openai/agents-core/_shims';
 import METADATA from './metadata';
 import type { OpenAIClient } from './openaiClient';
@@ -29,10 +30,20 @@ export function shouldUseResponsesWebSocketByDefault() {
 }
 
 export function setOpenAIAPI(value: 'chat_completions' | 'responses') {
+  if (value !== 'chat_completions' && value !== 'responses') {
+    throw new UserError(
+      "OpenAI API must be 'chat_completions' or 'responses'.",
+    );
+  }
   _defaultOpenAIAPI = value;
 }
 
 export function setOpenAIResponsesTransport(value: 'http' | 'websocket') {
+  if (value !== 'http' && value !== 'websocket') {
+    throw new UserError(
+      "OpenAI Responses transport must be 'http' or 'websocket'.",
+    );
+  }
   _defaultOpenAIResponsesTransport = value;
 }
 

--- a/packages/agents-openai/test/defaults.test.ts
+++ b/packages/agents-openai/test/defaults.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { afterEach, describe, test, expect } from 'vitest';
 import {
   DEFAULT_OPENAI_MODEL,
   setTracingExportApiKey,
@@ -15,6 +15,11 @@ import {
 import OpenAI from 'openai';
 
 describe('Defaults', () => {
+  afterEach(() => {
+    setOpenAIAPI('responses');
+    setOpenAIResponsesTransport('http');
+  });
+
   test('Default OpenAI model is gpt-5.6-luna', () => {
     expect(DEFAULT_OPENAI_MODEL).toBe('gpt-5.6-luna');
   });
@@ -28,11 +33,27 @@ describe('Defaults', () => {
     setOpenAIAPI('chat_completions');
     expect(shouldUseResponsesByDefault()).toBe(false);
   });
+  test('setOpenAIAPI rejects invalid runtime values without changing the default', () => {
+    setOpenAIAPI('responses');
+
+    expect(() => setOpenAIAPI('response' as any)).toThrow(
+      "OpenAI API must be 'chat_completions' or 'responses'.",
+    );
+    expect(shouldUseResponsesByDefault()).toBe(true);
+  });
   test('shouldUseResponsesWebSocketByDefault', async () => {
     setOpenAIResponsesTransport('websocket');
     expect(shouldUseResponsesWebSocketByDefault()).toBe(true);
     setOpenAIResponsesTransport('http');
     expect(shouldUseResponsesWebSocketByDefault()).toBe(false);
+  });
+  test('setOpenAIResponsesTransport rejects invalid runtime values without changing the default', () => {
+    setOpenAIResponsesTransport('websocket');
+
+    expect(() => setOpenAIResponsesTransport('ws' as any)).toThrow(
+      "OpenAI Responses transport must be 'http' or 'websocket'.",
+    );
+    expect(shouldUseResponsesWebSocketByDefault()).toBe(true);
   });
   test('get/setDefaultOpenAIClient', async () => {
     const client = new OpenAI({ apiKey: 'foo' });


### PR DESCRIPTION
### Summary

Validate the SDK-wide OpenAI API and Responses transport setters at runtime.

Both setters expose literal TypeScript types, but JavaScript callers and runtime values can still pass arbitrary strings. Today those invalid values are stored directly:

- `setOpenAIAPI('response')` makes `shouldUseResponsesByDefault()` return false, silently selecting Chat Completions.
- `setOpenAIResponsesTransport('ws')` makes `shouldUseResponsesWebSocketByDefault()` return false, silently selecting HTTP.

Reject unsupported values before mutating the defaults. Valid `responses` / `chat_completions` and `http` / `websocket` settings are unchanged.

### Test plan

- added regression coverage for an invalid OpenAI API runtime value and verified the prior `responses` setting remains active
- added regression coverage for an invalid Responses transport runtime value and verified the prior `websocket` setting remains active
- existing valid-mode tests continue to cover both supported values for each setter
- reset the mutable defaults after each test so the file remains order-independent
- verified the final branch is exactly one commit ahead of current upstream `main` with only the intended runtime, test, and changeset files changed
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing runtime validation of SDK-wide default mode setters.

### Checks

- [x] I've added new tests (if relevant)
- [x] No documentation update is required; supported values are unchanged
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
