### PR TITLE
fix(openai): reset compaction state after pop

### DIFF
--- a/.changeset/reset-compaction-pop-state.md
+++ b/.changeset/reset-compaction-pop-state.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix(openai): reset compaction response state after popping local history (#1823)

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -285,6 +285,8 @@ export class OpenAIResponsesCompactionSession
       if (!popped) {
         return popped;
       }
+      this.responseId = undefined;
+      this.lastStore = undefined;
       if (this.sessionItems) {
         const index = this.sessionItems.lastIndexOf(popped);
         if (index >= 0) {

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -296,28 +296,12 @@ export class OpenAIResponsesCompactionSession
       }
       this.responseId = undefined;
       this.lastStore = undefined;
-      if (this.sessionItems) {
-        const index = this.sessionItems.lastIndexOf(popped);
-        if (index >= 0) {
-          this.sessionItems.splice(index, 1);
-        } else {
-          this.sessionItems = await this.underlyingSession.getItems();
-        }
-      }
-      if (this.compactionCandidateItems) {
-        const isCandidate = selectCompactionCandidateItems([popped]).length > 0;
-        if (isCandidate) {
-          const index = this.compactionCandidateItems.indexOf(popped);
-          if (index >= 0) {
-            this.compactionCandidateItems.splice(index, 1);
-          } else {
-            // Fallback when the popped item reference differs from stored candidates.
-            this.compactionCandidateItems = selectCompactionCandidateItems(
-              await this.underlyingSession.getItems(),
-            );
-          }
-        }
-      }
+      // A successful destructive mutation makes both cached history views stale.
+      // Do not try to repair them from the returned item: some backends clone
+      // values, and a refresh can fail after the pop has already committed.
+      // The next compaction decision will reload authoritative persisted history.
+      this.compactionCandidateItems = undefined;
+      this.sessionItems = undefined;
       return popped;
     });
   }

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -281,7 +281,16 @@ export class OpenAIResponsesCompactionSession
 
   async popItem() {
     return this.runMutationOperation(async () => {
-      const popped = await this.underlyingSession.popItem();
+      let popped: AgentInputItem | undefined;
+      try {
+        popped = await this.underlyingSession.popItem();
+      } catch (error) {
+        this.responseId = undefined;
+        this.lastStore = undefined;
+        this.compactionCandidateItems = undefined;
+        this.sessionItems = undefined;
+        throw error;
+      }
       if (!popped) {
         return popped;
       }

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -168,6 +168,66 @@ describe('OpenAIResponsesCompactionSession', () => {
     });
   });
 
+  it('forgets response-chain state when session history is popped', async () => {
+    const compact = vi.fn();
+    const underlyingSession = new MemorySession({
+      initialItems: [
+        {
+          type: 'message',
+          role: 'assistant',
+          status: 'completed',
+          content: [{ type: 'output_text', text: 'old' }],
+        },
+      ] as AgentInputItem[],
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      shouldTriggerCompaction: () => false,
+    });
+
+    await session.runCompaction({ responseId: 'resp_old', store: true });
+    await expect(session.popItem()).resolves.toBeDefined();
+
+    await expect(
+      session.runCompaction({
+        force: true,
+        compactionMode: 'previous_response_id',
+      }),
+    ).rejects.toThrow(/requires a responseId/);
+    expect(compact).not.toHaveBeenCalled();
+
+    compact.mockResolvedValueOnce({ output: [], usage: undefined });
+    await session.runCompaction({ responseId: 'resp_new', force: true });
+    expect(compact).toHaveBeenCalledWith({
+      model: expect.any(String),
+      previous_response_id: 'resp_new',
+    });
+  });
+
+  it('keeps response-chain state when popItem is a no-op', async () => {
+    const compact = vi.fn().mockResolvedValueOnce({
+      output: [],
+      usage: undefined,
+    });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      shouldTriggerCompaction: () => false,
+    });
+
+    await session.runCompaction({ responseId: 'resp_old', store: true });
+    await expect(session.popItem()).resolves.toBeUndefined();
+    await session.runCompaction({
+      force: true,
+      compactionMode: 'previous_response_id',
+    });
+
+    expect(compact).toHaveBeenCalledWith({
+      model: expect.any(String),
+      previous_response_id: 'resp_old',
+    });
+  });
+
   it('rejects non-OpenAI model names', () => {
     expect(() => {
       new OpenAIResponsesCompactionSession({

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -135,6 +135,19 @@ class CommitThenRejectAppendSession extends MemorySession {
   }
 }
 
+class CommitThenRejectPopSession extends MemorySession {
+  failNextPop = false;
+
+  override async popItem(): Promise<AgentInputItem | undefined> {
+    const popped = await super.popItem();
+    if (this.failNextPop) {
+      this.failNextPop = false;
+      throw new Error('pop acknowledgement lost');
+    }
+    return popped;
+  }
+}
+
 describe('OpenAIResponsesCompactionSession', () => {
   it('forgets response-chain state when the session is cleared', async () => {
     const compact = vi.fn();
@@ -203,6 +216,47 @@ describe('OpenAIResponsesCompactionSession', () => {
       model: expect.any(String),
       previous_response_id: 'resp_new',
     });
+  });
+
+  it('invalidates response and history state when pop commits before rejecting', async () => {
+    const first = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'first' }],
+    } as AgentInputItem;
+    const second = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'second' }],
+    } as AgentInputItem;
+    const underlyingSession = new CommitThenRejectPopSession({
+      initialItems: [first, second],
+    });
+    const snapshots: AgentInputItem[][] = [];
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact: vi.fn() } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+      shouldTriggerCompaction: ({ sessionItems }) => {
+        snapshots.push(sessionItems);
+        return false;
+      },
+    });
+
+    await session.runCompaction({ responseId: 'resp_old', store: true });
+    underlyingSession.failNextPop = true;
+    await expect(session.popItem()).rejects.toThrow('pop acknowledgement lost');
+    await expect(underlyingSession.getItems()).resolves.toEqual([first]);
+
+    await expect(
+      session.runCompaction({ compactionMode: 'previous_response_id' }),
+    ).rejects.toThrow(/requires a responseId/);
+    await expect(
+      session.runCompaction({ compactionMode: 'input' }),
+    ).resolves.toBeNull();
+    expect(snapshots).toEqual([[first, second], [first]]);
   });
 
   it('keeps response-chain state when popItem is a no-op', async () => {

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.test.ts
@@ -148,6 +148,27 @@ class CommitThenRejectPopSession extends MemorySession {
   }
 }
 
+class CloningPopSessionWithRefreshFailure extends MemorySession {
+  failNextHistoryRead = false;
+
+  override async getItems(limit?: number): Promise<AgentInputItem[]> {
+    if (this.failNextHistoryRead) {
+      this.failNextHistoryRead = false;
+      throw new Error('history refresh failed');
+    }
+    return structuredClone(await super.getItems(limit));
+  }
+
+  override async popItem(): Promise<AgentInputItem | undefined> {
+    const popped = await super.popItem();
+    if (popped) {
+      this.failNextHistoryRead = true;
+      return structuredClone(popped);
+    }
+    return popped;
+  }
+}
+
 describe('OpenAIResponsesCompactionSession', () => {
   it('forgets response-chain state when the session is cleared', async () => {
     const compact = vi.fn();
@@ -257,6 +278,54 @@ describe('OpenAIResponsesCompactionSession', () => {
       session.runCompaction({ compactionMode: 'input' }),
     ).resolves.toBeNull();
     expect(snapshots).toEqual([[first, second], [first]]);
+  });
+
+  it('reloads persisted history after a successful pop when the first refresh fails', async () => {
+    const first = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'first' }],
+    } as AgentInputItem;
+    const second = {
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [{ type: 'output_text', text: 'second' }],
+    } as AgentInputItem;
+    const underlyingSession = new CloningPopSessionWithRefreshFailure({
+      initialItems: [first, second],
+    });
+    const compact = vi.fn().mockResolvedValue({ output: [], usage: undefined });
+    const session = new OpenAIResponsesCompactionSession({
+      client: { responses: { compact } } as any,
+      underlyingSession,
+      compactionMode: 'input',
+      shouldTriggerCompaction: () => false,
+    });
+
+    // Seed both wrapper caches with cloned values, then remove the newest item.
+    await session.runCompaction({ compactionMode: 'input' });
+    await expect(session.popItem()).resolves.toEqual(second);
+
+    // The backing store fails the first history read after the committed pop.
+    await expect(
+      session.runCompaction({ force: true, compactionMode: 'input' }),
+    ).rejects.toThrow('history refresh failed');
+    expect(compact).not.toHaveBeenCalled();
+
+    // A retry reloads authoritative persisted history and cannot reintroduce the pop.
+    await session.runCompaction({ force: true, compactionMode: 'input' });
+    expect(compact).toHaveBeenCalledTimes(1);
+    const compactRequest = compact.mock.calls[0][0];
+    expect(compactRequest.model).toEqual(expect.any(String));
+    expect(compactRequest.input).toHaveLength(1);
+    expect(compactRequest.input?.[0]).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'first' }],
+    });
+    expect(JSON.stringify(compactRequest.input)).not.toContain('second');
   });
 
   it('keeps response-chain state when popItem is a no-op', async () => {


### PR DESCRIPTION
## Summary

Invalidate retained Responses compaction chain state after `OpenAIResponsesCompactionSession.popItem()` actually removes local history.

Previously, `popItem()` updated the local session and compaction caches but kept `responseId` and `lastStore`. A later `previous_response_id` compaction could therefore reuse server-side history that still contained the item the caller had removed locally.

The response-chain state now resets immediately after a successful pop, before any later cache refresh can fail. A no-op pop preserves the existing chain, and a newly supplied response ID establishes a fresh chain normally.

## Tests

- `openaiResponsesCompactionSession.test.ts`: 36 passed.
- Full repository code-change verification passed end to end on the final diff.
- Full suite: 208 test files, 6,447 tests passed.
- All build, dist, lint, formatting, changeset, and pre-commit checks passed.

Fixes #1823.