### PR TITLE
fix(core): reject non-boolean approval results

### DIFF
--- a/.changeset/fail-closed-nonboolean-approvals.md
+++ b/.changeset/fail-closed-nonboolean-approvals.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reject non-boolean local tool approval callback results

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -950,10 +950,13 @@ async function handleFunctionApproval<TContext>(
   let needsApproval = forceApproval;
   if (!needsApproval) {
     try {
-      needsApproval = await toolRun.tool.needsApproval(
-        state._context,
-        parsedArgs,
-        toolRun.toolCall.callId,
+      needsApproval = requireBooleanApprovalResult(
+        await toolRun.tool.needsApproval(
+          state._context,
+          parsedArgs,
+          toolRun.toolCall.callId,
+        ),
+        toolRun.tool.name,
       );
     } catch (error) {
       if (
@@ -1643,6 +1646,18 @@ async function withRunStateToolFunctionSpan<TContext, T>(
 
 type ApprovalResolution = 'approved' | 'rejected' | 'pending' | 'cancelled';
 
+function requireBooleanApprovalResult(
+  result: unknown,
+  toolName: string,
+): boolean {
+  if (typeof result !== 'boolean') {
+    throw new UserError(
+      `needsApproval for tool ${toolName} must return a boolean.`,
+    );
+  }
+  return result;
+}
+
 type LocalApprovalDecision = {
   approve?: boolean;
   reason?: string;
@@ -1685,7 +1700,10 @@ async function resolveToolApproval(options: {
 
   let approvalRequired: boolean;
   try {
-    approvalRequired = await needsApproval();
+    approvalRequired = requireBooleanApprovalResult(
+      await needsApproval(),
+      toolName,
+    );
   } catch (error) {
     if (isCancelled?.()) {
       return 'cancelled';
@@ -2275,13 +2293,16 @@ export async function executeComputerActions(
         const approvalResults = await Promise.allSettled(
           computerActions.map(async (computerAction) => {
             try {
-              return await (
-                needsApprovalCandidate as (
-                  runContext: RunContext,
-                  action: protocol.ComputerAction,
-                  callId?: string,
-                ) => Promise<boolean>
-              )(runContext, computerAction, toolCall.callId);
+              return requireBooleanApprovalResult(
+                await (
+                  needsApprovalCandidate as (
+                    runContext: RunContext,
+                    action: protocol.ComputerAction,
+                    callId?: string,
+                  ) => Promise<boolean>
+                )(runContext, computerAction, toolCall.callId),
+                computerTool.name,
+              );
             } catch (error) {
               if (!firstError) {
                 firstError = { value: error };

--- a/packages/agents-core/test/runner/nonBooleanApproval.test.ts
+++ b/packages/agents-core/test/runner/nonBooleanApproval.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { Agent, run, tool, Usage } from '../../src';
+import * as protocol from '../../src/types/protocol';
+import {
+  ScriptedModel,
+  assistantMessage,
+  modelResponse,
+} from '../../src/testing';
+
+describe('needsApproval runtime validation', () => {
+  it('rejects a non-boolean function-tool approval result before execution', async () => {
+    const execute = vi.fn(async () => 'executed');
+    const guarded = tool({
+      name: 'guarded',
+      description: 'guarded operation',
+      parameters: z.object({}),
+      needsApproval: (async () => undefined) as any,
+      execute,
+    });
+    const call: protocol.FunctionCallItem = {
+      type: 'function_call',
+      id: 'fc_1',
+      callId: 'call_1',
+      name: guarded.name,
+      status: 'completed',
+      arguments: '{}',
+    };
+    const model = new ScriptedModel([
+      modelResponse({ output: [call], usage: new Usage() }),
+      modelResponse({
+        output: [assistantMessage('unexpected continuation')],
+        usage: new Usage(),
+      }),
+    ]);
+    const agent = new Agent({ name: 'approval-test', model, tools: [guarded] });
+
+    await expect(run(agent, 'run it')).rejects.toThrow(
+      'Failed to run function tools: UserError: needsApproval for tool guarded must return a boolean.',
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fail closed when a local tool `needsApproval` callback returns a non-boolean runtime value.

Function, shell, apply-patch, and computer approval paths are all typed to return `boolean`, but unchecked JavaScript or an accidental fall-through could return `undefined`. The runner previously treated that as falsy and authorized execution.

This change validates callback results before the approval decision is applied. Explicit `true`/`false`, existing approval state, callback exceptions, and cancellation behavior are unchanged.

## Tests

- Added a public `run()` regression proving a non-boolean function-tool result fails before tool execution.
- Focused Vitest regression passes.
- `tsc` for the agents-core test project passes.
- ESLint, Prettier, `git diff --check`, and the pre-commit secret scan pass.

Fixes #1808.