### PR TITLE
chore: run repository skill tests in a dedicated CI lane

### DIFF
--- a/.agents/skills/implementation-final-review/scripts/test_review_state.py
+++ b/.agents/skills/implementation-final-review/scripts/test_review_state.py
@@ -341,7 +341,8 @@ class ReviewStateTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "HEAD does not match.*vendor/dependency"):
             review_state(self.repo, self.base, ("vendor/dependency",))
 
-        self._git("add", "vendor/dependency")
+        # Explicit staging must override the fixture's ignore=all setting.
+        self._git("add", "--force", "vendor/dependency")
         clean_state = review_state(self.repo, self.base, ("vendor/dependency",))
 
         self.assertEqual(

--- a/.changeset/fix-pty-output-drain.md
+++ b/.changeset/fix-pty-output-drain.md
@@ -2,4 +2,4 @@
 '@openai/agents-core': patch
 ---
 
-fix: preserve buffered PTY output when a process exits after receiving stdin.
+fix: preserve buffered PTY output without waiting for background descendants.

--- a/.changeset/fix-pty-output-drain.md
+++ b/.changeset/fix-pty-output-drain.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: preserve buffered PTY output when a process exits after receiving stdin.

--- a/.github/workflows/repo-skills.yml
+++ b/.github/workflows/repo-skills.yml
@@ -1,0 +1,51 @@
+name: Repository skill tests
+
+on:
+  push:
+    branches: [main]
+    paths: &repo-skill-paths
+      - '.github/workflows/repo-skills.yml'
+      - 'scripts/run-repo-skill-tests.mjs'
+      - 'scripts/tests/run-repo-skill-tests.test.mjs'
+      - '.agents/skills/implementation-kickoff/**'
+      - '.agents/skills/implementation-final-review/**'
+      - '.agents/skills/sensitive-logging-audit/**'
+      - '.agents/skills/changeset-validation/**'
+      - 'CONTRIBUTING.md'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.npmrc'
+  pull_request:
+    paths: *repo-skill-paths
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repo-skills:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          run_install: false
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: pnpm
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.12'
+      - name: Install dependencies without lifecycle scripts
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Run offline repository skill tests
+        run: pnpm test:repo-skills

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,12 @@ For provider-neutral agent workflow tests, prefer `ScriptedModel` from the Core 
 
 During iterative implementation review, run focused tests for the changed behavior and relevant subsystem boundaries with `pnpm exec vitest run <path>`, including applicable review-optional cases. Resolve uncertain coverage by tracing affected callers and dependencies and selecting the needed focused checks. Follow [implementation-final-review](.agents/skills/implementation-final-review/SKILL.md) for review sequencing; defer broad tests, builds, and repository-wide type checking until clean review. Then follow [code-change-verification](.agents/skills/code-change-verification/SKILL.md) for the complete final SDK stack. Explicit requests to run a suite outside implementation review remain supported.
 
+### Repository skill tests
+
+Run `pnpm test:repo-skills` to check executable repository skill helpers independently of the SDK test suite. This offline command requires Node.js 22+, Python 3.10+, Git, and installed development dependencies; it does not require a package build. It runs the four Python handoff/review suites, the Node logging inventory suite, runner regression tests, and three changeset result-validator fixtures. A failed suite stops the command with a nonzero exit status.
+
+The runner isolates temporary files and Git configuration, passes only required environment variables to children, and limits Git fixture transports to local files. The changeset shell's prompt-generation check and all four milestone cases are excluded. The runner never invokes `run-fixtures.sh` or milestone assignment. `.github/workflows/repo-skills.yml` runs this command when its owning scripts, skills, or dependency manifests change.
+
 ### Code style
 
 - Maintain existing TypeScript style.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "docs:scripts:check": "pnpm exec tsc --pretty false --project docs/tsconfig.scripts.json",
     "test": "vitest run --mode full",
     "test:review": "vitest run --mode review",
+    "test:repo-skills": "node scripts/run-repo-skill-tests.mjs",
     "test:coverage": "vitest run --mode full --coverage",
     "test:examples": "pnpm -r build-check",
     "test:integration": "vitest run --config=vitest.integration.config.ts",

--- a/packages/agents-core/src/sandbox/sandboxes/shared/pty.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/pty.ts
@@ -59,6 +59,7 @@ signal.signal(signal.SIGINT, forward_signal)
 exit_status = 0
 stdin_open = True
 
+# PTY data can remain buffered after the child exits, so read until EOF.
 while True:
     readable = [fd]
     if stdin_open:
@@ -87,14 +88,6 @@ while True:
             os.write(fd, data)
         else:
             stdin_open = False
-
-    waited_pid, status = os.waitpid(pid, os.WNOHANG)
-    if waited_pid == pid:
-        if os.WIFEXITED(status):
-            exit_status = os.WEXITSTATUS(status)
-        elif os.WIFSIGNALED(status):
-            exit_status = 128 + os.WTERMSIG(status)
-        break
 
 try:
     _, status = os.waitpid(pid, 0)

--- a/packages/agents-core/src/sandbox/sandboxes/shared/pty.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/pty.ts
@@ -16,12 +16,15 @@ import sys
 sys.exit(0 if sys.version_info[0] >= 3 else 1)
 `;
 const PTY_BRIDGE_SCRIPT = String.raw`
+import array
 import errno
+import fcntl
 import os
 import pty
 import select
 import signal
 import sys
+import termios
 
 PTY_CHILD_SIGNAL_DEFAULTS = (signal.SIGINT, signal.SIGQUIT)
 
@@ -58,20 +61,24 @@ signal.signal(signal.SIGINT, forward_signal)
 
 exit_status = 0
 stdin_open = True
+drain_remaining = None
 
-# PTY data can remain buffered after the child exits, so read until EOF.
-while True:
+# The target PID owns completion; descendants may keep the terminal open.
+while drain_remaining is None or drain_remaining > 0:
     readable = [fd]
-    if stdin_open:
+    if stdin_open and drain_remaining is None:
         readable.append(sys.stdin.fileno())
     try:
-        ready, _, _ = select.select(readable, [], [], 0.1)
+        ready, _, _ = select.select(readable, [], [], 0.1 if drain_remaining is None else 0)
     except OSError:
+        break
+
+    if not ready and drain_remaining is not None:
         break
 
     if fd in ready:
         try:
-            data = os.read(fd, 4096)
+            data = os.read(fd, 4096 if drain_remaining is None else min(4096, drain_remaining))
         except OSError as exc:
             if exc.errno == errno.EIO:
                 data = b''
@@ -79,10 +86,24 @@ while True:
                 raise
         if data:
             os.write(sys.stdout.fileno(), data)
+            if drain_remaining is not None:
+                drain_remaining -= len(data)
         else:
             break
 
-    if stdin_open and sys.stdin.fileno() in ready:
+    if drain_remaining is None:
+        waited_pid, status = os.waitpid(pid, os.WNOHANG)
+        if waited_pid == pid:
+            if os.WIFEXITED(status):
+                exit_status = os.WEXITSTATUS(status)
+            elif os.WIFSIGNALED(status):
+                exit_status = 128 + os.WTERMSIG(status)
+            # Snapshot queued bytes so new descendant output cannot extend the drain.
+            available = array.array('i', [0])
+            fcntl.ioctl(fd, termios.FIONREAD, available)
+            drain_remaining = available[0]
+
+    if stdin_open and drain_remaining is None and sys.stdin.fileno() in ready:
         data = os.read(sys.stdin.fileno(), 4096)
         if data:
             os.write(fd, data)

--- a/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
@@ -3,7 +3,7 @@ import {
   type ChildProcessWithoutNullStreams,
 } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -236,6 +236,86 @@ exec(script)
     }
   });
 
