### PR TITLE
perf(agents-openai): avoid full instruction trim allocations

### DIFF
--- a/.changeset/avoid-instruction-trim-copies.md
+++ b/.changeset/avoid-instruction-trim-copies.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+perf: avoid full instruction string copies when checking for blank instructions

--- a/packages/agents-openai/src/responsesUtils.ts
+++ b/packages/agents-openai/src/responsesUtils.ts
@@ -5,7 +5,7 @@ export function normalizeInstructions(
   instructions: string | undefined,
 ): string | undefined {
   if (typeof instructions === 'string') {
-    return instructions.trim() === '' ? undefined : instructions;
+    return instructions.trimStart().length === 0 ? undefined : instructions;
   }
   return undefined;
 }

--- a/packages/agents-openai/test/responsesUtils.test.ts
+++ b/packages/agents-openai/test/responsesUtils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeInstructions } from '../src/responsesUtils';
+
+describe('normalizeInstructions', () => {
+  it('returns undefined for empty and whitespace-only instructions', () => {
+    expect(normalizeInstructions(undefined)).toBeUndefined();
+    expect(normalizeInstructions('')).toBeUndefined();
+    expect(normalizeInstructions(' \t\n\r\u00a0\u2028\u2029\ufeff')).toBeUndefined();
+  });
+
+  it('preserves non-empty instructions exactly', () => {
+    const instructions = '  Keep leading and trailing whitespace.  \n';
+    expect(normalizeInstructions(instructions)).toBe(instructions);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1773.

`normalizeInstructions()` currently calls `trim()` on every model request only to determine whether the instruction string is blank. That creates a full trimmed copy even though the original instruction string is returned unchanged.

Use `trimStart().length` for the blank check instead. For the common case where instructions do not begin with whitespace, the runtime can avoid constructing a fully trimmed copy. Whitespace-only input still resolves to `undefined`, and non-empty input is preserved exactly.

## Tests

Adds focused coverage for empty/whitespace-only instructions and for preserving non-empty instruction text exactly.

Includes a patch changeset for `@openai/agents-openai`.