### PR TITLE
perf: reduce Vitest global setup dependency loading

### DIFF
--- a/helpers/tests/setupTests.ts
+++ b/helpers/tests/setupTests.ts
@@ -1,4 +1,4 @@
-import { setTracingDisabled } from '../../packages/agents-core/src';
+import { setTracingDisabled } from '../../packages/agents-core/src/tracing';
 
 export function setupTests(): void {
   setTracingDisabled(true);


### PR DESCRIPTION
This pull request imports setTracingDisabled from the existing tracing entrypoint to avoid loading unrelated core modules during Vitest global setup. The same provider remains disabled under the existing output guard, and worker initialization is unchanged.

Repeated focused measurements reduced workspace/core startup and collection medians by about 730–750 ms. Whole-suite savings were not measured.