+  it.each(['native', 'retained-slave'] as const)(
+    'completes while a background descendant retains the PTY (%s)',
+    async (terminalMode) => {
+      const originalPython = process.env.OPENAI_AGENTS_PYTHON;
+      const pythonPath = await whichPython();
+      const controlledPython = join(rootDir, 'retained-slave-python');
+      // Keep real slave descriptors open without macOS controlling-terminal revocation.
+      await writeFile(
+        controlledPython,
+        String.raw`#!${pythonPath}
+import os
+import pty
+import sys
+
+def fork_without_controlling_terminal():
+    master, slave = pty.openpty()
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        for target in (0, 1, 2):
+            os.dup2(slave, target)
+        if slave > 2:
+            os.close(slave)
+        return 0, -1
+    os.close(slave)
+    return pid, master
+
+pty.fork = fork_without_controlling_terminal
+script = sys.argv[2]
+sys.argv = [sys.argv[0], *sys.argv[3:]]
+exec(script)
+`,
+        { mode: 0o755 },
+      );
+      const client = new UnixLocalSandboxClient({
+        workspaceBaseDir: rootDir,
+      });
+      const session = await client.create(new Manifest());
+      const descendantPidPath = join(
+        session.state.workspaceRootPath,
+        'descendant.pid',
+      );
+      if (terminalMode === 'retained-slave') {
+        process.env.OPENAI_AGENTS_PYTHON = controlledPython;
+      }
+
+      try {
+        const started = await session.execCommand({
+          cmd: `trap '' HUP; sleep 600 & printf '%s' $! > descendant.pid; printf 'target output\n'; exit 7`,
+          shell: '/bin/sh',
+          login: false,
+          tty: true,
+          yieldTimeMs: 0,
+        });
+        const output = await collectActiveCommandOutput(session, started);
+
+        expect(output).toContain('Process exited with code 7');
+        expect(output).toContain('target output');
+        const descendantPid = Number(await readFile(descendantPidPath, 'utf8'));
+        expect(() => process.kill(descendantPid, 0)).not.toThrow();
+      } finally {
+        if (originalPython === undefined) {
+          delete process.env.OPENAI_AGENTS_PYTHON;
+        } else {
+          process.env.OPENAI_AGENTS_PYTHON = originalPython;
+        }
+        const descendantPid = Number(
+          await readFile(descendantPidPath, 'utf8').catch(() => ''),
+        );
+        try {
+          if (descendantPid > 0) {
+            killProcessIfRunning(descendantPid);
+          }
+        } finally {
+          await session.close();
+        }
+      }
+    },
+  );
+
   it('waits for final output after observing process completion', async () => {
     const client = new UnixLocalSandboxClient({
       workspaceBaseDir: rootDir,
@@ -465,6 +545,16 @@ exec(script)
     expect(finalOutput).toContain('Process exited with code 0');
   }, 10_000);
 });
