### PR TITLE
fix(agents-extensions): 유니코드 스트림 청크 손상 수정

### DIFF
--- a/.changeset/tidy-text-encoding.md
+++ b/.changeset/tidy-text-encoding.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: TextEncoderStream이 없는 환경에서 청크 경계에 걸친 유니코드 문자가 손상되지 않도록 수정합니다.

--- a/packages/agents-extensions/src/ai-sdk-ui/textStream.ts
+++ b/packages/agents-extensions/src/ai-sdk-ui/textStream.ts
@@ -6,9 +6,7 @@ export type AiSdkTextStreamSource =
   | { toTextStream: () => ReadableStream<string> };
 
 export type AiSdkTextStreamHeaders =
-  | Headers
-  | Record<string, string>
-  | Array<[string, string]>;
+  Headers | Record<string, string> | Array<[string, string]>;
 
 export type AiSdkTextStreamResponseOptions = {
   headers?: AiSdkTextStreamHeaders;
@@ -37,10 +35,24 @@ function encodeTextStream(
   }
 
   const encoder = new TextEncoder();
+  let pendingHighSurrogate = '';
   return textStream.pipeThrough(
     new TransformStream<string, Uint8Array>({
       transform(chunk, controller) {
-        controller.enqueue(encoder.encode(chunk));
+        const text = pendingHighSurrogate + chunk;
+        const lastCodeUnit = text.charCodeAt(text.length - 1);
+        const endsWithHighSurrogate =
+          lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff;
+        pendingHighSurrogate = endsWithHighSurrogate ? text.slice(-1) : '';
+        const completeText = endsWithHighSurrogate ? text.slice(0, -1) : text;
+        if (completeText.length > 0) {
+          controller.enqueue(encoder.encode(completeText));
+        }
+      },
+      flush(controller) {
+        if (pendingHighSurrogate) {
+          controller.enqueue(encoder.encode(pendingHighSurrogate));
+        }
       },
     }),
   );

--- a/packages/agents-extensions/test/ai-sdk-ui/textStream.test.ts
+++ b/packages/agents-extensions/test/ai-sdk-ui/textStream.test.ts
@@ -38,6 +38,37 @@ afterEach(() => {
 });
 
 describe('createAiSdkTextStreamResponse', () => {
+  test.each([true, false])(
+    'preserves split Unicode characters (native encoder: %s)',
+    async (nativeEncoder) => {
+      if (!nativeEncoder) {
+        vi.stubGlobal('TextEncoderStream', undefined);
+      }
+
+      const text = 'Hello 🌍!';
+      const response = createAiSdkTextStreamResponse(
+        stringStream(text.split('').flatMap((chunk) => [chunk, ''])),
+      );
+
+      await expect(response.text()).resolves.toBe(text);
+    },
+  );
+
+  test.each([true, false])(
+    'replaces unmatched surrogates including at end of stream (native encoder: %s)',
+    async (nativeEncoder) => {
+      if (!nativeEncoder) {
+        vi.stubGlobal('TextEncoderStream', undefined);
+      }
+
+      const response = createAiSdkTextStreamResponse(
+        stringStream(['\ud83c', 'text', '\udf0d', '\ud83c', '']),
+      );
+
+      await expect(response.text()).resolves.toBe('\ufffdtext\ufffd\ufffd');
+    },
+  );
+
   test('streams text and applies default headers', async () => {
     const response = createAiSdkTextStreamResponse(
       stringStream(['Hello', ' ', 'world']),


### PR DESCRIPTION
## 변경 내용

`TextEncoderStream`을 사용할 수 없는 환경에서 문자열 스트림 청크 경계에 걸친 유니코드 문자가 손상되는 문제를 수정했습니다.

기존 fallback 구현은 각 청크를 개별적으로 인코딩했습니다. 이모지처럼 UTF-16 surrogate pair를 사용하는 문자가 청크 사이에서 분리되면 `�`로 변환되었습니다. 마지막 high surrogate를 다음 청크까지 보류하고 스트림 종료 시 기존 `TextEncoder` 동작으로 처리하도록 수정했습니다.

## 검증

- native `TextEncoderStream` 및 fallback 경로 테스트
- 청크 경계에서 분할된 이모지 테스트
- malformed surrogate 및 스트림 종료 처리 테스트
- 빈 청크와 한글 입력 테스트
- 관련 Vitest 7개 통과
- 패키지 빌드 체크, ESLint, Prettier 통과