### PR TITLE
refactor: share core Zod description lookup

### DIFF
--- a/.changeset/share-core-zod-description.md
+++ b/.changeset/share-core-zod-description.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+refactor: share Zod description lookup across structured agent input and JSON Schema conversion.

--- a/packages/agents-core/src/agentToolInput.ts
+++ b/packages/agents-core/src/agentToolInput.ts
@@ -7,7 +7,11 @@ import type {
 } from './types';
 import type { ToolInputParametersStrict } from './tool';
 import type { ZodObjectLike } from './utils/zodCompat';
-import { readZodDefinition, readZodType } from './utils/zodCompat';
+import {
+  readZodDefinition,
+  readZodDescription,
+  readZodType,
+} from './utils/zodCompat';
 import { getSchemaAndParserFromInputType } from './utils/tools';
 import { hasJsonSchemaObjectShape } from './utils/zodJsonSchemaCompat';
 import { isAgentToolInput, isZodObject } from './utils/typeGuards';
@@ -440,37 +444,6 @@ function readZodShape(input: unknown): Record<string, unknown> | undefined {
     } catch (_error) {
       return undefined;
     }
-  }
-  return undefined;
-}
-
-function readZodDescription(value: unknown): string | undefined {
-  if (typeof value === 'object' && value !== null) {
-    const direct = (value as { description?: unknown }).description;
-    if (typeof direct === 'string' && direct.trim()) {
-      return direct;
-    }
-  }
-
-  let current = value;
-  const visited = new Set<unknown>();
-  while (current && typeof current === 'object' && !visited.has(current)) {
-    visited.add(current);
-    const def = readZodDefinition(current);
-    if (typeof def?.description === 'string' && def.description.trim()) {
-      return def.description;
-    }
-    const next =
-      def?.innerType ??
-      def?.schema ??
-      def?.base ??
-      def?.type ??
-      def?.wrapped ??
-      def?.underlying;
-    if (!next || next === current) {
-      break;
-    }
-    current = next;
   }
   return undefined;
 }

--- a/packages/agents-core/src/utils/zodCompat.ts
+++ b/packages/agents-core/src/utils/zodCompat.ts
@@ -26,6 +26,37 @@ export function readZodDefinition(input: unknown): ZodDefinition {
   return candidate._zod?.def || candidate._def || candidate.def;
 }
 