+
+function killProcessIfRunning(pid: number): void {
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ESRCH') {
+      throw error;
+    }
+  }
+}
 
 async function writeUntilExit(
   session: {

--- a/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
@@ -3,7 +3,7 @@ import {
   type ChildProcessWithoutNullStreams,
 } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdtemp, rm, symlink } from 'node:fs/promises';
+import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -165,6 +165,75 @@ describe('UnixLocalSandboxClient process sessions', () => {
     expect(started).toContain('Process running with session ID');
     expect(finished).toContain('Process exited with code 0');
     expect(finished).toContain('hello stdin');
+  });
+
+  it('drains PTY output when the child exits while forwarding stdin', async () => {
+    const originalPython = process.env.OPENAI_AGENTS_PYTHON;
+    const pythonPath = await whichPython();
+    const controlledPython = join(rootDir, 'controlled-python');
+    // Control the real child's exit ordering without replacing its PTY output.
+    await writeFile(
+      controlledPython,
+      String.raw`#!${pythonPath}
+import os
+import sys
+
+original_write = os.write
+original_waitpid = os.waitpid
+forwarded_stdin = False
+
+def waitpid_after_stdin(pid, options):
+    return original_waitpid(pid, 0 if forwarded_stdin else options)
+
+def write_with_stdin_marker(fd, data):
+    global forwarded_stdin
+    written = original_write(fd, data)
+    if fd > 2 and data == b'hello stdin\n':
+        forwarded_stdin = True
+    return written
+
+os.write = write_with_stdin_marker
+os.waitpid = waitpid_after_stdin
+script = sys.argv[2]
+sys.argv = [sys.argv[0], *sys.argv[3:]]
+exec(script)
+`,
+      { mode: 0o755 },
+    );
+    const client = new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    });
+    const session = await client.create(new Manifest());
+    process.env.OPENAI_AGENTS_PYTHON = controlledPython;
+
+    try {
+      const started = await session.execCommand({
+        cmd: 'read value; printf "%s\\n" "$value"; exit 7',
+        shell: '/bin/sh',
+        login: false,
+        tty: true,
+        yieldTimeMs: 0,
+      });
+      const sessionId = Number(
+        started.match(/Process running with session ID (\d+)/)?.[1],
+      );
+      const finished = await writeUntilExit(
+        session,
+        sessionId,
+        'hello stdin\n',
+      );
+
+      expect(started).toContain('Process running with session ID');
+      expect(finished).toContain('Process exited with code 7');
+      expect(finished).toContain('hello stdin');
+    } finally {
+      if (originalPython === undefined) {
+        delete process.env.OPENAI_AGENTS_PYTHON;
+      } else {
+        process.env.OPENAI_AGENTS_PYTHON = originalPython;
+      }
+      await session.close();
+    }
   });
 
   it('waits for final output after observing process completion', async () => {

--- a/scripts/run-repo-skill-tests.mjs
+++ b/scripts/run-repo-skill-tests.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const { console } = globalThis;
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(scriptPath), '..');
+const skillsRoot = path.join(repoRoot, '.agents/skills');
+
+const pythonSuites = [
+  ['implementation-kickoff', 'test_validate_handoff.py'],
+  ['implementation-final-review', 'test_prepare_review_round.py'],
+  ['implementation-final-review', 'test_review_state.py'],
+  ['implementation-final-review', 'test_review_protocol.py'],
+].map(([skill, file]) => ({
+  name: `${skill}/${file}`,
+  command: 'python3',
+  args: ['-m', 'unittest', '-v', file],
+  cwd: path.join(skillsRoot, skill, 'scripts'),
+}));
+
+const suites = [
+  ...pythonSuites,
+  {
+    name: 'sensitive-logging-audit/inventory-logging.test.mjs',
+    command: process.execPath,
+    args: [
+      '--test',
+      path.join(
+        skillsRoot,
+        'sensitive-logging-audit/scripts/inventory-logging.test.mjs',
+      ),
+    ],
+    cwd: repoRoot,
+  },
+  {
+    name: 'runner and offline changeset fixtures',
+    command: process.execPath,
+    args: [
+      '--test',
+      path.join(repoRoot, 'scripts/tests/run-repo-skill-tests.test.mjs'),
+    ],
+    cwd: repoRoot,
+  },
+];
+
+// Keep credentials, runtime preload options, and user Git configuration out of children.
+function childEnvironment(temporaryRoot) {
+  const env = {};
+  for (const name of [
+    'PATH',
+    'SystemRoot',
+    'WINDIR',
+    'PATHEXT',
+    'LD_LIBRARY_PATH',
+  ]) {
+    if (process.env[name] !== undefined) env[name] = process.env[name];
+  }
+  return {
+    ...env,
+    HOME: temporaryRoot,
+    USERPROFILE: temporaryRoot,
+    TMPDIR: temporaryRoot,
+    TMP: temporaryRoot,
+    TEMP: temporaryRoot,
+    LANG: 'C',
+    LC_ALL: 'C',
+    PYTHONUTF8: '1',
+    PYTHONDONTWRITEBYTECODE: '1',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GIT_CONFIG_GLOBAL: process.platform === 'win32' ? 'NUL' : '/dev/null',
+    GIT_CONFIG_COUNT: '2',
+    GIT_CONFIG_KEY_0: 'core.hooksPath',
+    GIT_CONFIG_VALUE_0: temporaryRoot,
+    GIT_CONFIG_KEY_1: 'commit.gpgSign',
+    GIT_CONFIG_VALUE_1: 'false',
+    GIT_ALLOW_PROTOCOL: 'file',
+    GIT_TERMINAL_PROMPT: '0',
+  };
+}
+
+// Export only the execution boundary so tests can exercise real failing children.
+export function runSuites(selectedSuites) {
+  const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'repo-skill-tests-'));
+  try {
+    const env = childEnvironment(temporaryRoot);
+    for (const suite of selectedSuites) {
+      console.log(`\n=== ${suite.name} ===`);
+      const result = spawnSync(suite.command, suite.args, {
+        cwd: suite.cwd,
+        env,
+        stdio: 'inherit',
+      });
+      if (result.error || result.status !== 0) {
+        const reason =
+          result.error?.message ??
+          (result.signal ? `signal ${result.signal}` : `exit ${result.status}`);
+        console.error(`FAIL: ${suite.name} (${reason})`);
+        return 1;
+      }
+      console.log(`PASS: ${suite.name}`);
+    }
+    console.log(
+      `\nAll ${selectedSuites.length} repository skill suites passed.`,
+    );
+    return 0;
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  process.exitCode = runSuites(suites);
+}

