### PR TITLE
fix(ci): route executable docs and contract changes to existing checks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,10 @@ jobs:
           run_install: true
       - name: Run build
         run: pnpm build:ci
+      - name: Type-check docs scripts
+        run: pnpm docs:scripts:check
+      - name: Type-check rendered snippets
+        run: pnpm -F docs-code build-check
       - name: Build docs
         run: pnpm docs:build
       - name: Upload docs artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,18 @@ jobs:
               '.github/PULL_REQUEST_TEMPLATE/',
               '.github/codex/',
               '.husky/',
-              'integration-tests/',
             ];
             const CI_RELEVANT_PREFIXES = [
               '.agents/skills/code-change-verification/',
+              'docs/src/scripts/',
             ];
 
             const isIgnoredPath = (path) => {
               if (CI_RELEVANT_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+                return false;
+              }
+              // Docs source and configuration also own executable checks.
+              if (path.startsWith('docs/') && /\.(?:[cm]?[jt]sx?|json)$/.test(path)) {
                 return false;
               }
               if (IGNORED_PREFIXES.some((prefix) => path.startsWith(prefix))) {
@@ -52,44 +56,47 @@ jobs:
                 (path) => typeof path === 'string',
               );
 
-            let changedFiles = [];
+            let files;
+            let complete = false;
 
-            if (context.eventName === 'pull_request') {
-              const files = await github.paginate(github.rest.pulls.listFiles, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.payload.pull_request.number,
-                per_page: 100,
-              });
-              changedFiles = files.flatMap(changedPathsForFile);
-            } else if (context.eventName === 'push') {
-              const before = context.payload.before;
-              const after = context.payload.after;
+            try {
+              if (context.eventName === 'pull_request') {
+                files = await github.paginate(github.rest.pulls.listFiles, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100,
+                });
+                // The pull request files API returns at most 3,000 files.
+                complete = files.length < 3000 &&
+                  files.length === context.payload.pull_request.changed_files;
+              } else if (context.eventName === 'push') {
+                const before = context.payload.before;
+                const after = context.payload.after;
 
-              if (!before || /^0+$/.test(before)) {
-                core.info('No comparable base commit found. Running CI by default.');
-                core.setOutput('run_ci', 'true');
-                return;
+                if (before && !/^0+$/.test(before) && after) {
+                  const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    basehead: `${before}...${after}`,
+                  });
+                  files = comparison.data.files;
+                  // Comparisons cap files at 300; divergent history is not an exact push diff.
+                  complete = comparison.data.status === 'ahead' &&
+                    Array.isArray(files) && files.length < 300;
+                }
               }
+            } catch (error) {
+              core.warning(`Could not determine changed files: ${error.message}`);
+            }
 
-              const comparison = await github.rest.repos.compareCommitsWithBasehead({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                basehead: `${before}...${after}`,
-              });
-              changedFiles = (comparison.data.files ?? []).flatMap(changedPathsForFile);
-            } else {
-              core.info(`Unsupported event "${context.eventName}". Running CI by default.`);
+            if (!complete || !files?.length) {
+              core.info('No complete, comparable changed-file list found. Running CI by default.');
               core.setOutput('run_ci', 'true');
               return;
             }
 
-            if (changedFiles.length === 0) {
-              core.info('No changed files detected. Running CI by default.');
-              core.setOutput('run_ci', 'true');
-              return;
-            }
-
+            const changedFiles = files.flatMap(changedPathsForFile);
             const relevantFiles = changedFiles.filter((path) => !isIgnoredPath(path));
             const runCi = relevantFiles.length > 0;
 

--- a/helpers/vitest/codeChangeVerificationPolicy.test.ts
+++ b/helpers/vitest/codeChangeVerificationPolicy.test.ts
@@ -32,62 +32,256 @@ describe('code-change verification policy', () => {
     );
   });
 