+export function readZodDescription(value: unknown): string | undefined {
+  if (typeof value === 'object' && value !== null) {
+    const direct = (value as { description?: unknown }).description;
+    if (typeof direct === 'string' && direct.trim()) {
+      return direct;
+    }
+  }
+
+  let current = value;
+  const visited = new Set<unknown>();
+  while (current && typeof current === 'object' && !visited.has(current)) {
+    visited.add(current);
+    const def = readZodDefinition(current);
+    if (typeof def?.description === 'string' && def.description.trim()) {
+      return def.description;
+    }
+    const next =
+      def?.innerType ??
+      def?.schema ??
+      def?.base ??
+      def?.type ??
+      def?.wrapped ??
+      def?.underlying;
+    if (!next || next === current) {
+      break;
+    }
+    current = next;
+  }
+  return undefined;
+}
+
 export function readZodType(input: unknown): string | undefined {
   const def = readZodDefinition(input);
   if (!def) {

--- a/packages/agents-core/src/utils/zodJsonSchemaCompat.ts
+++ b/packages/agents-core/src/utils/zodJsonSchemaCompat.ts
@@ -1,7 +1,11 @@
 import type { JsonObjectSchema, JsonSchemaDefinitionEntry } from '../types';
 import { UserError } from '../errors';
 import type { ZodObjectLike } from './zodCompat';
-import { readZodDefinition, readZodType } from './zodCompat';
+import {
+  readZodDefinition,
+  readZodDescription,
+  readZodType,
+} from './zodCompat';
 
 /**
  * The JSON-schema helpers in openai/helpers/zod only emit complete schemas for
@@ -745,37 +749,6 @@ function unwrapDecorators(value: unknown): unknown {
     current = next;
   }
   return current;
-}
-
-function readZodDescription(value: unknown): string | undefined {
-  if (typeof value === 'object' && value !== null) {
-    const direct = (value as { description?: unknown }).description;
-    if (typeof direct === 'string' && direct.trim()) {
-      return direct;
-    }
-  }
-
-  let current = value;
-  const visited = new Set<unknown>();
-  while (current && typeof current === 'object' && !visited.has(current)) {
-    visited.add(current);
-    const def = readZodDefinition(current);
-    if (typeof def?.description === 'string' && def.description.trim()) {
-      return def.description;
-    }
-    const next =
-      def?.innerType ??
-      def?.schema ??
-      def?.base ??
-      def?.type ??
-      def?.wrapped ??
-      def?.underlying;
-    if (!next || next === current) {
-      break;
-    }
-    current = next;
-  }
-  return undefined;
 }
 
 function extractFirst(

--- a/packages/agents-core/test/agentToolInput.test.ts
+++ b/packages/agents-core/test/agentToolInput.test.ts
@@ -8,8 +8,79 @@ import {
 import type { AgentInputItem, JsonObjectSchema } from '../src/types';
 import type { ToolInputParametersStrict } from '../src/tool';
 import { z } from 'zod';
+import { z as zod3 } from 'zod/v3';
+import { Agent, RunContext } from '../src';
+import { ScriptedModel, assistantMessage } from '../src/testing';
 
 describe('agentToolInput', () => {
+  it.each([
+    {
+      version: 'v3',
+      schema: zod3
+        .object({
+          text: zod3
+            .string()
+            .describe('  Text to translate.  ')
+            .refine((value) => value.length > 0),
+          target: zod3
+            .string()
+            .describe('Inner target.')
+            .default('en')
+            .describe('  Target language.  '),
+          note: zod3.string().describe(' \t ').optional(),
+        })
+        .describe('  Translation input.  '),
+    },
+    {
+      version: 'v4',
+      schema: z
+        .object({
+          text: z
+            .string()
+            .describe('  Text to translate.  ')
+            .refine((value) => value.length > 0),
+          target: z
+            .string()
+            .describe('Inner target.')
+            .default('en')
+            .describe('  Target language.  '),
+          note: z.string().describe(' \t ').optional(),
+        })
+        .describe('  Translation input.  '),
+    },
+  ])(
+    'preserves $version descriptions in nested agent tool input',
+    async ({ schema }) => {
+      const model = new ScriptedModel([[assistantMessage('Translated.')]]);
+      const agent = new Agent({ name: 'Translator', model });
+      const agentTool = agent.asTool({
+        toolDescription: 'Translate structured input.',
+        // Exercise the existing v3 runtime path alongside the declared v4 types.
+        parameters: schema as unknown as z.ZodObject<any>,
+      });
+
+      const result = await agentTool.invoke(
+        new RunContext(),
+        JSON.stringify({ text: 'hola', target: 'en' }),
+      );
+
+      expect(result).toBe('Translated.');
+      expect(model.calls).toHaveLength(1);
+      expect(model.calls[0].request.input).toEqual([
+        expect.objectContaining({
+          role: 'user',
+          content: expect.stringContaining(
+            'Description:   Translation input.  \n' +
+              '- text (string, required) -   Text to translate.  \n' +
+              '- target (string, required) -   Target language.  \n' +
+              '- note (string, optional)',
+          ),
+        }),
+      ]);
+      model.assertComplete();
+    },
+  );
+
   it('AgentAsToolInputSchema accepts only string input', () => {
     expect(AgentAsToolInputSchema.safeParse({ input: 'hi' }).success).toBe(
       true,

--- a/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
+++ b/packages/agents-core/test/utils/zodJsonSchemaCompat.test.ts
@@ -7,6 +7,67 @@ import {
 } from '../../src/utils/zodJsonSchemaCompat';
 
 describe('utils/zodJsonSchemaCompat', () => {
+  it.each([
+    {
+      version: 'v3',
+      schema: zod3
+        .object({
+          text: zod3
+            .string()
+            .describe('  Text to translate.  ')
+            .refine((value) => value.length > 0),
+          target: zod3
+            .string()
+            .describe('Inner target.')
+            .default('en')
+            .describe('  Target language.  '),
+          blank: zod3.string().describe(' \t '),
+          missing: zod3.string(),
+        })
+        .describe('  Translation input.  '),
+    },
+    {
+      version: 'v4',
+      schema: z
+        .object({
+          text: z
+            .string()
+            .describe('  Text to translate.  ')
+            .refine((value) => value.length > 0),
+          target: z
+            .string()
+            .describe('Inner target.')
+            .default('en')
+            .describe('  Target language.  '),
+          blank: z.string().describe(' \t '),
+          missing: z.string(),
+        })
+        .describe('  Translation input.  '),
+    },
+  ])(
+    'preserves $version description precedence and whitespace through wrappers',
+    ({ schema }) => {
+      // Exercise the existing v3 runtime path alongside the declared v4 types.
+      const jsonSchema = zodJsonSchemaCompat(
+        schema as unknown as z.ZodObject<any>,
+      );
+
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        required: ['text', 'target', 'blank', 'missing'],
+        description: '  Translation input.  ',
+        properties: {
+          text: { type: 'string', description: '  Text to translate.  ' },
+          target: { type: 'string', description: 'Inner target.' },
+          blank: { type: 'string' },
+          missing: { type: 'string' },
+        },
+      });
+    },
+  );
+
   it('builds schema for basic object with optional property', () => {
     const schema = z.object({
       name: z.string(),


### PR DESCRIPTION
This pull request updates core Zod metadata handling by sharing the existing description lookup between structured agent-tool input and JSON Schema conversion. It preserves both callers' behavior and adds Zod v3/v4 regression coverage.