--- a/scripts/tests/run-repo-skill-tests.test.mjs
+++ b/scripts/tests/run-repo-skill-tests.test.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import test from 'node:test';
+import { URL, fileURLToPath } from 'node:url';
+
+const runnerUrl = new URL('../run-repo-skill-tests.mjs', import.meta.url).href;
+const validatorPath = fileURLToPath(
+  new URL(
+    '../../.agents/skills/changeset-validation/scripts/changeset-validation-result.mjs',
+    import.meta.url,
+  ),
+);
+
+function fixture(t) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'repo-skill-runner-test-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  return directory;
+}
+
+function runSelected(suites, env = {}) {
+  return spawnSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `
+    import { runSuites } from ${JSON.stringify(runnerUrl)};
+    process.exitCode = runSuites(${JSON.stringify(suites)});
+  `,
+    ],
+    {
+      encoding: 'utf8',
+      env: { PATH: process.env.PATH, ...env },
+    },
+  );
+}
+
+function nodeSuite(name, code) {
+  return {
+    name,
+    command: process.execPath,
+    args: ['--input-type=module', '-e', code],
+  };
+}
+
+test('runs children in order with isolated credentials, local Git, and cleanup', (t) => {
+  const directory = fixture(t);
+  const resultFile = path.join(directory, 'child.json');
+  const laterFile = path.join(directory, 'later');
+  const result = runSelected(
+    [
+      nodeSuite(
+        'environment probe',
+        `
+      import { writeFileSync } from 'node:fs';
+      import { spawnSync } from 'node:child_process';
+      const git = spawnSync('git', ['ls-remote', 'https://example.invalid/repo'], { encoding: 'utf8' });
+      writeFileSync(${JSON.stringify(resultFile)}, JSON.stringify({ env: process.env, gitStatus: git.status, gitError: git.stderr }));
+    `,
+      ),
+      nodeSuite(
+        'later suite',
+        `
+      import { existsSync, writeFileSync } from 'node:fs';
+      if (!existsSync(${JSON.stringify(resultFile)})) process.exit(2);
+      writeFileSync(${JSON.stringify(laterFile)}, 'ran');
+    `,
+      ),
+    ],
+    {
+      OPENAI_API_KEY: 'synthetic-test-value',
+      OPENAI_ADMIN_KEY: 'synthetic-test-value',
+      GITHUB_TOKEN: 'synthetic-test-value',
+      GH_TOKEN: 'synthetic-test-value',
+      GH_ENTERPRISE_TOKEN: 'synthetic-test-value',
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'protocol.allow',
+      GIT_CONFIG_VALUE_0: 'always',
+      PYTHONPATH: directory,
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const child = JSON.parse(readFileSync(resultFile, 'utf8'));
+  for (const name of [
+    'OPENAI_API_KEY',
+    'OPENAI_ADMIN_KEY',
+    'GITHUB_TOKEN',
+    'GH_TOKEN',
+    'GH_ENTERPRISE_TOKEN',
+    'PYTHONPATH',
+  ]) {
+    assert.equal(child.env[name], undefined, name);
+  }
+  assert.equal(child.gitStatus, 128);
+  assert.match(child.gitError, /transport 'https' not allowed/);
+  assert.equal(child.env.HOME, child.env.TMPDIR);
+  assert.equal(existsSync(child.env.TMPDIR), false);
+  assert.equal(existsSync(laterFile), true);
+  assert.match(result.stdout, /PASS: environment probe/);
+  assert.match(result.stdout, /All 2 repository skill suites passed/);
+});
+
+test('propagates a failing child and cleans up without running later suites', (t) => {
+  const directory = fixture(t);
+  const temporaryPathFile = path.join(directory, 'temporary-path');
+  const laterFile = path.join(directory, 'later');
+  const result = runSelected([
+    nodeSuite(
+      'controlled failure',
+      `
+      import { writeFileSync } from 'node:fs';
+      writeFileSync(${JSON.stringify(temporaryPathFile)}, process.env.TMPDIR);
+      writeFileSync(process.env.TMPDIR + '/partial-output', 'partial');
+      process.exit(23);
+    `,
+    ),
+    nodeSuite(
+      'must not run',
+      `
+      import { writeFileSync } from 'node:fs';
+      writeFileSync(${JSON.stringify(laterFile)}, 'unexpected');
+    `,
+    ),
+  ]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /FAIL: controlled failure \(exit 23\)/);
+  assert.equal(existsSync(readFileSync(temporaryPathFile, 'utf8')), false);
+  assert.equal(existsSync(laterFile), false);
+  assert.doesNotMatch(result.stdout, /All .* passed/);
+});
+
+test('fails when a child cannot start', (t) => {
+  const result = runSelected([
+    {
+      name: 'missing interpreter',
+      command: path.join(fixture(t), 'missing'),
+      args: [],
+    },
+  ]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /FAIL: missing interpreter .*ENOENT/);
+});
+
+test(
+  'fails when a child terminates from a signal',
+  { skip: process.platform === 'win32' },
+  () => {
+    const result = runSelected([
+      nodeSuite('signaled child', "process.kill(process.pid, 'SIGTERM');"),
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /FAIL: signaled child \(signal SIGTERM\)/);
+  },
+);
+
+// Reuse the three pure result-validator fixtures; never invoke milestone assignment.
+for (const [name, verdict, expectedStatus, expectedOutput] of [
+  [
+    'valid JSON passes',
+    { ok: true, errors: [], warnings: [], required_bump: 'none' },
+    0,
+    /changeset-validation passed/,
+  ],
+  [
+    'invalid verdict fails',
+    {
+      ok: false,
+      errors: ['Missing changeset.'],
+      warnings: [],
+      required_bump: 'patch',
+    },
+    1,
+    /Missing changeset/,
+  ],
+  ['schema errors fail', { ok: true }, 1, /Missing errors array/],
+]) {
+  test(`changeset fixture: ${name}`, (t) => {
+    const file = path.join(fixture(t), 'verdict.json');
+    writeFileSync(file, JSON.stringify(verdict));
+    const result = spawnSync(process.execPath, [validatorPath, file], {
+      encoding: 'utf8',
+      env: {},
+    });
+    assert.equal(result.status, expectedStatus, result.stderr);
+    assert.match(result.stdout + result.stderr, expectedOutput);
+  });
+}


### PR DESCRIPTION
This pull request adds pnpm test:repo-skills and a dedicated CI workflow covering existing Python and Node skill tests. It isolates child credentials and temporary files, verifies failure propagation and cleanup, and includes three offline changeset-validator fixtures.