### PR TITLE
fix(core): preserve tracing clone fidelity

### DIFF
--- a/.changeset/preserve-tracing-clones.md
+++ b/.changeset/preserve-tracing-clones.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve tracing processor and no-op behavior when cloning traces and spans

--- a/packages/agents-core/src/tracing/spans.ts
+++ b/packages/agents-core/src/tracing/spans.ts
@@ -273,6 +273,13 @@ export class Span<TData extends SpanData> {
   }
 
   clone(): Span<TData> {
+    if (
+      this.traceId === NOOP_TRACE_OR_SPAN_ID ||
+      this.spanId === NOOP_TRACE_OR_SPAN_ID
+    ) {
+      return new NoopSpan(this.spanData, this.#processor);
+    }
+
     const span = new Span(
       {
         traceId: this.traceId,

--- a/packages/agents-core/src/tracing/traces.ts
+++ b/packages/agents-core/src/tracing/traces.ts
@@ -50,14 +50,17 @@ export class Trace {
   }
 
   clone(): Trace {
-    return new Trace({
-      traceId: this.traceId,
-      name: this.name,
-      groupId: this.groupId ?? undefined,
-      metadata: this.metadata,
-      started: this.#started,
-      tracingApiKey: this.tracingApiKey,
-    });
+    return new Trace(
+      {
+        traceId: this.traceId,
+        name: this.name,
+        groupId: this.groupId ?? undefined,
+        metadata: this.metadata,
+        started: this.#started,
+        tracingApiKey: this.tracingApiKey,
+      },
+      this.#processor,
+    );
   }
 
   /**
@@ -94,6 +97,10 @@ export class NoopTrace extends Trace {
 
   async end(): Promise<void> {
     return;
+  }
+
+  clone(): NoopTrace {
+    return new NoopTrace();
   }
 
   toJSON(): object | null {

--- a/packages/agents-core/test/tracingCloneFidelity.test.ts
+++ b/packages/agents-core/test/tracingCloneFidelity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { NoopSpan, Span, type CustomSpanData } from '../src/tracing/spans';
+import { NoopTrace, Trace } from '../src/tracing/traces';
+import type { TracingProcessor } from '../src/tracing/processor';
+
+class RecordingProcessor implements TracingProcessor {
+  tracesStarted: Trace[] = [];
+  tracesEnded: Trace[] = [];
+  spansStarted: Span<any>[] = [];
+  spansEnded: Span<any>[] = [];
+
+  async onTraceStart(trace: Trace): Promise<void> {
+    this.tracesStarted.push(trace);
+  }
+
+  async onTraceEnd(trace: Trace): Promise<void> {
+    this.tracesEnded.push(trace);
+  }
+
+  async onSpanStart(span: Span<any>): Promise<void> {
+    this.spansStarted.push(span);
+  }
+
+  async onSpanEnd(span: Span<any>): Promise<void> {
+    this.spansEnded.push(span);
+  }
+
+  async shutdown(): Promise<void> {}
+
+  async forceFlush(): Promise<void> {}
+}
+
+describe('tracing clone fidelity', () => {
+  it('preserves a custom processor when cloning a trace', async () => {
+    const processor = new RecordingProcessor();
+    const clone = new Trace({ name: 'custom-processor' }, processor).clone();
+
+    await clone.start();
+    await clone.end();
+
+    expect(processor.tracesStarted).toEqual([clone]);
+    expect(processor.tracesEnded).toEqual([clone]);
+  });
+
+  it('keeps cloned no-op traces disabled', () => {
+    const clone = new NoopTrace().clone();
+
+    expect(clone).toBeInstanceOf(NoopTrace);
+    expect(clone.toJSON()).toBeNull();
+  });
+
+  it('keeps cloned no-op spans disabled', () => {
+    const processor = new RecordingProcessor();
+    const data: CustomSpanData = {
+      type: 'custom',
+      name: 'disabled',
+      data: {},
+    };
+    const clone = new NoopSpan(data, processor).clone();
+
+    expect(clone).toBeInstanceOf(NoopSpan);
+    expect(clone.toJSON()).toBeNull();
+
+    clone.start();
+    clone.end();
+
+    expect(processor.spansStarted).toEqual([]);
+    expect(processor.spansEnded).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Summary

Preserve tracing behavior when cloning trace/span objects.

`Trace.clone()` currently reconstructs the clone without the original processor, so a trace created with a custom processor silently switches to the SDK default processor after cloning. The no-op tracing subclasses also lose their no-op semantics when cloned: `NoopTrace` inherits `Trace.clone()`, and `NoopSpan` inherits `Span.clone()`, producing live base-class objects.

This change:
- keeps the original tracing processor on normal `Trace` clones
- keeps cloned `NoopTrace` instances as `NoopTrace`
- keeps spans with no-op trace/span IDs as `NoopSpan`
- preserves existing clone IDs, metadata, timestamps, errors, and tracing API-key behavior

### Test plan

- verifies a cloned trace continues dispatching lifecycle events to its custom processor
- verifies a cloned `NoopTrace` remains a no-op and serializes to `null`
- verifies a cloned `NoopSpan` remains a no-op and cannot emit span lifecycle callbacks
- verified the branch is exactly one commit ahead of current upstream `main`
- full repository verification is left to GitHub Actions

### Issue number

N/A. Found while auditing tracing clone fidelity.

### Checks

- [x] I've added new tests (if relevant)
- [x] Documentation change is not required; this restores existing tracing semantics
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration`
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
