### PR TITLE
fix(openai): reset compaction state on clear

### DIFF
--- a/.changeset/reset-compaction-clear-state.md
+++ b/.changeset/reset-compaction-clear-state.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix(openai): reset compaction response state after clearing a session (#1821)

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -316,6 +316,8 @@ export class OpenAIResponsesCompactionSession
       await this.underlyingSession.clearSession();
       this.compactionCandidateItems = [];
       this.sessionItems = [];
+      this.responseId = undefined;
+      this.lastStore = undefined;
     });
   }
 

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -136,6 +136,38 @@ class CommitThenRejectAppendSession extends MemorySession {
 }
 
 describe('OpenAIResponsesCompactionSession', () => {
+  it('forgets response-chain state when the session is cleared', async () => {
+    const compact = vi.fn();
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      model: 'gpt-4.1',
+      shouldTriggerCompaction: () => false,
+    });
+
+    await expect(
+      session.runCompaction({ responseId: 'resp_old', store: false }),
+    ).resolves.toBeNull();
+    await session.clearSession();
+
+    await expect(
+      session.runCompaction({
+        force: true,
+        compactionMode: 'previous_response_id',
+      }),
+    ).rejects.toThrow(/requires a responseId/);
+    expect(compact).not.toHaveBeenCalled();
+
+    compact.mockResolvedValueOnce({ output: [], usage: undefined });
+    await session.runCompaction({
+      responseId: 'resp_new',
+      force: true,
+    });
+    expect(compact).toHaveBeenCalledWith({
+      model: 'gpt-4.1',
+      previous_response_id: 'resp_new',
+    });
+  });
+
   it('rejects non-OpenAI model names', () => {
     expect(() => {
       new OpenAIResponsesCompactionSession({


### PR DESCRIPTION
## Summary

Reset response-chain state after `OpenAIResponsesCompactionSession.clearSession()` successfully clears the underlying history.

The wrapper previously cleared its cached session items but retained `responseId` and `lastStore`. A later compaction could therefore reuse a response ID from history the caller explicitly erased, and `auto` mode could inherit the old storage decision.

A successful clear now resets both values alongside the history caches. The reset happens only after the underlying clear succeeds, so failed clears preserve the response-chain state that may still correspond to retained history.

## Tests

- Added a regression proving `previous_response_id` compaction cannot reuse a pre-clear response ID.
- Added coverage proving a new post-clear response does not inherit the old `store: false` state.
- `openaiResponsesCompactionSession.test.ts`: 35 passed.
- Repository code-change verification passed end to end.
- Full suite: 208 test files, 6,446 tests passed.
- All package/example build checks, dist checks, lint, formatting, and pre-commit checks passed.

Fixes #1821.