### PR TITLE
fix: preserve model settings for GPT-5 and newer models

### DIFF
--- a/.changeset/tidy-astra-settings.md
+++ b/.changeset/tidy-astra-settings.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: preserve explicit settings for GPT-5-and-newer models and concrete model instances, default gpt-6-astra reasoning to low, and use adapter-declared prompt model selection when applying implicit defaults (#1849).

--- a/packages/agents-core/src/agent.ts
+++ b/packages/agents-core/src/agent.ts
@@ -8,8 +8,8 @@ import {
 import type { Model, ModelSettings, Prompt } from './model';
 import {
   getDefaultModelSettings,
-  gpt5ReasoningSettingsRequired,
-  isGpt5Default,
+  isGpt5OrNewerReasoningModel,
+  isGpt5OrNewerDefault,
 } from './defaultModel';
 import { RunContext } from './runContext';
 import {
@@ -599,20 +599,18 @@ export class Agent<
     this.resetToolChoice = config.resetToolChoice ?? true;
 
     if (
-      // The user sets a non-default model
+      // The user sets a non-default model.
       config.model !== undefined &&
       config.model !== Agent.DEFAULT_MODEL_PLACEHOLDER &&
-      // The default model is gpt-5
-      isGpt5Default() &&
-      // However, the specified model is not a gpt-5 model
+      // The default model uses GPT-5-and-newer settings.
+      isGpt5OrNewerDefault() &&
+      // The specified model is outside that settings family.
       (typeof config.model !== 'string' ||
-        !gpt5ReasoningSettingsRequired(config.model)) &&
-      // The model settings are not customized for the specified model
+        !isGpt5OrNewerReasoningModel(config.model)) &&
+      // The model settings are not customized for the specified model.
       config.modelSettings === undefined
     ) {
-      // In this scenario, we should use a generic model settings
-      // because non-gpt-5 models are not compatible with the default gpt-5 model settings.
-      // This is a best-effort attempt to make the agent work with non-gpt-5 models.
+      // Avoid applying reasoning-family defaults to an unrelated model.
       this.modelSettings = {};
     }
 

--- a/packages/agents-core/src/defaultModel.ts
+++ b/packages/agents-core/src/defaultModel.ts
@@ -21,12 +21,32 @@ export function gpt5ReasoningSettingsRequired(modelName: string): boolean {
   return modelName.startsWith('gpt-5');
 }
 
+/**
+ * Identifies the GPT-5-and-newer settings family, excluding known chat aliases.
+ * Membership does not require a model-specific default reasoning effort.
+ */
+export function isGpt5OrNewerReasoningModel(modelName: string): boolean {
+  if (GPT_5_CHAT_MODEL_PATTERNS.some((pattern) => pattern.test(modelName))) {
+    return false;
+  }
+  const version = /^gpt-(\d+)(?:\.\d+)?(?:-|$)/.exec(modelName);
+  return version !== null && Number(version[1]) >= 5;
+}
+
+/**
+ * Returns whether the default model belongs to the GPT-5-and-newer settings family.
+ */
+export function isGpt5OrNewerDefault(): boolean {
+  return isGpt5OrNewerReasoningModel(getDefaultModel());
+}
+
 const DEFAULT_REASONING_EFFORT_PATTERNS: Array<
   readonly [
     RegExp,
     Exclude<ModelSettingsReasoningEffort, 'minimal' | 'xhigh' | 'max' | null>,
   ]
 > = [
+  [/^gpt-6-astra$/, 'low'],
   [/^gpt-5(?:-\d{4}-\d{2}-\d{2})?$/, 'low'],
   [/^gpt-5\.1(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
   [/^gpt-5\.2(?:-\d{4}-\d{2}-\d{2})?$/, 'none'],
@@ -78,12 +98,12 @@ export function getDefaultModel(): string {
 
 /**
  * Returns the default model settings.
- * If the default model is a GPT-5 model, returns the GPT-5 default model settings.
+ * GPT-5-and-newer reasoning models receive model-specific defaults when known.
  * Otherwise, returns the legacy default model settings.
  */
 export function getDefaultModelSettings(model?: string): ModelSettings {
   const _model = model ?? getDefaultModel();
-  if (gpt5ReasoningSettingsRequired(_model)) {
+  if (isGpt5OrNewerReasoningModel(_model)) {
     const effort = getDefaultReasoningEffort(_model);
     if (effort !== undefined) {
       return {
@@ -92,7 +112,7 @@ export function getDefaultModelSettings(model?: string): ModelSettings {
       };
     }
     return {
-      // Keep the GPT-5 text verbosity default, but omit reasoning.effort for
+      // Keep the shared text verbosity default, but omit reasoning.effort for
       // variants whose supported values are not confirmed yet.
       text: { verbosity: 'low' },
     };

--- a/packages/agents-core/src/model.ts
+++ b/packages/agents-core/src/model.ts
@@ -687,6 +687,13 @@ export type ModelResponse = {
  */
 export interface Model {
   /**
+   * Whether this adapter lets a supplied prompt select the model unless
+   * `overridePromptModel` is true. Defaults to false when omitted.
+   * The Runner omits implicit model settings when such a prompt owns selection.
+   */
+  readonly supportsPromptModelSelection?: boolean;
+
+  /**
    * Get a response from the model.
    *
    * @param request - The request to get a response for.

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -66,7 +66,7 @@ import {
   finalizeOutputGuardrails,
 } from './runner/guardrails';
 import {
-  adjustModelSettingsForNonGPT5RunnerModel,
+  adjustModelSettingsForLegacyModel,
   mergeModelSettings,
   maybeResetToolChoice,
   selectModel,
@@ -3673,12 +3673,18 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
     const agentModelSettings = hasExplicitAgentModelSettings
       ? executionAgent.modelSettings
       : undefined;
-    const implicitModelSettings = hasExplicitAgentModelSettings
-      ? undefined
-      : getImplicitModelSettingsForResolvedModel(
-          explicitlyModelSet,
-          resolvedModelName,
-        );
+    // Only adapters that honor prompt model selection can replace the default model.
+    const promptOwnsModel =
+      model.supportsPromptModelSelection === true &&
+      executionAgent.prompt !== undefined &&
+      !explicitlyModelSet;
+    const implicitModelSettings =
+      hasExplicitAgentModelSettings || promptOwnsModel
+        ? undefined
+        : getImplicitModelSettingsForResolvedModel(
+            explicitlyModelSet,
+            resolvedModelName,
+          );
     const modelRequestInternal = {
       reasoningEffortImplicit:
         implicitModelSettings?.reasoning?.effort !== undefined &&
@@ -3694,10 +3700,9 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
       this.config.modelSettings,
     );
     modelSettings = mergeModelSettings(modelSettings, agentModelSettings);
-    modelSettings = adjustModelSettingsForNonGPT5RunnerModel(
+    modelSettings = adjustModelSettingsForLegacyModel(
       explicitlyModelSet,
       agentModelSettings ?? implicitModelSettings ?? {},
-      model,
       modelSettings,
       resolvedModelName,
     );

--- a/packages/agents-core/src/runner/modelSettings.ts
+++ b/packages/agents-core/src/runner/modelSettings.ts
@@ -1,10 +1,13 @@
 import { Agent } from '../agent';
-import { gpt5ReasoningSettingsRequired, isGpt5Default } from '../defaultModel';
+import {
+  isGpt5OrNewerReasoningModel,
+  isGpt5OrNewerDefault,
+} from '../defaultModel';
 import { Model, ModelSettings } from '../model';
 import { AgentToolUseTracker } from './toolUseTracker';
 export { mergeModelSettings } from './modelSettingsMerge';
 
-const hasGpt5OnlySettings = (settings?: ModelSettings): boolean => {
+const hasReasoningModelSettings = (settings?: ModelSettings): boolean => {
   const providerData = settings?.providerData as
     | {
         reasoning?: unknown;
@@ -58,44 +61,37 @@ export function maybeResetToolChoice(
 }
 
 /**
- * When the default model is a GPT-5 variant, agents may carry GPT-5-specific providerData
- * (e.g., reasoning effort, text verbosity). If a run resolves to a non-GPT-5 model and the
- * agent relied on the default model (i.e., no explicit model set), these GPT-5-only settings
- * are incompatible and should be stripped to avoid runtime errors.
+ * Preserves legacy settings cleanup for explicitly selected models outside the
+ * GPT-5-and-newer reasoning family when the default model belongs to that family.
  */
-export function adjustModelSettingsForNonGPT5RunnerModel(
+export function adjustModelSettingsForLegacyModel(
   explicitlyModelSet: boolean,
   agentModelSettings: ModelSettings,
-  runnerModel: string | Model,
   modelSettings: ModelSettings,
   resolvedModelName?: string,
 ): ModelSettings {
-  const modelName =
-    resolvedModelName ??
-    (typeof runnerModel === 'string'
-      ? runnerModel
-      : ((runnerModel as { model?: string; name?: string } | undefined)
-          ?.model ?? (runnerModel as { name?: string } | undefined)?.name));
-  const isNonGpt5RunnerModel =
-    typeof modelName === 'string'
-      ? !gpt5ReasoningSettingsRequired(modelName)
-      : true;
-  const hasGpt5Defaults =
-    hasGpt5OnlySettings(agentModelSettings) ||
-    hasGpt5OnlySettings(modelSettings);
+  // Only a resolved string selection establishes model identity.
+  const isLegacyModel =
+    typeof resolvedModelName === 'string' &&
+    !isGpt5OrNewerReasoningModel(resolvedModelName);
+  const hasReasoningSettings =
+    hasReasoningModelSettings(agentModelSettings) ||
+    hasReasoningModelSettings(modelSettings);
 
   if (
-    isGpt5Default() &&
+    isGpt5OrNewerDefault() &&
     explicitlyModelSet &&
-    isNonGpt5RunnerModel &&
-    hasGpt5Defaults
+    isLegacyModel &&
+    hasReasoningSettings
   ) {
-    return stripGpt5OnlySettings(modelSettings);
+    return stripReasoningModelSettings(modelSettings);
   }
   return modelSettings;
 }
 
-function stripGpt5OnlySettings(modelSettings: ModelSettings): ModelSettings {
+function stripReasoningModelSettings(
+  modelSettings: ModelSettings,
+): ModelSettings {
   const copiedProviderData = modelSettings.providerData
     ? { ...modelSettings.providerData }
     : undefined;

--- a/packages/agents-core/test/defaultModel.test.ts
+++ b/packages/agents-core/test/defaultModel.test.ts
@@ -5,6 +5,8 @@ import {
   getDefaultModelSettings,
   gpt5ReasoningSettingsRequired,
   isGpt5Default,
+  isGpt5OrNewerReasoningModel,
+  isGpt5OrNewerDefault,
 } from '../src/defaultModel';
 import { loadEnv } from '../src/config';
 import { Agent } from '../src/agent';
@@ -37,6 +39,34 @@ describe('gpt5ReasoningSettingsRequired', () => {
   });
   test('returns false for non GPT-5 models', () => {
     expect(gpt5ReasoningSettingsRequired('gpt-4o')).toBe(false);
+  });
+});
+describe('GPT-5-and-newer settings family', () => {
+  test.each(['gpt-5', 'gpt-5.1', 'gpt-6-astra'])(
+    'recognizes %s independently of effort defaults',
+    (model) => {
+      expect(isGpt5OrNewerReasoningModel(model)).toBe(true);
+    },
+  );
+
+  test.each([
+    'gpt-4.1',
+    'o3',
+    'gpt-5-chat-latest',
+    'gpt-5.1-chat-latest',
+    'gpt-5.2-chat-latest',
+    'gpt-5.3-chat-latest',
+  ])('keeps %s outside the settings family', (model) => {
+    expect(isGpt5OrNewerReasoningModel(model)).toBe(false);
+  });
+
+  test('preserves the public GPT-5 helper semantics for later generations', () => {
+    mockedLoadEnv.mockReturnValue({
+      [OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]: 'gpt-6-astra',
+    });
+    expect(isGpt5OrNewerDefault()).toBe(true);
+    expect(gpt5ReasoningSettingsRequired('gpt-6-astra')).toBe(false);
+    expect(isGpt5Default()).toBe(false);
   });
 });
 describe('getDefaultModel', () => {
@@ -84,6 +114,39 @@ describe('isGpt5Default', () => {
   });
 });
 describe('getDefaultModelSettings', () => {
+  test('uses low reasoning and verbosity for Astra explicitly and through the environment', () => {
+    const expected = {
+      reasoning: { effort: 'low' },
+      text: { verbosity: 'low' },
+    };
+    expect(getDefaultModelSettings('gpt-6-astra')).toEqual(expected);
+    expect(
+      new Agent({ name: 'Astra', model: 'gpt-6-astra' }).modelSettings,
+    ).toEqual(expected);
+    mockedLoadEnv.mockReturnValue({
+      [OPENAI_DEFAULT_MODEL_ENV_VARIABLE_NAME]: 'gpt-6-astra',
+    });
+    expect(getDefaultModelSettings()).toEqual(expected);
+    expect(new Agent({ name: 'Default Astra' }).modelSettings).toEqual(
+      expected,
+    );
+  });
+
+  test.each(['gpt-5-mini'])(
+    'omits an unregistered effort for %s while retaining shared verbosity',
+    (model) => {
+      expect(getDefaultModelSettings(model)).toEqual({
+        text: { verbosity: 'low' },
+      });
+      expect(
+        new Agent({ name: 'Model without an effort default', model })
+          .modelSettings,
+      ).toEqual({
+        text: { verbosity: 'low' },
+      });
+    },
+  );
+
   test('returns GPT-5.6 Luna defaults when no model is specified', () => {
     mockedLoadEnv.mockReturnValue({});
     expect(getDefaultModelSettings()).toEqual({

--- a/packages/agents-core/test/run.test.ts
+++ b/packages/agents-core/test/run.test.ts
@@ -8577,7 +8577,7 @@ describe('Runner.run', () => {
 
     beforeEach(() => {
       originalDefaultModel = process.env.OPENAI_DEFAULT_MODEL;
-      process.env.OPENAI_DEFAULT_MODEL = 'gpt-5o';
+      process.env.OPENAI_DEFAULT_MODEL = 'gpt-5.6-luna';
     });
 
     afterEach(() => {
@@ -8602,14 +8602,14 @@ describe('Runner.run', () => {
       };
     }
 
-    it('strips GPT-5-only settings when the RunConfig model is not a GPT-5 string', async () => {
+    it('preserves explicit settings for a model instance with no public name', async () => {
       const modelResponse: ModelResponse = {
-        output: [fakeModelMessage('Hello non GPT-5')],
+        output: [fakeModelMessage('Hello concrete model')],
         usage: new Usage(),
       };
       const inspectableModel = new InspectableModel(modelResponse);
       const agent = new Agent({
-        name: 'NonGpt5Runner',
+        name: 'ConcreteModelAgent',
         model: inspectableModel,
         modelSettings: createGpt5ModelSettings(),
       });
@@ -8617,20 +8617,36 @@ describe('Runner.run', () => {
       const runner = new Runner();
       const result = await runner.run(agent, 'hello');
 
-      expect(result.finalOutput).toBe('Hello non GPT-5');
+      expect(result.finalOutput).toBe('Hello concrete model');
       expect(inspectableModel.lastRequest).toBeDefined();
 
       const requestSettings = inspectableModel.lastRequest!.modelSettings;
-      expect(requestSettings.temperature).toBe(0.42);
-      expect(requestSettings.providerData?.keep).toBe('value');
-      expect(requestSettings.providerData?.reasoning).toBeUndefined();
-      expect(requestSettings.providerData?.text?.verbosity).toBeUndefined();
-      expect(
-        (requestSettings.providerData as any)?.reasoning_effort,
-      ).toBeUndefined();
-      expect(requestSettings.reasoning?.effort).toBeUndefined();
-      expect(requestSettings.reasoning?.summary).toBeUndefined();
-      expect(requestSettings.text?.verbosity).toBeUndefined();
+      expect(requestSettings).toEqual(createGpt5ModelSettings());
+      expect(agent.modelSettings).toEqual(createGpt5ModelSettings());
+    });
+
+    it('preserves explicit settings when a custom model has a descriptive name', async () => {
+      process.env.OPENAI_DEFAULT_MODEL = 'gpt-6-astra';
+      class EchoModel extends ScriptedModel {
+        name = 'Echo';
+      }
+      const model = new EchoModel([
+        modelResponse({
+          output: [fakeModelMessage('hello')],
+          usage: new Usage(),
+        }),
+      ]);
+      const agent = new Agent({
+        name: 'Custom model',
+        model,
+        modelSettings: createGpt5ModelSettings(),
+      });
+      const result = await new Runner().run(agent, 'hello');
+      expect(result.finalOutput).toBe('hello');
+      expect(model.lastCall?.request.modelSettings).toEqual(
+        createGpt5ModelSettings(),
+      );
+      expect(agent.modelSettings).toEqual(createGpt5ModelSettings());
     });
 
     it('keeps GPT-5-only settings when the agent relies on the default model', async () => {
@@ -8669,6 +8685,7 @@ describe('Runner.run', () => {
     it.each([
       ['gpt-5', 'low'],
       ['gpt-5.6', 'none'],
+      ['gpt-6-astra', 'low'],
     ] as const)(
       'uses model-specific defaults when the RunConfig model is %s',
       async (modelName, reasoningEffort) => {

--- a/packages/agents-core/test/runner/modelSettings.test.ts
+++ b/packages/agents-core/test/runner/modelSettings.test.ts
@@ -3,9 +3,9 @@ import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { Agent } from '../../src/agent';
 import { setDefaultModelProvider, setTracingDisabled } from '../../src';
 import * as defaultModelModule from '../../src/defaultModel';
-import type { Model, ModelSettings } from '../../src/model';
+import type { ModelSettings } from '../../src/model';
 import {
-  adjustModelSettingsForNonGPT5RunnerModel,
+  adjustModelSettingsForLegacyModel,
   mergeModelSettings,
   maybeResetToolChoice,
 } from '../../src/runner/modelSettings';
@@ -53,7 +53,7 @@ describe('maybeResetToolChoice', () => {
   });
 });
 
-describe('adjustModelSettingsForNonGPT5RunnerModel', () => {
+describe('adjustModelSettingsForLegacyModel', () => {
   const gpt5Settings: ModelSettings = {
     providerData: { reasoning: { effort: 'low' }, text: { verbosity: 'low' } },
     reasoning: { effort: 'low' },
@@ -61,14 +61,13 @@ describe('adjustModelSettingsForNonGPT5RunnerModel', () => {
   };
 
   const withGpt5Default = () =>
-    vi.spyOn(defaultModelModule, 'isGpt5Default').mockReturnValue(true);
+    vi.spyOn(defaultModelModule, 'isGpt5OrNewerDefault').mockReturnValue(true);
 
   it('keeps GPT-5 provider data when the explicit model is GPT-5', () => {
     const spy = withGpt5Default();
-    const result = adjustModelSettingsForNonGPT5RunnerModel(
+    const result = adjustModelSettingsForLegacyModel(
       true,
       gpt5Settings,
-      'gpt-5-mini',
       { ...gpt5Settings },
       'gpt-5-mini',
     );
@@ -77,31 +76,26 @@ describe('adjustModelSettingsForNonGPT5RunnerModel', () => {
     spy.mockRestore();
   });
 
-  it('strips GPT-5 provider data when the resolved model name is unavailable', () => {
+  it('preserves explicit provider data when the resolved model name is unavailable', () => {
     const spy = withGpt5Default();
-    const anonymousModel = {
-      getResponse: vi.fn(),
-      getStreamedResponse: vi.fn(),
-    } as unknown as Model;
-
-    const result = adjustModelSettingsForNonGPT5RunnerModel(
+    const result = adjustModelSettingsForLegacyModel(
       true,
       gpt5Settings,
-      anonymousModel,
       { ...gpt5Settings },
       undefined,
     );
-    expect(result.providerData?.reasoning).toBeUndefined();
-    expect(result.providerData?.text?.verbosity).toBeUndefined();
+    expect(result.providerData?.reasoning).toEqual(
+      gpt5Settings.providerData?.reasoning,
+    );
+    expect(result.providerData?.text?.verbosity).toBe('low');
     spy.mockRestore();
   });
 
   it('strips GPT-5-only provider data when a non-GPT-5 model is explicitly set', () => {
     const spy = withGpt5Default();
-    const result = adjustModelSettingsForNonGPT5RunnerModel(
+    const result = adjustModelSettingsForLegacyModel(
       true,
       gpt5Settings,
-      'gpt-4o',
       { ...gpt5Settings },
       'gpt-4o',
     );
@@ -132,10 +126,9 @@ describe('adjustModelSettingsForNonGPT5RunnerModel', () => {
       text: { verbosity: 'low' },
     };
 
-    const result = adjustModelSettingsForNonGPT5RunnerModel(
+    const result = adjustModelSettingsForLegacyModel(
       true,
       agentModelSettings,
-      'gpt-4o',
       modelSettings,
       'gpt-4o',
     );

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1468,6 +1468,11 @@ async function* withAttachedResponseRequestId(
  * Model implementation that uses OpenAI's Responses API to generate responses.
  */
 export class OpenAIResponsesModel implements Model {
+  /**
+   * Responses prompts can select the model when no explicit override is supplied.
+   */
+  readonly supportsPromptModelSelection = true;
+
   protected readonly _client: OpenAI;
   protected readonly _model: string;
 

--- a/packages/agents-openai/test/runnerAstraSettings.test.ts
+++ b/packages/agents-openai/test/runnerAstraSettings.test.ts
@@ -1,0 +1,293 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OpenAI from 'openai';
+import { Agent, Runner, setTracingDisabled } from '@openai/agents-core';
+import type { ModelSettings } from '@openai/agents-core';
+import { OpenAIProvider } from '../src/openaiProvider';
+import { OpenAIResponsesModel } from '../src/openaiResponsesModel';
+import logger from '../src/logger';
+
+describe('Runner GPT-5-and-newer settings', () => {
+  beforeEach(() => {
+    vi.stubEnv('OPENAI_DEFAULT_MODEL', 'gpt-5.6-luna');
+    setTracingDisabled(true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  const cases: {
+    name: string;
+    settings?: ModelSettings;
+    model?: string;
+    modelSource?: 'agent-instance' | 'runner-instance' | 'runner-name';
+    prompt?: Agent['prompt'];
+    runnerSettings?: ModelSettings;
+    defaultModel?: string;
+    expectedVerbosity?: string;
+    expectedReasoning?: Record<string, unknown>;
+  }[] = [
+    ...(['low', 'high'] as const).map((effort) => ({
+      name: `provider reasoning ${effort}`,
+      settings: { providerData: { reasoning: { effort, summary: 'auto' } } },
+      expectedReasoning: { effort, summary: 'auto' },
+    })),
+    {
+      name: 'mixed reasoning with provider overrides',
+      settings: {
+        reasoning: { effort: 'high', summary: 'auto', mode: 'pro' },
+        providerData: { reasoning: { effort: 'low' } },
+      },
+      expectedReasoning: { effort: 'low', summary: 'auto', mode: 'pro' },
+    },
+    {
+      name: 'Astra defaults',
+      expectedReasoning: { effort: 'low' },
+      expectedVerbosity: 'low',
+    },
+    {
+      name: 'Astra environment defaults',
+      defaultModel: 'gpt-6-astra',
+      expectedReasoning: { effort: 'low' },
+      expectedVerbosity: 'low',
+    },
+    {
+      name: 'explicit reasoning without a registered default',
+      model: 'gpt-5-mini',
+      settings: {
+        providerData: { reasoning: { effort: 'high', summary: 'auto' } },
+      },
+      expectedReasoning: { effort: 'high', summary: 'auto' },
+    },
+    {
+      name: 'shared defaults without an invented effort',
+      model: 'gpt-5-mini',
+      expectedVerbosity: 'low',
+    },
+    {
+      name: 'legacy cleanup with an Astra environment default',
+      model: 'gpt-4.1',
+      defaultModel: 'gpt-6-astra',
+      settings: { providerData: { reasoning: { effort: 'low' } } },
+    },
+    {
+      name: 'stored prompt model defaults',
+      defaultModel: 'gpt-6-astra',
+      prompt: { promptId: 'pmpt_legacy' },
+    },
+    {
+      name: 'dynamic stored prompt model defaults',
+      defaultModel: 'gpt-6-astra',
+      prompt: async () => ({ promptId: 'pmpt_legacy' }),
+    },
+    {
+      name: 'explicit agent settings for a prompt-owned model',
+      defaultModel: 'gpt-6-astra',
+      prompt: { promptId: 'pmpt_reasoning' },
+      settings: { providerData: { reasoning: { effort: 'high' } } },
+      expectedReasoning: { effort: 'high' },
+    },
+    {
+      name: 'explicit runner settings for a prompt-owned model',
+      defaultModel: 'gpt-6-astra',
+      prompt: { promptId: 'pmpt_reasoning' },
+      runnerSettings: { reasoning: { effort: 'high' } },
+      expectedReasoning: { effort: 'high' },
+    },
+    {
+      name: 'agent model override of a stored prompt',
+      model: 'gpt-6-astra',
+      prompt: { promptId: 'pmpt_legacy' },
+      expectedReasoning: { effort: 'low' },
+      expectedVerbosity: 'low',
+    },
+    {
+      name: 'runner model override of a stored prompt',
+      model: 'gpt-6-astra',
+      modelSource: 'runner-name',
+      prompt: { promptId: 'pmpt_legacy' },
+      expectedReasoning: { effort: 'low' },
+      expectedVerbosity: 'low',
+    },
+    {
+      name: 'concrete instance without implicit defaults',
+      modelSource: 'agent-instance',
+      model: 'gpt-6-astra',
+      defaultModel: 'gpt-6-astra',
+    },
+    ...(['agent-instance', 'runner-instance'] as const).map((modelSource) => ({
+      name: `explicit settings for a concrete ${modelSource}`,
+      modelSource,
+      model: 'gpt-6-astra',
+      defaultModel: 'gpt-6-astra',
+      settings: {
+        providerData: { reasoning: { effort: 'high', summary: 'auto' } },
+      },
+      expectedReasoning: { effort: 'high', summary: 'auto' },
+    })),
+  ];
+
+  describe.each([false, true])('stream=%s', (stream) => {
+    it.each(cases)(
+      'preserves $name',
+      async ({
+        settings,
+        expectedReasoning,
+        model,
+        modelSource,
+        prompt,
+        runnerSettings,
+        defaultModel,
+        expectedVerbosity,
+      }) => {
+        if (defaultModel) vi.stubEnv('OPENAI_DEFAULT_MODEL', defaultModel);
+        const selectedModel =
+          model ?? (defaultModel ? undefined : 'gpt-6-astra');
+        const originalSettings = structuredClone(settings);
+        const originalRunnerSettings = structuredClone(runnerSettings);
+        const promptCallback =
+          typeof prompt === 'function' ? vi.fn(prompt) : undefined;
+        const bodies: Record<string, any>[] = [];
+        const response = {
+          id: 'resp_astra',
+          object: 'response',
+          status: 'completed',
+          output: [
+            {
+              id: 'msg_astra',
+              type: 'message',
+              role: 'assistant',
+              status: 'completed',
+              content: [{ type: 'output_text', text: '391', annotations: [] }],
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        };
+        // Exercise client serialization; a ScriptedModel bypasses the provider wire boundary.
+        const client = new OpenAI({
+          apiKey: 'test-key',
+          fetch: async (_url, init) => {
+            bodies.push(JSON.parse(init!.body as string));
+            return new Response(
+              stream
+                ? `event: response.completed\ndata: ${JSON.stringify({ type: 'response.completed', sequence_number: 0, response })}\n\n`
+                : JSON.stringify(response),
+              {
+                headers: {
+                  'content-type': stream
+                    ? 'text/event-stream'
+                    : 'application/json',
+                },
+              },
+            );
+          },
+        });
+        const configuredModel = modelSource?.endsWith('instance')
+          ? new OpenAIResponsesModel(client, selectedModel!)
+          : selectedModel;
+        const modelOnRunner = modelSource?.startsWith('runner');
+        const runner = new Runner({
+          model: modelOnRunner ? configuredModel : undefined,
+          modelSettings: runnerSettings,
+          modelProvider: new OpenAIProvider({ openAIClient: client }),
+          tracingDisabled: true,
+        });
+        const agent = new Agent({
+          name: 'Astra',
+          model: modelOnRunner ? undefined : configuredModel,
+          prompt: promptCallback ?? prompt,
+          modelSettings: settings,
+        });
+
+        const result = stream
+          ? await runner.run(agent, 'What is 17 * 23?', { stream: true })
+          : await runner.run(agent, 'What is 17 * 23?');
+        if ('completed' in result) {
+          await result.completed;
+        }
+        expect(result.finalOutput).toBe('391');
+        expect(bodies).toHaveLength(1);
+        expect(bodies[0].model).toBe(
+          prompt && !selectedModel
+            ? undefined
+            : (selectedModel ?? defaultModel),
+        );
+        if (prompt) expect(bodies[0].prompt).toBeDefined();
+        if (promptCallback) expect(promptCallback).toHaveBeenCalledTimes(1);
+        expect(bodies[0].stream).toBe(stream);
+        expect(bodies[0].reasoning).toEqual(expectedReasoning);
+        expect(bodies[0].text?.verbosity).toBe(expectedVerbosity);
+        expect(settings).toEqual(originalSettings);
+        expect(runnerSettings).toEqual(originalRunnerSettings);
+      },
+    );
+  });
+  it.each([false, true])(
+    'keeps defaults when Chat Completions ignores a prompt (stream=%s)',
+    async (stream) => {
+      const bodies: Record<string, any>[] = [];
+      const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const message = { role: 'assistant', content: '391' };
+      // Capture client serialization for the adapter that ignores reusable prompts.
+      const client = new OpenAI({
+        apiKey: 'test-key',
+        fetch: async (_url, init) => {
+          bodies.push(JSON.parse(init!.body as string));
+          const response = {
+            id: 'chatcmpl_prompt',
+            object: 'chat.completion',
+            created: 1,
+            model: 'gpt-5.6-luna',
+            choices: [{ index: 0, message, finish_reason: 'stop' }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          };
+          const chunk = {
+            ...response,
+            object: 'chat.completion.chunk',
+            choices: [{ index: 0, delta: message, finish_reason: 'stop' }],
+          };
+          return new Response(
+            stream
+              ? `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`
+              : JSON.stringify(response),
+            {
+              headers: {
+                'content-type': stream
+                  ? 'text/event-stream'
+                  : 'application/json',
+              },
+            },
+          );
+        },
+      });
+      const runner = new Runner({
+        modelProvider: new OpenAIProvider({
+          openAIClient: client,
+          useResponses: false,
+        }),
+        tracingDisabled: true,
+      });
+      const agent = new Agent({
+        name: 'Chat prompt',
+        prompt: { promptId: 'pmpt_legacy' },
+      });
+      const result = stream
+        ? await runner.run(agent, 'What is 17 * 23?', { stream: true })
+        : await runner.run(agent, 'What is 17 * 23?');
+      if ('completed' in result) await result.completed;
+      expect(result.finalOutput).toBe('391');
+      expect(bodies).toHaveLength(1);
+      expect(bodies[0]).toMatchObject({
+        model: 'gpt-5.6-luna',
+        reasoning_effort: 'none',
+        verbosity: 'low',
+        stream,
+      });
+      expect(bodies[0]).not.toHaveProperty('prompt');
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Ignoring prompt'),
+      );
+    },
+  );
+});


### PR DESCRIPTION
This pull request fixes Runner silently stripping explicit reasoning settings for gpt-6-astra. It recognizes GPT models with numeric major versions >= 5, including minor versions, independently of model-specific defaults.

Astra defaults to low reasoning effort. Models without a registered effort default retain low text verbosity and omit implicit reasoning effort. Existing GPT-5 defaults, public helper semantics, known chat-alias exclusions, and legacy cleanup remain intact.

This pull request resolves #1849.