### PR TITLE
fix(core): handle span processor rejections

### DIFF
--- a/.changeset/handle-span-processor-rejections.md
+++ b/.changeset/handle-span-processor-rejections.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: handle rejected async tracing processor hooks from synchronous span lifecycle methods

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -1,4 +1,4 @@
-import logger from '../logger';
+import logger, { logModelAndToolActionError } from '../logger';
 import { TracingProcessor } from './processor';
 import {
   generateSpanId,
@@ -235,7 +235,13 @@ export class Span<TData extends SpanData> {
     }
 
     this.#startedAt = timeIso();
-    this.#processor.onSpanStart(this);
+    void this.#processor.onSpanStart(this).catch((error) => {
+      logModelAndToolActionError(
+        logger,
+        'Tracing processor failed during span start',
+        error,
+      );
+    });
   }
 
   end() {
@@ -249,7 +255,13 @@ export class Span<TData extends SpanData> {
     }
 
     this.#endedAt = timeIso();
-    this.#processor.onSpanEnd(this);
+    void this.#processor.onSpanEnd(this).catch((error) => {
+      logModelAndToolActionError(
+        logger,
+        'Tracing processor failed during span end',
+        error,
+      );
+    });
   }
 
   setError(error: SpanError) {

--- a/packages/agents-core/test/tracingProcessorRejections.test.ts
+++ b/packages/agents-core/test/tracingProcessorRejections.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import coreLogger from '../src/logger';
+import { Span, type CustomSpanData } from '../src/tracing/spans';
+import type { TracingProcessor } from '../src/tracing/processor';
+import type { Trace } from '../src/tracing/traces';
+
+function handledRejection(error: Error): Promise<void> {
+  const promise = Promise.reject(error);
+  void promise.catch(() => {});
+  return promise;
+}
+
+class RejectingSpanProcessor implements TracingProcessor {
+  async onTraceStart(_trace: Trace): Promise<void> {}
+
+  async onTraceEnd(_trace: Trace): Promise<void> {}
+
+  onSpanStart(): Promise<void> {
+    return handledRejection(new Error('span start failed'));
+  }
+
+  onSpanEnd(): Promise<void> {
+    return handledRejection(new Error('span end failed'));
+  }
+
+  async shutdown(): Promise<void> {}
+
+  async forceFlush(): Promise<void> {}
+}
+
+describe('span tracing processor failures', () => {
+  it('handles rejected async span lifecycle hooks without unhandled rejections', async () => {
+    const errorSpy = vi.spyOn(coreLogger, 'error').mockImplementation(() => {});
+    const data: CustomSpanData = {
+      type: 'custom',
+      name: 'processor-failure',
+      data: {},
+    };
+    const span = new Span(
+      {
+        traceId: 'trace_processor_failure',
+        data,
+      },
+      new RejectingSpanProcessor(),
+    );
+
+    expect(() => span.start()).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(() => span.end()).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(
+      errorSpy.mock.calls.some(
+        ([message]) => message === 'Tracing processor failed during span start',
+      ),
+    ).toBe(true);
+    expect(
+      errorSpy.mock.calls.some(
+        ([message]) => message === 'Tracing processor failed during span end',
+      ),
+    ).toBe(true);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/agents-core/test/tracingProcessorRejections.test.ts
+++ b/packages/agents-core/test/tracingProcessorRejections.test.ts
@@ -1,27 +1,27 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import coreLogger from '../src/logger';
-import { Span, type CustomSpanData } from '../src/tracing/spans';
 import type { TracingProcessor } from '../src/tracing/processor';
+import type { Span } from '../src/tracing/spans';
 import type { Trace } from '../src/tracing/traces';
-
-function handledRejection(error: Error): Promise<void> {
-  const promise = Promise.reject(error);
-  void promise.catch(() => {});
-  return promise;
-}
+import {
+  setTraceProcessors,
+  setTracingDisabled,
+  withCustomSpan,
+  withTrace,
+} from '../src/tracing';
 
 class RejectingSpanProcessor implements TracingProcessor {
   async onTraceStart(_trace: Trace): Promise<void> {}
 
   async onTraceEnd(_trace: Trace): Promise<void> {}
 
-  onSpanStart(): Promise<void> {
-    return handledRejection(new Error('span start failed'));
+  onSpanStart(_span: Span<any>): Promise<void> {
+    return Promise.reject(new Error('span start failed'));
   }
 
-  onSpanEnd(): Promise<void> {
-    return handledRejection(new Error('span end failed'));
+  onSpanEnd(_span: Span<any>): Promise<void> {
+    return Promise.reject(new Error('span end failed'));
   }
 
   async shutdown(): Promise<void> {}
@@ -30,40 +30,37 @@ class RejectingSpanProcessor implements TracingProcessor {
 }
 
 describe('span tracing processor failures', () => {
-  it('handles rejected async span lifecycle hooks without unhandled rejections', async () => {
+  it('contains rejected registered span hooks while the traced operation completes', async () => {
     const errorSpy = vi.spyOn(coreLogger, 'error').mockImplementation(() => {});
-    const data: CustomSpanData = {
-      type: 'custom',
-      name: 'processor-failure',
-      data: {},
-    };
-    const span = new Span(
-      {
-        traceId: 'trace_processor_failure',
-        data,
-      },
-      new RejectingSpanProcessor(),
-    );
+    setTracingDisabled(false);
+    setTraceProcessors([new RejectingSpanProcessor()]);
 
-    expect(() => span.start()).not.toThrow();
-    await Promise.resolve();
-    await Promise.resolve();
+    try {
+      const result = await withTrace('processor-failure-trace', async () =>
+        withCustomSpan(
+          async () => 'completed',
+          { data: { name: 'processor-failure', data: {} } },
+        ),
+      );
 
-    expect(() => span.end()).not.toThrow();
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(
-      errorSpy.mock.calls.some(
-        ([message]) => message === 'Tracing processor failed during span start',
-      ),
-    ).toBe(true);
-    expect(
-      errorSpy.mock.calls.some(
-        ([message]) => message === 'Tracing processor failed during span end',
-      ),
-    ).toBe(true);
-
-    errorSpy.mockRestore();
+      expect(result).toBe('completed');
+      await vi.waitFor(() => {
+        expect(
+          errorSpy.mock.calls.some(
+            ([message]) =>
+              message === 'Tracing processor failed during span start',
+          ),
+        ).toBe(true);
+        expect(
+          errorSpy.mock.calls.some(
+            ([message]) => message === 'Tracing processor failed during span end',
+          ),
+        ).toBe(true);
+      });
+    } finally {
+      setTraceProcessors([]);
+      setTracingDisabled(true);
+      errorSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
### Summary

Handle rejected async tracing-processor hooks invoked from the synchronous `Span.start()` and `Span.end()` APIs.

`TracingProcessor.onSpanStart()` and `onSpanEnd()` return promises, but the span lifecycle methods currently discard those promises. A custom processor rejection can therefore become an unhandled promise rejection even though the caller has no promise to await or catch.

Attach rejection handlers to both fire-and-forget hooks and report failures through the SDK's existing redaction-aware tracing error logger. Span lifecycle timing and the synchronous public API remain unchanged.

### Test plan

- adds a processor whose async span-start and span-end hooks reject
- verifies `Span.start()` and `Span.end()` remain synchronous/non-throwing
- verifies both rejected hook failures are observed and logged by the SDK
- verified the branch is exactly one commit ahead of current upstream `main`
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing async tracing hooks called from synchronous APIs.

### Checks

- [x] I've added new tests (if relevant)
- [x] Documentation change is not required; public API behavior is unchanged
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
