### PR TITLE
fix(core): validate tracing batch options

### DIFF
--- a/.changeset/validate-tracing-batch-options.md
+++ b/.changeset/validate-tracing-batch-options.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: validate tracing batch size and schedule delay options

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -1,6 +1,7 @@
 import { Span as TSpan } from './spans';
 import { Trace } from './traces';
 import logger, { logModelAndToolActionError } from '../logger';
+import { UserError } from '../errors';
 import {
   timer as _timer,
   isTracingLoopRunningByDefault,
@@ -11,6 +12,8 @@ import { combineAbortSignals } from '../utils/abortSignals';
 import { NOOP_TRACE_OR_SPAN_ID } from './utils';
 
 type Span = TSpan<any>;
+
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 function isNoopSpan(span: Span): boolean {
   return (
@@ -144,6 +147,21 @@ export class BatchTraceProcessor implements TracingProcessor {
       exportTriggerRatio = 0.8,
     }: BatchTraceProcessorOptions = {},
   ) {
+    if (!Number.isInteger(maxBatchSize) || maxBatchSize <= 0) {
+      throw new UserError(
+        'BatchTraceProcessor maxBatchSize must be a positive integer.',
+      );
+    }
+    if (
+      !Number.isFinite(scheduleDelay) ||
+      scheduleDelay <= 0 ||
+      scheduleDelay > MAX_TIMER_DELAY_MS
+    ) {
+      throw new UserError(
+        `BatchTraceProcessor scheduleDelay must be a positive finite number less than or equal to ${MAX_TIMER_DELAY_MS}.`,
+      );
+    }
+
     this.#maxQueueSize = maxQueueSize;
     this.#maxBatchSize = maxBatchSize;
     this.#scheduleDelay = scheduleDelay;

--- a/packages/agents-core/test/tracingBatchProcessorValidation.test.ts
+++ b/packages/agents-core/test/tracingBatchProcessorValidation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BatchTraceProcessor,
+  type TracingExporter,
+} from '../src/tracing/processor';
+import { UserError } from '../src/errors';
+
+const exporter: TracingExporter = {
+  async export() {},
+};
+
+describe('BatchTraceProcessor option validation', () => {
+  it.each([0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'rejects invalid maxBatchSize %s',
+    (maxBatchSize) => {
+      expect(
+        () => new BatchTraceProcessor(exporter, { maxBatchSize }),
+      ).toThrow(
+        new UserError(
+          'BatchTraceProcessor maxBatchSize must be a positive integer.',
+        ),
+      );
+    },
+  );
+
+  it.each([
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    2_147_483_648,
+  ])('rejects invalid scheduleDelay %s', (scheduleDelay) => {
+    expect(
+      () => new BatchTraceProcessor(exporter, { scheduleDelay }),
+    ).toThrow(
+      new UserError(
+        'BatchTraceProcessor scheduleDelay must be a positive finite number less than or equal to 2147483647.',
+      ),
+    );
+  });
+});


### PR DESCRIPTION
### Summary

Validate the `BatchTraceProcessor` options that control batch progress and the recurring export timer.

`maxBatchSize` is currently used directly as the `Array.splice()` delete count. A value of `0` therefore makes normal scheduled/threshold exports remove and export an empty batch while leaving the trace buffer untouched, so the export loop cannot make progress and the queue can eventually fill and drop traces. Fractional and non-finite values likewise do not represent a valid batch size.

`scheduleDelay` is also passed directly to the runtime timer. Non-finite, non-positive, or values above the JavaScript timer limit can be normalised or overflow to near-zero delays in Node, turning the recurring export loop into a tight timer loop instead of the configured schedule.

Fail fast when `maxBatchSize` is not a positive integer, or when `scheduleDelay` is not a positive finite value at or below `2147483647` milliseconds. Existing valid queue sizing, trigger ratios, and batch sizes larger than the queue remain unchanged.

### Test plan

- added focused validation coverage for `maxBatchSize` values `0`, `-1`, `1.5`, `NaN`, and `Infinity`
- added focused validation coverage for `scheduleDelay` values `0`, `-1`, `NaN`, both infinities, and a value above the JavaScript timer limit
- verified v0.17.0 has the same unvalidated constructor behavior
- verified the final branch is exactly one commit ahead of current upstream `main` with only the intended runtime, test, and changeset files changed
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing tracing processor runtime configuration boundaries.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
