### PR TITLE
fix(core): stop stale trace export loops after shutdown

### DIFF
--- a/.changeset/stop-stale-trace-loop.md
+++ b/.changeset/stop-stale-trace-loop.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): stop stale trace export loops from re-arming after shutdown (#1814)

--- a/packages/agents-core/src/tracing/processor.ts
+++ b/packages/agents-core/src/tracing/processor.ts
@@ -134,6 +134,7 @@ export class BatchTraceProcessor implements TracingProcessor {
   #exportInProgress = false;
   #timeoutAbortController: AbortController | null = null;
   #activeExportAbortControllers = new Set<AbortController>();
+  #exportLoopGeneration = 0;
 
   constructor(
     exporter: TracingExporter,
@@ -160,8 +161,9 @@ export class BatchTraceProcessor implements TracingProcessor {
   }
 
   start(): void {
+    const generation = ++this.#exportLoopGeneration;
     this.#timeoutAbortController = new AbortController();
-    this.#runExportLoop();
+    this.#runExportLoop(generation);
   }
 
   async #safeAddItem(item: Trace | Span): Promise<void> {
@@ -179,11 +181,17 @@ export class BatchTraceProcessor implements TracingProcessor {
     }
   }
 
-  #runExportLoop(): void {
+  #runExportLoop(generation: number): void {
+    if (generation !== this.#exportLoopGeneration) {
+      return;
+    }
     this.#timeout = this.#timer.setTimeout(async () => {
+      if (generation !== this.#exportLoopGeneration) {
+        return;
+      }
       // scheduled export
       await this.#exportBatches();
-      this.#runExportLoop();
+      this.#runExportLoop(generation);
     }, this.#scheduleDelay);
 
     // We set this so that Node no longer considers this part of the event loop and keeps the
@@ -286,6 +294,7 @@ export class BatchTraceProcessor implements TracingProcessor {
   }
 
   async shutdown(timeout?: number): Promise<void> {
+    ++this.#exportLoopGeneration;
     let shutdownTimeout: Timeout | undefined;
     const shutdownAbortController = timeout
       ? (this.#timeoutAbortController ?? new AbortController())

--- a/packages/agents-core/test/tracingShutdownRearm.test.ts
+++ b/packages/agents-core/test/tracingShutdownRearm.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BatchTraceProcessor, Trace, type TracingExporter } from '../src';
+
+describe('BatchTraceProcessor timed shutdown', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not re-arm the scheduled export loop after shutdown returns', async () => {
+    vi.useFakeTimers();
+    let markExportStarted!: () => void;
+    let releaseExport!: () => void;
+    const exportStarted = new Promise<void>((resolve) => {
+      markExportStarted = resolve;
+    });
+    const exportGate = new Promise<void>((resolve) => {
+      releaseExport = resolve;
+    });
+    const exporter: TracingExporter = {
+      export: async () => {
+        markExportStarted();
+        await exportGate;
+      },
+    };
+    const processor = new BatchTraceProcessor(exporter, {
+      scheduleDelay: 10,
+      maxQueueSize: 10,
+      maxBatchSize: 10,
+    });
+
+    await processor.onTraceStart(new Trace({ name: 'pending' }));
+    vi.advanceTimersByTime(10);
+    await exportStarted;
+
+    const shutdown = processor.shutdown(5);
+    await vi.advanceTimersByTimeAsync(5);
+    await shutdown;
+    expect(vi.getTimerCount()).toBe(0);
+
+    releaseExport();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('allows an explicit restart after shutdown', async () => {
+    vi.useFakeTimers();
+    const exportCalls: number[] = [];
+    const exporter: TracingExporter = {
+      export: async (items) => {
+        exportCalls.push(items.length);
+      },
+    };
+    const processor = new BatchTraceProcessor(exporter, {
+      scheduleDelay: 10,
+      maxQueueSize: 10,
+      maxBatchSize: 10,
+    });
+
+    await processor.shutdown();
+    processor.start();
+    await processor.onTraceStart(new Trace({ name: 'after-restart' }));
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(exportCalls).toEqual([1]);
+    await processor.shutdown();
+  });
+});


### PR DESCRIPTION
## Summary

Prevent a scheduled `BatchTraceProcessor` callback from re-arming the export timer after a timed shutdown has already returned.

The export loop now carries a lifecycle generation. `start()` creates a new generation and `shutdown()` invalidates the current one. Scheduled callbacks verify that their generation is still active before exporting or scheduling the next timer, so an exporter that settles after shutdown cannot resurrect the loop.

An explicit later `start()` still starts a fresh export loop.

## Tests

- Added a deterministic fake-timer regression covering timed shutdown while an exporter ignores cancellation and settles later.
- Added coverage proving an explicit restart after shutdown still exports normally.
- Agents-core TypeScript, ESLint, Prettier, and `git diff --check` pass.
- `.agents/skills/code-change-verification/scripts/run.sh` passed end to end: install, build, package build/dist checks, lint, full tests, and changed-file formatting.
- Pre-commit formatting, lint, and secret scan passed.

Fixes #1814.