### PR TITLE
fix(openai): preserve WebSocket auth query parameters

### DIFF
--- a/.changeset/preserve-websocket-auth-query.md
+++ b/.changeset/preserve-websocket-auth-query.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: preserve all WebSocket authentication query parameters

--- a/packages/agents-openai/src/responsesUtils.ts
+++ b/packages/agents-openai/src/responsesUtils.ts
@@ -13,22 +13,22 @@ export function normalizeInstructions(
 export function searchParamsToAuthHeaderQuery(
   searchParams: URLSearchParams,
 ): Record<string, string | string[]> | undefined {
-  const query: Record<string, string | string[]> = {};
+  const query = new Map<string, string | string[]>();
   let hasEntries = false;
 
   for (const [key, value] of searchParams.entries()) {
     hasEntries = true;
-    const existingValue = query[key];
+    const existingValue = query.get(key);
     if (typeof existingValue === 'undefined') {
-      query[key] = value;
+      query.set(key, value);
     } else if (Array.isArray(existingValue)) {
       existingValue.push(value);
     } else {
-      query[key] = [existingValue, value];
+      query.set(key, [existingValue, value]);
     }
   }
 
-  return hasEntries ? query : undefined;
+  return hasEntries ? Object.fromEntries(query) : undefined;
 }
 
 export function toRequestUsageEntry(

--- a/packages/agents-openai/test/openaiResponsesWSModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesWSModel.test.ts
@@ -585,7 +585,7 @@ describe('OpenAIResponsesWSModel', () => {
     );
   });
 
-  it('uses the client authHeaders strategy for websocket handshakes', async () => {
+  it('preserves websocket query parameters for client authHeaders', async () => {
     const fakeClient = createFakeClient() as any;
     fakeClient._options.defaultQuery = { client_default: '1' };
     const authHeadersSpy = vi.fn().mockResolvedValue({
@@ -614,7 +614,8 @@ describe('OpenAIResponsesWSModel', () => {
     };
 
     const model = new OpenAIResponsesWSModel(fakeClient, 'gpt-ws', {
-      websocketBaseURL: 'wss://proxy.example.test/v1?base_param=1',
+      websocketBaseURL:
+        'wss://proxy.example.test/v1?base_param=1&__proto__=tenant&__proto__=partner&constructor=ctor',
     });
     const request = {
       systemInstructions: undefined,
@@ -637,6 +638,21 @@ describe('OpenAIResponsesWSModel', () => {
       // Consume the stream to trigger the websocket handshake.
     }
 
+    expect(authHeadersSpy).toHaveBeenCalledTimes(1);
+    const authHeaderRequest = authHeadersSpy.mock.calls[0]?.[0] as {
+      query: Record<string, string | string[]>;
+    };
+    expect(Object.getPrototypeOf(authHeaderRequest.query)).toBe(
+      Object.prototype,
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        authHeaderRequest.query,
+        '__proto__',
+      ),
+    ).toBe(true);
+    expect(authHeaderRequest.query['__proto__']).toEqual(['tenant', 'partner']);
+    expect(authHeaderRequest.query.constructor).toBe('ctor');
     expect(authHeadersSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         method: 'get',
@@ -648,6 +664,12 @@ describe('OpenAIResponsesWSModel', () => {
         }),
       }),
     );
+    const websocketURL = new URL(TestWebSocket.instances[0]!.url);
+    expect(websocketURL.searchParams.getAll('__proto__')).toEqual([
+      'tenant',
+      'partner',
+    ]);
+    expect(websocketURL.searchParams.get('constructor')).toBe('ctor');
     expect(TestWebSocket.instances[0]?.init).toMatchObject({
       headers: {
         'api-key': 'azure-key',

--- a/packages/agents-openai/test/responsesUtils.test.ts
+++ b/packages/agents-openai/test/responsesUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { searchParamsToAuthHeaderQuery } from '../src/responsesUtils';
+
+describe('searchParamsToAuthHeaderQuery', () => {
+  it('preserves ordinary, repeated, and prototype-sensitive keys', () => {
+    const query = searchParamsToAuthHeaderQuery(
+      new URLSearchParams(
+        'base=1&__proto__=tenant&__proto__=partner&constructor=ctor&a=1&a=2',
+      ),
+    );
+
+    expect(query).toBeDefined();
+    expect(Object.getPrototypeOf(query)).toBe(Object.prototype);
+    expect(Object.prototype.hasOwnProperty.call(query, '__proto__')).toBe(true);
+    expect(query?.base).toBe('1');
+    expect(query?.['__proto__']).toEqual(['tenant', 'partner']);
+    expect(query?.constructor).toBe('ctor');
+    expect(query?.a).toEqual(['1', '2']);
+  });
+
+  it('returns undefined for empty parameters', () => {
+    expect(
+      searchParamsToAuthHeaderQuery(new URLSearchParams()),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Summary

This pull request fixes WebSocket authentication query conversion when parameter names collide with properties inherited from `Object.prototype`.

The previous plain-object accumulator could fail to preserve parameters such as `__proto__` and incorrectly combine parameters such as `constructor`, causing the query supplied to custom `authHeaders()` implementations to differ from the actual WebSocket handshake URL.

Query parameters are now accumulated in a `Map` and materialized with `Object.fromEntries()`. This preserves prototype-sensitive keys and repeated values while retaining the existing ordinary-object callback shape and empty-query behavior.

Regression coverage exercises both the shared conversion helper and the WebSocket handshake path, including repeated and prototype-sensitive parameter names.

### Test plan

- Confirmed the WebSocket regression fails with the baseline helper and passes with the fix.
- Focused helper, WebSocket, and hosted multi-agent tests: 3 files, 119 tests passed.
- Ran `.agents/skills/code-change-verification/scripts/run.sh` on Linux against the exact final files: install, build, workspace typechecks, distribution checks, lint, full tests, and formatting passed. Full test suite: 209 files, 6,447 tests passed.

### Checks

- [x] I've added new tests.
- [x] I've added a patch changeset for `@openai/agents-openai`.
- [x] I've run `pnpm test` and the `pnpm test:examples` equivalent, `pnpm -r build-check`.
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`.
- [x] I've confirmed all verification steps pass on Linux.
- [ ] I've added/updated the relevant documentation (not applicable: no API or usage change).
- [ ] I've run `pnpm test:integration` (not applicable to this focused fix).
- [ ] If using Codex, I've run `/review` before submitting this PR (independent Claude reviews completed instead).
