### PR TITLE
fix(core): validate maxTurns runtime values

### DIFF
--- a/.changeset/validate-max-turns.md
+++ b/.changeset/validate-max-turns.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix(core): reject invalid runtime maxTurns values (#1819)

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -441,6 +441,17 @@ export type RunConfig = {
 /**
  * Common run options shared between streaming and non-streaming execution pathways.
  */
+function validateMaxTurns(maxTurns: number | null | undefined): void {
+  if (maxTurns == null) {
+    return;
+  }
+  if (!Number.isInteger(maxTurns) || maxTurns < 0) {
+    throw new UserError(
+      'maxTurns must be a non-negative integer or null when provided.',
+    );
+  }
+}
+
 type SharedRunOptions<
   TContext = undefined,
   TAgent extends Agent<any, any> = Agent<any, any>,
@@ -712,6 +723,13 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
   ): Promise<
     RunResult<TContext, TAgent> | StreamedRunResult<TContext, TAgent>
   > {
+    validateMaxTurns(
+      options.maxTurns !== undefined
+        ? options.maxTurns
+        : input instanceof RunState
+          ? input._maxTurns
+          : undefined,
+    );
     this.#validateModelTimeoutForAgent(
       input instanceof RunState ? input._currentAgent : agent,
     );

--- a/packages/agents-core/test/maxTurnsValidation.test.ts
+++ b/packages/agents-core/test/maxTurnsValidation.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { Agent, RunState, UserError, run } from '../src';
+import { RunContext } from '../src/runContext';
+import { ScriptedModel, assistantMessage } from '../src/testing';
+
+describe('maxTurns runtime validation', () => {
+  it.each([Number.NaN, Infinity, -Infinity, -1, 1.5])(
+    'rejects invalid maxTurns %s before invoking the model',
+    async (maxTurns) => {
+      const model = new ScriptedModel([[assistantMessage('unused')]]);
+      const agent = new Agent({ name: 'test', model });
+
+      await expect(run(agent, 'go', { maxTurns })).rejects.toThrow(
+        new UserError(
+          'maxTurns must be a non-negative integer or null when provided.',
+        ),
+      );
+      expect(model.calls).toHaveLength(0);
+    },
+  );
+
+  it('validates maxTurns overrides before resuming a RunState', async () => {
+    const model = new ScriptedModel([[assistantMessage('unused')]]);
+    const agent = new Agent({ name: 'test', model });
+    const state = new RunState(new RunContext(), 'go', agent, 1);
+
+    await expect(
+      run(agent, state, { maxTurns: Number.NaN }),
+    ).rejects.toBeInstanceOf(UserError);
+    expect(model.calls).toHaveLength(0);
+    expect(state._maxTurns).toBe(1);
+  });
+
+  it('preserves the explicit unlimited null value', async () => {
+    const model = new ScriptedModel([[assistantMessage('done')]]);
+    const agent = new Agent({ name: 'test', model });
+
+    const result = await run(agent, 'go', { maxTurns: null });
+
+    expect(result.finalOutput).toBe('done');
+    expect(model.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Validate `maxTurns` before a run starts or a resumed `RunState` is modified.

`maxTurns` is a runtime JavaScript value even though its TypeScript type is `number | null`. An unchecked `NaN` value makes every turn-limit comparison false, silently disabling the limit. Other non-integer, non-finite, or negative values likewise cannot represent a bounded number of model turns.

Numeric values must now be non-negative integers. The existing `null` value remains the explicit unlimited-run setting, and valid integer behavior including `maxTurns: 0` is unchanged.

## Tests

- Added rejection coverage for `NaN`, both infinities, negative, and fractional values.
- Added a resumed-state regression proving an invalid override fails before mutating the stored turn limit or invoking the model.
- Added a control preserving `maxTurns: null` unlimited behavior.
- Focused runner suites: 314 tests passed.
- `.agents/skills/code-change-verification/scripts/run.mjs` passed end to end.
- Full suite: 209 test files, 6,452 tests passed.
- All package/example build checks, dist checks, lint, and formatting checks passed.

Fixes #1819.