### PR TITLE
feat: support image results in web search tools

### DIFF
--- a/.changeset/web-search-image-results.md
+++ b/.changeset/web-search-image-results.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+feat: support image results in web search tools

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -22,6 +22,7 @@ import type {
   SerializedOutputType,
 } from '@openai/agents-core';
 import OpenAI from 'openai';
+import type { WebSearchTool as WebSearchToolProviderData } from './types/providerData';
 import logger from './logger';
 import { OPENAI_RESPONSES_RAW_MODEL_EVENT_SOURCE } from './rawModelEvents';
 import { getOpenAIRetryAdvice } from './retryAdvice';
@@ -1168,9 +1169,7 @@ function convertTool<_TContext = unknown>(
     };
   } else if (tool.type === 'hosted_tool') {
     if (tool.providerData?.type === 'web_search') {
-      const webSearchTool: OpenAI.Responses.WebSearchTool & {
-        external_web_access?: boolean;
-      } = {
+      const webSearchTool: Omit<WebSearchToolProviderData, 'name'> = {
         type: 'web_search',
         user_location: tool.providerData.user_location,
         filters: tool.providerData.filters,
@@ -1180,9 +1179,18 @@ function convertTool<_TContext = unknown>(
         webSearchTool.external_web_access =
           tool.providerData.external_web_access;
       }
+      if (tool.providerData.search_content_types !== undefined) {
+        webSearchTool.search_content_types =
+          tool.providerData.search_content_types;
+      }
+      if (tool.providerData.image_settings !== undefined) {
+        webSearchTool.image_settings = tool.providerData.image_settings;
+      }
       return {
         tool: webSearchTool,
-        include: undefined,
+        include: webSearchTool.search_content_types?.includes('image')
+          ? ['web_search_call.results']
+          : undefined,
       };
     } else if (tool.providerData?.type === 'web_search_preview') {
       return {

--- a/packages/agents-openai/src/tools.ts
+++ b/packages/agents-openai/src/tools.ts
@@ -63,6 +63,27 @@ export type WebSearchTool = {
    * default is used.
    */
   externalWebAccess?: boolean;
+
+  /**
+   * The kinds of search results to return. When omitted, the API default is used.
+   * Including `image` also requests raw results, available on web search call
+   * items in `providerData.results`.
+   */
+  searchContentTypes?: ProviderData.WebSearchTool['search_content_types'];
+
+  /**
+   * Image result settings when `searchContentTypes` includes `image`.
+   */
+  imageSettings?: {
+    /**
+     * The positive number of image results to request.
+     */
+    maxResults?: number;
+    /**
+     * Whether to request a short caption for each image when available.
+     */
+    caption?: boolean;
+  };
 };
 
 /**
@@ -84,6 +105,15 @@ export function webSearchTool(
   };
   if (options.externalWebAccess !== undefined) {
     providerData.external_web_access = options.externalWebAccess;
+  }
+  if (options.searchContentTypes !== undefined) {
+    providerData.search_content_types = options.searchContentTypes;
+  }
+  if (options.imageSettings !== undefined) {
+    providerData.image_settings = {
+      max_results: options.imageSettings.maxResults,
+      caption: options.imageSettings.caption,
+    };
   }
   return {
     type: 'hosted_tool',

--- a/packages/agents-openai/src/types/providerData.ts
+++ b/packages/agents-openai/src/types/providerData.ts
@@ -3,8 +3,13 @@ import OpenAI from 'openai';
 export type WebSearchTool = Omit<OpenAI.Responses.WebSearchTool, 'type'> & {
   type: 'web_search';
   name: 'web_search' | 'web_search_preview' | (string & {});
-  // The Responses API supports this field, but openai-node typings do not expose it yet.
+  // The Responses API supports these fields, but openai-node typings do not expose them yet.
   external_web_access?: boolean;
+  search_content_types?: Array<'text' | 'image'>;
+  image_settings?: {
+    max_results?: number;
+    caption?: boolean;
+  };
 };
 
 export type FileSearchTool = Omit<OpenAI.Responses.FileSearchTool, 'type'> & {

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -6,6 +6,7 @@ import {
 import { HEADERS } from '../src/defaults';
 import { ResponsesWebSocketInternalError } from '../src/responsesWebSocketConnection';
 import OpenAI from 'openai';
+import { fileSearchTool, webSearchTool } from '../src';
 import {
   Agent,
   retryPolicies,
@@ -128,6 +129,155 @@ describe('OpenAIResponsesModel', () => {
     setTracingDisabled(true);
     setTraceProcessors([]);
   });
+
+  describe.each([false, true])(
+    'web search image requests (stream=%s)',
+    (stream) => {
+      const cases: {
+        label: string;
+        options: NonNullable<Parameters<typeof webSearchTool>[0]>;
+        expectedFields: Record<string, unknown>;
+        expectedInclude: string[];
+      }[] = [
+        {
+          label: 'default',
+          options: {},
+          expectedFields: {},
+          expectedInclude: [],
+        },
+        {
+          label: 'text only',
+          options: { searchContentTypes: ['text'] },
+          expectedFields: { search_content_types: ['text'] },
+          expectedInclude: [],
+        },
+        {
+          label: 'image only with default settings',
+          options: { searchContentTypes: ['image'] },
+          expectedFields: { search_content_types: ['image'] },
+          expectedInclude: ['web_search_call.results'],
+        },
+        {
+          label: 'image and text with settings',
+          options: {
+            searchContentTypes: ['image', 'text'],
+            imageSettings: { maxResults: 3, caption: false },
+            externalWebAccess: false,
+          },
+          expectedFields: {
+            search_content_types: ['image', 'text'],
+            image_settings: { max_results: 3, caption: false },
+            external_web_access: false,
+          },
+          expectedInclude: ['web_search_call.results'],
+        },
+        {
+          label: 'settings without image selection',
+          options: { imageSettings: { caption: true } },
+          expectedFields: { image_settings: { caption: true } },
+          expectedInclude: [],
+        },
+      ];
+
+      it.each(cases)(
+        'serializes $label and preserves returned image metadata',
+        async ({ options, expectedFields, expectedInclude }) => {
+          const imageResults = [
+            {
+              type: 'image_result',
+              image_url: 'https://example.com/bridge.jpg',
+              source_website_url: 'https://example.com/bridge',
+              thumbnail_url: 'https://example.com/bridge-thumb.jpg',
+            },
+          ];
+          const response = {
+            id: 'resp_web_search',
+            object: 'response',
+            status: 'completed',
+            output: expectedInclude.length
+              ? [
+                  {
+                    id: 'ws_image',
+                    type: 'web_search_call',
+                    status: 'completed',
+                    action: { type: 'search', query: 'bridge' },
+                    results: imageResults,
+                  },
+                ]
+              : [],
+            usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+          };
+          const bodies: Record<string, unknown>[] = [];
+          // Capture the real client's serialized wire payload without making network requests.
+          const client = new OpenAI({
+            apiKey: 'test-key',
+            fetch: async (_url, init) => {
+              bodies.push(JSON.parse(init!.body as string));
+              const body = stream
+                ? `event: response.completed\ndata: ${JSON.stringify({ type: 'response.completed', sequence_number: 0, response })}\n\n`
+                : JSON.stringify(response);
+              return new Response(body, {
+                headers: {
+                  'content-type': stream
+                    ? 'text/event-stream'
+                    : 'application/json',
+                },
+              });
+            },
+          });
+          const model = new OpenAIResponsesModel(client, 'gpt-test');
+          const request: ModelRequest = {
+            systemInstructions: undefined,
+            input: 'Find bridge images.',
+            modelSettings: {},
+            tools: [
+              webSearchTool(options),
+              fileSearchTool('vs_test', { includeSearchResults: true }),
+            ],
+            outputType: 'text',
+            handoffs: [],
+            tracing: false,
+          };
+          let output;
+          if (stream) {
+            for await (const event of model.getStreamedResponse(request)) {
+              if (event.type === 'response_done') {
+                output = event.response.output;
+              }
+            }
+          } else {
+            output = (
+              await withTrace('web search image request', () =>
+                model.getResponse(request),
+              )
+            ).output;
+          }
+
+          expect(bodies).toHaveLength(1);
+          expect(bodies[0]).toMatchObject({
+            stream,
+            include: [...expectedInclude, 'file_search_call.results'],
+          });
+          expect((bodies[0].tools as unknown[])[0]).toEqual({
+            type: 'web_search',
+            search_context_size: 'medium',
+            ...expectedFields,
+          });
+          if (expectedInclude.length) {
+            expect(output).toMatchObject([
+              {
+                type: 'hosted_tool_call',
+                name: 'web_search_call',
+                providerData: { results: imageResults },
+              },
+            ]);
+          } else {
+            expect(output).toEqual([]);
+          }
+        },
+      );
+    },
+  );
 
   it.each([
     {

--- a/packages/agents-openai/test/tools.test.ts
+++ b/packages/agents-openai/test/tools.test.ts
@@ -46,6 +46,24 @@ describe('Tool', () => {
     });
   });
 
+  it('webSearchTool leaves image options absent by default', () => {
+    const tool = webSearchTool();
+    expect(tool.providerData).not.toHaveProperty('search_content_types');
+    expect(tool.providerData).not.toHaveProperty('image_settings');
+  });
+
+  it('webSearchTool maps image settings to provider data', () => {
+    const tool = webSearchTool({
+      searchContentTypes: ['text', 'image'],
+      imageSettings: { maxResults: 3, caption: false },
+    });
+    expect(tool.providerData).toMatchObject({
+      search_content_types: ['text', 'image'],
+      image_settings: { max_results: 3, caption: false },
+    });
+    expect(tool.providerData?.image_settings).not.toHaveProperty('maxResults');
+  });
+
   it('fileSearchTool', () => {
     const t = fileSearchTool(['test'], {});
     expect(t).toBeDefined();


### PR DESCRIPTION
This pull request adds `searchContentTypes` and `imageSettings` to `webSearchTool`, maps camelCase options to the Responses API wire fields, and automatically includes `web_search_call.results` when images are requested.

Image URLs and metadata remain available in hosted tool call `providerData.results`. Existing defaults and request override precedence are preserved, with regression coverage for streaming and non-streaming requests.