### PR TITLE
fix(core): wait for in-flight trace exports in forceFlush

### DIFF
--- a/.changeset/wait-for-inflight-trace-flush.md
+++ b/.changeset/wait-for-inflight-trace-flush.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): wait for in-flight trace exports during force flush (#1812)

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -134,6 +134,7 @@ export class BatchTraceProcessor implements TracingProcessor {
   #exportInProgress = false;
   #timeoutAbortController: AbortController | null = null;
   #activeExportAbortControllers = new Set<AbortController>();
+  #activeExportPromises = new Set<Promise<void>>();
 
   constructor(
     exporter: TracingExporter,
@@ -213,18 +214,28 @@ export class BatchTraceProcessor implements TracingProcessor {
         signal,
         activeExportAbortController.signal,
       );
+      const exportPromise = (async () => {
+        try {
+          await this.#exporter.export(batch, combinedSignal.signal);
+        } catch (error) {
+          logModelAndToolActionError(
+            logger,
+            'Tracing exporter failed to export batch',
+            error,
+          );
+        } finally {
+          combinedSignal.cleanup();
+          this.#activeExportAbortControllers.delete(
+            activeExportAbortController,
+          );
+          this.#exportInProgress = this.#activeExportAbortControllers.size > 0;
+        }
+      })();
+      this.#activeExportPromises.add(exportPromise);
       try {
-        await this.#exporter.export(batch, combinedSignal.signal);
-      } catch (error) {
-        logModelAndToolActionError(
-          logger,
-          'Tracing exporter failed to export batch',
-          error,
-        );
+        await exportPromise;
       } finally {
-        combinedSignal.cleanup();
-        this.#activeExportAbortControllers.delete(activeExportAbortController);
-        this.#exportInProgress = this.#activeExportAbortControllers.size > 0;
+        this.#activeExportPromises.delete(exportPromise);
       }
     };
 
@@ -334,8 +345,12 @@ export class BatchTraceProcessor implements TracingProcessor {
   }
 
   async forceFlush(): Promise<void> {
+    const inFlightExports = [...this.#activeExportPromises];
     if (this.#buffer.length > 0) {
       await this.#exportBatches(true);
+    }
+    if (inFlightExports.length > 0) {
+      await Promise.all(inFlightExports);
     }
   }
 }

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -2345,3 +2345,48 @@ describe('ResponseSpanData serialization', () => {
     expect(json.span_data).not.toHaveProperty('_response');
   });
 });
+
+// Regression: forceFlush must not resolve while a previously-triggered export is still running.
+describe('BatchTraceProcessor forceFlush in-flight export', () => {
+  it('waits for an in-flight export after the buffer has been drained', async () => {
+    let markExportStarted!: () => void;
+    let releaseExport!: () => void;
+    const exportStarted = new Promise<void>((resolve) => {
+      markExportStarted = resolve;
+    });
+    const exportReleased = new Promise<void>((resolve) => {
+      releaseExport = resolve;
+    });
+    const delayedExporter: TracingExporter = {
+      export: async () => {
+        markExportStarted();
+        await exportReleased;
+      },
+    };
+    const processor = new BatchTraceProcessor(delayedExporter, {
+      maxQueueSize: 10,
+      maxBatchSize: 100,
+      exportTriggerRatio: 0.1,
+      scheduleDelay: 10000,
+    });
+
+    await processor.onTraceStart(new Trace({ name: 'first' }));
+    const pendingExport = processor.onTraceStart(new Trace({ name: 'second' }));
+    await exportStarted;
+
+    let flushSettled = false;
+    const flushPromise = processor.forceFlush().then(() => {
+      flushSettled = true;
+    });
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(flushSettled).toBe(false);
+    } finally {
+      releaseExport();
+      await pendingExport;
+      await flushPromise;
+      await processor.shutdown();
+    }
+  });
+});

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -2444,7 +2444,7 @@ describe('BatchTraceProcessor forceFlush in-flight export', () => {
       });
 
       await secondAttempted;
-      await Promise.resolve();
+      await new Promise((resolve) => setTimeout(resolve, 0));
       expect(flushSettled).toBe(false);
 
       releaseFirst();

--- a/packages/agents-core/test/tracing.test.ts
+++ b/packages/agents-core/test/tracing.test.ts
@@ -2389,4 +2389,122 @@ describe('BatchTraceProcessor forceFlush in-flight export', () => {
       await processor.shutdown();
     }
   });
