### PR TITLE
fix(core): validate guardrail tripwire results

### DIFF
--- a/.changeset/validate-guardrail-tripwire.md
+++ b/.changeset/validate-guardrail-tripwire.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: reject non-boolean guardrail tripwire results

--- a/packages/agents-core/src/runner/guardrails.ts
+++ b/packages/agents-core/src/runner/guardrails.ts
@@ -200,7 +200,12 @@ async function runGuardrailsWithTripwire<
     const observedResult = await withGuardrailSpan(
       async (span) => {
         const result = await guardrail.run(guardrailArgs);
-        const tripwireTriggered = result.output.tripwireTriggered;
+        const tripwireTriggered: unknown = result.output.tripwireTriggered;
+        if (typeof tripwireTriggered !== 'boolean') {
+          throw new UserError(
+            `Guardrail ${guardrail.name} must return a boolean tripwireTriggered value.`,
+          );
+        }
         span.spanData.triggered = tripwireTriggered;
         return {
           result,

--- a/packages/agents-core/test/runner/nonBooleanGuardrailTripwire.test.ts
+++ b/packages/agents-core/test/runner/nonBooleanGuardrailTripwire.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, run, Usage } from '../../src';
+import { GuardrailExecutionError } from '../../src/errors';
+import {
+  ScriptedModel,
+  assistantMessage,
+  modelResponse,
+} from '../../src/testing';
+
+describe('guardrail tripwire runtime validation', () => {
+  it('rejects a non-boolean blocking input tripwire before model execution', async () => {
+    const guardrail = {
+      name: 'policy',
+      runInParallel: false,
+      execute: async () =>
+        ({ tripwireTriggered: undefined, outputInfo: undefined }) as any,
+    };
+    const model = new ScriptedModel([
+      modelResponse({
+        output: [assistantMessage('should not run')],
+        usage: new Usage(),
+      }),
+    ]);
+    const agent = new Agent({
+      name: 'guardrail-test',
+      model,
+      inputGuardrails: [guardrail],
+    });
+
+    await expect(run(agent, 'sensitive input')).rejects.toThrow(
+      GuardrailExecutionError,
+    );
+    expect(model.calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Reject non-boolean `tripwireTriggered` values returned by input or output guardrails.

The shared guardrail runner previously trusted the callback result and later used it as a truthiness check. Unchecked JavaScript or an accidental fall-through could therefore return `undefined`, which was treated as a passing guardrail.

The shared guardrail boundary now requires an actual boolean before recording or acting on the result. Explicit `true` and `false` behavior is unchanged.

## Tests

- Added a public runner regression with a blocking input guardrail returning `tripwireTriggered: undefined`.
- The regression verifies the run fails and the model is never invoked.
- Focused Vitest, agents-core TypeScript, ESLint, Prettier, `git diff --check`, and the pre-commit secret scan pass.

Fixes #1810.