### PR TITLE
fix(sessions): preserve concurrent writes during automatic compaction

### DIFF
--- a/.changeset/preserve-compaction-run-ownership.md
+++ b/.changeset/preserve-compaction-run-ownership.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: preserve concurrent wrapper writes by skipping automatic session compaction when the run no longer owns its history snapshot.

--- a/packages/agents-core/src/index.ts
+++ b/packages/agents-core/src/index.ts
@@ -344,10 +344,12 @@ export type {
   SessionHistoryTransactionAwareSession,
   OpenAIResponsesCompactionArgs,
   OpenAIResponsesCompactionAwareSession,
+  OpenAIResponsesCompactionOwnershipAwareSession,
   OpenAIResponsesCompactionResult,
 } from './memory/session';
 export {
   isOpenAIResponsesCompactionAwareSession,
+  isOpenAIResponsesCompactionOwnershipAwareSession,
   isRunContextAwareSession,
   isSessionHistoryRewriteAwareSession,
   isSessionHistoryTransactionAwareSession,

--- a/packages/agents-core/src/memory/session.ts
+++ b/packages/agents-core/src/memory/session.ts
@@ -215,10 +215,43 @@ export interface OpenAIResponsesCompactionAwareSession extends Session {
   runCompaction(
     args?: OpenAIResponsesCompactionArgs,
     runContext?: RunContext<any>,
+    ownership?: object | null,
   ):
     | Promise<OpenAIResponsesCompactionResult | null>
     | OpenAIResponsesCompactionResult
     | null;
+}
+
+/**
+ * Optional compaction capability that binds automatic replacement to a live history read.
+ *
+ * Receipts belong to one wrapper and one run. They must not be serialized. An append still
+ * persists its items when its receipt is stale, but must not restore that receipt's ownership.
+ * Ordinary history reads must not grant ownership. The runner supplies a receipt, or null when
+ * none survived, as the third runCompaction argument. Undefined preserves manual compaction.
+ */
+export interface OpenAIResponsesCompactionOwnershipAwareSession extends OpenAIResponsesCompactionAwareSession {
+  getItemsWithCompactionOwnership(
+    runContext?: RunContext<any>,
+  ): Promise<{ items: AgentInputItem[]; ownership: object }>;
+
+  addItemsWithCompactionOwnership(
+    items: AgentInputItem[],
+    ownership: object | null,
+    runContext?: RunContext<any>,
+  ): Promise<void>;
+}
+
+export function isOpenAIResponsesCompactionOwnershipAwareSession(
+  session: Session | undefined,
+): session is OpenAIResponsesCompactionOwnershipAwareSession {
+  return (
+    isOpenAIResponsesCompactionAwareSession(session) &&
+    typeof (session as OpenAIResponsesCompactionOwnershipAwareSession)
+      .getItemsWithCompactionOwnership === 'function' &&
+    typeof (session as OpenAIResponsesCompactionOwnershipAwareSession)
+      .addItemsWithCompactionOwnership === 'function'
+  );
 }
 
 export function isOpenAIResponsesCompactionAwareSession(

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -85,6 +85,9 @@ import {
 import {
   acquireResumedSessionWriteOperation,
   createSessionPersistenceTracker,
+  getSessionCompactionState,
+  bindSessionCompactionState,
+  type SessionCompactionState,
   captureSessionHistoryTransactionInputItems,
   markSessionHistoryTransactionInputPersisted,
   prepareSessionHistoryTransactionsForRun,
@@ -817,6 +820,10 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     // When the server tracks conversation history we defer to it for previous turns so local session
     // persistence can focus solely on the new delta being generated in this process.
     const session = effectiveOptions.session;
+    const sessionCompaction = getSessionCompactionState(
+      session,
+      input instanceof RunState ? input : undefined,
+    );
     const resumedState = resumingFromState
       ? (input as RunState<TContext, TAgent>)
       : undefined;
@@ -885,6 +892,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       const sessionPersistence = createSessionPersistenceTracker({
         session,
         runContext,
+        compactionState: sessionCompaction,
         hasCallModelInputFilter,
         persistInput: saveStreamInputToSession,
         resumingFromState,
@@ -908,6 +916,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             reasoningItemIdPolicy,
           },
           runContext,
+          sessionCompaction,
         );
         if (serverManagesConversation && session) {
           // When the server manages memory we only persist the new turn inputs locally so the
@@ -956,6 +965,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             },
             effectiveInvocationSpanParent,
             pendingSessionWriteReconciled,
+            sessionCompaction,
           );
           if (releaseResumedSessionWriteOperation) {
             releaseResumedSessionWriteOperationOnReturn = false;
@@ -996,6 +1006,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               }
             : undefined,
           pendingSessionWriteReconciled,
+          sessionCompaction,
         );
         return runResult;
       };
@@ -1230,6 +1241,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       options?: SessionPersistenceOptions,
     ) => Promise<void>,
     pendingSessionWriteReconciled = false,
