### PR TITLE
fix: preserve tool-search attribution across agent handoffs

### DIFF
--- a/.changeset/tidy-tool-search-owners.md
+++ b/.changeset/tidy-tool-search-owners.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: Preserve tool-search Agent attribution across handoffs and history replay; persisted discovery requires a unique logical Agent name, and unattributed or ambiguous history requires a new search.

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -2057,6 +2057,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               },
             );
 
+            serverConversationTracker?.trackServerItems(
+              state._lastTurnResponse,
+              processedResponse.newItems,
+            );
             state._lastProcessedResponse = processedResponse;
             const suppressedToolCalls = preflightToolInvocations(
               state._currentAgent,
@@ -3236,6 +3240,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             },
           );
 
+          serverConversationTracker?.trackServerItems(
+            result.state._lastTurnResponse,
+            processedResponse.newItems,
+          );
           result.state._lastProcessedResponse = processedResponse;
           const suppressedToolCalls = preflightToolInvocations(
             currentAgent,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -4,6 +4,7 @@ import { Agent, type ToolUseBehavior } from './agent';
 import type { Handoff } from './handoff';
 import { getAgentToolSourceAgent } from './agentToolSourceRegistry';
 import { buildAgentIdentityMap } from './runStateIdentity';
+import { getToolSearchAgentName } from './runner/toolSearchAttribution';
 import { rehydrateLegacyCompactionRunItems } from './runStateLegacyCompaction';
 export { buildAgentIdentityMap } from './runStateIdentity';
 import {
@@ -2754,6 +2755,14 @@ export class RunState<TContext, TAgent extends Agent<any, any>> {
         deserializeItem(item, identities.byIdentity),
       ),
     };
+  }
+
+  /** @internal Resolves discovery ownership within the complete starting Agent graph. */
+  _getToolSearchAgentName(agent: Agent<any, any>): string | undefined {
+    return getToolSearchAgentName(
+      agent,
+      buildAgentIdentityMap(this.#startingAgent).byAgent.keys(),
+    );
   }
 
   private getOrCreateToolSearchRuntimeToolState(

--- a/packages/agents-core/src/runner/conversation.ts
+++ b/packages/agents-core/src/runner/conversation.ts
@@ -1,6 +1,7 @@
 import { Agent, AgentOutputType } from '../agent';
 import { UserError } from '../errors';
-import { RunInputItem, RunItem } from '../items';
+import { RunInputItem, RunItem, RunToolSearchOutputItem } from '../items';
+import { attributeToolSearchOutput } from './toolSearchAttribution';
 import { ModelResponse } from '../model';
 import { RunContext } from '../runContext';
 import { AgentInputItem } from '../types';
@@ -353,6 +354,15 @@ function consumeCorrelationCount(
   return true;
 }
 
+// SDK discovery ownership does not change the item already stored by the provider.
+function getServerItemKey(item: AgentInputItem): string {
+  return getAgentInputItemKey(
+    item.type === 'tool_search_output'
+      ? attributeToolSearchOutput(item, undefined)
+      : item,
+  );
+}
+
 /**
  * Tracks which items have already been sent to or received from the Responses API when the caller
  * supplies `conversationId`/`previousResponseId`. This ensures we only send the delta each turn.
@@ -425,7 +435,7 @@ export class ServerConversationTracker {
       for (const item of response.output) {
         if (item && typeof item === 'object') {
           this.serverItems.add(item);
-          serverItemKeys.add(getAgentInputItemKey(item as AgentInputItem));
+          serverItemKeys.add(getServerItemKey(item as AgentInputItem));
         }
       }
     }
@@ -452,7 +462,7 @@ export class ServerConversationTracker {
         if (!rawItem || typeof rawItem !== 'object') {
           continue;
         }
-        const rawItemKey = getAgentInputItemKey(rawItem as AgentInputItem);
+        const rawItemKey = getServerItemKey(rawItem as AgentInputItem);
         if (item instanceof RunInputItem) {
           this.sentItems.add(rawItem);
           continue;
@@ -479,13 +489,33 @@ export class ServerConversationTracker {
    * Records the raw items returned by the server so future delta calculations skip them.
    * Also captures the latest response identifier to chain follow-up calls when possible.
    */
-  trackServerItems(modelResponse: ModelResponse | undefined) {
+  trackServerItems(
+    modelResponse: ModelResponse | undefined,
+    processedItems: RunItem[] = [],
+  ) {
     if (!modelResponse) {
       return;
     }
     for (const item of modelResponse.output) {
       if (item && typeof item === 'object') {
         this.serverItems.add(item);
+      }
+    }
+    const searchOutputs = processedItems.filter(
+      (item): item is RunToolSearchOutputItem =>
+        item instanceof RunToolSearchOutputItem,
+    );
+    if (searchOutputs.length > 0) {
+      const serverSearchKeys = new Set(
+        modelResponse.output
+          .filter((item) => item.type === 'tool_search_output')
+          .map(getServerItemKey),
+      );
+      // A client-generated result is unsent unless the response actually contains that output.
+      for (const item of searchOutputs) {
+        if (serverSearchKeys.has(getServerItemKey(item.rawItem))) {
+          this.serverItems.add(item.rawItem);
+        }
       }
     }
     if (!this.conversationId && modelResponse.responseId) {

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -67,6 +67,7 @@ import {
 } from './toolSearch';
 import { ensureToolCallerAllowed } from './toolCaller';
 import { assertValidCompactionItems } from './items';
+import { attributeToolSearchOutput } from './toolSearchAttribution';
 
 function ensureToolAvailable<T>(
   tool: T | undefined,
@@ -108,6 +109,7 @@ function ensureProgrammaticToolCallingAvailable<TContext>(
 }
 
 type ModelResponseProcessingOptions = {
+  toolSearchAgentName?: string;
   allowPromptSuppliedTools?: boolean;
   beforeClientToolSearch?: () => void;
 };
@@ -395,6 +397,7 @@ function recordLoadedToolSearchOutput(
 function collectLoadedDeferredToolStateFromHistory(
   items: Array<RunItem | AgentInputItem>,
   agent: Agent<any, any>,
+  agentName: string | undefined,
 ): LoadedDeferredToolState {
   const state: LoadedDeferredToolState = {
     anonymousToolSearchOutputs: [],
@@ -403,15 +406,21 @@ function collectLoadedDeferredToolStateFromHistory(
   };
 
   for (const item of items) {
-    if (
-      item instanceof RunToolSearchOutputItem &&
-      item.agent.name !== agent.name
-    ) {
+    if (item instanceof RunToolSearchOutputItem && item.agent !== agent) {
       continue;
     }
 
     const rawItem = getRawAgentInputItem(item);
     if (rawItem?.type !== 'tool_search_output') {
+      continue;
+    }
+
+    // Raw history has no live owner; only an unambiguous recorded name can restore discovery.
+    if (
+      !(item instanceof RunToolSearchOutputItem) &&
+      (typeof agentName !== 'string' ||
+        rawItem.toolSearchAgentName !== agentName)
+    ) {
       continue;
     }
 
@@ -731,6 +740,7 @@ export function processModelResponse<TContext>(
   const loadedDeferredToolState = collectLoadedDeferredToolStateFromHistory(
     priorItems,
     agent,
+    processingOptions.toolSearchAgentName,
   );
   seedHostedMcpToolsFromLoadedDeferredToolState(
     loadedDeferredToolState,
@@ -756,7 +766,15 @@ export function processModelResponse<TContext>(
       const generatedOutput =
         generatedClientToolSearchOutputsByCall.get(output);
       if (generatedOutput) {
-        items.push(new RunToolSearchOutputItem(generatedOutput, agent));
+        items.push(
+          new RunToolSearchOutputItem(
+            attributeToolSearchOutput(
+              generatedOutput,
+              processingOptions.toolSearchAgentName,
+            ),
+            agent,
+          ),
+        );
         recordLoadedToolSearchOutput(loadedDeferredToolState, generatedOutput);
         addHostedMcpToolsFromToolSearchOutput(generatedOutput, mcpToolMap, {
           preserveExistingServerLabels: originalMcpServerLabels,
@@ -764,7 +782,15 @@ export function processModelResponse<TContext>(
         hasGeneratedClientToolSearchOutputs = true;
       }
     } else if (output.type === 'tool_search_output') {
-      items.push(new RunToolSearchOutputItem(output, agent));
+      items.push(
+        new RunToolSearchOutputItem(
+          attributeToolSearchOutput(
+            output,
+            processingOptions.toolSearchAgentName,
+          ),
+          agent,
+        ),
+      );
       recordLoadedToolSearchOutput(loadedDeferredToolState, output);
       addHostedMcpToolsFromToolSearchOutput(output, mcpToolMap, {
         preserveExistingServerLabels: originalMcpServerLabels,
@@ -1018,6 +1044,10 @@ export async function processModelResponseAsync<TContext>(
   processingOptions: ModelResponseProcessingOptions = {},
 ): Promise<ProcessedResponse<TContext>> {
   assertValidCompactionItems(modelResponse.output);
+  processingOptions = {
+    ...processingOptions,
+    toolSearchAgentName: state._getToolSearchAgentName(agent),
+  };
   const clientToolSearchTool = getClientToolSearchHelper(tools);
   const hasCustomClientToolSearchExecutor = Boolean(
     clientToolSearchTool && getClientToolSearchExecutor(clientToolSearchTool),
@@ -1078,6 +1108,7 @@ export async function processModelResponseAsync<TContext>(
   const loadedDeferredToolState = collectLoadedDeferredToolStateFromHistory(
     priorItems,
     agent,
+    processingOptions.toolSearchAgentName,
   );
   seedHostedMcpToolsFromLoadedDeferredToolState(
     loadedDeferredToolState,
@@ -1107,7 +1138,15 @@ export async function processModelResponseAsync<TContext>(
       const generatedOutput =
         generatedClientToolSearchOutputsByCall.get(output);
       if (generatedOutput) {
-        items.push(new RunToolSearchOutputItem(generatedOutput.output, agent));
+        items.push(
+          new RunToolSearchOutputItem(
+            attributeToolSearchOutput(
+              generatedOutput.output,
+              processingOptions.toolSearchAgentName,
+            ),
+            agent,
+          ),
+        );
         recordLoadedToolSearchOutput(
           loadedDeferredToolState,
           generatedOutput.output,
@@ -1140,7 +1179,15 @@ export async function processModelResponseAsync<TContext>(
         hasGeneratedClientToolSearchOutputs = true;
       }
     } else if (output.type === 'tool_search_output') {
-      items.push(new RunToolSearchOutputItem(output, agent));
+      items.push(
+        new RunToolSearchOutputItem(
+          attributeToolSearchOutput(
+            output,
+            processingOptions.toolSearchAgentName,
+          ),
+          agent,
+        ),
+      );
       recordLoadedToolSearchOutput(loadedDeferredToolState, output);
       addHostedMcpToolsFromToolSearchOutput(output, mcpToolMap, {
         preserveExistingServerLabels: originalMcpServerLabels,

--- a/packages/agents-core/src/runner/toolSearchAttribution.ts
+++ b/packages/agents-core/src/runner/toolSearchAttribution.ts
@@ -1,0 +1,26 @@
+import type { Agent } from '../agent';
+import type * as protocol from '../types/protocol';
+
+/** Returns a durable name only when it identifies one Agent in the run graph. */
+export function getToolSearchAgentName(
+  agent: Agent<any, any>,
+  agents: Iterable<Agent<any, any>>,
+): string | undefined {
+  const matchingAgents = new Set(
+    [...agents].filter((candidate) => candidate.name === agent.name),
+  );
+  return matchingAgents.size === 1 && matchingAgents.has(agent)
+    ? agent.name
+    : undefined;
+}
+
+/** Records SDK-owned discovery attribution without changing the provider payload. */
+export function attributeToolSearchOutput(
+  output: protocol.ToolSearchOutputItem,
+  agentName: string | undefined,
+): protocol.ToolSearchOutputItem {
+  const { toolSearchAgentName: _suppliedOwner, ...rawOutput } = output;
+  return typeof agentName === 'string'
+    ? { ...rawOutput, toolSearchAgentName: agentName }
+    : rawOutput;
+}

--- a/packages/agents-core/src/types/protocol.ts
+++ b/packages/agents-core/src/types/protocol.ts
@@ -577,6 +577,12 @@ export const ToolSearchCallItem = ItemBase.extend({
 export type ToolSearchCallItem = z.infer<typeof ToolSearchCallItem>;
 
 export const ToolSearchOutputItem = ItemBase.extend({
+  /**
+   * SDK-only discovery attribution, excluded from provider requests. Names must identify the
+   * same logical Agent across reused history. Missing or ambiguous ownership requires a new
+   * search; this field does not grant tool execution permissions.
+   */
+  toolSearchAgentName: z.string().optional(),
   type: z.literal('tool_search_output'),
   call_id: z.string().nullable().optional(),
   callId: z.string().nullable().optional(),

--- a/packages/agents-core/test/run.stream.test.ts
+++ b/packages/agents-core/test/run.stream.test.ts
@@ -543,7 +543,7 @@ describe('Runner.run (streaming)', () => {
     expect(replaceHistoryWithCompaction).not.toHaveBeenCalled();
   });
 
-  it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
+  it('treats attributed tool_search outputs in input history as loaded deferred tools', async () => {
     const getShippingEta = tool({
       name: 'get_shipping_eta',
       description: 'Look up a shipping ETA.',
@@ -587,6 +587,7 @@ describe('Runner.run (streaming)', () => {
       user('Load shipping tools first.'),
       {
         type: 'tool_search_output',
+        toolSearchAgentName: 'StreamingShippingAgent',
         status: 'completed',
         tools: [
           {

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -2885,7 +2885,7 @@ describe('Runner.run', () => {
       expect(restored.getToolSearchRuntimeTools(agent)).toEqual([]);
     });
 
-    it('treats prior tool_search outputs in input history as loaded deferred tools', async () => {
+    it('treats attributed tool_search outputs in input history as loaded deferred tools', async () => {
       const getShippingEta = tool({
         name: 'get_shipping_eta',
         description: 'Look up a shipping ETA.',
@@ -2925,6 +2925,7 @@ describe('Runner.run', () => {
         user('Load shipping tools first.'),
         {
           type: 'tool_search_output',
+          toolSearchAgentName: 'ShippingAgent',
           status: 'completed',
           tools: [
             {

--- a/packages/agents-core/test/toolSearchAttribution.test.ts
+++ b/packages/agents-core/test/toolSearchAttribution.test.ts
@@ -1,0 +1,544 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CallModelInputFilterArgs, Session } from '../src';
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  Runner,
+  MemorySession,
+  RunState,
+  attachClientToolSearchExecutor,
+  handoff,
+  tool,
+} from '../src';
+import { ScriptedModel } from '../src/testing';
+import type * as protocol from '../src/types/protocol';
+
+const search = (id = 'search'): protocol.ToolSearchOutputItem => ({
+  type: 'tool_search_output',
+  id,
+  execution: 'server',
+  status: 'completed',
+  tools: [
+    {
+      type: 'function',
+      name: 'lookup',
+      defer_loading: true,
+      parameters: { type: 'object', properties: {} },
+    },
+  ],
+});
+const call = (
+  name = 'lookup',
+  callId = 'lookup-call',
+): protocol.FunctionCallItem => ({
+  type: 'function_call',
+  name,
+  callId,
+  arguments: '{}',
+});
+const done = (): protocol.AssistantMessageItem => ({
+  type: 'message',
+  role: 'assistant',
+  content: [{ type: 'output_text', text: 'done' }],
+  status: 'completed',
+});
+function lookup(execute = vi.fn(async () => 'found')) {
+  return tool({
+    name: 'lookup',
+    description: 'Look up a record.',
+    parameters: z.object({}),
+    deferLoading: true,
+    execute,
+  });
+}
+const searchTool = {
+  type: 'hosted_tool',
+  name: 'tool_search',
+  providerData: { type: 'tool_search' },
+} as const;
+const runner = () => new Runner({ tracingDisabled: true });
+
+async function finish(
+  agent: Agent,
+  input: string | protocol.ModelItem[],
+  stream: boolean,
+) {
+  if (stream) {
+    const result = await runner().run(agent, input, { stream: true });
+    await result.completed;
+    return result;
+  }
+  return runner().run(agent, input);
+}
+
+describe('tool-search Agent attribution', () => {
+  it.each([false, true])(
+    'does not load the receiving Agent through flattened history (stream: %s)',
+    async (stream) => {
+      const execute = vi.fn(async () => 'found');
+      const b = new Agent({
+        name: 'B',
+        tools: [lookup(execute), searchTool],
+        model: new ScriptedModel([[call()], [done()]]),
+      });
+      const a = new Agent({
+        name: 'A',
+        tools: [lookup(), searchTool],
+        handoffs: [b],
+        model: new ScriptedModel([
+          [search(), call(handoff(b).toolName, 'handoff')],
+        ]),
+      });
+      await expect(finish(a, 'start', stream)).rejects.toThrow(
+        /before it was loaded via tool_search/,
+      );
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    'keeps each Agent search local across A-B-A (stream: %s)',
+    async (stream) => {
+      const aExecute = vi.fn(async () => 'A result');
+      const bExecute = vi.fn(async () => 'B result');
+      const aModel = new ScriptedModel([]);
+      const a = new Agent({
+        name: 'A',
+        tools: [lookup(aExecute), searchTool],
+        model: aModel,
+      });
+      const b = new Agent({
+        name: 'B',
+        tools: [lookup(bExecute), searchTool],
+        handoffs: [a],
+        model: new ScriptedModel([
+          [search('B-search'), call('lookup', 'B-call')],
+          [call(handoff(a).toolName, 'back')],
+        ]),
+      });
+      a.handoffs = [b];
+      aModel.enqueue(
+        [search(), call('lookup', 'A-first')],
+        [call(handoff(b).toolName, 'away')],
+        [call('lookup', 'A-second')],
+        [done()],
+      );
+      const result = await finish(a, 'start', stream);
+      expect(result.finalOutput).toBe('done');
+      expect(aExecute).toHaveBeenCalledTimes(2);
+      expect(bExecute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(['json', 'session'] as const)(
+    'preserves unique ownership through %s replay with reconstructed Agents',
+    async (mode) => {
+      const session = new MemorySession();
+      const original = new Agent({
+        name: 'A',
+        tools: [lookup(), searchTool],
+        model: new ScriptedModel([[search(), done()]]),
+      });
+      const first = await runner().run(original, 'start', { session });
+      const history = JSON.parse(
+        JSON.stringify(
+          mode === 'json' ? first.history : await session.getItems(),
+        ),
+      );
+      expect(
+        history.find(
+          (item: protocol.ModelItem) => item.type === 'tool_search_output',
+        ).toolSearchAgentName,
+      ).toBe('A');
+      for (const name of ['A', 'B']) {
+        const execute = vi.fn(async () => 'found');
+        const agent = new Agent({
+          name,
+          tools: [lookup(execute), searchTool],
+          model: new ScriptedModel([[call()], [done()]]),
+        });
+        const promise =
+          mode === 'json'
+            ? runner().run(agent, history)
+            : runner().run(agent, 'again', {
+                session: new MemorySession({ initialItems: history }),
+              });
+        if (name === 'A') {
+          expect((await promise).finalOutput).toBe('done');
+          expect(execute).toHaveBeenCalledTimes(1);
+        } else {
+          await expect(promise).rejects.toThrow(
+            /before it was loaded via tool_search/,
+          );
+          expect(execute).not.toHaveBeenCalled();
+        }
+      }
+    },
+  );
+
+  it('keeps unattributed history but requires a fresh search', async () => {
+    const oldSearch = search();
+    const model = new ScriptedModel([[call()]]);
+    const execute = vi.fn(async () => 'found');
+    const agent = new Agent({
+      name: 'A',
+      tools: [lookup(execute), searchTool],
+      model,
+    });
+    await expect(runner().run(agent, [oldSearch])).rejects.toThrow(
+      /before it was loaded via tool_search/,
+    );
+    expect(execute).not.toHaveBeenCalled();
+    expect(model.firstCall?.request.input).toContainEqual(oldSearch);
+    model.enqueue([search('fresh'), call()], [done()]);
+    expect((await runner().run(agent, [oldSearch])).finalOutput).toBe('done');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([false, true])(
+    'distinguishes same-name Agents and leaves ambiguous raw history unscoped (stream: %s)',
+    async (stream) => {
+      const bExecute = vi.fn(async () => 'B result');
+      const b = new Agent({
+        name: 'Same',
+        tools: [lookup(bExecute), searchTool],
+        model: new ScriptedModel([[call()], [done()]]),
+      });
+      const a = new Agent({
+        name: 'Same',
+        tools: [lookup(), searchTool],
+        handoffs: [b],
+        model: new ScriptedModel([
+          [search(), call(handoff(b).toolName, 'handoff')],
+        ]),
+      });
+      await expect(finish(a, 'start', stream)).rejects.toThrow(
+        /before it was loaded via tool_search/,
+      );
+      expect(bExecute).not.toHaveBeenCalled();
+      a.model = new ScriptedModel([[search(), call()], [done()]]);
+      const result = await finish(a, 'start', stream);
+      const output = result.history.find(
+        (item) => item.type === 'tool_search_output',
+      );
+      expect(output).not.toHaveProperty('toolSearchAgentName');
+      const independent = new Agent({
+        name: 'Same',
+        tools: [lookup(bExecute), searchTool],
+        model: new ScriptedModel([[call()]]),
+      });
+      await expect(
+        runner().run(independent, JSON.parse(JSON.stringify(result.history))),
+      ).rejects.toThrow(/before it was loaded via tool_search/);
+    },
+  );
+
+  it.each([false, true])(
+    'restores attributed RunItems through RunState (legacy: %s)',
+    async (legacy) => {
+      const execute = vi.fn(async () => 'found');
+      const deferred = lookup(execute);
+      deferred.needsApproval = async () => true;
+      const a = new Agent({
+        name: 'A',
+        tools: [deferred, searchTool],
+        model: new ScriptedModel([[search(), call()]]),
+      });
+      const paused = await runner().run(a, 'start');
+      const json = JSON.parse(await paused.state.toString());
+      if (legacy) {
+        json.$schemaVersion = '1.19';
+        delete json.currentResponseGeneratedItemOwnership;
+        for (const item of json.generatedItems)
+          delete item.rawItem.toolSearchAgentName;
+      }
+      const nextModel = new ScriptedModel([
+        [call('lookup', 'second')],
+        [done()],
+      ]);
+      const replacement = new Agent({
+        name: 'A',
+        tools: [lookup(execute), searchTool],
+        model: nextModel,
+      });
+      const restored = await RunState.fromString(
+        replacement,
+        JSON.stringify(json),
+      );
+      restored.approve(restored.getInterruptions()[0]);
+      const result = await runner().run(replacement, restored);
+      expect(result.finalOutput).toBe('done');
+      expect(execute).toHaveBeenCalledTimes(2);
+      const restoredOutput = result.history.find(
+        (item) => item.type === 'tool_search_output',
+      );
+      if (legacy) {
+        expect(restoredOutput).not.toHaveProperty('toolSearchAgentName');
+      } else {
+        expect(restoredOutput).toMatchObject({ toolSearchAgentName: 'A' });
+      }
+    },
+  );
+
+  it.each(['hosted', 'built-in', 'custom'] as const)(
+    'attributes accepted %s search output instead of trusting supplied ownership',
+    async (mode) => {
+      const execute = vi.fn(async () => 'found');
+      const deferred = lookup(execute);
+      const supplied = { ...search(), toolSearchAgentName: 'B' };
+      const clientSearch =
+        mode === 'custom'
+          ? attachClientToolSearchExecutor(
+              {
+                ...searchTool,
+                providerData: { type: 'tool_search', execution: 'client' },
+              },
+              async () => deferred,
+            )
+          : {
+              ...searchTool,
+              providerData: { type: 'tool_search', execution: 'client' },
+            };
+      const searchCall: protocol.ToolSearchCallItem = {
+        type: 'tool_search_call',
+        callId: 'search-call',
+        execution: 'client',
+        arguments: { paths: ['lookup'] },
+      };
+      const model = new ScriptedModel([
+        [mode === 'hosted' ? supplied : searchCall],
+        [call()],
+        [done()],
+      ]);
+      const agent = new Agent({
+        name: 'A',
+        tools: [deferred, mode === 'hosted' ? searchTool : clientSearch],
+        model,
+      });
+      const result = await runner().run(agent, 'start');
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(
+        result.history.find((item) => item.type === 'tool_search_output'),
+      ).toMatchObject({ toolSearchAgentName: 'A' });
+      expect(supplied.toolSearchAgentName).toBe('B');
+    },
+  );
+
+  it.each(['filter', 'conversationId', 'previousResponseId'] as const)(
+    'does not transfer discovery through %s',
+    async (mode) => {
+      const execute = vi.fn(async () => 'found');
+      const b = new Agent({
+        name: 'B',
+        tools: [lookup(execute), searchTool],
+        model: new ScriptedModel([[call()]]),
+      });
+      const a = new Agent({
+        name: 'A',
+        tools: [lookup(), searchTool],
+        handoffs: [b],
+        model: new ScriptedModel([
+          [search(), call(handoff(b).toolName, 'handoff')],
+        ]),
+      });
+      const options =
+        mode === 'filter'
+          ? {
+              callModelInputFilter: ({ modelData }: CallModelInputFilterArgs) =>
+                structuredClone(modelData),
+            }
+          : { [mode]: 'server-id' };
+      await expect(runner().run(a, 'start', options)).rejects.toThrow(
+        /before it was loaded via tool_search/,
+      );
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
+  it('preserves attribution through an application-owned disk Session', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'tool-search-session-'));
+    const path = join(directory, 'history.json');
+    // This backend exercises the public Session persistence boundary across reconstruction.
+    const openSession = (): Session => ({
+      getSessionId: async () => path,
+      getItems: async (limit) => {
+        const items = JSON.parse(await readFile(path, 'utf8'));
+        return limit === undefined ? items : items.slice(-limit);
+      },
+      addItems: async (items) => {
+        const previous = JSON.parse(await readFile(path, 'utf8'));
+        await writeFile(path, JSON.stringify([...previous, ...items]));
+      },
+      popItem: async () => {
+        const items = JSON.parse(await readFile(path, 'utf8'));
+        const item = items.pop();
+        await writeFile(path, JSON.stringify(items));
+        return item;
+      },
+      clearSession: async () => {
+        await writeFile(path, '[]');
+      },
+    });
+    try {
+      await writeFile(path, '[]');
+      const first = new Agent({
+        name: 'A',
+        tools: [lookup(), searchTool],
+        model: new ScriptedModel([[search(), done()]]),
+      });
+      await runner().run(first, 'start', { session: openSession() });
+      const execute = vi.fn(async () => 'found');
+      const second = new Agent({
+        name: 'A',
+        tools: [lookup(execute), searchTool],
+        model: new ScriptedModel([[call()], [done()]]),
+      });
+      expect(
+        (await runner().run(second, 'again', { session: openSession() }))
+          .finalOutput,
+      ).toBe('done');
+      const other = new Agent({
+        name: 'B',
+        tools: [lookup(execute), searchTool],
+        model: new ScriptedModel([[call('lookup', 'other')]]),
+      });
+      await expect(
+        runner().run(other, 'again', { session: openSession() }),
+      ).rejects.toThrow(/before it was loaded via tool_search/);
+      expect(execute).toHaveBeenCalledTimes(1);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('honors replacement search outputs within one Agent', async () => {
+    const execute = vi.fn(async () => 'found');
+    const agent = new Agent({
+      name: 'A',
+      tools: [lookup(execute), searchTool],
+      model: new ScriptedModel([[search(), done()]]),
+    });
+    const first = await runner().run(agent, 'start');
+    agent.model = new ScriptedModel([[call()]]);
+    const history = [
+      ...first.history,
+      { ...search(), tools: [], toolSearchAgentName: 'A' },
+    ];
+    await expect(runner().run(agent, history)).rejects.toThrow(
+      /before it was loaded via tool_search/,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+  it('keeps same-name Agent ownership through approval restoration and handoff', async () => {
+    const aExecute = vi.fn(async () => 'A result');
+    const bExecute = vi.fn(async () => 'B result');
+    const deferred = lookup(aExecute);
+    deferred.needsApproval = async () => true;
+    const b = new Agent({
+      name: 'Same',
+      tools: [lookup(bExecute), searchTool],
+      model: new ScriptedModel([[call('lookup', 'B-call')]]),
+    });
+    const a = new Agent({
+      name: 'Same',
+      tools: [deferred, searchTool],
+      handoffs: [b],
+      model: new ScriptedModel([
+        [search(), call()],
+        [call(handoff(b).toolName, 'handoff')],
+      ]),
+    });
+    const paused = await runner().run(a, 'start');
+    const restored = await RunState.fromString(a, paused.state.toString());
+    restored.approve(restored.getInterruptions()[0]);
+    await expect(runner().run(a, restored)).rejects.toThrow(
+      /before it was loaded via tool_search/,
+    );
+    expect(aExecute).toHaveBeenCalledTimes(1);
+    expect(bExecute).not.toHaveBeenCalled();
+  });
+  it.each([
+    ['conversationId', false],
+    ['conversationId', true],
+    ['previousResponseId', false],
+    ['previousResponseId', true],
+  ] as const)(
+    'sends only new tool output after hosted search with %s (stream: %s)',
+    async (mode, stream) => {
+      const model = new ScriptedModel([[search(), call()], [done()]]);
+      const agent = new Agent({
+        name: 'A',
+        tools: [lookup(), searchTool],
+        model,
+      });
+      if (stream) {
+        const result = await runner().run(agent, 'start', {
+          [mode]: 'server-id',
+          stream: true,
+        });
+        await result.completed;
+      } else {
+        await runner().run(agent, 'start', { [mode]: 'server-id' });
+      }
+      expect(model.calls[1].request.input).toEqual([
+        expect.objectContaining({ type: 'function_call_result' }),
+      ]);
+    },
+  );
+
+  it.each(['conversationId', 'previousResponseId'] as const)(
+    'does not replay hosted search after approval restoration with %s',
+    async (mode) => {
+      const deferred = lookup();
+      deferred.needsApproval = async () => true;
+      const model = new ScriptedModel([[search(), call()], [done()]]);
+      const agent = new Agent({
+        name: 'A',
+        tools: [deferred, searchTool],
+        model,
+      });
+      const paused = await runner().run(agent, 'start', {
+        [mode]: 'server-id',
+      });
+      const restored = await RunState.fromString(
+        agent,
+        paused.state.toString(),
+      );
+      restored.approve(restored.getInterruptions()[0]);
+      await runner().run(agent, restored);
+      expect(model.calls[1].request.input).toEqual([
+        expect.objectContaining({ type: 'function_call_result' }),
+      ]);
+    },
+  );
+
+  it('still sends newly generated client search output in server continuation', async () => {
+    const searchCall: protocol.ToolSearchCallItem = {
+      type: 'tool_search_call',
+      callId: 'client-search',
+      execution: 'client',
+      arguments: { paths: ['lookup'] },
+    };
+    const model = new ScriptedModel([[searchCall], [call()], [done()]]);
+    const agent = new Agent({
+      name: 'A',
+      tools: [
+        lookup(),
+        {
+          ...searchTool,
+          providerData: { type: 'tool_search', execution: 'client' },
+        },
+      ],
+      model,
+    });
+    await runner().run(agent, 'start', { conversationId: 'server-id' });
+    expect(model.calls[1].request.input).toEqual([
+      expect.objectContaining({ type: 'tool_search_output' }),
+    ]);
+    expect(model.calls[2].request.input).toEqual([
+      expect.objectContaining({ type: 'function_call_result' }),
+    ]);
+  });
+});

--- a/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.helpers.test.ts
@@ -639,6 +639,22 @@ describe('convertTool', () => {
 });
 
 describe('getInputItems', () => {
+  it('keeps SDK tool-search ownership out of provider input and output conversion', () => {
+    const raw = {
+      type: 'tool_search_output' as const,
+      id: 'search-output',
+      execution: 'server' as const,
+      status: 'completed',
+      tools: [],
+    };
+    const owned = { ...raw, toolSearchAgentName: 'Owner' };
+    expect(getInputItems([owned])).toEqual(getInputItems([raw]));
+    expect(owned.toolSearchAgentName).toBe('Owner');
+    expect(
+      convertToOutputItem(getInputItems([owned]) as any)[0],
+    ).not.toHaveProperty('toolSearchAgentName');
+  });
+
   it('replays caller linkage on MCP approval requests and responses', () => {
     expect(
       getInputItems([


### PR DESCRIPTION
This pull request fixes deferred tools being treated as loaded after a handoff because another Agent searched for a tool with the same name. Accepted search results retain SDK-only ownership, and history loading resolves that ownership before applying existing search-result replacement rules.

Live runs and restored RunState use Agent identity. JSON and Session history can restore discovery for unique logical Agent names; unattributed or ambiguous history remains in the conversation and requires a new search. Responses requests omit the ownership metadata, and server-managed continuation still sends only pending items. Tool registration, caller restrictions, approvals, and guardrails remain enforced.