### PR TITLE
fix: prevent sandbox Git repository argument injection

### DIFF
--- a/.changeset/fix-sandbox-git-operands.md
+++ b/.changeset/fix-sandbox-git-operands.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-extensions': patch
+---
+
+fix: prevent sandbox Git repository inputs from being interpreted as host Git options.

--- a/packages/agents-core/src/sandbox/manifest.ts
+++ b/packages/agents-core/src/sandbox/manifest.ts
@@ -1007,6 +1007,10 @@ function normalizeEntry(
       throw new Error('git_repo entries must include a non-empty repo.');
     }
     normalized.repo = repo.trim();
+    // URL-like values pass through to host Git without an HTTPS prefix.
+    if (normalized.repo.startsWith('-') && normalized.repo.includes('://')) {
+      throw new Error('git_repo repository URL must not start with "-".');
+    }
     normalized.host = normalizeGitHost(normalized.host);
     if (normalized.subpath !== undefined) {
       normalized.subpath = normalizeGitRepoSubpath(

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
@@ -1169,7 +1169,7 @@ async function cloneNamedRef(
   if (ref) {
     args.push('--branch', ref);
   }
-  args.push(repository, destination);
+  args.push('--', repository, destination);
   return await runSandboxProcess('git', args, {
     timeoutMs: GIT_CLONE_TIMEOUT_MS,
   });

--- a/packages/agents-core/test/sandboxManifest.test.ts
+++ b/packages/agents-core/test/sandboxManifest.test.ts
@@ -71,6 +71,39 @@ function parseTestSecretReference(
 }
 
 describe('Manifest', () => {
+  it.each(['--upload-pack=marker #://', '  --upload-pack=marker #://  '])(
+    'rejects option-like repository URLs in nested entries: %s',
+    (repo) => {
+      expect(
+        () =>
+          new Manifest({
+            entries: {
+              deps: {
+                type: 'dir',
+                children: {
+                  app: { type: 'git_repo', repo },
+                },
+              },
+            },
+          }),
+      ).toThrow('git_repo repository URL must not start with "-".');
+    },
+  );
+
+  it.each([
+    'https://example.test/repo.git',
+    'ssh://git@example.test/repo.git',
+    'git@example.test:owner/repo.git',
+    'file:///tmp/repo',
+    'owner/repo',
+    '-owner/repo',
+  ])('preserves supported repository spelling: %s', (repo) => {
+    const manifest = new Manifest({
+      entries: { app: { type: 'git_repo', repo } },
+    });
+    expect(manifest.entries.app.repo).toBe(repo);
+  });
+
   it('infers inline entry types from entry discriminators', () => {
     const entries = {
       'README.md': {

--- a/packages/agents-core/test/sandboxes/dockerUnit.test.ts
+++ b/packages/agents-core/test/sandboxes/dockerUnit.test.ts
@@ -242,6 +242,31 @@ describe('DockerSandboxClient unit behavior', () => {
     await rm(rootDir, { recursive: true, force: true });
   });
 
+  it('rejects repository options before Docker update effects', async () => {
+    const manifest = new Manifest();
+    const session = new DockerSandboxSession({
+      state: {
+        manifest,
+        workspaceRootPath: rootDir,
+        workspaceRootOwned: false,
+        environment: {},
+        containerId: 'existing-container',
+        image: 'test:image',
+      },
+    });
+    const update = new Manifest({
+      entries: { app: { type: 'git_repo', repo: 'owner/repo' } },
+    });
+    update.entries.app.repo = '--upload-pack=unused #://';
+    await expect(session.applyManifest(update)).rejects.toThrow(
+      'git_repo repository URL must not start with "-".',
+    );
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+    expect(session.state.manifest).toBe(manifest);
+    expect(await readdir(rootDir)).toEqual([]);
+  });
+
   it('rejects replacing active mounts before Docker or filesystem effects', async () => {
     const manifest = new Manifest({
       entries: {

--- a/packages/agents-core/test/sandboxes/unixLocal.git.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.git.test.ts
@@ -1,10 +1,20 @@
 import { execFile } from 'node:child_process';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Manifest, UnixLocalSandboxClient } from '../../src/sandbox/local';
+
+import * as gitProcess from '../../src/sandbox/sandboxes/shared/runProcess';
 
 const execFileAsync = promisify(execFile);
 
@@ -16,8 +26,120 @@ describe('UnixLocalSandboxClient git repository entries', () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await rm(rootDir, { recursive: true, force: true });
   });
+
+  it('rejects repository option injection before changing an existing workspace', async () => {
+    const repository = join(rootDir, 'source');
+    await mkdir(repository);
+    await createGitRepository(repository, 'original\n');
+    const session = await new UnixLocalSandboxClient({
+      workspaceBaseDir: rootDir,
+    }).create(
+      new Manifest({
+        entries: { app: { type: 'git_repo', repo: `file://${repository}` } },
+      }),
+    );
+    const workspace = session.state.workspaceRootPath;
+    const config = await readFile(join(workspace, 'app/.git/config'), 'utf8');
+    const previousManifest = session.state.manifest;
+    const marker = join(rootDir, 'injected-marker');
+    const markerScript = join(rootDir, 'marker.sh');
+    // The only injected action writes a marker inside this test's temporary directory.
+    await writeFile(markerScript, `#!/bin/sh\nprintf injected > '${marker}'\n`);
+    const repo = `--upload-pack=/bin/sh '${markerScript}' #://`;
+    const update = new Manifest({
+      entries: {
+        'before.txt': { type: 'file', content: 'must not be written' },
+        app: { type: 'git_repo', repo: `file://${repository}` },
+      },
+    });
+    // Manifest entries are mutable; applyManifest must validate its snapshot too.
+    update.entries.app.repo = repo;
+    const updateError = await session
+      .applyManifest(update)
+      .catch((error: unknown) => error);
+    await expect(stat(marker)).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(updateError).toEqual(
+      new Error('git_repo repository URL must not start with "-".'),
+    );
+    await expect(
+      session.materializeEntry({
+        path: 'app',
+        entry: { type: 'git_repo', repo },
+      }),
+    ).rejects.toThrow('git_repo repository URL must not start with "-".');
+    await expect(stat(marker)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(stat(join(workspace, 'before.txt'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    expect(await readFile(join(workspace, 'app/README.md'), 'utf8')).toBe(
+      'original\n',
+    );
+    expect(await readFile(join(workspace, 'app/.git/config'), 'utf8')).toBe(
+      config,
+    );
+    expect(session.state.manifest).toBe(previousManifest);
+  }, 10_000);
+
+  it('rejects repository options on fresh creation before creating a workspace', async () => {
+    const manifest = new Manifest({
+      entries: { app: { type: 'git_repo', repo: 'owner/repo' } },
+    });
+    manifest.entries.app.repo = '--upload-pack=unused #://';
+    await expect(
+      new UnixLocalSandboxClient({ workspaceBaseDir: rootDir }).create(
+        manifest,
+      ),
+    ).rejects.toThrow('git_repo repository URL must not start with "-".');
+    expect(await readdir(rootDir)).toEqual([]);
+  });
+
+  it.each(['branch', 'tag'] as const)(
+    'preserves named %s refs with a subpath',
+    async (kind) => {
+      const processSpy = vi.spyOn(gitProcess, 'runSandboxProcess');
+      const repository = join(rootDir, 'named-source');
+      await mkdir(repository);
+      await createGitRepository(repository, 'named ref\n');
+      await execFileAsync('git', [kind, 'selected-ref'], { cwd: repository });
+      const session = await new UnixLocalSandboxClient({
+        workspaceBaseDir: rootDir,
+      }).create(
+        new Manifest({
+          entries: {
+            'selected.txt': {
+              type: 'git_repo',
+              repo: `file://${repository}`,
+              ref: 'selected-ref',
+              subpath: 'README.md',
+            },
+          },
+        }),
+      );
+      expect(
+        Buffer.from(
+          await session.readFile({ path: 'selected.txt' }),
+        ).toString(),
+      ).toBe('named ref\n');
+      expect(processSpy).toHaveBeenCalledWith(
+        'git',
+        [
+          'clone',
+          '--depth',
+          '1',
+          '--branch',
+          'selected-ref',
+          '--',
+          `file://${repository}`,
+          expect.any(String),
+        ],
+        expect.any(Object),
+      );
+    },
+    10_000,
+  );
 
   it('creates parent directories before cloning nested git repositories', async () => {
     const repository = join(rootDir, 'source-repo');

--- a/packages/agents-extensions/src/sandbox/shared/localSources.ts
+++ b/packages/agents-extensions/src/sandbox/shared/localSources.ts
@@ -645,7 +645,7 @@ async function cloneNamedRef(
   if (ref) {
     cloneArgs.push('--branch', ref);
   }
-  cloneArgs.push(repositoryUrl, destination);
+  cloneArgs.push('--', repositoryUrl, destination);
   return await runSandboxProcess('git', cloneArgs, {
     timeoutMs: GIT_CLONE_TIMEOUT_MS,
   });

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -5,8 +5,11 @@ import {
   SandboxProviderError,
   SandboxUnsupportedFeatureError,
 } from '@openai/agents-core/sandbox';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ONE_BY_ONE_PNG } from './imageFixture';
 import {
@@ -275,6 +278,71 @@ describe('E2BSandboxClient', () => {
     expect(output).toContain('boom');
   });
 
+  test('rejects repository options before provider creation or update effects', async () => {
+    const client = new E2BSandboxClient();
+    const session = await client.create(new Manifest());
+    vi.clearAllMocks();
+    const manifest = new Manifest({
+      entries: { app: { type: 'git_repo', repo: 'owner/repo' } },
+    });
+    manifest.entries.app.repo = '--upload-pack=unused #://';
+    await expect(client.create(manifest)).rejects.toThrow(
+      'git_repo repository URL must not start with "-".',
+    );
+    await expect(session.applyManifest(manifest)).rejects.toThrow(
+      'git_repo repository URL must not start with "-".',
+    );
+    expect(createMock).not.toHaveBeenCalled();
+    expect(runMock).not.toHaveBeenCalled();
+    expect(writeMock).not.toHaveBeenCalled();
+    expect(removeMock).not.toHaveBeenCalled();
+    expect(processMocks.runSandboxProcess).not.toHaveBeenCalled();
+  });
+
+  test('clones a local Git source before uploading its selected file', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'agents-e2b-git-test-'));
+    const exec = promisify(execFile);
+    try {
+      await exec('git', ['init', root]);
+      await writeFile(join(root, 'selected.txt'), 'local Git contents');
+      await exec('git', ['-C', root, 'add', 'selected.txt']);
+      await exec('git', [
+        '-C',
+        root,
+        '-c',
+        'user.name=Test',
+        '-c',
+        'user.email=test@example.com',
+        'commit',
+        '-m',
+        'fixture',
+      ]);
+      // Keep the provider mocked but exercise the actual host Git materializer.
+      processMocks.runSandboxProcess.mockImplementation(
+        async (command: string, args: string[]) => {
+          const { stdout } = await exec(command, args);
+          return processSuccess(stdout);
+        },
+      );
+      await new E2BSandboxClient().create(
+        new Manifest({
+          entries: {
+            'selected.txt': {
+              type: 'git_repo',
+              repo: `file://${root}`,
+              subpath: 'selected.txt',
+            },
+          },
+        }),
+      );
+      expect(
+        Buffer.from(files.get('/workspace/selected.txt')!).toString(),
+      ).toBe('local Git contents');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('materializes git_repo file subpaths as files', async () => {
     processMocks.runSandboxProcess.mockImplementation(
       async (_command: string, args: string[]) => {
@@ -282,6 +350,10 @@ describe('E2BSandboxClient', () => {
           return processSuccess('git version 2.0.0');
         }
         if (args[0] === 'clone') {
+          expect(args.slice(-3, -1)).toEqual([
+            '--',
+            'https://example.test/repo.git',
+          ]);
           const tempDir = args[args.length - 1];
           await mkdir(join(tempDir, 'nested'), { recursive: true });
           await writeFile(join(tempDir, 'nested', 'selected.txt'), 'selected');


### PR DESCRIPTION
This pull request fixes host Git argument injection through sandbox repository inputs. An option-like repository URL could be interpreted as a Git option when updating an existing cloned workspace.

Reject these inputs during Manifest validation before workspace or provider effects, and terminate clone options with `--` in both core and extension materializers. Preserve supported repository URLs, shorthand, refs, and subpaths. Add regression coverage for existing-workspace updates, fresh creation, and Docker and extension entry points.