+    sessionCompaction?: SessionCompactionState,
   ): Promise<RunResult<TContext, TAgent>> {
     return withNewSpanContext(async () => {
       // if we have a saved state we use that one, otherwise we create a new one
@@ -1246,6 +1258,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ? DEFAULT_MAX_TURNS
               : options.maxTurns,
           );
+      bindSessionCompactionState(state, sessionCompaction);
       this.#validateModelTimeoutForAgent(state._currentAgent);
       if (isResumedState) {
         state._agentToolInvocation = undefined;
@@ -3479,6 +3492,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     sandboxMemoryRunContext?: SandboxMemoryPersistenceContext,
     invocationSpanParent?: Span<any> | Trace,
     pendingSessionWriteReconciled = false,
+    sessionCompaction?: SessionCompactionState,
   ): Promise<StreamedRunResult<TContext, TAgent>> {
     options = options ?? ({} as StreamRunOptions<TContext>);
     return withNewSpanContext(async () => {
@@ -3496,6 +3510,7 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               ? DEFAULT_MAX_TURNS
               : options.maxTurns,
           );
+      bindSessionCompactionState(state, sessionCompaction);
       this.#validateModelTimeoutForAgent(state._currentAgent);
       if (isResumedState) {
         state._agentToolInvocation = undefined;

--- a/packages/agents-core/src/runner/sessionPersistence.ts
+++ b/packages/agents-core/src/runner/sessionPersistence.ts
@@ -1,6 +1,7 @@
 import { UserError } from '../errors';
 import {
   isOpenAIResponsesCompactionAwareSession,
+  isOpenAIResponsesCompactionOwnershipAwareSession,
   isRunContextAwareSession,
   isSessionHistoryTransactionAwareSession,
   type OpenAIResponsesCompactionArgs,
@@ -80,6 +81,44 @@ export type ResumedSessionWritePreparation = {
 
 const SESSION_LIMIT_UNSET = Symbol('sessionLimitUnset');
 
+export type SessionCompactionState = {
+  session: Session;
+  ownership: object | null;
+};
+
+// Ownership survives same-live resume, but never RunState serialization or a different session.
+const sessionCompactionStates = new WeakMap<
+  RunState<any, any>,
+  SessionCompactionState
+>();
+
+export function getSessionCompactionState(
+  session: Session | undefined,
+  state?: RunState<any, any>,
+): SessionCompactionState | undefined {
+  if (!isOpenAIResponsesCompactionOwnershipAwareSession(session)) {
+    return undefined;
+  }
+  const existing = state && sessionCompactionStates.get(state);
+  if (existing?.session === session) {
+    return existing;
+  }
+  const binding = { session, ownership: null };
+  if (state) {
+    sessionCompactionStates.set(state, binding);
+  }
+  return binding;
+}
+
+export function bindSessionCompactionState(
+  state: RunState<any, any>,
+  binding: SessionCompactionState | undefined,
+): void {
+  if (binding) {
+    sessionCompactionStates.set(state, binding);
+  }
+}
+
 async function getSessionItems(
   session: Session,
   runContext: RunContext<any> | undefined,
@@ -100,7 +139,16 @@ async function addSessionItems(
   session: Session,
   items: AgentInputItem[],
   runContext: RunContext<any> | undefined,
+  compactionState?: SessionCompactionState,
 ): Promise<void> {
+  if (isOpenAIResponsesCompactionOwnershipAwareSession(session)) {
+    await session.addItemsWithCompactionOwnership(
+      items,
+      compactionState?.session === session ? compactionState.ownership : null,
+      runContext,
+    );
+    return;
+  }
   if (runContext && isRunContextAwareSession(session)) {
     await session.addItems(items, runContext);
     return;
@@ -453,6 +501,7 @@ async function appendPreparedResumedSessionWrite(options: {
     session,
     getPendingSessionWriteAppendItems(state, pending),
     state._context,
+    getSessionCompactionState(session, state),
   );
 }
 
@@ -549,7 +598,12 @@ export async function reconcilePendingSessionWriteBeforeRun(
       ...appendReady.comparableAppendItems,
     ];
     if (sessionItemArraysMatch(currentItems, appendReady.beforeItems)) {
-      await addSessionItems(session, appendItems, state._context);
+      await addSessionItems(
+        session,
+        appendItems,
+        state._context,
+        getSessionCompactionState(session, state),
+      );
     } else if (!sessionItemArraysMatch(currentItems, expectedAfterItems)) {
       throw new UserError(
         'Session history changed while a resumed write was unacknowledged and cannot be reconciled safely.',
@@ -1000,6 +1054,7 @@ export type SessionPersistenceTracker = {
 export function createSessionPersistenceTracker(options: {
   session?: Session;
   runContext?: RunContext<any>;
+  compactionState?: SessionCompactionState;
   hasCallModelInputFilter: boolean;
   persistInput?: typeof saveStreamInputToSession;
   resumingFromState?: boolean;
@@ -1150,7 +1205,16 @@ export function createSessionPersistenceTracker(options: {
           return;
         }
         this.persistedInput = true;
-        await persistInput(this.session, itemsToPersist, this.runContext);
+        if (options.compactionState) {
+          await persistInput(
+            this.session,
+            itemsToPersist,
+            this.runContext,
+            options.compactionState,
+          );
+        } else {
+          await persistInput(this.session, itemsToPersist, this.runContext);
+        }
       };
     };
   }
@@ -1618,6 +1682,7 @@ export async function saveStreamInputToSession(
   session: Session | undefined,
   sessionInputItems: AgentInputItem[] | undefined,
   runContext?: RunContext<any>,
+  compactionState?: SessionCompactionState,
 ): Promise<void> {
   if (!session) {
     return;
@@ -1638,7 +1703,7 @@ export async function saveStreamInputToSession(
     );
     return;
   }
-  await addSessionItems(session, sanitizedInput, runContext);
+  await addSessionItems(session, sanitizedInput, runContext, compactionState);
 }
 
 export async function saveStreamResultToSession(
@@ -1788,6 +1853,7 @@ export async function prepareInputItemsWithSession(
     reasoningItemIdPolicy?: ReasoningItemIdPolicy;
   },
   runContext?: RunContext<any>,
+  compactionState?: SessionCompactionState,
 ): Promise<PreparedInputWithSessionResult> {
   const newInputItems = toAgentInputList(input);
   assertValidCompactionItems(newInputItems);
@@ -1803,9 +1869,18 @@ export async function prepareInputItemsWithSession(
   const preserveDroppedNewItems = options?.preserveDroppedNewItems ?? false;
   const reasoningItemIdPolicy = options?.reasoningItemIdPolicy;
 
-  const history = trimToLatestCompaction(
-    await getSessionItems(session, runContext),
-  );
+  let storedItems: AgentInputItem[];
+  if (
+    compactionState?.session === session &&
+    isOpenAIResponsesCompactionOwnershipAwareSession(session)
+  ) {
+    const snapshot = await session.getItemsWithCompactionOwnership(runContext);
+    compactionState.ownership = snapshot.ownership;
+    storedItems = snapshot.items;
+  } else {
+    storedItems = await getSessionItems(session, runContext);
+  }
+  const history = trimToLatestCompaction(storedItems);
   assertPersistableCompactionBoundary(history);
   if (!sessionInputCallback) {
     const historyForModelInput = history.map((item) =>
@@ -2197,7 +2272,12 @@ async function persistRunItemsToSession(options: {
         preparation: resumedSessionWritePreparation,
       });
     } else {
-      await addSessionItems(session, sanitizedItems, state._context);
+      await addSessionItems(
+        session,
+        sanitizedItems,
+        state._context,
+        getSessionCompactionState(session, state),
+      );
     }
   }
   if (resumedSessionWritePreparation) {
@@ -2464,9 +2544,17 @@ async function runCompactionOnSession(
           ...(typeof store === 'undefined' ? {} : { store }),
           ...(typeof compactionMode === 'undefined' ? {} : { compactionMode }),
         };
-  const compactionResult = isRunContextAwareSession(session)
-    ? await session.runCompaction(compactionArgs, state._context)
-    : await session.runCompaction(compactionArgs);
+  const compactionResult = isOpenAIResponsesCompactionOwnershipAwareSession(
+    session,
+  )
+    ? await session.runCompaction(
+        compactionArgs,
+        state._context,
+        getSessionCompactionState(session, state)?.ownership ?? null,
+      )
+    : isRunContextAwareSession(session)
+      ? await session.runCompaction(compactionArgs, state._context)
+      : await session.runCompaction(compactionArgs);
   if (!compactionResult) {
     return;
   }

--- a/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
+++ b/packages/agents-openai/src/memory/openaiResponsesCompactionSession.ts
@@ -8,7 +8,8 @@ import {
 import type {
   AgentInputItem,
   OpenAIResponsesCompactionArgs,
-  OpenAIResponsesCompactionAwareSession as OpenAIResponsesCompactionSessionLike,
+  OpenAIResponsesCompactionOwnershipAwareSession as OpenAIResponsesCompactionSessionLike,
+  RunContext,
   Session,
 } from '@openai/agents-core';
 import type { OpenAIResponsesCompactionResult } from '@openai/agents-core';
@@ -126,6 +127,8 @@ export class OpenAIResponsesCompactionSession
   private compactionCandidateItems: AgentInputItem[] | undefined;
   private sessionItems: AgentInputItem[] | undefined;
   private mutationOperation: Promise<void> = Promise.resolve();
+  private mutationGeneration: object = {};
+  private readonly compactionOwnership = new WeakMap<object, object>();
 
   constructor(options: OpenAIResponsesCompactionSessionOptions) {
     this.client = resolveClient(options);
@@ -150,8 +153,22 @@ export class OpenAIResponsesCompactionSession
 
   async runCompaction(
     args: OpenAIResponsesCompactionArgs = {},
+    _runContext?: RunContext<any>,
+    ownership?: object | null,
   ): Promise<OpenAIResponsesCompactionResult | null> {
-    return this.runMutationOperation(() => this.runCompactionOperation(args));
+    return this.runMutationOperation(async () => {
+      if (ownership !== undefined && !this.ownsCompaction(ownership)) {
+        logger.debug(
+          'skip: automatic compaction no longer owns session history',
+        );
+        return null;
+      }
+      const result = await this.runCompactionOperation(args);
+      if (result && ownership) {
+        this.compactionOwnership.set(ownership, this.mutationGeneration);
+      }
+      return result;
+    });
   }
 
   private async runCompactionOperation(
@@ -214,10 +231,15 @@ export class OpenAIResponsesCompactionSession
     const outputCompactionCandidateItems =
       selectCompactionCandidateItems(outputItems);
     const previousItems = await this.getAllUnderlyingSessionItems();
-    await this.replaceUnderlyingSessionItems({
-      outputItems,
-      previousItems,
-    });
+    try {
+      await this.replaceUnderlyingSessionItems({ outputItems, previousItems });
+    } catch (error) {
+      this.compactionCandidateItems = undefined;
+      this.sessionItems = undefined;
+      throw error;
+    } finally {
+      this.mutationGeneration = {};
+    }
     this.compactionCandidateItems = outputCompactionCandidateItems;
     this.sessionItems = outputItems;
 
@@ -241,6 +263,20 @@ export class OpenAIResponsesCompactionSession
     return this.underlyingSession.getItems(limit);
   }
 
+  async getItemsWithCompactionOwnership(
+    _runContext?: RunContext<any>,
+  ): Promise<{
+    items: AgentInputItem[];
+    ownership: object;
+  }> {
+    return this.runMutationOperation(async () => {
+      const items = await this.underlyingSession.getItems();
+      const ownership = {};
+      this.compactionOwnership.set(ownership, this.mutationGeneration);
+      return { items, ownership };
+    });
+  }
+
   prepareHistoryItemsForPersistenceComparison(
     items: AgentInputItem[],
   ): AgentInputItem[] {
@@ -250,11 +286,20 @@ export class OpenAIResponsesCompactionSession
   }
 
   async addItems(items: AgentInputItem[]) {
+    await this.addItemsWithCompactionOwnership(items, null);
+  }
+
+  async addItemsWithCompactionOwnership(
+    items: AgentInputItem[],
+    ownership: object | null,
+    _runContext?: RunContext<any>,
+  ): Promise<void> {
     if (items.length === 0) {
       return;
     }
 
     await this.runMutationOperation(async () => {
+      const ownsGeneration = this.ownsCompaction(ownership);
       try {
         await this.underlyingSession.addItems(items);
       } catch (error) {
@@ -263,6 +308,11 @@ export class OpenAIResponsesCompactionSession
         this.compactionCandidateItems = undefined;
         this.sessionItems = undefined;
         throw error;
+      } finally {
+        this.mutationGeneration = {};
+      }
+      if (ownsGeneration && ownership) {
+        this.compactionOwnership.set(ownership, this.mutationGeneration);
       }
       if (this.compactionCandidateItems) {
         const candidates = selectCompactionCandidateItems(items);
@@ -285,6 +335,7 @@ export class OpenAIResponsesCompactionSession
       try {
         popped = await this.underlyingSession.popItem();
       } catch (error) {
+        this.mutationGeneration = {};
         this.responseId = undefined;
         this.lastStore = undefined;
         this.compactionCandidateItems = undefined;
@@ -294,6 +345,7 @@ export class OpenAIResponsesCompactionSession
       if (!popped) {
         return popped;
       }
+      this.mutationGeneration = {};
       this.responseId = undefined;
       this.lastStore = undefined;
       // A successful destructive mutation makes both cached history views stale.
@@ -308,12 +360,27 @@ export class OpenAIResponsesCompactionSession
 
   async clearSession() {
     await this.runMutationOperation(async () => {
-      await this.underlyingSession.clearSession();
+      try {
+        await this.underlyingSession.clearSession();
+      } catch (error) {
+        this.compactionCandidateItems = undefined;
+        this.sessionItems = undefined;
+        throw error;
+      } finally {
+        this.mutationGeneration = {};
+        this.responseId = undefined;
+        this.lastStore = undefined;
+      }
       this.compactionCandidateItems = [];
       this.sessionItems = [];
-      this.responseId = undefined;
-      this.lastStore = undefined;
     });
+  }
+
+  private ownsCompaction(ownership: object | null): boolean {
+    return (
+      ownership !== null &&
+      this.compactionOwnership.get(ownership) === this.mutationGeneration
+    );
   }
 
   private runMutationOperation<T>(operation: () => Promise<T>): Promise<T> {

--- a/packages/agents-openai/test/openaiResponsesCompactionSession.runner.test.ts
+++ b/packages/agents-openai/test/openaiResponsesCompactionSession.runner.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  MemorySession,
+  Runner,
+  RunContext,
+  RunState,
+  tool,
+  type AgentInputItem,
+  type NonStreamRunOptions,
+} from '@openai/agents-core';
+import {
+  ScriptedModel,
+  assistantMessage,
+  functionCall,
+} from '@openai/agents-core/testing';
+import { OpenAIResponsesCompactionSession } from '../src';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function user(text: string): AgentInputItem {
+  return {
+    type: 'message',
+    role: 'user',
+    content: text,
+  };
+}
+
+function setup(underlyingSession = new MemorySession()) {
+  const compacted = assistantMessage('compacted history');
+  const compact = vi.fn().mockResolvedValue({
+    output: [compacted],
+    usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
+  });
+  const decision = vi.fn(() => true);
+  const session = new OpenAIResponsesCompactionSession({
+    underlyingSession,
+    client: { responses: { compact } } as any,
+    shouldTriggerCompaction: decision,
+  });
+  const runner = new Runner({ tracingDisabled: true });
+  return { session, runner, compact, compacted, decision };
+}
+
+function startRun(
+  runner: Runner,
+  agent: Agent,
+  stream: boolean,
+  options: NonStreamRunOptions<unknown, Agent>,
+) {
+  return stream
+    ? runner.run<Agent, unknown>(agent, 'hello', { ...options, stream: true })
+    : runner.run<Agent, unknown>(agent, 'hello', options);
+}
+
+describe('Runner compaction ownership', () => {
+  it('reconciles an acknowledged-lost append without regaining compaction ownership', async () => {
+    class UnacknowledgedSession extends MemorySession {
+      failNextAppend = false;
+      override async addItems(items: AgentInputItem[]) {
+        await super.addItems(items);
+        if (this.failNextAppend) {
+          this.failNextAppend = false;
+          throw new Error('append acknowledgement lost');
+        }
+      }
+    }
+    const underlying = new UnacknowledgedSession();
+    const { session, runner, compact, decision } = setup(underlying);
+    decision.mockReturnValue(false);
+    const execute = vi.fn(async () => 'tool done');
+    const agent = new Agent({
+      name: 'approval recovery',
+      model: new ScriptedModel([
+        [functionCall('approved', '{}', { callId: 'call-1' })],
+      ]),
+      tools: [
+        tool({
+          name: 'approved',
+          description: 'Approved action.',
+          parameters: z.object({}),
+          needsApproval: true,
+          execute,
+        }),
+      ],
+      toolUseBehavior: 'stop_on_first_tool',
+    });
+    const paused = await runner.run(agent, 'hello', { session });
+    paused.state.approve(paused.interruptions[0]);
+    underlying.failNextAppend = true;
+    decision.mockReturnValue(true);
+    await expect(runner.run(agent, paused.state, { session })).rejects.toThrow(
+      'append acknowledgement lost',
+    );
+    const committed = await session.getItems();
+    const result = await runner.run(agent, paused.state, { session });
+    expect(result.finalOutput).toBe('tool done');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(await session.getItems()).toEqual(committed);
+    expect(compact).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    'skips a stale history read (stream=%s)',
+    async (stream) => {
+      const { session, runner, compact, decision } = setup();
+      const read = deferred();
+      const proceed = deferred();
+      const reply = assistantMessage('done');
+      const agent = new Agent({
+        name: 'test',
+        model: new ScriptedModel([[reply]]),
+      });
+      const running = startRun(runner, agent, stream, {
+        session,
+        sessionInputCallback: async (history, input) => {
+          read.resolve();
+          await proceed.promise;
+          return [...history, ...input];
+        },
+      });
+      await read.promise;
+      const foreign = user('concurrent write');
+      await session.addItems([foreign]);
+      proceed.resolve();
+      const result = await running;
+      if ('completed' in result) await result.completed;
+      expect(result.finalOutput).toBe('done');
+      expect(await session.getItems()).toEqual([foreign, user('hello'), reply]);
+      expect(decision).not.toHaveBeenCalled();
+      expect(compact).not.toHaveBeenCalled();
+      expect(
+        (result.runContext.usage.requestUsageEntries ?? []).filter(
+          (entry) => entry.endpoint === 'responses.compact',
+        ),
+      ).toEqual([]);
+    },
+  );
+
+  it.each([false, true])(
+    'skips compaction after a queued append (stream=%s)',
+    async (stream) => {
+      // Gate the real backend acknowledgement while the wrapper owns its mutation queue.
+      class GatedSession extends MemorySession {
+        readonly appended = deferred();
+        readonly proceed = deferred();
+        private gated = false;
+        override async addItems(items: AgentInputItem[]) {
+          await super.addItems(items);
+          if (!this.gated) {
+            this.gated = true;
+            this.appended.resolve();
+            await this.proceed.promise;
+          }
+        }
+      }
+      const underlying = new GatedSession();
+      const { session, runner, compact } = setup(underlying);
+      const reply = assistantMessage('done');
+      const running = startRun(
+        runner,
+        new Agent({ name: 'test', model: new ScriptedModel([[reply]]) }),
+        stream,
+        { session },
+      );
+      await underlying.appended.promise;
+      const foreign = user('concurrent write');
+      const mutation = session.addItems([foreign]);
+      underlying.proceed.resolve();
+      await mutation;
+      const result = await running;
+      if ('completed' in result) await result.completed;
+      expect(result.finalOutput).toBe('done');
+      const items = await session.getItems();
+      expect(
+        items.filter((item) => item.type === 'message' && item.role === 'user'),
+      ).toEqual([user('hello'), foreign]);
+      expect(
+        items.filter(
+          (item) => item.type === 'message' && item.role === 'assistant',
+        ),
+      ).toEqual([reply]);
+      expect(items).toHaveLength(3);
+      expect(compact).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['pop', 'clear'] as const)(
+    'revokes a read after %s',
+    async (mutation) => {
+      const original = user('original');
+      const { session, runner, compact } = setup(
+        new MemorySession({ initialItems: [original] }),
+      );
+      const reply = assistantMessage('done');
+      const result = await startRun(
+        runner,
+        new Agent({ name: 'test', model: new ScriptedModel([[reply]]) }),
+        false,
+        {
+          session,
+          sessionInputCallback: async (history, input) => {
+            if (mutation === 'pop') await session.popItem();
+            else await session.clearSession();
+            return [...history, ...input];
+          },
+        },
+      );
+      expect(result.finalOutput).toBe('done');
+      expect(await session.getItems()).toEqual([user('hello'), reply]);
+      expect(compact).not.toHaveBeenCalled();
+    },
+  );
+
+  it('isolates concurrent runs sharing a caller RunContext and preserves manual compaction', async () => {
+    const { session, runner, compact, compacted } = setup();
+    const context = new RunContext({ shared: true });
+    const read = deferred();
+    const proceed = deferred();
+    const firstReply = assistantMessage('first reply');
+    const first = runner.run(
+      new Agent({ name: 'first', model: new ScriptedModel([[firstReply]]) }),
+      'first',
+      {
+        session,
+        context,
+        sessionInputCallback: async (history, input) => {
+          read.resolve();
+          await proceed.promise;
+          return [...history, ...input];
+        },
+      },
+    );
+    await read.promise;
+    await runner.run(
+      new Agent({
+        name: 'second',
+        model: new ScriptedModel([[assistantMessage('second reply')]]),
+      }),
+      'second',
+      { session, context },
+    );
+    expect(compact).toHaveBeenCalledTimes(1);
+    proceed.resolve();
+    await first;
+    expect(compact).toHaveBeenCalledTimes(1);
+    expect(await session.getItems()).toEqual([
+      compacted,
+      user('first'),
+      firstReply,
+    ]);
+    await session.runCompaction({ force: true, compactionMode: 'input' });
+    expect(compact).toHaveBeenCalledTimes(2);
+    expect(compact.mock.calls[1][0].input).toHaveLength(3);
+  });
+
+  it.each([false, true])(
+    'compacts an uncontended run and accounts usage once (stream=%s)',
+    async (stream) => {
+      const { session, runner, compact, compacted } = setup();
+      const result = await startRun(
+        runner,
+        new Agent({
+          name: 'test',
+          model: new ScriptedModel([[assistantMessage('done')]]),
+        }),
+        stream,
+        { session },
+      );
+      if ('completed' in result) await result.completed;
+      expect(result.finalOutput).toBe('done');
+      expect(compact).toHaveBeenCalledTimes(1);
+      expect(await session.getItems()).toEqual([compacted]);
+      expect(
+        (result.runContext.usage.requestUsageEntries ?? []).filter(
+          (entry) => entry.endpoint === 'responses.compact',
+        ),
+      ).toHaveLength(1);
+      expect(result.runContext.usage.totalTokens).toBe(10);
+    },
+  );
+
+  it.each([false, true])(
+    'settles pending compaction without replaying tools (serialized=%s)',
+    async (serialized) => {
+      const { session, runner, compact, decision } = setup();
+      decision.mockReturnValue(false);
+      const execute = vi.fn(async () => 'tool done');
+      const agent = new Agent({
+        name: 'approval',
+        model: new ScriptedModel([
+          [functionCall('approved', '{}', { callId: 'call-1' })],
+        ]),
+        tools: [
+          tool({
+            name: 'approved',
+            description: 'Approved action.',
+            parameters: z.object({}),
+            needsApproval: true,
+            execute,
+          }),
+        ],
+        toolUseBehavior: 'stop_on_first_tool',
+      });
+      const paused = await runner.run<typeof agent, unknown>(agent, 'hello', {
+        session,
+      });
+      paused.state.approve(paused.interruptions[0]);
+      decision.mockReturnValue(true);
+      compact.mockRejectedValueOnce(new Error('compact unavailable'));
+      await expect(
+        runner.run(agent, paused.state, { session }),
+      ).rejects.toThrow('compact unavailable');
+      expect(execute).toHaveBeenCalledTimes(1);
+      const before = await session.getItems();
+      const state = serialized
+        ? await RunState.fromString(agent, paused.state.toString())
+        : paused.state;
+      const result = await runner.run(agent, state, { session });
+      expect(result.finalOutput).toBe('tool done');
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(compact).toHaveBeenCalledTimes(serialized ? 1 : 2);
+      if (serialized) expect(await session.getItems()).toEqual(before);
+    },
+  );
+});


### PR DESCRIPTION
This pull request fixes automatic session compaction overwriting concurrent writes made through the same `OpenAIResponsesCompactionSession` instance after a run reads its history or appends its result.

The runner carries an ephemeral ownership receipt through persistence and compaction. Stale receipts skip automatic compaction while preserving appends. Manual compaction remains available. Deserialized runs conservatively skip automatic compaction; the RunState schema is unchanged.