### PR TITLE
fix(core): handle processor replacement rejections

### DIFF
--- a/.changeset/handle-tracing-processor-replacement-rejections.md
+++ b/.changeset/handle-tracing-processor-replacement-rejections.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: handle rejected tracing processor shutdowns during processor replacement

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -358,7 +358,13 @@ export class MultiTracingProcessor implements TracingProcessor {
   setProcessors(processors: TracingProcessor[]): void {
     logger.debug('Shutting down old processors');
     for (const processor of this.#processors) {
-      processor.shutdown();
+      void processor.shutdown().catch((error) => {
+        logModelAndToolActionError(
+          logger,
+          'Error shutting down replaced tracing processor',
+          error,
+        );
+      });
     }
     this.#processors = processors;
   }

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -1624,9 +1624,9 @@ describe('withTrace & span helpers (integration)', () => {
 describe('MultiTracingProcessor', () => {
   it('should call all processors shutdown when setting new processors', () => {
     const processor1 = new TestProcessor();
-    processor1.shutdown = vi.fn();
+    processor1.shutdown = vi.fn(async () => {});
     const processor2 = new TestProcessor();
-    processor2.shutdown = vi.fn();
+    processor2.shutdown = vi.fn(async () => {});
     const multiProcessor = new MultiTracingProcessor();
     multiProcessor.setProcessors([processor1]);
     expect(processor1.shutdown).not.toHaveBeenCalled();

--- a/packages/agents-core/test/tracingProcessorReplacementRejections.test.ts
+++ b/packages/agents-core/test/tracingProcessorReplacementRejections.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import coreLogger from '../src/logger';
+import {
+  MultiTracingProcessor,
+  type TracingProcessor,
+} from '../src/tracing/processor';
+import type { Span } from '../src/tracing/spans';
+import { Trace } from '../src/tracing/traces';
+
+function handledRejection(error: Error): Promise<void> {
+  const promise = Promise.reject(error);
+  void promise.catch(() => {});
+  return promise;
+}
+
+class BaseProcessor implements TracingProcessor {
+  tracesStarted: Trace[] = [];
+
+  async onTraceStart(trace: Trace): Promise<void> {
+    this.tracesStarted.push(trace);
+  }
+
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+
+  async onSpanStart(_span: Span<any>): Promise<void> {}
+
+  async onSpanEnd(_span: Span<any>): Promise<void> {}
+
+  async shutdown(): Promise<void> {}
+
+  async forceFlush(): Promise<void> {}
+}
+
+class RejectingShutdownProcessor extends BaseProcessor {
+  shutdown(): Promise<void> {
+    return handledRejection(new Error('shutdown failed'));
+  }
+}
+
+describe('tracing processor replacement failures', () => {
+  it('handles rejected old-processor shutdowns while installing replacements', async () => {
+    const errorSpy = vi.spyOn(coreLogger, 'error').mockImplementation(() => {});
+    const multiProcessor = new MultiTracingProcessor();
+    const oldProcessor = new RejectingShutdownProcessor();
+    const replacement = new BaseProcessor();
+    multiProcessor.addTraceProcessor(oldProcessor);
+
+    expect(() => multiProcessor.setProcessors([replacement])).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(
+      errorSpy.mock.calls.some(
+        ([message]) =>
+          message === 'Error shutting down replaced tracing processor',
+      ),
+    ).toBe(true);
+
+    const trace = new Trace({ name: 'replacement-check' }, replacement);
+    await multiProcessor.onTraceStart(trace);
+    expect(replacement.tracesStarted).toEqual([trace]);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/agents-core/test/tracingProcessorReplacementRejections.test.ts
+++ b/packages/agents-core/test/tracingProcessorReplacementRejections.test.ts
@@ -8,12 +8,6 @@ import {
 import type { Span } from '../src/tracing/spans';
 import { Trace } from '../src/tracing/traces';
 
-function handledRejection(error: Error): Promise<void> {
-  const promise = Promise.reject(error);
-  void promise.catch(() => {});
-  return promise;
-}
-
 class BaseProcessor implements TracingProcessor {
   tracesStarted: Trace[] = [];
 
@@ -34,7 +28,7 @@ class BaseProcessor implements TracingProcessor {
 
 class RejectingShutdownProcessor extends BaseProcessor {
   shutdown(): Promise<void> {
-    return handledRejection(new Error('shutdown failed'));
+    return Promise.reject(new Error('shutdown failed'));
   }
 }
 


### PR DESCRIPTION
### Summary

Handle rejected shutdown promises when replacing tracing processors.

`MultiTracingProcessor.setProcessors()` is synchronous but invokes each old processor's async `shutdown()` without observing its returned promise. If a custom processor rejects during shutdown, the rejection can surface as unhandled while the replacement processor list has already been installed.

Keep the synchronous replacement contract, attach a rejection handler to each old-processor shutdown, and report failures through the existing redaction-aware tracing error logger. Replacement processors continue to be installed immediately.

### Test plan

- replaces a processor whose `shutdown()` returns a rejected promise
- verifies replacement remains synchronous/non-throwing
- verifies the rejected shutdown is observed and logged
- verifies the replacement processor is installed and receives subsequent trace events
- verified the branch is exactly one commit ahead of current upstream `main`
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing tracing processor replacement lifecycle.

### Checks

- [x] I've added new tests (if relevant)
- [x] Documentation change is not required; public replacement semantics are unchanged
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
