### PR TITLE
fix(core): avoid redundant final computer screenshots

### DIFF
--- a/.changeset/single-final-computer-screenshot.md
+++ b/.changeset/single-final-computer-screenshot.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: capture a single final computer screenshot for explicit screenshot actions (#1735)

--- a/.changeset/single-final-computer-screenshot.md
+++ b/.changeset/single-final-computer-screenshot.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix: capture a single final computer screenshot for explicit screenshot actions (#1735)
+fix: avoid redundant final computer screenshots without reordering explicit screenshot actions (#1735)

--- a/.changeset/single-final-computer-screenshot.md
+++ b/.changeset/single-final-computer-screenshot.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix: avoid redundant final computer screenshots without reordering explicit screenshot actions (#1735)
+fix: capture the final computer screenshot once per action batch (#1735)

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1523,6 +1523,7 @@ async function _runComputerActionAndScreenshot(
   runContext: RunContext,
   signal?: AbortSignal,
 ): Promise<{ type: 'completed'; output: string } | { type: 'cancelled' }> {
+  let latestScreenshot: string | undefined;
   for (const action of getComputerToolActions(toolCall)) {
     if (signal?.aborted) {
       return { type: 'cancelled' };
@@ -1547,7 +1548,10 @@ async function _runComputerActionAndScreenshot(
         await computer.move(action.x, action.y, runContext);
         break;
       case 'screenshot':
-        // A single final screenshot is captured after all actions complete.
+        if (typeof computer.screenshot !== 'function') {
+          throw new Error('Computer does not implement screenshot()');
+        }
+        latestScreenshot = await computer.screenshot(runContext);
         break;
       case 'scroll':
         await computer.scroll(
@@ -1568,6 +1572,9 @@ async function _runComputerActionAndScreenshot(
         action satisfies never;
         break;
     }
+    if (action.type !== 'screenshot') {
+      latestScreenshot = undefined;
+    }
     if (signal?.aborted) {
       return { type: 'cancelled' };
     }
@@ -1575,6 +1582,9 @@ async function _runComputerActionAndScreenshot(
 
   if (signal?.aborted) {
     return { type: 'cancelled' };
+  }
+  if (typeof latestScreenshot !== 'undefined') {
+    return { type: 'completed', output: latestScreenshot };
   }
   if (typeof computer.screenshot === 'function') {
     const screenshot = await computer.screenshot(runContext);

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1547,7 +1547,7 @@ async function _runComputerActionAndScreenshot(
         await computer.move(action.x, action.y, runContext);
         break;
       case 'screenshot':
-        await computer.screenshot(runContext);
+        // A single final screenshot is captured after all actions complete.
         break;
       case 'scroll':
         await computer.scroll(

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1523,7 +1523,6 @@ async function _runComputerActionAndScreenshot(
   runContext: RunContext,
   signal?: AbortSignal,
 ): Promise<{ type: 'completed'; output: string } | { type: 'cancelled' }> {
-  let latestScreenshot: string | undefined;
   for (const action of getComputerToolActions(toolCall)) {
     if (signal?.aborted) {
       return { type: 'cancelled' };
@@ -1548,10 +1547,7 @@ async function _runComputerActionAndScreenshot(
         await computer.move(action.x, action.y, runContext);
         break;
       case 'screenshot':
-        if (typeof computer.screenshot !== 'function') {
-          throw new Error('Computer does not implement screenshot()');
-        }
-        latestScreenshot = await computer.screenshot(runContext);
+        // Screenshot actions are no-ops; capture the final state after the batch.
         break;
       case 'scroll':
         await computer.scroll(
@@ -1572,9 +1568,6 @@ async function _runComputerActionAndScreenshot(
         action satisfies never;
         break;
     }
-    if (action.type !== 'screenshot') {
-      latestScreenshot = undefined;
-    }
     if (signal?.aborted) {
       return { type: 'cancelled' };
     }
@@ -1582,9 +1575,6 @@ async function _runComputerActionAndScreenshot(
 
   if (signal?.aborted) {
     return { type: 'cancelled' };
-  }
-  if (typeof latestScreenshot !== 'undefined') {
-    return { type: 'completed', output: latestScreenshot };
   }
   if (typeof computer.screenshot === 'function') {
     const screenshot = await computer.screenshot(runContext);

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1728,14 +1728,16 @@ describe('executeComputerActions', () => {
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
   });
 
-  it('captures once after a screenshot action followed by another action', async () => {
+  it('preserves screenshot ordering before a later action', async () => {
     const invocations: string[] = [];
+    let screenshotCount = 0;
     const fakeComputer = {
       environment: 'mac',
       dimensions: [1, 1] as [number, number],
       screenshot: vi.fn().mockImplementation(async () => {
         invocations.push('screenshot');
-        return 'final-img';
+        screenshotCount += 1;
+        return screenshotCount === 1 ? 'before-click' : 'after-click';
       }),
       click: vi.fn().mockImplementation(async () => {
         invocations.push('click');
@@ -1766,10 +1768,54 @@ describe('executeComputerActions', () => {
       new RunContext(),
     );
 
+    expect(invocations).toEqual(['screenshot', 'click', 'screenshot']);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(items).toHaveLength(1);
+    expect((items[0] as any).output).toBe('data:image/png;base64,after-click');
+  });
+
+  it('reuses an explicit screenshot when it is the final action', async () => {
+    const invocations: string[] = [];
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockImplementation(async () => {
+        invocations.push('screenshot');
+        return 'after-click';
+      }),
+      click: vi.fn().mockImplementation(async () => {
+        invocations.push('click');
+      }),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+    const tool = computerTool({ computer: fakeComputer });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'c-click-then-screenshot',
+      status: 'completed',
+      actions: [
+        { type: 'click', x: 1, y: 2, button: 'left' },
+        { type: 'screenshot' },
+      ],
+    };
+
+    const items = await executeComputerActions(
+      new Agent({ name: 'Comp' }),
+      [{ toolCall: call, computer: tool }],
+      new Runner(),
+      new RunContext(),
+    );
+
     expect(invocations).toEqual(['click', 'screenshot']);
     expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
     expect(items).toHaveLength(1);
-    expect((items[0] as any).output).toBe('data:image/png;base64,final-img');
+    expect((items[0] as any).output).toBe('data:image/png;base64,after-click');
   });
 
   it.each(['fulfills', 'rejects'] as const)(

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1019,6 +1019,7 @@ describe('executeComputerActions', () => {
     );
     expect(items).toHaveLength(1);
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('does not start an action after cancellation', async () => {
@@ -1727,6 +1728,50 @@ describe('executeComputerActions', () => {
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
   });
 
+  it('captures once after a screenshot action followed by another action', async () => {
+    const invocations: string[] = [];
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockImplementation(async () => {
+        invocations.push('screenshot');
+        return 'final-img';
+      }),
+      click: vi.fn().mockImplementation(async () => {
+        invocations.push('click');
+      }),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+    const tool = computerTool({ computer: fakeComputer });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'c-screenshot-then-click',
+      status: 'completed',
+      actions: [
+        { type: 'screenshot' },
+        { type: 'click', x: 1, y: 2, button: 'left' },
+      ],
+    };
+
+    const items = await executeComputerActions(
+      new Agent({ name: 'Comp' }),
+      [{ toolCall: call, computer: tool }],
+      new Runner(),
+      new RunContext(),
+    );
+
+    expect(invocations).toEqual(['click', 'screenshot']);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
+    expect(items).toHaveLength(1);
+    expect((items[0] as any).output).toBe('data:image/png;base64,final-img');
+  });
+
   it.each(['fulfills', 'rejects'] as const)(
     'does not start later batched computer actions when the active action %s after cancellation',
     async (settlement) => {
@@ -2034,7 +2079,7 @@ describe('executeComputerActions', () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]).toBeInstanceOf(ToolCallOutputItem);
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('passes RunContext to computer actions', async () => {
@@ -2248,7 +2293,7 @@ describe('executeComputerActions', () => {
     expect(items).toHaveLength(1);
     expect(items[0]).toBeInstanceOf(ToolCallOutputItem);
     expect(needsApproval).not.toHaveBeenCalled();
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1728,19 +1728,19 @@ describe('executeComputerActions', () => {
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
   });
 
-  it('preserves screenshot ordering before a later action', async () => {
+  it('captures once after a batch that requests a screenshot before a click', async () => {
     const invocations: string[] = [];
-    let screenshotCount = 0;
+    let clicked = false;
     const fakeComputer = {
       environment: 'mac',
       dimensions: [1, 1] as [number, number],
       screenshot: vi.fn().mockImplementation(async () => {
         invocations.push('screenshot');
-        screenshotCount += 1;
-        return screenshotCount === 1 ? 'before-click' : 'after-click';
+        return clicked ? 'after-click' : 'before-click';
       }),
       click: vi.fn().mockImplementation(async () => {
         invocations.push('click');
+        clicked = true;
       }),
       doubleClick: vi.fn(),
       drag: vi.fn(),
@@ -1768,13 +1768,13 @@ describe('executeComputerActions', () => {
       new RunContext(),
     );
 
-    expect(invocations).toEqual(['screenshot', 'click', 'screenshot']);
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(invocations).toEqual(['click', 'screenshot']);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
     expect(items).toHaveLength(1);
     expect((items[0] as any).output).toBe('data:image/png;base64,after-click');
   });
 
-  it('reuses an explicit screenshot when it is the final action', async () => {
+  it('captures once after a batch that ends with a screenshot action', async () => {
     const invocations: string[] = [];
     const fakeComputer = {
       environment: 'mac',

--- a/packages/agents-core/test/runner/turnResolution.test.ts
+++ b/packages/agents-core/test/runner/turnResolution.test.ts
@@ -1517,7 +1517,7 @@ describe('resolveInterruptedTurn', () => {
     expect(
       (toolOutputs[0].rawItem as protocol.ComputerCallResultItem).callId,
     ).toBe(computerCall.callId);
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('resumes approved computer actions after restoring legacy approval aliases', async () => {
@@ -1605,7 +1605,7 @@ describe('resolveInterruptedTurn', () => {
     expect(result.newStepItems).not.toContainEqual(
       expect.objectContaining({ type: 'tool_approval_item' }),
     );
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('skips rerunning already completed computer actions when resuming an interruption', async () => {

--- a/packages/agents-core/test/toolInvocationReplay.test.ts
+++ b/packages/agents-core/test/toolInvocationReplay.test.ts
@@ -1466,7 +1466,7 @@ describe('tool invocation replay binding', () => {
     const runner = new Runner();
 
     const interrupted = await runner.run(agent, 'start');
-    expect(screenshot).toHaveBeenCalledTimes(2);
+    expect(screenshot).toHaveBeenCalledTimes(1);
     const serialized = interrupted.state.toJSON() as any;
     serialized.$schemaVersion = '1.17';
     delete serialized.currentResponseGeneratedItemOwnership;
@@ -1481,7 +1481,7 @@ describe('tool invocation replay binding', () => {
     const result = await runner.run(agent, restored);
 
     expect(result.finalOutput).toBe('done');
-    expect(screenshot).toHaveBeenCalledTimes(2);
+    expect(screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('reconstructs unapproved apply-patch completion from schema 1.17 state', async () => {


### PR DESCRIPTION
### Summary

- Treat screenshot actions as no-ops during computer-action dispatch and use the existing post-batch capture for the observation.
- Remove the branch-local screenshot cache and invalidation logic, as requested in review.
- Cover a screenshot request before a click, a trailing screenshot request, direct execution, HITL resume, and legacy replay. The screenshot-before-click regression checks that the returned image reflects the completed click.

### Test plan

- Direct execution, HITL and replay: 337 passed.
- Runner tests: 692 passed.
- Full Linux suite: 6453 passed, 2 skipped (209 test files passed).
- Frozen dependency installation, build, recursive build-check, package dist:check, lint, Prettier for all changed files, and `git diff --check` passed.

### Issue number

Fixes #1735

### Checks

- [x] I've added new tests.
- [x] I've added a patch changeset for `@openai/agents-core`.
- [x] No public API or documentation changes are needed.
