### PR TITLE
fix(core): validate tool guardrail behaviors

### DIFF
--- a/.changeset/validate-tool-guardrail-behavior.md
+++ b/.changeset/validate-tool-guardrail-behavior.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): reject invalid tool guardrail behaviors (#1816)

--- a/packages/agents-core/src/utils/toolGuardrails.ts
+++ b/packages/agents-core/src/utils/toolGuardrails.ts
@@ -11,12 +11,23 @@ import type * as protocol from '../types/protocol';
 import {
   ToolInputGuardrailTripwireTriggered,
   ToolOutputGuardrailTripwireTriggered,
+  UserError,
 } from '../errors';
 
 function normalizeBehavior(
   output: ToolGuardrailFunctionOutput,
+  guardrailName: string,
 ): ToolGuardrailFunctionOutput['behavior'] {
-  return output.behavior ?? { type: 'allow' };
+  const behavior = output.behavior as unknown;
+  if (behavior == null) {
+    return { type: 'allow' };
+  }
+  if (typeof behavior !== 'object') {
+    throw new UserError(
+      `Tool guardrail ${guardrailName} returned an invalid behavior`,
+    );
+  }
+  return behavior as ToolGuardrailFunctionOutput['behavior'];
 }
 
 export async function runToolInputGuardrails<
@@ -42,19 +53,31 @@ export async function runToolInputGuardrails<
       agent,
       toolCall,
     });
-    const behavior = normalizeBehavior(output);
+    const behavior = normalizeBehavior(output, guardrail.name);
     const result: ToolInputGuardrailResult = {
       guardrail: { type: 'tool_input', name: guardrail.name },
       output: { ...output, behavior },
     };
     onResult?.(result);
-    if (behavior.type === 'rejectContent') {
+    const firstBehaviorType = behavior.type;
+    if (firstBehaviorType === 'rejectContent') {
+      if (typeof behavior.message !== 'string') {
+        throw new UserError(
+          `Tool guardrail ${guardrail.name} returned an invalid behavior`,
+        );
+      }
       return { type: 'reject', message: behavior.message };
     }
-    if (behavior.type === 'throwException') {
+    const secondBehaviorType = behavior.type;
+    if (secondBehaviorType === 'throwException') {
       throw new ToolInputGuardrailTripwireTriggered(
         `Tool input guardrail triggered: ${guardrail.name}`,
         result,
+      );
+    }
+    if (firstBehaviorType !== 'allow' || secondBehaviorType !== 'allow') {
+      throw new UserError(
+        `Tool guardrail ${guardrail.name} returned an invalid behavior`,
       );
     }
   }
@@ -88,20 +111,32 @@ export async function runToolOutputGuardrails<
       toolCall,
       output: toolOutput,
     });
-    const behavior = normalizeBehavior(output);
+    const behavior = normalizeBehavior(output, guardrail.name);
     const result: ToolOutputGuardrailResult = {
       guardrail: { type: 'tool_output', name: guardrail.name },
       output: { ...output, behavior },
     };
     onResult?.(result);
-    if (behavior.type === 'rejectContent') {
+    const firstBehaviorType = behavior.type;
+    if (firstBehaviorType === 'rejectContent') {
+      if (typeof behavior.message !== 'string') {
+        throw new UserError(
+          `Tool guardrail ${guardrail.name} returned an invalid behavior`,
+        );
+      }
       finalOutput = behavior.message;
       break;
     }
-    if (behavior.type === 'throwException') {
+    const secondBehaviorType = behavior.type;
+    if (secondBehaviorType === 'throwException') {
       throw new ToolOutputGuardrailTripwireTriggered(
         `Tool output guardrail triggered: ${guardrail.name}`,
         result,
+      );
+    }
+    if (firstBehaviorType !== 'allow' || secondBehaviorType !== 'allow') {
+      throw new UserError(
+        `Tool guardrail ${guardrail.name} returned an invalid behavior`,
       );
     }
   }

--- a/packages/agents-core/test/toolGuardrailInvalidBehavior.test.ts
+++ b/packages/agents-core/test/toolGuardrailInvalidBehavior.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  Agent,
+  RunContext,
+  UserError,
+  defineToolInputGuardrail,
+  defineToolOutputGuardrail,
+  runToolInputGuardrails,
+  runToolOutputGuardrails,
+} from '../src';
+import type { ToolGuardrailFunctionOutput } from '../src/toolGuardrail';
+import type * as protocol from '../src/types/protocol';
+
+const toolCall: protocol.FunctionCallItem = {
+  type: 'function_call',
+  id: 'function-1',
+  callId: 'call-1',
+  name: 'dangerous',
+  status: 'completed',
+  arguments: '{}',
+};
+
+const invalidOutput = {
+  behavior: { type: 'unknown' },
+} as unknown as ToolGuardrailFunctionOutput;
+
+describe('tool guardrail behavior validation', () => {
+  it('rejects an unknown input guardrail behavior', async () => {
+    await expect(
+      runToolInputGuardrails({
+        guardrails: [
+          defineToolInputGuardrail({
+            name: 'policy',
+            run: async () => invalidOutput,
+          }),
+        ],
+        context: new RunContext(),
+        agent: new Agent({ name: 'test' }),
+        toolCall,
+      }),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+
+  it('rejects an unknown output guardrail behavior', async () => {
+    await expect(
+      runToolOutputGuardrails({
+        guardrails: [
+          defineToolOutputGuardrail({
+            name: 'policy',
+            run: async () => invalidOutput,
+          }),
+        ],
+        context: new RunContext(),
+        agent: new Agent({ name: 'test' }),
+        toolCall,
+        toolOutput: 'sensitive output',
+      }),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+  it('rejects rejectContent without a string message', async () => {
+    const malformedOutput = {
+      behavior: { type: 'rejectContent' },
+    } as unknown as ToolGuardrailFunctionOutput;
+
+    await expect(
+      runToolInputGuardrails({
+        guardrails: [
+          defineToolInputGuardrail({
+            name: 'policy',
+            run: async () => malformedOutput,
+          }),
+        ],
+        context: new RunContext(),
+        agent: new Agent({ name: 'test' }),
+        toolCall,
+      }),
+    ).rejects.toBeInstanceOf(UserError);
+  });
+});


### PR DESCRIPTION
## Summary

Fail closed when a tool guardrail returns an explicit invalid behavior type.

The shared tool-guardrail runners previously handled `rejectContent` and `throwException`, then implicitly treated every other behavior type as allow. An unchecked callback could therefore return `{ behavior: { type: 'unknown' } }` and allow a guarded tool to execute or accept its original output.

The runtime now rejects unknown behavior values and malformed `rejectContent` values with `UserError`. Valid `allow`, `rejectContent`, and `throwException` behavior is unchanged, and the existing compatibility fallback for an omitted/null `behavior` remains `allow`.

The validation preserves the existing caller-owned behavior read pattern so redaction/replay handling for results that later become unreadable remains unchanged.

## Tests

- Added input/output regressions for explicit unknown behavior and malformed `rejectContent`.
- Focused tool guardrail and output-redaction suites pass, including 150 existing redaction tests.
- `.agents/skills/code-change-verification/scripts/run.sh` passed end to end.
- Full suite: 209 test files, 6,448 tests passed.
- All package/example build checks, dist checks, lint, changed-file formatting, and pre-commit secret scanning passed.

Fixes #1816.