### PR TITLE
fix: reject invalid local approval results

### DIFF
--- a/.changeset/fail-closed-tool-approval.md
+++ b/.changeset/fail-closed-tool-approval.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-realtime': patch
+---
+
+fix: reject non-boolean local tool approval callback results instead of treating them as approval. (#1803)

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -66,6 +66,7 @@ import {
   isSiblingCancellationSignal,
 } from '../utils/abortSignals';
 import { isAsyncStandardSchemaValidationError } from '../utils/standardSchema';
+import { requireBooleanApprovalResult } from '../utils/toolApproval';
 import { toSmartString } from '../utils/smartString';
 import { withFunctionSpan, withHandoffSpan } from '../tracing/createSpans';
 import { getCurrentTrace } from '../tracing/context';
@@ -116,8 +117,10 @@ import {
 } from './usageTracking';
 import { getRunStateTurnSpanParent } from './invocationContext';
 import {
+  buildApplyPatchAbortResult,
   buildComputerAbortResult,
   buildFunctionAbortResult,
+  buildShellAbortResult,
   COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
 } from './streamReconciliation';
 import { runWithSiblingCancellation } from './siblingCancellation';
@@ -949,13 +952,17 @@ async function handleFunctionApproval<TContext>(
 
   let needsApproval = forceApproval;
   if (!needsApproval) {
+    let approvalResult: unknown;
     try {
-      needsApproval = await toolRun.tool.needsApproval(
+      approvalResult = await toolRun.tool.needsApproval(
         state._context,
         parsedArgs,
         toolRun.toolCall.callId,
       );
     } catch (error) {
+      if (deps.signal?.aborted) {
+        return buildFunctionCancellationResult(deps, toolRun);
+      }
       if (
         invalidInputFailure &&
         refreshInvalidToolInputFailure(invalidInputFailure)
@@ -964,6 +971,13 @@ async function handleFunctionApproval<TContext>(
       }
       throw error;
     }
+    if (deps.signal?.aborted) {
+      return buildFunctionCancellationResult(deps, toolRun);
+    }
+    needsApproval = requireBooleanApprovalResult(
+      toolRun.tool.name,
+      approvalResult,
+    );
   }
 
   if (deps.signal?.aborted) {
@@ -1685,7 +1699,10 @@ async function resolveToolApproval(options: {
 
   let approvalRequired: boolean;
   try {
-    approvalRequired = await needsApproval();
+    approvalRequired = requireBooleanApprovalResult(
+      toolName,
+      await needsApproval(),
+    );
   } catch (error) {
     if (isCancelled?.()) {
       return 'cancelled';
@@ -1893,6 +1910,7 @@ export async function executeShellActions(
   runContext: RunContext,
   customLogger: Logger | undefined = undefined,
   toolErrorFormatter?: ToolErrorFormatter,
+  signal?: AbortSignal,
 ): Promise<RunItem[]> {
   const _logger = customLogger ?? logger;
   const results: RunItem[] = [];
@@ -1901,6 +1919,16 @@ export async function executeShellActions(
     const shellTool = action.shell;
     const toolCall = action.toolCall;
     const toolCallKey = getToolCallKey(toolCall) ?? toolCall.callId;
+    if (signal?.aborted) {
+      results.push(
+        new RunToolCallOutputItem(
+          buildShellAbortResult(toolCall),
+          agent,
+          'aborted',
+        ),
+      );
+      continue;
+    }
     if (!shellTool.shell) {
       _logger.warn(
         `Skipping shell action for tool "${shellTool.name}" because no local shell implementation is configured.`,
@@ -1919,6 +1947,13 @@ export async function executeShellActions(
       needsApproval: () =>
         shellTool.needsApproval(runContext, toolCall.action, toolCallKey),
       onApproval: shellTool.onApproval,
+      isCancelled: () => Boolean(signal?.aborted),
+      buildCancellationItem: () =>
+        new RunToolCallOutputItem(
+          buildShellAbortResult(toolCall),
+          agent,
+          'aborted',
+        ),
       buildRejectionItem: async () => {
         const response = await resolveApprovalRejectionMessage({
           runContext,
@@ -1949,6 +1984,16 @@ export async function executeShellActions(
       results.push(approvalDecision.item);
       continue;
     }
+    if (signal?.aborted) {
+      results.push(
+        new RunToolCallOutputItem(
+          buildShellAbortResult(toolCall),
+          agent,
+          'aborted',
+        ),
+      );
+      continue;
+    }
 
     const shellItem = await withToolFunctionSpan(
       runner,
@@ -1959,6 +2004,24 @@ export async function executeShellActions(
         }
 
         emitToolStart(runner, runContext, agent, shellTool, toolCall);
+        if (signal?.aborted) {
+          if (span && runner.config.traceIncludeSensitiveData) {
+            span.spanData.output = 'aborted';
+          }
+          emitToolEnd(
+            runner,
+            runContext,
+            agent,
+            shellTool,
+            'aborted',
+            toolCall,
+          );
+          return new RunToolCallOutputItem(
+            buildShellAbortResult(toolCall),
+            agent,
+            'aborted',
+          );
+        }
 
         let shellOutputs: ShellResult['output'] | undefined;
         const providerMeta: Record<string, unknown> = {};
@@ -2044,6 +2107,7 @@ export async function executeApplyPatchOperations(
   runContext: RunContext,
   customLogger: Logger | undefined = undefined,
   toolErrorFormatter?: ToolErrorFormatter,
+  signal?: AbortSignal,
 ): Promise<RunItem[]> {
   const _logger = customLogger ?? logger;
   const results: RunItem[] = [];
@@ -2053,6 +2117,16 @@ export async function executeApplyPatchOperations(
     const toolCall = action.toolCall;
     const toolCallKey = getToolCallKey(toolCall) ?? toolCall.callId;
     const editorContext = { runContext };
+    if (signal?.aborted) {
+      results.push(
+        new RunToolCallOutputItem(
+          buildApplyPatchAbortResult(toolCall),
+          agent,
+          'aborted',
+        ),
+      );
+      continue;
+    }
     const approvalItem = new RunToolApprovalItem(
       toolCall,
       agent,
@@ -2069,6 +2143,13 @@ export async function executeApplyPatchOperations(
           toolCallKey,
         ),
       onApproval: applyPatchTool.onApproval,
+      isCancelled: () => Boolean(signal?.aborted),
+      buildCancellationItem: () =>
+        new RunToolCallOutputItem(
+          buildApplyPatchAbortResult(toolCall),
+          agent,
+          'aborted',
+        ),
       buildRejectionItem: async () => {
         const response = await resolveApprovalRejectionMessage({
           runContext,
@@ -2095,6 +2176,16 @@ export async function executeApplyPatchOperations(
       results.push(approvalDecision.item);
       continue;
     }
+    if (signal?.aborted) {
+      results.push(
+        new RunToolCallOutputItem(
+          buildApplyPatchAbortResult(toolCall),
+          agent,
+          'aborted',
+        ),
+      );
+      continue;
+    }
 
     const applyPatchItem = await withToolFunctionSpan(
       runner,
@@ -2105,6 +2196,24 @@ export async function executeApplyPatchOperations(
         }
 
         emitToolStart(runner, runContext, agent, applyPatchTool, toolCall);
+        if (signal?.aborted) {
+          if (span && runner.config.traceIncludeSensitiveData) {
+            span.spanData.output = 'aborted';
+          }
+          emitToolEnd(
+            runner,
+            runContext,
+            agent,
+            applyPatchTool,
+            'aborted',
+            toolCall,
+          );
+          return new RunToolCallOutputItem(
+            buildApplyPatchAbortResult(toolCall),
+            agent,
+            'aborted',
+          );
+        }
 
         let status: 'completed' | 'failed' = 'completed';
         let output = '';
@@ -2275,15 +2384,19 @@ export async function executeComputerActions(
         const approvalResults = await Promise.allSettled(
           computerActions.map(async (computerAction) => {
             try {
-              return await (
+              const approvalResult = await (
                 needsApprovalCandidate as (
                   runContext: RunContext,
                   action: protocol.ComputerAction,
                   callId?: string,
-                ) => Promise<boolean>
+                ) => Promise<unknown>
               )(runContext, computerAction, toolCall.callId);
+              return requireBooleanApprovalResult(
+                computerTool.name,
+                approvalResult,
+              );
             } catch (error) {
-              if (!firstError) {
+              if (!signal?.aborted && !firstError) {
                 firstError = { value: error };
                 onFatalFailure?.(error);
               }
@@ -2319,19 +2432,19 @@ export async function executeComputerActions(
           COMPUTER_FALLBACK_SCREENSHOT_DATA_URL,
         );
       },
-      isCancelled: () => isSiblingCancellationSignal(signal),
+      isCancelled: () => Boolean(signal?.aborted),
       buildCancellationItem: () =>
         buildComputerCancellationItem(agent, toolCall),
     });
 
-    if (isSiblingCancellationSignal(signal)) {
+    if (signal?.aborted) {
       results.push(buildComputerCancellationItem(agent, toolCall));
       continue;
     }
 
     if (approvalDecision.status === 'rejected') {
       const rejectionMessage = await getRejectionMessage();
-      if (isSiblingCancellationSignal(signal)) {
+      if (signal?.aborted) {
         results.push(buildComputerCancellationItem(agent, toolCall));
         continue;
       }

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -849,6 +849,7 @@ async function executeShellAndApplyPatchActionsInOrder<TContext>(args: {
             args.state._context,
             undefined,
             args.toolErrorFormatter,
+            args.signal,
           )
         : await executeApplyPatchOperations(
             args.agent,
@@ -857,6 +858,7 @@ async function executeShellAndApplyPatchActionsInOrder<TContext>(args: {
             args.state._context,
             undefined,
             args.toolErrorFormatter,
+            args.signal,
           );
     results.push(...items);
   }

--- a/packages/agents-core/src/utils/internal.ts
+++ b/packages/agents-core/src/utils/internal.ts
@@ -34,3 +34,5 @@ export {
   validateToolInvocationApproval,
   validateToolInvocationName,
 } from '../toolInvocation';
+
+export { requireBooleanApprovalResult } from './toolApproval';

--- a/packages/agents-core/src/utils/toolApproval.ts
+++ b/packages/agents-core/src/utils/toolApproval.ts
@@ -1,0 +1,13 @@
+import { UserError } from '../errors';
+
+export function requireBooleanApprovalResult(
+  toolName: string,
+  result: unknown,
+): boolean {
+  if (typeof result !== 'boolean') {
+    throw new UserError(
+      `Tool '${toolName}' needsApproval callback must return a boolean.`,
+    );
+  }
+  return result;
+}

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1999,6 +1999,106 @@ describe('executeComputerActions', () => {
     expect(fakeComputer.screenshot).not.toHaveBeenCalled();
   });
 
+  it.each(['resolves invalid', 'rejects'] as const)(
+    'prefers caller abort when computer approval %s after cancellation',
+    async (settlement) => {
+      const controller = new AbortController();
+      let approvalStartedResolve: (() => void) | undefined;
+      const approvalStarted = new Promise<void>((resolve) => {
+        approvalStartedResolve = resolve;
+      });
+      let approvalRelease: (() => void) | undefined;
+      const approvalCanFinish = new Promise<void>((resolve) => {
+        approvalRelease = resolve;
+      });
+      const fakeComputer = {
+        environment: 'mac',
+        dimensions: [1, 1] as [number, number],
+        screenshot: vi.fn().mockResolvedValue('img'),
+      } as any;
+      const needsApproval = vi.fn(async () => {
+        approvalStartedResolve?.();
+        await approvalCanFinish;
+        if (settlement === 'rejects') {
+          throw new Error('stale computer approval error');
+        }
+        return undefined;
+      });
+      const computer = computerTool({
+        computer: fakeComputer,
+        needsApproval: needsApproval as any,
+      });
+      const call: protocol.ComputerUseCallItem = {
+        type: 'computer_call',
+        callId: 'caller-cancelled-computer-approval',
+        status: 'completed',
+        action: { type: 'screenshot' } as any,
+      };
+      const onFatalFailure = vi.fn();
+
+      const resultPromise = executeComputerActions(
+        new Agent({ name: 'CancelledComputerApproval' }),
+        [{ toolCall: call, computer }],
+        new Runner(),
+        new RunContext(),
+        undefined,
+        undefined,
+        controller.signal,
+        onFatalFailure,
+      );
+      await approvalStarted;
+      controller.abort(new Error('caller cancelled'));
+      approvalRelease?.();
+
+      const [item] = await resultPromise;
+      expect(item.rawItem).toMatchObject({
+        type: 'computer_call_result',
+        callId: call.callId,
+        providerData: { status: 'incomplete' },
+      });
+      expect(fakeComputer.screenshot).not.toHaveBeenCalled();
+      expect(onFatalFailure).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects non-boolean computer approval results', async () => {
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockResolvedValue('img'),
+      click: vi.fn(),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+    const tool = computerTool({
+      computer: fakeComputer,
+      needsApproval: (async () => undefined) as any,
+    });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'c-invalid-approval',
+      status: 'completed',
+      action: { type: 'click', x: 1, y: 2, button: 'left' },
+    };
+
+    await expect(
+      executeComputerActions(
+        new Agent({ name: 'Comp' }),
+        [{ toolCall: call, computer: tool }],
+        new Runner(),
+        new RunContext(),
+      ),
+    ).rejects.toThrow(
+      "Tool 'computer_use_preview' needsApproval callback must return a boolean.",
+    );
+    expect(fakeComputer.click).not.toHaveBeenCalled();
+  });
+
   it('defaults missing needsApproval to false for computer tools', async () => {
     const fakeComputer = {
       environment: 'mac',
@@ -3116,6 +3216,134 @@ describe('executeShellActions', () => {
       expect(editor.operations).toHaveLength(0);
     });
 
+    it('does not execute apply_patch after a start hook aborts the run', async () => {
+      const controller = new AbortController();
+      const editor = new FakeEditor();
+      const applyPatch = applyPatchTool({ editor });
+      const agent = new Agent({ name: 'EditorAgent' });
+      const runContext = new RunContext();
+      const runner = new Runner({ tracingDisabled: true });
+      const end = vi.fn();
+      runner.on('agent_tool_start', () =>
+        controller.abort(new Error('stop apply_patch')),
+      );
+      runner.on('agent_tool_end', end);
+      const toolCall: protocol.ApplyPatchCallItem = {
+        type: 'apply_patch_call',
+        callId: 'start_hook_cancelled_patch',
+        status: 'completed',
+        operation: { type: 'delete_file', path: 'README.md' },
+      };
+
+      const [result] = await executeApplyPatchOperations(
+        agent,
+        [{ toolCall, applyPatch } as any],
+        runner,
+        runContext,
+        undefined,
+        undefined,
+        controller.signal,
+      );
+
+      expect(editor.operations).toHaveLength(0);
+      expect(result.rawItem).toMatchObject({
+        type: 'apply_patch_call_output',
+        callId: toolCall.callId,
+        status: 'failed',
+        output: 'aborted',
+      });
+      expect(end).toHaveBeenCalledWith(
+        runContext,
+        agent,
+        applyPatch,
+        'aborted',
+        { toolCall },
+      );
+    });
+
+    it.each(['resolves invalid', 'rejects'] as const)(
+      'prefers cancellation when apply_patch approval %s after abort',
+      async (settlement) => {
+        const controller = new AbortController();
+        let approvalStartedResolve: (() => void) | undefined;
+        const approvalStarted = new Promise<void>((resolve) => {
+          approvalStartedResolve = resolve;
+        });
+        let approvalRelease: (() => void) | undefined;
+        const approvalCanFinish = new Promise<void>((resolve) => {
+          approvalRelease = resolve;
+        });
+        const editor = new FakeEditor();
+        const applyPatch = applyPatchTool({
+          editor,
+          needsApproval: (async () => {
+            approvalStartedResolve?.();
+            await approvalCanFinish;
+            if (settlement === 'rejects') {
+              throw new Error('stale apply_patch approval error');
+            }
+            return undefined;
+          }) as any,
+        });
+        const agent = new Agent({ name: 'EditorAgent' });
+        const toolCall: protocol.ApplyPatchCallItem = {
+          type: 'apply_patch_call',
+          callId: 'cancelled_patch_approval',
+          status: 'completed',
+          operation: { type: 'delete_file', path: 'README.md' },
+        };
+
+        const resultPromise = executeApplyPatchOperations(
+          agent,
+          [{ toolCall, applyPatch } as any],
+          new Runner({ tracingDisabled: true }),
+          new RunContext(),
+          undefined,
+          undefined,
+          controller.signal,
+        );
+        await approvalStarted;
+        controller.abort(new Error('cancel apply_patch approval'));
+        approvalRelease?.();
+
+        const [result] = await resultPromise;
+        expect(result.rawItem).toMatchObject({
+          type: 'apply_patch_call_output',
+          callId: toolCall.callId,
+          status: 'failed',
+          output: 'aborted',
+        });
+        expect(editor.operations).toHaveLength(0);
+      },
+    );
+
+    it('rejects non-boolean apply_patch approval results', async () => {
+      const editor = new FakeEditor();
+      const applyPatch = applyPatchTool({
+        editor,
+        needsApproval: (async () => undefined) as any,
+      });
+      const agent = new Agent({ name: 'EditorAgent' });
+      const toolCall: protocol.ApplyPatchCallItem = {
+        type: 'apply_patch_call',
+        callId: 'call_patch_invalid_approval',
+        status: 'completed',
+        operation: { type: 'delete_file', path: 'README.md' },
+      };
+
+      await expect(
+        executeApplyPatchOperations(
+          agent,
+          [{ toolCall, applyPatch } as any],
+          new Runner({ tracingDisabled: true }),
+          new RunContext(),
+        ),
+      ).rejects.toThrow(
+        "Tool 'apply_patch' needsApproval callback must return a boolean.",
+      );
+      expect(editor.operations).toHaveLength(0);
+    });
+
     it('does not recheck apply_patch approval after approval', async () => {
       const editor = new FakeEditor();
       const needsApproval = vi.fn(async () => true);
@@ -3295,6 +3523,74 @@ describe('executeShellActions', () => {
     beforeEach(() => {
       runner = new Runner({ tracingDisabled: true });
       state = new RunState(new RunContext(), '', new Agent({ name: 'T' }), 1);
+    });
+
+    it('rejects non-boolean function tool approval results', async () => {
+      const execute = vi.fn(async () => 'unexpected');
+      const t = tool({
+        name: 'hi',
+        description: 't',
+        parameters: z.object({}),
+        needsApproval: (async () => undefined) as any,
+        execute,
+      }) as unknown as FunctionTool;
+
+      await expect(
+        executeFunctionToolCalls(
+          state._currentAgent,
+          [{ toolCall, tool: t }],
+          runner,
+          state,
+        ),
+      ).rejects.toThrow(
+        "Tool 'hi' needsApproval callback must return a boolean.",
+      );
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('prefers cancellation when invalid function approval resolves after abort', async () => {
+      let approvalStartedResolve: (() => void) | undefined;
+      const approvalStarted = new Promise<void>((resolve) => {
+        approvalStartedResolve = resolve;
+      });
+      let approvalRelease: (() => void) | undefined;
+      const approvalCanFinish = new Promise<void>((resolve) => {
+        approvalRelease = resolve;
+      });
+      const execute = vi.fn(async () => 'unexpected');
+      const t = tool({
+        name: 'hi',
+        description: 't',
+        parameters: z.object({}),
+        needsApproval: (async () => {
+          approvalStartedResolve?.();
+          await approvalCanFinish;
+          return undefined;
+        }) as any,
+        execute,
+      }) as unknown as FunctionTool;
+      const controller = new AbortController();
+
+      const resultPromise = executeFunctionToolCalls(
+        state._currentAgent,
+        [{ toolCall, tool: t }],
+        runner,
+        state,
+        undefined,
+        undefined,
+        controller.signal,
+      );
+      await approvalStarted;
+      controller.abort(new Error('cancel approval'));
+      approvalRelease?.();
+
+      const [result] = await resultPromise;
+      expect(result).toMatchObject({
+        type: 'function_output',
+        output: 'aborted',
+        runItem: { rawItem: { status: 'incomplete' } },
+      });
+      expect(execute).not.toHaveBeenCalled();
     });
 
     it('wraps hostile unrelated errors without inspecting their prototype twice', async () => {
@@ -10086,6 +10382,105 @@ describe('executeShellActions', () => {
     expect(results[0].type).toBe('tool_approval_item');
     expect(shell.calls).toHaveLength(0);
   });
+
+  it('does not execute shell after a start hook aborts the run', async () => {
+    const controller = new AbortController();
+    const shell = new FakeShell();
+    const shellToolDef = shellTool({ shell });
+    const agent = new Agent({ name: 'ShellAgent' });
+    const runContext = new RunContext();
+    const runner = new Runner({ tracingDisabled: true });
+    const end = vi.fn();
+    runner.on('agent_tool_start', () =>
+      controller.abort(new Error('stop shell')),
+    );
+    runner.on('agent_tool_end', end);
+    const toolCall: protocol.ShellCallItem = {
+      type: 'shell_call',
+      callId: 'start_hook_cancelled_shell',
+      status: 'completed',
+      action: { commands: ['echo hi'] },
+    };
+
+    const [result] = await executeShellActions(
+      agent,
+      [{ toolCall, shell: shellToolDef } as any],
+      runner,
+      runContext,
+      undefined,
+      undefined,
+      controller.signal,
+    );
+
+    expect(shell.calls).toHaveLength(0);
+    expect(result.rawItem).toMatchObject({
+      type: 'shell_call_output',
+      callId: toolCall.callId,
+      status: 'incomplete',
+    });
+    expect(end).toHaveBeenCalledWith(
+      runContext,
+      agent,
+      shellToolDef,
+      'aborted',
+      { toolCall },
+    );
+  });
+
+  it.each(['resolves invalid', 'rejects'] as const)(
+    'prefers cancellation when shell approval %s after abort',
+    async (settlement) => {
+      const controller = new AbortController();
+      let approvalStartedResolve: (() => void) | undefined;
+      const approvalStarted = new Promise<void>((resolve) => {
+        approvalStartedResolve = resolve;
+      });
+      let approvalRelease: (() => void) | undefined;
+      const approvalCanFinish = new Promise<void>((resolve) => {
+        approvalRelease = resolve;
+      });
+      const shell = new FakeShell();
+      const shellToolDef = shellTool({
+        shell,
+        needsApproval: (async () => {
+          approvalStartedResolve?.();
+          await approvalCanFinish;
+          if (settlement === 'rejects') {
+            throw new Error('stale shell approval error');
+          }
+          return undefined;
+        }) as any,
+      });
+      const agent = new Agent({ name: 'ShellAgent' });
+      const toolCall: protocol.ShellCallItem = {
+        type: 'shell_call',
+        callId: 'cancelled_shell_approval',
+        status: 'completed',
+        action: { commands: ['echo hi'] },
+      };
+
+      const resultPromise = executeShellActions(
+        agent,
+        [{ toolCall, shell: shellToolDef } as any],
+        new Runner({ tracingDisabled: true }),
+        new RunContext(),
+        undefined,
+        undefined,
+        controller.signal,
+      );
+      await approvalStarted;
+      controller.abort(new Error('cancel shell approval'));
+      approvalRelease?.();
+
+      const [result] = await resultPromise;
+      expect(result.rawItem).toMatchObject({
+        type: 'shell_call_output',
+        callId: toolCall.callId,
+        status: 'incomplete',
+      });
+      expect(shell.calls).toHaveLength(0);
+    },
+  );
 
   it('does not recheck shell approval after approval', async () => {
     const shell = new FakeShell();

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -28,6 +28,7 @@ import {
   validateHandoffToolInvocation,
   validateToolInvocationApproval,
   validateToolInvocationName,
+  requireBooleanApprovalResult,
 } from '@openai/agents-core/utils/internal';
 import type {
   RealtimeSessionConfig,
@@ -1119,10 +1120,26 @@ export class RealtimeSession<
     const existingApproval = dynamicApprovalPolicy
       ? getToolInvocationApproval(this.context, agent, tool, toolCall)
       : undefined;
-    const needsApproval =
-      forceApproval ||
-      existingApproval !== undefined ||
-      (await tool.needsApproval(this.#context, parsedArgs, toolCall.callId));
+    let needsApproval = forceApproval || existingApproval !== undefined;
+    if (!needsApproval) {
+      let approvalResult: unknown;
+      try {
+        approvalResult = await tool.needsApproval(
+          this.#context,
+          parsedArgs,
+          toolCall.callId,
+        );
+      } catch (error) {
+        if (!this.#isCurrentRealtimeInvocation(invocation)) {
+          return;
+        }
+        throw error;
+      }
+      if (!this.#isCurrentRealtimeInvocation(invocation)) {
+        return;
+      }
+      needsApproval = requireBooleanApprovalResult(tool.name, approvalResult);
+    }
     if (!this.#isCurrentRealtimeInvocation(invocation)) {
       return;
     }

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -1672,6 +1672,152 @@ describe('RealtimeSession', () => {
     expect(invokeSpy).not.toHaveBeenCalled();
   });
 
+  it('rejects non-boolean realtime approval results', async () => {
+    const execute = vi.fn(async () => 'unexpected');
+    const guardedTool = tool({
+      name: 'invalid_approval_result',
+      description: 'Dynamic approval tool',
+      parameters: z.object({}),
+      needsApproval: (async () => undefined) as any,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    await localSession.connect({ apiKey: 'test' });
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+    const errorEvent = waitForEvent<any[]>(localSession, 'error');
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: guardedTool.name,
+      callId: 'invalid-approval-result-call',
+      arguments: '{}',
+      status: 'completed',
+      responseId: 'invalid-approval-result-response',
+    } as any);
+
+    const [error] = await errorEvent;
+    expect(error.error).toBeInstanceOf(UserError);
+    expect(error.error).toMatchObject({
+      message:
+        "Tool 'invalid_approval_result' needsApproval callback must return a boolean.",
+    });
+    expect(execute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+    errorSpy.mockRestore();
+  });
+
+  it('ignores invalid approval results after realtime disconnect', async () => {
+    let approvalStartedResolve: (() => void) | undefined;
+    const approvalStarted = new Promise<void>((resolve) => {
+      approvalStartedResolve = resolve;
+    });
+    let approvalRelease: (() => void) | undefined;
+    const approvalCanFinish = new Promise<void>((resolve) => {
+      approvalRelease = resolve;
+    });
+    const execute = vi.fn(async () => 'unexpected');
+    const guardedTool = tool({
+      name: 'cancelled_invalid_approval',
+      description: 'Dynamic approval tool',
+      parameters: z.object({}),
+      needsApproval: (async () => {
+        approvalStartedResolve?.();
+        await approvalCanFinish;
+        return undefined;
+      }) as any,
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    const errors: unknown[] = [];
+    localSession.on('error', (event) => errors.push(event.error));
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: guardedTool.name,
+      callId: 'cancelled-invalid-approval-call',
+      arguments: '{}',
+      status: 'completed',
+      responseId: 'cancelled-invalid-approval-response',
+    } as any);
+    await approvalStarted;
+    localSession.close();
+    approvalRelease?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errors).toEqual([]);
+    expect(execute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
+  it('ignores approval callback errors after realtime disconnect', async () => {
+    let approvalStartedResolve: (() => void) | undefined;
+    const approvalStarted = new Promise<void>((resolve) => {
+      approvalStartedResolve = resolve;
+    });
+    let approvalRelease: (() => void) | undefined;
+    const approvalCanFinish = new Promise<void>((resolve) => {
+      approvalRelease = resolve;
+    });
+    const execute = vi.fn(async () => 'unexpected');
+    const guardedTool = tool({
+      name: 'cancelled_rejected_approval',
+      description: 'Dynamic approval tool',
+      parameters: z.object({}),
+      needsApproval: async () => {
+        approvalStartedResolve?.();
+        await approvalCanFinish;
+        throw new Error('stale approval failure');
+      },
+      execute,
+    });
+    const agent = new RealtimeAgent({
+      name: 'ApprovalAgent',
+      handoffs: [],
+      tools: [guardedTool],
+    });
+    const localTransport = new FakeTransport();
+    const localSession = new RealtimeSession(agent, {
+      transport: localTransport,
+    });
+    const errors: unknown[] = [];
+    localSession.on('error', (event) => errors.push(event.error));
+    await localSession.connect({ apiKey: 'test' });
+
+    localTransport.emit('function_call', {
+      type: 'function_call',
+      name: guardedTool.name,
+      callId: 'cancelled-rejected-approval-call',
+      arguments: '{}',
+      status: 'completed',
+      responseId: 'cancelled-rejected-approval-response',
+    } as any);
+    await approvalStarted;
+    localSession.close();
+    approvalRelease?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errors).toEqual([]);
+    expect(execute).not.toHaveBeenCalled();
+    expect(localTransport.sendFunctionCallOutputCalls).toHaveLength(0);
+  });
+
   it.each([
     ['malformed JSON', '{'],
     ['an array', '[]'],


### PR DESCRIPTION
### Summary

Reject non-boolean dynamic `needsApproval` callback results before local tool execution instead of treating falsy JavaScript values as approval.

The fix applies consistently to function, shell, apply-patch, computer, and Realtime tool paths. Existing `true`/`false` behavior and stored approval/rejection decisions are unchanged. Cancellation and Realtime disconnects remain authoritative when an approval callback settles after the invocation becomes stale, including callbacks that reject and start hooks that abort the run.

### Test plan

- Focused core approval lifecycle tests passed across function, shell, apply-patch, and computer paths.
- Focused Realtime approval lifecycle tests passed, including resolve/reject after disconnect.
- `.agents/skills/code-change-verification/scripts/run.sh` passed with build, dist checks, lint, full tests, and formatting checks.
- Pre-commit formatting, lint, and secret scan passed.

### Issue number

Closes #1803

### Checks

- [x] I've added new tests (if relevant)
- [x] I've run `pnpm test` and `pnpm test:examples`
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] I've added a changeset using `pnpm changeset` to indicate my changes