+
+  it('waits for a surviving export when a concurrent forced batch fails', async () => {
+    const errorSpy = vi.spyOn(coreLogger, 'error').mockImplementation(() => {});
+    let releaseFirst!: () => void;
+    let markFirstStarted!: () => void;
+    let markSecondAttempted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondAttempted = new Promise<void>((resolve) => {
+      markSecondAttempted = resolve;
+    });
+    let exportCalls = 0;
+    const exported: Array<(Trace | Span<any>)[]> = [];
+    const exporter: TracingExporter = {
+      export: async (items) => {
+        exportCalls += 1;
+        if (exportCalls === 1) {
+          markFirstStarted();
+          await firstReleased;
+          return;
+        }
+        if (exportCalls === 2) {
+          markSecondAttempted();
+          throw new Error('forced batch failed');
+        }
+        exported.push([...items]);
+      },
+    };
+    const processor = new BatchTraceProcessor(exporter, {
+      maxQueueSize: 10,
+      maxBatchSize: 100,
+      exportTriggerRatio: 0.5,
+      scheduleDelay: 10000,
+    });
+
+    try {
+      for (let index = 0; index < 5; index += 1) {
+        await processor.onTraceStart(new Trace({ name: `queued-${index}` }));
+      }
+      const firstExport = processor.onTraceStart(
+        new Trace({ name: 'trigger-first-export' }),
+      );
+      await firstStarted;
+
+      await processor.onTraceStart(new Trace({ name: 'buffered-for-flush' }));
+      let flushSettled = false;
+      const flushPromise = processor.forceFlush().then(() => {
+        flushSettled = true;
+      });
+
+      await secondAttempted;
+      await Promise.resolve();
+      expect(flushSettled).toBe(false);
+
+      releaseFirst();
+      await firstExport;
+      await flushPromise;
+
+      await processor.onTraceStart(new Trace({ name: 'after-failure' }));
+      await processor.forceFlush();
+      expect(exportCalls).toBe(3);
+      expect(exported).toHaveLength(1);
+      expect((exported[0][0] as Trace).name).toBe('after-failure');
+    } finally {
+      releaseFirst?.();
+      await processor.shutdown();
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('finishes forceFlush when timed shutdown cancels the export it is waiting for', async () => {
+    vi.useFakeTimers();
+    let markExportStarted!: () => void;
+    const exportStarted = new Promise<void>((resolve) => {
+      markExportStarted = resolve;
+    });
+    let exportSignal: AbortSignal | undefined;
+    const exporter: TracingExporter = {
+      export: async (_items, signal) => {
+        exportSignal = signal;
+        markExportStarted();
+        await new Promise<void>((resolve) => {
+          if (signal?.aborted) {
+            resolve();
+            return;
+          }
+          signal?.addEventListener('abort', () => resolve(), { once: true });
+        });
+      },
+    };
+    const processor = new BatchTraceProcessor(exporter, {
+      maxQueueSize: 10,
+      maxBatchSize: 100,
+      exportTriggerRatio: 0.1,
+      scheduleDelay: 10000,
+    });
+
+    try {
+      await processor.onTraceStart(new Trace({ name: 'queued' }));
+      const activeExport = processor.onTraceStart(
+        new Trace({ name: 'trigger-export' }),
+      );
+      await exportStarted;
+
+      const flushPromise = processor.forceFlush();
+      const shutdownPromise = processor.shutdown(1);
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(exportSignal?.aborted).toBe(true);
+      await Promise.all([activeExport, flushPromise, shutdownPromise]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Make `BatchTraceProcessor.forceFlush()` wait for trace exports that were already in flight when the flush began.

A scheduled or threshold-triggered export removes its batch from the internal buffer before awaiting the exporter. Previously, `forceFlush()` could therefore observe an empty buffer and return even though that export was still pending.

The processor now tracks active export promises and awaits the ones already running when `forceFlush()` starts. The normal scheduled export loop, exporter error handling, and shutdown behavior are unchanged.

## Tests

- Added a deterministic regression that drains the buffer into a blocked exporter, calls `forceFlush()`, and verifies the flush does not resolve until the exporter is released.
- `packages/agents-core/test/tracing.test.ts` — 80 passed.
- Agents-core test TypeScript, ESLint, Prettier, and `git diff --check` pass.
- `.agents/skills/code-change-verification/scripts/run.sh` passed end to end: install, build, package build/dist checks, lint, full tests, and changed-file formatting.
- Pre-commit formatting, lint, and secret scan passed.

Fixes #1812.