### PR TITLE
fix(core): preserve CRLF line endings in applyDiff

### DIFF
--- a/.changeset/preserve-crlf-patches.md
+++ b/.changeset/preserve-crlf-patches.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve CRLF line endings when applyDiff inserts or replaces lines in CRLF files. (#1804)

--- a/packages/agents-core/src/utils/applyDiff.ts
+++ b/packages/agents-core/src/utils/applyDiff.ts
@@ -17,8 +17,23 @@ export function applyDiff(
     return parseCreateDiff(diffLines);
   }
 
-  const { chunks } = parseUpdateDiff(diffLines, input);
-  return applyChunks(input, chunks);
+  const lineEnding = updateLineEnding(input);
+  const normalizedInput =
+    lineEnding === '\r\n' ? input.replace(/\r\n/g, '\n') : input;
+  const { chunks } = parseUpdateDiff(diffLines, normalizedInput);
+  return applyChunks(normalizedInput, chunks, lineEnding);
+}
+
+function updateLineEnding(input: string): '\n' | '\r\n' {
+  let hasNewline = false;
+  for (let index = 0; index < input.length; index += 1) {
+    if (input[index] !== '\n') continue;
+    hasNewline = true;
+    if (index === 0 || input[index - 1] !== '\r') {
+      return '\n';
+    }
+  }
+  return hasNewline ? '\r\n' : '\n';
 }
 
 type Chunk = { origIndex: number; delLines: string[]; insLines: string[] };
@@ -380,7 +395,11 @@ function equalsSlice(
   return true;
 }
 
-function applyChunks(input: string, chunks: Chunk[]): string {
+function applyChunks(
+  input: string,
+  chunks: Chunk[],
+  lineEnding: '\n' | '\r\n',
+): string {
   const origLines = input.split('\n');
   const destLines: string[] = [];
   let origIndex = 0;
@@ -408,6 +427,6 @@ function applyChunks(input: string, chunks: Chunk[]): string {
   }
 
   destLines.push(...origLines.slice(origIndex));
-  const result = destLines.join('\n');
+  const result = destLines.join(lineEnding);
   return result;
 }

--- a/packages/agents-core/test/utils/applyDiff.crlf-workflow.test.ts
+++ b/packages/agents-core/test/utils/applyDiff.crlf-workflow.test.ts
@@ -1,0 +1,24 @@
+import { check } from 'prettier';
+import { describe, expect, it } from 'vitest';
+import { applyDiff } from '../../src/utils/applyDiff';
+
+describe('applyDiff CRLF workflow', () => {
+  it('keeps a patched CRLF TypeScript file acceptable to a CRLF formatting check', async () => {
+    const input = 'const alpha = 1;\r\nconst beta = 2;\r\n';
+    const diff = [
+      '@@',
+      ' const alpha = 1;',
+      '+const inserted = 3;',
+      ' const beta = 2;',
+    ].join('\n');
+
+    const patched = applyDiff(input, diff);
+
+    expect(
+      await check(patched, {
+        parser: 'typescript',
+        endOfLine: 'crlf',
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/agents-core/test/utils/applyDiff.test.ts
+++ b/packages/agents-core/test/utils/applyDiff.test.ts
@@ -41,6 +41,45 @@ describe('applyDiff', () => {
     );
   });
 
+  it.each([
+    [
+      'insertion',
+      'alpha\r\nbeta\r\n',
+      '@@\n alpha\n+inserted\n beta',
+      'alpha\r\ninserted\r\nbeta\r\n',
+    ],
+    [
+      'replacement',
+      'alpha\r\nbeta\r\n',
+      '@@\n alpha\n-beta\n+gamma',
+      'alpha\r\ngamma\r\n',
+    ],
+    [
+      'EOF insertion without a final newline',
+      'alpha\r\nbeta',
+      '@@\n alpha\n beta\n+inserted',
+      'alpha\r\nbeta\r\ninserted',
+    ],
+    [
+      'EOF replacement without a final newline',
+      'alpha\r\nbeta',
+      '@@\n alpha\n-beta\n+gamma',
+      'alpha\r\ngamma',
+    ],
+  ])(
+    'preserves CRLF line endings for %s hunks',
+    (_name, input, diff, expected) => {
+      expect(applyDiff(input, diff)).toBe(expected);
+    },
+  );
+
+  it('preserves mixed line endings byte-for-byte outside inserted LF content', () => {
+    const input = 'alpha\r\nbeta\ngamma';
+    const diff = '@@\n alpha\r\n beta\n+inserted\n gamma';
+
+    expect(applyDiff(input, diff)).toBe('alpha\r\nbeta\ninserted\ngamma');
+  });
+
   it('applies V4A replacements with context', () => {
     const input = ['line1', 'line2', 'line3'].join('\n') + '\n';
     const diff = ['@@ line1', '-line2', '+updated', ' line3'].join('\n');


### PR DESCRIPTION
### Summary

Preserve CRLF line endings when `applyDiff()` inserts or replaces lines in an existing CRLF file.

Update-mode CRLF input is normalized only for logical patch matching and then reconstructed with the original CRLF separator. Files using LF or mixed line endings retain their existing behavior, create-file mode is unchanged, and files without a final newline preserve that state.

### Concrete downstream workflow

`applyDiff()` is used by the sandbox/editor paths to rewrite files on disk. A CRLF-enforced project can then run a formatter check on the patched file. Before this fix, inserting a line into an otherwise CRLF TypeScript file produces mixed line endings, so a Prettier check configured with `endOfLine: 'crlf'` rejects the result even though the source file passed that policy before the patch.

Added `applyDiff.crlf-workflow.test.ts` to exercise that workflow directly: patch a CRLF TypeScript file, then require Prettier's CRLF formatting check to accept the resulting content.

### Test plan

- existing `packages/agents-core/test/utils/applyDiff.test.ts` coverage includes CRLF insertion/replacement, EOF changes without a final newline, mixed endings, and existing patch behavior
- new workflow regression checks the patched CRLF TypeScript result with Prettier using `endOfLine: 'crlf'`
- the previous head passed `.agents/skills/code-change-verification/scripts/run.sh`, the full suite, formatting, lint, and pre-commit checks; pushed-head CI is required for the added workflow regression

### Issue number

Closes #1804

### Checks

- [x] I've added new tests (if relevant)
- [x] I've run `pnpm test` and `pnpm test:examples` on the previous head
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh` on the previous head
- [ ] I've confirmed all verification steps pass on the current head; awaiting pushed-head CI
- [x] I've added a changeset using `pnpm changeset` to indicate my changes