### PR TITLE
fix(sandbox): settle PTY output before cleanup

### DIFF
--- a/.changeset/quiet-pty-output.md
+++ b/.changeset/quiet-pty-output.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: retain final PTY output until collection completes

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -47,7 +47,7 @@ import {
   shellQuote,
   shellCommandForPty,
   toUint8Array,
-  markPtyDone,
+  closePtyOutput,
   writePtyStdin,
   isRecord,
   readOptionalBoolean,
@@ -278,11 +278,11 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
       socket,
       'close',
       (event) => {
-        markPtyDone(entry, blaxelPtyCloseExitCode(entry, event));
+        closePtyOutput(entry, blaxelPtyCloseExitCode(entry, event));
       },
     );
     const removeErrorListener = addPtyWebSocketListener(socket, 'error', () => {
-      markPtyDone(entry, 1);
+      closePtyOutput(entry, 1);
     });
     entry.sendInput = async (chars) => {
       socket.send(JSON.stringify({ type: 'input', data: chars }));
@@ -1643,7 +1643,7 @@ function handleBlaxelPtyMessage(entry: PtyProcessEntry, event: unknown): void {
     if (typeof data === 'string') {
       appendPtyOutput(entry, data);
     }
-    markPtyDone(entry, 1);
+    closePtyOutput(entry, 1);
   }
 }
 

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -73,7 +73,7 @@ import {
   appendPtyOutput,
   createPtyProcessEntry,
   formatPtyExecUpdate,
-  markPtyDone,
+  closePtyOutput,
   openPtyWebSocket,
   PtyProcessRegistry,
   shellCommandForPty,
@@ -292,13 +292,13 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       },
     });
     const removeCloseListener = addPtyWebSocketListener(socket, 'close', () => {
-      if (!entry.done) {
-        markPtyDone(entry);
+      if (!entry.outputClosed) {
+        closePtyOutput(entry, entry.exitCode);
       }
     });
     const removeErrorListener = addPtyWebSocketListener(socket, 'error', () => {
-      if (!entry.done) {
-        markPtyDone(entry, 1);
+      if (!entry.outputClosed) {
+        closePtyOutput(entry, entry.exitCode ?? 1);
       }
     });
 
@@ -1675,10 +1675,8 @@ function handleCloudflarePtyMessage(
       return;
     }
     if (payload.type === 'exit') {
-      markPtyDone(
-        entry,
-        typeof payload.code === 'number' ? payload.code : null,
-      );
+      // The exit frame reports status; later frames may still carry PTY bytes.
+      entry.exitCode = typeof payload.code === 'number' ? payload.code : null;
       return;
     }
     if (payload.type === 'error') {
@@ -1686,8 +1684,8 @@ function handleCloudflarePtyMessage(
       if (typeof message === 'string') {
         appendPtyOutput(entry, message);
       }
-      if (!entry.done) {
-        markPtyDone(entry, 1);
+      if (!entry.outputClosed) {
+        closePtyOutput(entry, entry.exitCode ?? 1);
       }
       return;
     }

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -79,7 +79,7 @@ import {
   serializeRemoteSandboxSessionState,
   truncateOutput,
   validateRemoteSandboxPathForManifest,
-  watchPtyProcess,
+  watchPtyOutput,
   readOptionalNumber,
   readOptionalNumberArray,
   readOptionalRecord,
@@ -394,7 +394,7 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
     if (pruned) {
       await pruned.terminate?.().catch(() => {});
     }
-    watchPtyProcess(
+    watchPtyOutput(
       entry,
       async () => await waitForExit(),
       (result, error) =>

--- a/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/e2b/sandbox.ts
@@ -42,7 +42,7 @@ import {
   shellQuote,
   shellCommandForPty,
   serializeRemoteSandboxSessionState,
-  watchPtyProcess,
+  watchPtyOutput,
   isRecord,
   readOptionalBoolean,
   readOptionalNumber,
@@ -313,7 +313,7 @@ export class E2BSandboxSession extends RemoteSandboxSessionBase<E2BSandboxSessio
         requestTimeoutMs: this.state.requestTimeoutMs,
       });
     };
-    watchPtyProcess(
+    watchPtyOutput(
       entry,
       async () => (handle.wait ? await handle.wait() : undefined),
       (result, error) =>

--- a/packages/agents-extensions/src/sandbox/shared/index.ts
+++ b/packages/agents-extensions/src/sandbox/shared/index.ts
@@ -62,11 +62,11 @@ export {
   appendPtyOutput,
   createPtyProcessEntry,
   formatPtyExecUpdate,
-  markPtyDone,
+  closePtyOutput,
   openPtyWebSocket,
   PtyProcessRegistry,
   shellCommandForPty,
-  watchPtyProcess,
+  watchPtyOutput,
   writePtyStdin,
 } from './pty';
 export {

--- a/packages/agents-extensions/src/sandbox/shared/pty.ts
+++ b/packages/agents-extensions/src/sandbox/shared/pty.ts
@@ -16,7 +16,8 @@ const PTY_PROCESS_ID_MAX_EXCLUSIVE = 100_000;
 export type PtyProcessEntry = {
   tty: boolean;
   output: string;
-  done: boolean;
+  /** True only after the provider can no longer append output. */
+  outputClosed: boolean;
   exitCode: number | null;
   lastUsed: number;
   waiters: Set<() => void>;
@@ -59,7 +60,7 @@ export function createPtyProcessEntry(args: {
   return {
     tty: args.tty ?? true,
     output: '',
-    done: false,
+    outputClosed: false,
     exitCode: null,
     lastUsed: Date.now(),
     waiters: new Set(),
@@ -87,27 +88,31 @@ export function appendPtyOutput(
   notifyPtyWaiters(entry);
 }
 
-export function markPtyDone(
+export function closePtyOutput(
   entry: PtyProcessEntry,
   exitCode: number | null = null,
 ): void {
+  if (entry.outputClosed) {
+    return;
+  }
   entry.output += flushPtyDecoder(entry);
-  entry.done = true;
+  entry.outputClosed = true;
   entry.exitCode = exitCode;
   notifyPtyWaiters(entry);
 }
 
-export function watchPtyProcess(
+/** Observe a provider wait that settles after its output callbacks finish. */
+export function watchPtyOutput(
   entry: PtyProcessEntry,
-  wait: () => Promise<unknown>,
+  waitForOutputClosed: () => Promise<unknown>,
   exitCode: (result: unknown, error?: unknown) => number | null | undefined,
 ): void {
   void (async () => {
     try {
-      const result = await wait();
-      markPtyDone(entry, coerceExitCode(exitCode(result)));
+      const result = await waitForOutputClosed();
+      closePtyOutput(entry, coerceExitCode(exitCode(result)));
     } catch (error) {
-      markPtyDone(entry, coerceExitCode(exitCode(undefined, error) ?? 1));
+      closePtyOutput(entry, coerceExitCode(exitCode(undefined, error) ?? 1));
     }
   })();
 }
@@ -181,7 +186,10 @@ export class PtyProcessRegistry {
     await Promise.allSettled(entries.map((entry) => terminatePtyEntry(entry)));
   }
 
-  async finalize(sessionId: number): Promise<{
+  async finalize(
+    sessionId: number,
+    outputClosed: boolean,
+  ): Promise<{
     processId?: number;
     exitCode?: number | null;
   }> {
@@ -190,7 +198,7 @@ export class PtyProcessRegistry {
       return { processId: undefined, exitCode: 1 };
     }
 
-    if (!entry.done) {
+    if (!outputClosed) {
       return { processId: sessionId };
     }
 
@@ -218,7 +226,7 @@ export class PtyProcessRegistry {
     );
 
     for (const [sessionId, entry] of byLeastRecentlyUsed) {
-      if (!protectedIds.has(sessionId) && entry.done) {
+      if (!protectedIds.has(sessionId) && entry.outputClosed) {
         this.processes.delete(sessionId);
         return entry;
       }
@@ -357,11 +365,15 @@ export async function collectPtyOutput(args: {
   entry: PtyProcessEntry;
   yieldTimeMs: number;
   maxOutputTokens?: number;
-}): Promise<{ text: string; originalTokenCount?: number }> {
+}): Promise<{
+  text: string;
+  originalTokenCount?: number;
+  outputClosed: boolean;
+}> {
   const deadline = Date.now() + args.yieldTimeMs;
   let output = consumePtyOutput(args.entry);
 
-  while (!args.entry.done && Date.now() < deadline) {
+  while (!args.entry.outputClosed && Date.now() < deadline) {
     const remainingMs = deadline - Date.now();
     if (remainingMs <= 0) {
       break;
@@ -370,11 +382,12 @@ export async function collectPtyOutput(args: {
     output += consumePtyOutput(args.entry);
   }
 
-  if (args.entry.done) {
-    output += consumePtyOutput(args.entry);
-  }
+  // Capture closure with the final drain. A caller may resume after more output
+  // arrives, so finalization must use this snapshot rather than the live entry.
+  const outputClosed = args.entry.outputClosed;
+  output += consumePtyOutput(args.entry);
 
-  return truncateOutput(output, args.maxOutputTokens);
+  return { ...truncateOutput(output, args.maxOutputTokens), outputClosed };
 }
 
 export async function writePtyStdin(args: {
@@ -414,7 +427,10 @@ export async function writePtyStdin(args: {
     maxOutputTokens: args.maxOutputTokens,
   });
   entry.lastUsed = Date.now();
-  const finalized = await args.registry.finalize(args.sessionId);
+  const finalized = await args.registry.finalize(
+    args.sessionId,
+    output.outputClosed,
+  );
 
   return formatExecResponse({
     output: output.text,
@@ -438,7 +454,10 @@ export async function formatPtyExecUpdate(args: {
     yieldTimeMs: clampPtyYieldTimeMs(args.yieldTimeMs ?? 10_000),
     maxOutputTokens: args.maxOutputTokens,
   });
-  const finalized = await args.registry.finalize(args.sessionId);
+  const finalized = await args.registry.finalize(
+    args.sessionId,
+    output.outputClosed,
+  );
 
   return formatExecResponse({
     output: output.text,

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -1300,6 +1300,7 @@ describe('CloudflareSandboxClient', () => {
     await secondSend;
     socket.message(new TextEncoder().encode('next\n'));
     socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    socket.close();
     const next = await writePromise;
 
     expect(socket.url).toBe(
@@ -1314,6 +1315,53 @@ describe('CloudflareSandboxClient', () => {
     expect(started).toContain('ready');
     expect(next).toContain('next');
     expect(next).toContain('Process exited with code 0');
+  });
+
+  test('collects delayed final PTY bytes after exit status and before socket close', async () => {
+    vi.useFakeTimers();
+    try {
+      globalThis.WebSocket =
+        TestWebSocket as unknown as typeof globalThis.WebSocket;
+      const client = new CloudflareSandboxClient({ apiKey: '' });
+      const session = await client.create(new Manifest(), {
+        workerUrl: 'https://worker.example.com',
+      });
+      const pending = session.execCommand({
+        cmd: 'exit 7',
+        tty: true,
+        yieldTimeMs: 250,
+      });
+      const socket = await TestWebSocket.nextInstance();
+      const firstSend = socket.nextSend();
+      socket.open();
+      socket.message(JSON.stringify({ type: 'ready' }));
+      await firstSend;
+      socket.message(new Uint8Array([0xe5]));
+      socket.message(JSON.stringify({ type: 'exit', code: 7 }));
+      await vi.advanceTimersByTimeAsync(250);
+      const first = await pending;
+      const sessionId = Number(
+        first.match(/Process running with session ID (\d+)/)?.[1],
+      );
+      expect(sessionId).toBeGreaterThan(0);
+      expect(first).not.toContain('\uFFFD');
+      expect(socket.readyState).toBe(1);
+
+      const lastPending = session.writeStdin({ sessionId, yieldTimeMs: 250 });
+      socket.message(new Uint8Array([0xae, 0x8c]));
+      await vi.advanceTimersByTimeAsync(1);
+      expect(socket.readyState).toBe(1);
+      socket.close();
+      const last = await lastPending;
+      expect(last).toContain('完');
+      expect(last).not.toContain('\uFFFD');
+      expect(last).toContain('Process exited with code 7');
+      await expect(session.writeStdin({ sessionId })).resolves.toContain(
+        'session not found',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test('preserves plain-text PTY websocket frames as output', async () => {
@@ -1408,6 +1456,7 @@ describe('CloudflareSandboxClient', () => {
     socket.message(JSON.stringify({ type: 'ready' }));
     await firstSend;
     socket.message(Buffer.from(JSON.stringify({ type: 'exit', code: 7 })));
+    socket.close();
     const started = await startedPromise;
 
     expect(started).toContain('Process exited with code 7');
@@ -1435,6 +1484,7 @@ describe('CloudflareSandboxClient', () => {
     socket.message(JSON.stringify({ type: 'ready' }));
     await firstSend;
     socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    socket.close();
     const started = await startedPromise;
     const socketUrl = new URL(socket.url);
 
@@ -1466,6 +1516,7 @@ describe('CloudflareSandboxClient', () => {
     socket.message(JSON.stringify({ type: 'ready' }));
     await firstSend;
     socket.message(JSON.stringify({ type: 'exit', code: 0 }));
+    socket.close();
     const started = await startedPromise;
     const socketUrl = new URL(socket.url);
 

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -574,12 +574,21 @@ describe('DaytonaSandboxClient', () => {
       chars: 'echo next\n',
       yieldTimeMs: 250,
     });
+    // Deliver the final character in separate callbacks before the SDK reader closes.
+    onData(new Uint8Array([0xe5]));
+    const pendingDone = session.writeStdin({ sessionId, yieldTimeMs: 250 });
+    await Promise.resolve();
+    onData(new Uint8Array([0xae, 0x8c]));
     finishWait({ exitCode: 0 });
-    const done = await session.writeStdin({
+    const done = await pendingDone;
+    expect(done).toContain('完');
+    expect(done).not.toContain('\uFFFD');
+    const missing = await session.writeStdin({
       sessionId,
       yieldTimeMs: 250,
     });
 
+    expect(missing).toContain('session not found');
     expect(next).toContain('echo next');
     expect(done).toContain('Process exited with code 0');
     expect(createPtyMock).toHaveBeenCalledWith(

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -689,12 +689,21 @@ describe('E2BSandboxClient', () => {
       chars: 'echo next\n',
       yieldTimeMs: 250,
     });
+    // Deliver the final character in separate callbacks before the SDK reader closes.
+    onData(new Uint8Array([0xe5]));
+    const pendingDone = session.writeStdin({ sessionId, yieldTimeMs: 250 });
+    await Promise.resolve();
+    onData(new Uint8Array([0xae, 0x8c]));
     finishWait({ exitCode: 0 });
-    const done = await session.writeStdin({
+    const done = await pendingDone;
+    expect(done).toContain('完');
+    expect(done).not.toContain('\uFFFD');
+    const missing = await session.writeStdin({
       sessionId,
       yieldTimeMs: 250,
     });
 
+    expect(missing).toContain('session not found');
     expect(next).toContain('echo next');
     expect(done).toContain('Process exited with code 0');
     expect(ptyCreateMock).toHaveBeenCalledWith(

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -29,7 +29,7 @@ import {
   formatPtyExecUpdate,
   hydrateRemoteWorkspaceTar,
   manifestContainsLocalSource,
-  markPtyDone,
+  closePtyOutput,
   materializeEnvironment,
   materializeInlineManifest,
   materializeInlineManifestEntry,
@@ -69,7 +69,7 @@ import {
   validateRemoteSandboxPath,
   validateRemoteSandboxPathForManifest,
   validateWorkspaceTarArchive,
-  watchPtyProcess,
+  watchPtyOutput,
   withSandboxSpan,
   writePtyStdin,
   writeRunAsRemoteText,
@@ -4528,7 +4528,7 @@ describe('remote sandbox path helpers', () => {
     const registry = new PtyProcessRegistry();
     const entry = createPtyProcessEntry({});
     const { sessionId } = registry.register(entry);
-    markPtyDone(entry);
+    closePtyOutput(entry);
 
     const output = await formatPtyExecUpdate({
       registry,
@@ -4690,10 +4690,11 @@ describe('remote sandbox path helpers', () => {
 
     appendPtyOutput(entry, 'hello ');
     appendPtyOutput(entry, new TextEncoder().encode('from bytes'));
-    markPtyDone(entry, 0);
+    closePtyOutput(entry, 0);
 
     await expect(pendingOutput).resolves.toEqual({
       text: 'hello from bytes',
+      outputClosed: true,
     });
   });
 
@@ -4709,9 +4710,12 @@ describe('remote sandbox path helpers', () => {
 
       appendPtyOutput(entry, bytes.slice(0, splitAt));
       appendPtyOutput(entry, bytes.slice(splitAt));
-      markPtyDone(entry, 0);
+      closePtyOutput(entry, 0);
 
-      await expect(pendingOutput).resolves.toEqual({ text });
+      await expect(pendingOutput).resolves.toEqual({
+        text,
+        outputClosed: true,
+      });
     }
   });
 
@@ -4722,10 +4726,11 @@ describe('remote sandbox path helpers', () => {
     const bytes = new TextEncoder().encode('\u5b8c\u4e86');
     appendPtyOutput(entry, bytes.slice(0, 4));
     appendPtyOutput(entry, ' done');
-    markPtyDone(entry, 0);
+    closePtyOutput(entry, 0);
 
     await expect(pendingOutput).resolves.toEqual({
       text: '\u5b8c\uFFFD done',
+      outputClosed: true,
     });
   });
 
@@ -4734,9 +4739,89 @@ describe('remote sandbox path helpers', () => {
     const pendingOutput = collectPtyOutput({ entry, yieldTimeMs: 1_000 });
 
     appendPtyOutput(entry, new Uint8Array([0x68, 0x69, 0xf0, 0x9f]));
-    markPtyDone(entry, 0);
+    closePtyOutput(entry, 0);
 
-    await expect(pendingOutput).resolves.toEqual({ text: 'hi\uFFFD' });
+    await expect(pendingOutput).resolves.toEqual({
+      text: 'hi\uFFFD',
+      outputClosed: true,
+    });
+  });
+
+  test.each(['exec', 'stdin'] as const)(
+    'retains final PTY bytes arriving after the %s collector returns',
+    async (operation) => {
+      const terminate = vi.fn(async () => {});
+      const entry = createPtyProcessEntry({ terminate });
+      const registry = new PtyProcessRegistry();
+      const { sessionId } = registry.register(entry);
+      appendPtyOutput(entry, 'first\n');
+      appendPtyOutput(entry, new Uint8Array([0xe5]));
+
+      // Expire the collection deadline synchronously, then deliver the tail before
+      // the response continuation resumes and decides whether to delete the entry.
+      let clock = 0;
+      const now = vi
+        .spyOn(Date, 'now')
+        .mockImplementation(() => clock++ * 30_000);
+      const pending =
+        operation === 'exec'
+          ? formatPtyExecUpdate({
+              registry,
+              sessionId,
+              entry,
+              startTime: 0,
+              yieldTimeMs: 250,
+            })
+          : writePtyStdin({
+              providerName: 'TestSandbox',
+              registry,
+              sessionId,
+              yieldTimeMs: 250,
+            });
+      now.mockRestore();
+      appendPtyOutput(entry, new Uint8Array([0xae, 0x8c]));
+      closePtyOutput(entry, 7);
+
+      const first = await pending;
+      expect(first).toContain(`Process running with session ID ${sessionId}`);
+      expect(first).toContain('first');
+      expect(first).not.toContain('完');
+      expect(terminate).not.toHaveBeenCalled();
+
+      const last = await writePtyStdin({
+        providerName: 'TestSandbox',
+        registry,
+        sessionId,
+      });
+      expect(last).toContain('完');
+      expect(last).not.toContain('first');
+      expect(last).not.toContain('\uFFFD');
+      expect(last).toContain('Process exited with code 7');
+      expect(terminate).toHaveBeenCalledOnce();
+      expect(registry.get(sessionId)).toBeUndefined();
+    },
+  );
+
+  test('retains PTY UTF-8 carry across a truncated yield and flushes once on closure', async () => {
+    const entry = createPtyProcessEntry({});
+    appendPtyOutput(entry, '0123456789abcdef');
+    appendPtyOutput(entry, new Uint8Array([0xf0, 0x9f]));
+    await expect(
+      collectPtyOutput({ entry, yieldTimeMs: 0, maxOutputTokens: 1 }),
+    ).resolves.toEqual({
+      text: '...4',
+      originalTokenCount: 4,
+      outputClosed: false,
+    });
+    appendPtyOutput(entry, new Uint8Array([0x8e, 0x89]));
+    appendPtyOutput(entry, new Uint8Array([0xe5]));
+    closePtyOutput(entry, 0);
+    closePtyOutput(entry, 1);
+    await expect(collectPtyOutput({ entry, yieldTimeMs: 0 })).resolves.toEqual({
+      text: '🎉\uFFFD',
+      outputClosed: true,
+    });
+    expect(entry.exitCode).toBe(0);
   });
 
   test('writes PTY stdin, finalizes completed sessions, and reports missing sessions', async () => {
@@ -4748,7 +4833,7 @@ describe('remote sandbox path helpers', () => {
     const { sessionId } = registry.register(entry);
 
     appendPtyOutput(entry, 'ready\n');
-    markPtyDone(entry, 0);
+    closePtyOutput(entry, 0);
 
     const output = await writePtyStdin({
       providerName: 'FakeSandboxClient',
@@ -4798,12 +4883,12 @@ describe('remote sandbox path helpers', () => {
     const success = registry.register(successEntry);
     const failure = registry.register(failureEntry);
 
-    watchPtyProcess(
+    watchPtyOutput(
       successEntry,
       async () => ({ exitCode: 2.9 }),
       (result) => (result as { exitCode: number }).exitCode,
     );
-    watchPtyProcess(
+    watchPtyOutput(
       failureEntry,
       async () => {
         throw new Error('boom');
@@ -4812,8 +4897,8 @@ describe('remote sandbox path helpers', () => {
     );
 
     await vi.waitFor(() => {
-      expect(successEntry.done).toBe(true);
-      expect(failureEntry.done).toBe(true);
+      expect(successEntry.outputClosed).toBe(true);
+      expect(failureEntry.outputClosed).toBe(true);
     });
 
     expect(successEntry.exitCode).toBe(2);


### PR DESCRIPTION
This pull request fixes loss of trailing PTY output when completion races with response collection. Sessions remain available until a response drains closed output, and Cloudflare preserves exit status while collecting output through WebSocket closure. Existing UTF-8 decoding, yield limits, and truncation are preserved.