-  it('runs CI for code-change verification policy updates', () => {
-    const workflow = readFileSync(workflowPath, 'utf8');
-    const relevantBranch = [
-      'if (CI_RELEVANT_PREFIXES.some((prefix) => path.startsWith(prefix))) {',
-      '                return false;',
-      '              }',
-    ].join('\n');
-    const ignoredBranch =
-      'if (IGNORED_PREFIXES.some((prefix) => path.startsWith(prefix))) {';
-
-    expect(workflow).toContain(
-      "const CI_RELEVANT_PREFIXES = [\n              '.agents/skills/code-change-verification/',\n            ];",
-    );
-    expect(workflow).toContain(relevantBranch);
-    expect(workflow.indexOf(relevantBranch)).toBeLessThan(
-      workflow.indexOf(ignoredBranch),
-    );
-    expect(workflow).toContain(
-      'changedFiles = files.flatMap(changedPathsForFile);',
-    );
-    expect(workflow).toContain(
-      'changedFiles = (comparison.data.files ?? []).flatMap(changedPathsForFile);',
-    );
-
-    const scriptStart = workflow.indexOf('            const IGNORED_PREFIXES');
-    const scriptEnd = workflow.indexOf('\n\n            let changedFiles');
-    expect(scriptStart).toBeGreaterThanOrEqual(0);
-    expect(scriptEnd).toBeGreaterThan(scriptStart);
-    const policyScript = `${workflow
-      .slice(scriptStart, scriptEnd)
-      .replace(/^ {12}/gm, '')}
-this.isIgnoredPath = isIgnoredPath;
-this.changedPathsForFile = changedPathsForFile;`;
-    const context: {
-      isIgnoredPath?: (path: string) => boolean;
-      changedPathsForFile?: (file: {
-        filename: string;
-        previous_filename?: string;
-      }) => string[];
-    } = {};
-
-    runInNewContext(policyScript, context);
-    expect(context.isIgnoredPath).toBeTypeOf('function');
-    expect(context.changedPathsForFile).toBeTypeOf('function');
-
-    const changedPaths = context.changedPathsForFile!({
-      filename: '.agents/disabled-code-change-verification/SKILL.md',
-      previous_filename: '.agents/skills/code-change-verification/SKILL.md',
+  describe.each(['pull_request', 'push'])('%s routing', (eventName) => {
+    it.each([
+      ['docs/src/scripts/translate.ts', true],
+      ['docs/src/scripts/headingAnchors.test.ts', true],
+      ['docs/src/plugins/rehypeCanonicalHeadingIds.ts', true],
+      ['docs/tsconfig.scripts.json', true],
+      ['docs/astro.config.mjs', true],
+      ['docs/package.json', true],
+      ['integration-tests/released-api-contract.test.ts', true],
+      ['integration-tests/_helpers/env.ts', true],
+      ['integration-tests/node/package.json', true],
+      ['examples/docs/tools.ts', true],
+      ['packages/agents-core/src/run.ts', true],
+      ['pnpm-lock.yaml', true],
+      ['pnpm-workspace.yaml', true],
+      ['package.json', true],
+      ['tsconfig.json', true],
+      ['vitest.integration.config.ts', true],
+      ['.github/workflows/docs.yml', true],
+      ['.agents/skills/code-change-verification/SKILL.md', true],
+      ['.agents/skills/maintainer-review/SKILL.md', false],
+      ['docs/src/content/docs/guides/tools.mdx', false],
+      ['docs/README.md', false],
+      ['docs/src/assets/light-logo.svg', false],
+      ['README.md', false],
+    ])('%s routes SDK CI to %s', async (filename, expected) => {
+      expect(await runFilter(eventName, { files: [{ filename }] })).toBe(
+        String(expected),
+      );
     });
 
-    expect(changedPaths).toEqual([
-      '.agents/disabled-code-change-verification/SKILL.md',
+    it.each([
       '.agents/skills/code-change-verification/SKILL.md',
-    ]);
-    expect(changedPaths.some((path) => !context.isIgnoredPath!(path))).toBe(
-      true,
+      'docs/src/scripts/headingAnchors.test.ts',
+      'integration-tests/released-api-contract.test.ts',
+      'examples/docs/tools.ts',
+    ])('checks both sides of a rename from %s', async (previous_filename) => {
+      expect(
+        await runFilter(eventName, {
+          files: [{ filename: '.agents/archive/notes.md', previous_filename }],
+        }),
+      ).toBe('true');
+    });
+
+    it('runs CI for mixed editorial and executable changes', async () => {
+      expect(
+        await runFilter(eventName, {
+          files: [
+            { filename: 'README.md' },
+            { filename: 'examples/docs/tools.ts' },
+          ],
+        }),
+      ).toBe('true');
+    });
+
+    it('defaults to CI for empty or unavailable file lists', async () => {
+      expect(await runFilter(eventName, { files: [] })).toBe('true');
+      expect(await runFilter(eventName, { apiError: true })).toBe('true');
+    });
+  });
+
+  it('does not skip CI when pull request file evidence is incomplete', async () => {
+    expect(await runFilter('pull_request', { changedFiles: 2 })).toBe('true');
+    expect(await runFilter('pull_request', { changedFiles: undefined })).toBe(
+      'true',
     );
+    expect(
+      await runFilter('pull_request', {
+        files: Array.from({ length: 3000 }, (_, i) => ({
+          filename: `docs/page-${i}.md`,
+        })),
+      }),
+    ).toBe('true');
+  });
+
+  it('does not skip CI at the push comparison file limit', async () => {
+    const files = Array.from({ length: 300 }, (_, i) => ({
+      filename: `docs/page-${i}.md`,
+    }));
+    expect(await runFilter('push', { files })).toBe('true');
+    expect(await runFilter('push', { files: files.slice(1) })).toBe('false');
+  });
+
+  it('defaults to CI without a comparable push base or comparison files', async () => {
+    for (const before of ['', '0'.repeat(40)]) {
+      expect(await runFilter('push', { before })).toBe('true');
+    }
+    expect(await runFilter('push', { files: undefined })).toBe('true');
+    expect(await runFilter('push', { comparisonStatus: 'diverged' })).toBe(
+      'true',
+    );
+    expect(await runFilter('workflow_dispatch')).toBe('true');
+  });
+
+  it('routes executable changes to existing checks and keeps required job identities', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    for (const job of [
+      'changes',
+      'test',
+      'windows-sandbox-paths',
+      'coverage',
+    ]) {
+      expect(workflow).toMatch(new RegExp(`^  ${job}:$`, 'm'));
+    }
+    for (const command of [
+      'pnpm docs:scripts:check',
+      'pnpm -r build-check',
+      'pnpm test',
+      'pnpm test:integration:api-contract',
+    ]) {
+      const step = workflow
+        .split(/\n\s+- name:/)
+        .find((part) =>
+          part
+            .split('\n')
+            .some(
+              (line) =>
+                line.trim() === command || line.trim() === `run: ${command}`,
+            ),
+        );
+      expect(step, command).toBeDefined();
+      expect(step).toContain("needs.changes.outputs.run_ci == 'true'");
+    }
+    expect(workflow).not.toContain('pnpm docs:build');
+    expect(workflow).not.toContain('pnpm -F docs-code build-check');
+  });
+
+  it('typechecks MDX snippet wiring without widening docs deployment eligibility', () => {
+    const workflow = readFileSync(
+      resolve(rootDir, '.github/workflows/docs.yml'),
+      'utf8',
+    );
+    const normalized = workflow
+      .split('\n')
+      .map((line) => line.trim())
+      .join('\n');
+    expect(normalized).toContain(`on:
+push:
+branches: [main]
+paths:
+- "docs/**"
+pull_request:
+paths:
+- "docs/**"
+workflow_dispatch:`);
+    expect(normalized).toContain(`deploy:
+if: github.event_name == 'push' && github.ref == 'refs/heads/main'`);
+    expect(normalized).toContain('permissions:\ncontents: read');
+    expect(normalized).toContain('permissions:\npages: write\nid-token: write');
+    for (const command of [
+      'pnpm docs:scripts:check',
+      'pnpm -F docs-code build-check',
+    ]) {
+      const step = workflow
+        .split(/\n\s+- name:/)
+        .find((part) => part.includes(`run: ${command}`));
+      expect(step, command).toBeDefined();
+      expect(step).not.toMatch(/^\s*if:/m);
+      expect(workflow.indexOf(`run: ${command}`)).toBeGreaterThan(
+        workflow.indexOf('run: pnpm build:ci'),
+      );
+      expect(workflow.indexOf(`run: ${command}`)).toBeLessThan(
+        workflow.indexOf('run: pnpm docs:build'),
+      );
+    }
   });
 });
+
+type ChangedFile = { filename: string; previous_filename?: string };
+type FilterOptions = {
+  files?: ChangedFile[];
+  changedFiles?: number;
+  before?: string;
+  comparisonStatus?: string;
+  apiError?: boolean;
+};
+
+// Read the full YAML literal block, independent of JavaScript names or indentation width.
+function classifierScript(): string {
+  const lines = readFileSync(workflowPath, 'utf8').split('\n');
+  const start = lines.findIndex((line) => /^\s*script: \|\s*$/.test(line));
+  if (start < 0) throw new Error('Missing CI classifier script.');
+  const indentation = lines[start].search(/\S/);
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() && line.search(/\S/) <= indentation) break;
+    body.push(line);
+  }
+  return body.join('\n');
+}
+
+async function runFilter(eventName: string, options: FilterOptions = {}) {
+  const files =
+    'files' in options ? options.files : [{ filename: 'README.md' }];
+  const changedFiles =
+    'changedFiles' in options ? options.changedFiles : files?.length;
+  const outputs: Record<string, string> = {};
+  const listFiles = () => {};
+  const context = {
+    eventName,
+    repo: { owner: 'openai', repo: 'openai-agents-js' },
+    payload: {
+      pull_request: { number: 123, changed_files: changedFiles },
+      before: options.before ?? 'a'.repeat(40),
+      after: 'b'.repeat(40),
+    },
+  };
+  await runInNewContext(`(async () => {${classifierScript()}\n})()`, {
+    context,
+    core: {
+      info: () => {},
+      warning: () => {},
+      setOutput: (key: string, value: string) => {
+        outputs[key] = value;
+      },
+    },
+    github: {
+      paginate: async (
+        method: unknown,
+        parameters: Record<string, unknown>,
+      ) => {
+        expect(method).toBe(listFiles);
+        expect(parameters).toEqual({
+          owner: 'openai',
+          repo: 'openai-agents-js',
+          pull_number: 123,
+          per_page: 100,
+        });
+        if (options.apiError) throw new Error('File listing unavailable.');
+        return files;
+      },
+      rest: {
+        pulls: { listFiles },
+        repos: {
+          compareCommitsWithBasehead: async (
+            parameters: Record<string, unknown>,
+          ) => {
+            expect(parameters).toEqual({
+              owner: 'openai',
+              repo: 'openai-agents-js',
+              basehead: `${context.payload.before}...${context.payload.after}`,
+            });
+            if (options.apiError) throw new Error('Comparison unavailable.');
+            return {
+              data: { files, status: options.comparisonStatus ?? 'ahead' },
+            };
+          },
+        },
+      },
+    },
+  });
+  return outputs.run_ci;
+}


### PR DESCRIPTION
This pull request fixes CI skipping executable docs and packaged API contract changes. It routes those changes through existing checks, runs CI when changed-file evidence is incomplete, and typechecks scripts and rendered snippets during existing docs builds.

Integration changes use the full CI path to cover shared contract helpers and fixtures. Snippet-only changes retain the existing recursive typecheck. Docs deployment triggers, permissions, and required job names remain unchanged.