### PR TITLE
fix(sandbox): await PTY startup cleanup

### DIFF
--- a/.changeset/tidy-pty-startup.md
+++ b/.changeset/tidy-pty-startup.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-extensions': patch
+'@openai/agents-core': patch
+---
+
+fix: bound WebSocket startup cleanup, settle acquired PTY resources, and stabilize local PTY exit regression coverage

--- a/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocal.process.test.ts
@@ -19,6 +19,24 @@ const execFileAsync = promisify(execFile);
 const ACTIVE_PROCESS_POLL_MS = 50;
 const ACTIVE_PROCESS_MAX_POLLS = 80;
 
+// Keep real PTY output without macOS controlling-terminal exit teardown.
+const forkPtyWithoutControllingTerminal = String.raw`
+def fork_without_controlling_terminal():
+    master, slave = pty.openpty()
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        for target in (0, 1, 2):
+            os.dup2(slave, target)
+        if slave > 2:
+            os.close(slave)
+        return 0, -1
+    os.close(slave)
+    return pid, master
+
+pty.fork = fork_without_controlling_terminal
+`;
+
 describe('UnixLocalSandboxClient process sessions', () => {
   let rootDir: string;
 
@@ -171,12 +189,15 @@ describe('UnixLocalSandboxClient process sessions', () => {
     const originalPython = process.env.OPENAI_AGENTS_PYTHON;
     const pythonPath = await whichPython();
     const controlledPython = join(rootDir, 'controlled-python');
-    // Control the real child's exit ordering without replacing its PTY output.
+    // A blocking wait must not wait for macOS to drain a controlling terminal.
     await writeFile(
       controlledPython,
       String.raw`#!${pythonPath}
 import os
+import pty
 import sys
+
+${forkPtyWithoutControllingTerminal}
 
 original_write = os.write
 original_waitpid = os.waitpid
@@ -250,20 +271,8 @@ import os
 import pty
 import sys
 
-def fork_without_controlling_terminal():
-    master, slave = pty.openpty()
-    pid = os.fork()
-    if pid == 0:
-        os.close(master)
-        for target in (0, 1, 2):
-            os.dup2(slave, target)
-        if slave > 2:
-            os.close(slave)
-        return 0, -1
-    os.close(slave)
-    return pid, master
+${forkPtyWithoutControllingTerminal}
 
-pty.fork = fork_without_controlling_terminal
 script = sys.argv[2]
 sys.argv = [sys.argv[0], *sys.argv[3:]]
 exec(script)

--- a/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/sandbox.ts
@@ -65,6 +65,7 @@ import {
   type PtyProcessEntry,
   type ManifestMountMaterializationContext,
 } from '../shared';
+import { closePtyWebSocket } from '../shared/pty';
 import {
   configuredMountCredentialFields,
   validateMountCredentialBoundaries,
@@ -318,7 +319,10 @@ export class BlaxelSandboxSession extends RemoteSandboxSessionBase<BlaxelSandbox
       });
     } finally {
       if (!registered) {
-        await entry.terminate?.().catch(() => {});
+        removeMessageListener();
+        removeCloseListener();
+        removeErrorListener();
+        await closePtyWebSocket(socket).catch(() => {});
       }
     }
   }

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -71,6 +71,7 @@ import {
 import {
   addPtyWebSocketListener,
   appendPtyOutput,
+  closePtyWebSocket,
   createPtyProcessEntry,
   formatPtyExecUpdate,
   closePtyOutput,
@@ -272,55 +273,56 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
     const start = Date.now();
     const entry = createPtyProcessEntry({ tty: true });
     let readyPromise: Promise<void> = Promise.resolve();
+    let disposeReadyWait = () => {};
     let removeMessageListener = () => {};
-    const socket = await openPtyWebSocket({
-      url: buildCloudflarePtyWebSocketUrl(this.state),
-      providerName: 'CloudflareSandboxClient',
-      headers: buildCloudflarePtyWebSocketHeaders(this.apiKey),
-      headersUnsupportedUrl: buildCloudflarePtyWebSocketUrl(
-        this.state,
-        this.apiKey,
-      ),
-      configure: (pendingSocket) => {
-        removeMessageListener = addPtyWebSocketListener(
-          pendingSocket,
-          'message',
-          (event) => handleCloudflarePtyMessage(entry, event),
-        );
-        readyPromise = waitForCloudflarePtyReady(pendingSocket);
-        readyPromise.catch(() => {});
-      },
-    });
-    const removeCloseListener = addPtyWebSocketListener(socket, 'close', () => {
-      if (!entry.outputClosed) {
-        closePtyOutput(entry, entry.exitCode);
-      }
-    });
-    const removeErrorListener = addPtyWebSocketListener(socket, 'error', () => {
-      if (!entry.outputClosed) {
-        closePtyOutput(entry, entry.exitCode ?? 1);
-      }
-    });
-
-    try {
-      await readyPromise;
-    } catch (error) {
-      socket.close();
-      throw error;
-    }
-
-    entry.sendInput = async (chars) => {
-      socket.send(new TextEncoder().encode(chars));
-    };
-    entry.terminate = async () => {
-      removeMessageListener();
-      removeCloseListener();
-      removeErrorListener();
-      socket.close();
-    };
+    let removeCloseListener = () => {};
+    let removeErrorListener = () => {};
+    let socket: PtyWebSocket | undefined;
     let registered = false;
     let sessionId: number;
     try {
+      socket = await openPtyWebSocket({
+        url: buildCloudflarePtyWebSocketUrl(this.state),
+        providerName: 'CloudflareSandboxClient',
+        headers: buildCloudflarePtyWebSocketHeaders(this.apiKey),
+        headersUnsupportedUrl: buildCloudflarePtyWebSocketUrl(
+          this.state,
+          this.apiKey,
+        ),
+        configure: (pendingSocket) => {
+          removeMessageListener = addPtyWebSocketListener(
+            pendingSocket,
+            'message',
+            (event) => handleCloudflarePtyMessage(entry, event),
+          );
+          const readyWait = waitForCloudflarePtyReady(pendingSocket);
+          readyPromise = readyWait.promise;
+          disposeReadyWait = readyWait.dispose;
+          readyPromise.catch(() => {});
+        },
+      });
+      const openedSocket = socket;
+      removeCloseListener = addPtyWebSocketListener(socket, 'close', () => {
+        if (!entry.outputClosed) {
+          closePtyOutput(entry, entry.exitCode);
+        }
+      });
+      removeErrorListener = addPtyWebSocketListener(socket, 'error', () => {
+        if (!entry.outputClosed) {
+          closePtyOutput(entry, entry.exitCode ?? 1);
+        }
+      });
+      await readyPromise;
+
+      entry.sendInput = async (chars) => {
+        openedSocket.send(new TextEncoder().encode(chars));
+      };
+      entry.terminate = async () => {
+        removeMessageListener();
+        removeCloseListener();
+        removeErrorListener();
+        openedSocket.close();
+      };
       const command = shellCommandForPty({
         ...args,
         cmd: sandboxUserShellCommand(
@@ -340,11 +342,16 @@ export class CloudflareSandboxSession implements SandboxSession<CloudflareSandbo
       if (registeredProcess.pruned) {
         await registeredProcess.pruned.terminate?.().catch(() => {});
       }
-    } catch (error) {
+    } finally {
+      disposeReadyWait();
       if (!registered) {
-        await entry.terminate?.().catch(() => {});
+        removeMessageListener();
+        removeCloseListener();
+        removeErrorListener();
+        if (socket) {
+          await closePtyWebSocket(socket).catch(() => {});
+        }
       }
-      throw error;
     }
 
     return await formatPtyExecUpdate({
@@ -1612,8 +1619,12 @@ function truncateCloudflareErrorBody(body: string): string {
   return body.length > 500 ? `${body.slice(0, 497)}...` : body;
 }
 
-function waitForCloudflarePtyReady(socket: PtyWebSocket): Promise<void> {
-  return new Promise((resolve, reject) => {
+function waitForCloudflarePtyReady(socket: PtyWebSocket): {
+  promise: Promise<void>;
+  dispose: () => void;
+} {
+  let dispose = () => {};
+  const promise = new Promise<void>((resolve, reject) => {
     let removeMessage = () => {};
     let removeClose = () => {};
     let removeError = () => {};
@@ -1627,6 +1638,7 @@ function waitForCloudflarePtyReady(socket: PtyWebSocket): Promise<void> {
       removeClose();
       removeError();
     };
+    dispose = cleanup;
     removeMessage = addPtyWebSocketListener(socket, 'message', (event) => {
       const payload = parseCloudflarePtyControlPayload(event);
       if (isRecord(payload)) {
@@ -1654,6 +1666,7 @@ function waitForCloudflarePtyReady(socket: PtyWebSocket): Promise<void> {
       reject(new UserError('CloudflareSandboxClient PTY WebSocket failed.'));
     });
   });
+  return { promise, dispose };
 }
 
 function cloudflarePtyReadyErrorMessage(

--- a/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/daytona/sandbox.ts
@@ -352,29 +352,32 @@ export class DaytonaSandboxSession implements SandboxSession<DaytonaSandboxSessi
       rows: 24,
       onData: (data: Uint8Array | string) => appendPtyOutput(entry, data),
     });
-    if (handle.waitForConnection) {
-      await handle.waitForConnection();
-    }
+    try {
+      if (handle.waitForConnection) {
+        await handle.waitForConnection();
+      }
 
-    if (!handle.sendInput) {
+      if (!handle.sendInput) {
+        throw new SandboxUnsupportedFeatureError(
+          'DaytonaSandboxClient tty=true requires Daytona SDK PTY stdin support.',
+          {
+            provider: 'daytona',
+            feature: 'tty.stdin',
+          },
+        );
+      }
+      if (!handle.wait) {
+        throw new SandboxUnsupportedFeatureError(
+          'DaytonaSandboxClient tty=true requires Daytona SDK PTY wait support.',
+          {
+            provider: 'daytona',
+            feature: 'tty.wait',
+          },
+        );
+      }
+    } catch (error) {
       await this.terminatePtyHandle(handle, providerSessionId);
-      throw new SandboxUnsupportedFeatureError(
-        'DaytonaSandboxClient tty=true requires Daytona SDK PTY stdin support.',
-        {
-          provider: 'daytona',
-          feature: 'tty.stdin',
-        },
-      );
-    }
-    if (!handle.wait) {
-      await this.terminatePtyHandle(handle, providerSessionId);
-      throw new SandboxUnsupportedFeatureError(
-        'DaytonaSandboxClient tty=true requires Daytona SDK PTY wait support.',
-        {
-          provider: 'daytona',
-          feature: 'tty.wait',
-        },
-      );
+      throw error;
     }
     const waitForExit = handle.wait.bind(handle);
     entry.sendInput = async (chars) => {

--- a/packages/agents-extensions/src/sandbox/shared/pty.ts
+++ b/packages/agents-extensions/src/sandbox/shared/pty.ts
@@ -6,6 +6,7 @@ import { shellQuote } from './paths';
 const PTY_YIELD_TIME_MS_MIN = 250;
 const PTY_EMPTY_YIELD_TIME_MS_MIN = 5_000;
 const PTY_YIELD_TIME_MS_MAX = 30_000;
+const PTY_WEBSOCKET_CLOSE_TIMEOUT_MS = 1_000;
 
 const PTY_PROCESSES_MAX = 64;
 const PTY_PROCESSES_PROTECTED_RECENT = 8;
@@ -126,14 +127,42 @@ export async function openPtyWebSocket(args: {
   configure?: (socket: PtyWebSocket) => void | Promise<void>;
 }): Promise<PtyWebSocket> {
   const socket = await createWebSocket(args);
-  socket.binaryType = 'arraybuffer';
-  await args.configure?.(socket);
-  await waitForPtyWebSocketOpen(
-    socket,
-    args.timeoutMs ?? 30_000,
-    args.providerName,
-  );
-  return socket;
+  try {
+    socket.binaryType = 'arraybuffer';
+    await args.configure?.(socket);
+    await waitForPtyWebSocketOpen(
+      socket,
+      args.timeoutMs ?? 30_000,
+      args.providerName,
+    );
+    return socket;
+  } catch (error) {
+    await closePtyWebSocket(socket).catch(() => {});
+    throw error;
+  }
+}
+
+export async function closePtyWebSocket(socket: PtyWebSocket): Promise<void> {
+  if (socket.readyState === 3) {
+    return;
+  }
+  let removeClose = () => {};
+  let removeError = () => {};
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await new Promise<void>((resolve) => {
+      // Native WebSocket may never emit close after a failed connection.
+      timeout = setTimeout(resolve, PTY_WEBSOCKET_CLOSE_TIMEOUT_MS);
+      removeClose = addPtyWebSocketListener(socket, 'close', () => resolve());
+      // Node ws emits an error when closing a socket that is still connecting.
+      removeError = addPtyWebSocketListener(socket, 'error', () => {});
+      socket.close();
+    });
+  } finally {
+    clearTimeout(timeout);
+    removeClose();
+    removeError();
+  }
 }
 
 export function addPtyWebSocketListener(

--- a/packages/agents-extensions/test/sandbox/blaxel.test.ts
+++ b/packages/agents-extensions/test/sandbox/blaxel.test.ts
@@ -642,33 +642,110 @@ describe('BlaxelSandboxClient', () => {
     expect(command).toContain('printf "$CLIENT_SECRET:$MANIFEST_VALUE"');
   });
 
-  test('terminates PTY sockets when the initial command cannot be built', async () => {
+  test.each([false, true])(
+    'settles PTY cleanup when the initial command cannot be built (close fails: %s)',
+    async (closeFails) => {
+      globalThis.WebSocket =
+        TestWebSocket as unknown as typeof globalThis.WebSocket;
+      const client = new BlaxelSandboxClient({
+        apiKey: 'blaxel-token',
+      });
+      const session = await client.create(
+        new Manifest({
+          environment: {
+            'X; touch /tmp/pwned; #': 'bad',
+          },
+        }),
+      );
+
+      let settled = false;
+      const startedPromise = session
+        .execCommand({
+          cmd: 'ls',
+          tty: true,
+          yieldTimeMs: 250,
+        })
+        .catch((error) => {
+          settled = true;
+          return error;
+        });
+      const socket = await TestWebSocket.nextInstance();
+      const finishClose = socket.close.bind(socket);
+      const close = vi.spyOn(socket, 'close').mockImplementation(() => {
+        if (closeFails) throw new Error('close failed');
+      });
+      socket.open();
+      await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+      if (!closeFails) {
+        expect(settled).toBe(false);
+        finishClose();
+      }
+
+      expect((await startedPromise).message).toContain(
+        'Invalid environment variable name',
+      );
+      if (!closeFails) expect(socket.readyState).toBe(3);
+      expect(socket.sent).toHaveLength(0);
+      await session.close();
+      expect(close).toHaveBeenCalledOnce();
+    },
+  );
+
+  test('closes the acquired socket when PTY opening fails', async () => {
     globalThis.WebSocket =
       TestWebSocket as unknown as typeof globalThis.WebSocket;
-    const client = new BlaxelSandboxClient({
-      apiKey: 'blaxel-token',
-    });
-    const session = await client.create(
-      new Manifest({
-        environment: {
-          'X; touch /tmp/pwned; #': 'bad',
-        },
-      }),
-    );
-
-    const startedPromise = session.execCommand({
-      cmd: 'ls',
-      tty: true,
-      yieldTimeMs: 250,
-    });
+    const session = await new BlaxelSandboxClient({
+      apiKey: 'test-key',
+    }).create(new Manifest());
+    const result = session.execCommand({ cmd: 'echo ready', tty: true });
     const socket = await TestWebSocket.nextInstance();
-    socket.open();
-
-    await expect(startedPromise).rejects.toThrow(
-      'Invalid environment variable name',
-    );
-    expect(socket.readyState).toBe(3);
+    const close = vi.spyOn(socket, 'close');
+    await vi.waitFor(() => expect(socket.listenerCount('open')).toBe(1));
+    socket.failOpening();
+    await expect(result).rejects.toThrow('failed to connect');
+    expect(close).toHaveBeenCalledOnce();
     expect(socket.sent).toHaveLength(0);
+    await session.close();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  test('bounds failed PTY startup when the socket never emits close', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const session = await new BlaxelSandboxClient({
+      apiKey: 'test-key',
+    }).create(new Manifest());
+    let failure: Error | undefined;
+    const result = session
+      .execCommand({ cmd: 'echo ready', tty: true })
+      .catch((error) => {
+        failure = error;
+      });
+    const socket = await TestWebSocket.nextInstance();
+    await vi.waitFor(() => expect(socket.listenerCount('open')).toBe(1));
+    // Native Node 22 WebSocket can remain CLOSING after a failed handshake.
+    const close = vi.spyOn(socket, 'close').mockImplementation(() => {
+      socket.readyState = 2;
+    });
+    vi.useFakeTimers();
+    try {
+      socket.failOpening();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(close).toHaveBeenCalledOnce();
+      expect(failure).toBeUndefined();
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(failure?.message).toContain('failed to connect');
+      await result;
+      for (const event of ['open', 'error', 'close', 'message']) {
+        expect(socket.listenerCount(event)).toBe(0);
+      }
+      expect(vi.getTimerCount()).toBe(0);
+      expect(socket.sent).toHaveLength(0);
+      await session.close();
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test('preserves PTY error exit codes after websocket close', async () => {
@@ -2730,6 +2807,14 @@ class TestWebSocket {
     }
     this.readyState = 3;
     this.dispatch('close', { code });
+  }
+
+  listenerCount(type: string): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+
+  failOpening(): void {
+    this.dispatch('error', { message: 'connection failed' });
   }
 
   open(): void {

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -1389,6 +1389,67 @@ describe('CloudflareSandboxClient', () => {
     expect(started).toContain('Process running with session ID');
   });
 
+  test.each(['opening', 'ready'] as const)(
+    'settles PTY socket cleanup after %s failure',
+    async (phase) => {
+      globalThis.WebSocket =
+        TestWebSocket as unknown as typeof globalThis.WebSocket;
+      const session = await new CloudflareSandboxClient({ apiKey: '' }).create(
+        new Manifest(),
+        { workerUrl: 'https://worker.example.com' },
+      );
+      let settled = false;
+      const result = session
+        .execCommand({ cmd: 'echo ready', tty: true })
+        .catch((error) => {
+          settled = true;
+          return error;
+        });
+      const socket = await TestWebSocket.nextInstance();
+      const finishClose = socket.close.bind(socket);
+      const close = vi.spyOn(socket, 'close').mockImplementation(() => {});
+      if (phase === 'ready') {
+        socket.open();
+        socket.message(
+          JSON.stringify({ type: 'error', message: 'pty disabled' }),
+        );
+      } else {
+        await vi.waitFor(() => expect(socket.listenerCount('open')).toBe(1));
+        socket.error();
+      }
+      await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+      expect(settled).toBe(false);
+      finishClose();
+      const error = await result;
+      expect(error.message).toContain(
+        phase === 'ready' ? 'pty disabled' : 'failed to connect',
+      );
+      expect(socket.sent).toHaveLength(0);
+      expect(socket.listenerCount()).toBe(0);
+      await session.close();
+      expect(close).toHaveBeenCalledOnce();
+    },
+  );
+
+  test('preserves PTY ready failure when socket close throws', async () => {
+    globalThis.WebSocket =
+      TestWebSocket as unknown as typeof globalThis.WebSocket;
+    const session = await new CloudflareSandboxClient({ apiKey: '' }).create(
+      new Manifest(),
+      { workerUrl: 'https://worker.example.com' },
+    );
+    const result = session.execCommand({ cmd: 'echo ready', tty: true });
+    const socket = await TestWebSocket.nextInstance();
+    vi.spyOn(socket, 'close').mockImplementation(() => {
+      throw new Error('close failed');
+    });
+    socket.open();
+    socket.message(JSON.stringify({ type: 'error', message: 'pty disabled' }));
+    await expect(result).rejects.toThrow('pty disabled');
+    expect(socket.listenerCount()).toBe(0);
+    await session.close();
+  });
+
   test('rejects PTY error control frames before ready', async () => {
     globalThis.WebSocket =
       TestWebSocket as unknown as typeof globalThis.WebSocket;
@@ -2233,6 +2294,14 @@ class TestWebSocket {
 
   removeEventListener(type: string, listener: (event: unknown) => void): void {
     this.listeners.get(type)?.delete(listener);
+  }
+
+  listenerCount(type?: string): number {
+    if (type) return this.listeners.get(type)?.size ?? 0;
+    return [...this.listeners.values()].reduce(
+      (count, listeners) => count + listeners.size,
+      0,
+    );
   }
 
   send(data: string | Uint8Array | ArrayBuffer): void {

--- a/packages/agents-extensions/test/sandbox/daytona.test.ts
+++ b/packages/agents-extensions/test/sandbox/daytona.test.ts
@@ -21,6 +21,7 @@ const createMock = vi.fn();
 const getMock = vi.fn();
 const executeCommandMock = vi.fn();
 const createPtyMock = vi.fn();
+const killPtySessionMock = vi.fn();
 const createFolderMock = vi.fn();
 const uploadFileMock = vi.fn();
 const downloadFileMock = vi.fn();
@@ -59,6 +60,7 @@ describe('DaytonaSandboxClient', () => {
     getMock.mockReset();
     executeCommandMock.mockReset();
     createPtyMock.mockReset();
+    killPtySessionMock.mockReset();
     createFolderMock.mockReset();
     uploadFileMock.mockReset();
     downloadFileMock.mockReset();
@@ -83,6 +85,7 @@ describe('DaytonaSandboxClient', () => {
       process: {
         executeCommand: executeCommandMock,
         createPty: createPtyMock,
+        killPtySession: killPtySessionMock,
       },
       getSignedPreviewUrl: getSignedPreviewUrlMock,
     };
@@ -624,6 +627,93 @@ describe('DaytonaSandboxClient', () => {
 
     expect(killMock).toHaveBeenCalledOnce();
     expect(disconnectMock).toHaveBeenCalledOnce();
+  });
+
+  test('does not kill a PTY when creation returns no handle', async () => {
+    const failure = new Error('create failed');
+    createPtyMock.mockRejectedValueOnce(failure);
+    const session = await new DaytonaSandboxClient().create(new Manifest());
+    await expect(session.execCommand({ cmd: 'sh', tty: true })).rejects.toBe(
+      failure,
+    );
+    await session.close();
+    expect(killPtySessionMock).not.toHaveBeenCalled();
+  });
+
+  test.each([false, true])(
+    'settles failed PTY connection cleanup before rejecting (fallback kill: %s)',
+    async (fallbackKill) => {
+      const failure = new Error('connection failed');
+      let finishKill!: () => void;
+      let finishDisconnect!: () => void;
+      const kill = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishKill = resolve;
+          }),
+      );
+      const disconnect = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            finishDisconnect = resolve;
+          }),
+      );
+      // Provider handles are doubled to control cleanup completion ordering.
+      createPtyMock.mockResolvedValueOnce({
+        sessionId: 'failed-connection',
+        waitForConnection: async () => {
+          throw failure;
+        },
+        ...(fallbackKill ? {} : { kill }),
+        disconnect,
+      });
+      if (fallbackKill) killPtySessionMock.mockImplementation(kill);
+      const client = new DaytonaSandboxClient();
+      const session = await client.create(new Manifest());
+      let settled = false;
+      const result = session
+        .execCommand({ cmd: 'sh', tty: true })
+        .catch((error) => {
+          settled = true;
+          return error;
+        });
+      await vi.waitFor(() => expect(kill).toHaveBeenCalledOnce());
+      expect(settled).toBe(false);
+      finishKill();
+      await vi.waitFor(() => expect(disconnect).toHaveBeenCalledOnce());
+      expect(settled).toBe(false);
+      finishDisconnect();
+      expect(await result).toBe(failure);
+      if (fallbackKill) expect(kill).toHaveBeenCalledWith('failed-connection');
+      await session.close();
+      expect(kill).toHaveBeenCalledOnce();
+      expect(disconnect).toHaveBeenCalledOnce();
+    },
+  );
+
+  test('preserves the PTY connection error when kill and disconnect fail', async () => {
+    const failure = new Error('connection failed');
+    const kill = vi.fn(async () => {
+      throw new Error('kill failed');
+    });
+    const disconnect = vi.fn(async () => {
+      throw new Error('disconnect failed');
+    });
+    createPtyMock.mockResolvedValueOnce({
+      waitForConnection: async () => {
+        throw failure;
+      },
+      kill,
+      disconnect,
+    });
+    const session = await new DaytonaSandboxClient().create(new Manifest());
+    await expect(session.execCommand({ cmd: 'sh', tty: true })).rejects.toBe(
+      failure,
+    );
+    expect(kill).toHaveBeenCalledOnce();
+    expect(disconnect).toHaveBeenCalledOnce();
+    await session.close();
+    expect(kill).toHaveBeenCalledOnce();
   });
 
   test('registers PTY handles before sending the initial command', async () => {

--- a/packages/agents-extensions/test/sandbox/e2b.test.ts
+++ b/packages/agents-extensions/test/sandbox/e2b.test.ts
@@ -722,14 +722,21 @@ describe('E2BSandboxClient', () => {
   });
 
   test('terminates PTY execution when the initial stdin write fails', async () => {
-    const handleKillMock = vi.fn(async () => true);
+    let failCleanup!: (error: Error) => void;
+    const handleKillMock = vi.fn(
+      () =>
+        new Promise<boolean>((_resolve, reject) => {
+          failCleanup = reject;
+        }),
+    );
+    const failure = new Error('stdin unavailable');
     const ptyCreateMock = vi.fn(async () => ({
       pid: 42,
       wait: async () => ({ exitCode: 1 }),
       kill: handleKillMock,
     }));
     const ptySendInputMock = vi.fn(async () => {
-      throw new Error('stdin unavailable');
+      throw failure;
     });
     createMock.mockResolvedValueOnce({
       sandboxId: 'sbx_test',
@@ -754,9 +761,17 @@ describe('E2BSandboxClient', () => {
     const client = new E2BSandboxClient();
     const session = await client.create(new Manifest());
 
-    await expect(
-      session.execCommand({ cmd: 'echo ready', tty: true }),
-    ).rejects.toThrow('stdin unavailable');
+    let settled = false;
+    const result = session
+      .execCommand({ cmd: 'echo ready', tty: true })
+      .catch((error) => {
+        settled = true;
+        return error;
+      });
+    await vi.waitFor(() => expect(handleKillMock).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    failCleanup(new Error('kill failed'));
+    expect(await result).toBe(failure);
 
     expect(ptySendInputMock).toHaveBeenCalledOnce();
     expect(handleKillMock).toHaveBeenCalledOnce();

--- a/packages/agents-extensions/test/sandbox/pty.test.ts
+++ b/packages/agents-extensions/test/sandbox/pty.test.ts
@@ -1,0 +1,136 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, expect, test, vi } from 'vitest';
+import { openPtyWebSocket } from '../../src/sandbox/shared/pty';
+
+// This transport controls error/close ordering, including Node ws cleanup errors.
+class StartupWebSocket extends EventEmitter {
+  static instances: StartupWebSocket[] = [];
+  readyState = 0;
+  binaryType = '';
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 2;
+  });
+
+  constructor(_url: string) {
+    super();
+    StartupWebSocket.instances.push(this);
+  }
+
+  finishClose() {
+    this.readyState = 3;
+    this.emit('close');
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  StartupWebSocket.instances = [];
+});
+
+test.each(['configure', 'error', 'close', 'timeout'] as const)(
+  'settles socket cleanup before reporting startup %s',
+  async (mode) => {
+    vi.stubGlobal('WebSocket', StartupWebSocket);
+    const original = new Error('configuration failed');
+    let settled = false;
+    const result = openPtyWebSocket({
+      url: 'wss://pty.example.test',
+      providerName: 'Test',
+      timeoutMs: mode === 'timeout' ? 100 : 30_000,
+      configure:
+        mode === 'configure'
+          ? async () => {
+              throw original;
+            }
+          : undefined,
+    }).catch((error) => {
+      settled = true;
+      return error;
+    });
+    await vi.waitFor(() => expect(StartupWebSocket.instances).toHaveLength(1));
+    const socket = StartupWebSocket.instances[0]!;
+    if (mode === 'error' || mode === 'close') {
+      await vi.waitFor(() => expect(socket.listenerCount('open')).toBe(1));
+    }
+    if (mode === 'error') socket.emit('error', new Error('open failed'));
+    if (mode === 'close') socket.finishClose();
+    if (mode !== 'close') {
+      await vi.waitFor(() => expect(socket.close).toHaveBeenCalledOnce());
+      expect(settled).toBe(false);
+      // Closing a connecting Node ws socket emits error before close.
+      socket.emit('error', new Error('closed before connection established'));
+      expect(settled).toBe(false);
+      socket.finishClose();
+    }
+    const error = await result;
+    if (mode === 'configure') expect(error).toBe(original);
+    else
+      expect(error.message).toContain(
+        {
+          error: 'failed to connect',
+          close: 'closed before opening',
+          timeout: 'connection timed out',
+        }[mode],
+      );
+    expect(socket.eventNames()).toEqual([]);
+  },
+);
+
+test('preserves configuration failure if closing throws', async () => {
+  vi.stubGlobal('WebSocket', StartupWebSocket);
+  const original = new Error('configuration failed');
+  await expect(
+    openPtyWebSocket({
+      url: 'wss://pty.example.test',
+      providerName: 'Test',
+      configure: () => {
+        StartupWebSocket.instances[0]!.close.mockImplementation(() => {
+          throw new Error('close failed');
+        });
+        throw original;
+      },
+    }),
+  ).rejects.toBe(original);
+  expect(StartupWebSocket.instances[0]!.eventNames()).toEqual([]);
+});
+
+test('leaves a successfully opened socket owned by its caller', async () => {
+  vi.stubGlobal('WebSocket', StartupWebSocket);
+  const pending = openPtyWebSocket({
+    url: 'wss://pty.example.test',
+    providerName: 'Test',
+  });
+  await vi.waitFor(() => expect(StartupWebSocket.instances).toHaveLength(1));
+  const socket = StartupWebSocket.instances[0]!;
+  socket.readyState = 1;
+  socket.emit('open');
+  expect(await pending).toBe(socket);
+  expect(socket.close).not.toHaveBeenCalled();
+  expect(socket.eventNames()).toEqual([]);
+});
+
+test.each(['close', 'throw'] as const)(
+  'clears the cleanup deadline when cleanup completes through %s',
+  async (mode) => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', StartupWebSocket);
+    const original = new Error('configuration failed');
+    const result = openPtyWebSocket({
+      url: 'wss://pty.example.test',
+      providerName: 'Test',
+      configure: () => {
+        const socket = StartupWebSocket.instances[0]!;
+        socket.close.mockImplementation(() => {
+          if (mode === 'throw') throw new Error('close failed');
+          socket.finishClose();
+        });
+        throw original;
+      },
+    }).catch((error) => error);
+    expect(await result).toBe(original);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(StartupWebSocket.instances[0]!.eventNames()).toEqual([]);
+  },
+);

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -4557,7 +4557,10 @@ describe('remote sandbox path helpers', () => {
 
       send() {}
 
-      close() {}
+      close() {
+        this.readyState = 3;
+        this.emit('close');
+      }
 
       addEventListener(type: string, listener: FakeListener) {
         const listeners = this.listeners.get(type) ?? new Set<FakeListener>();


### PR DESCRIPTION
This pull request fixes acquired PTY resources being left open when startup fails before process registration. It awaits WebSocket and Daytona handle cleanup, removes Cloudflare startup listeners and timers, and preserves the original error when cleanup also fails. Public APIs and registered-process teardown retain their existing behavior.

It also makes the local PTY output-draining regression test portable on macOS by reusing the existing real PTY fixture while retaining native terminal and signal coverage.