### PR TITLE
fix(core): avoid duplicate computer screenshots

### DIFF
--- a/.changeset/plenty-moles-wait.md
+++ b/.changeset/plenty-moles-wait.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+Avoid duplicate screenshots for explicit computer screenshot actions.

--- a/packages/agents-core/src/runner/toolExecution.ts
+++ b/packages/agents-core/src/runner/toolExecution.ts
@@ -1523,10 +1523,15 @@ async function _runComputerActionAndScreenshot(
   runContext: RunContext,
   signal?: AbortSignal,
 ): Promise<{ type: 'completed'; output: string } | { type: 'cancelled' }> {
+  let screenshot: string | undefined;
+
   for (const action of getComputerToolActions(toolCall)) {
     if (signal?.aborted) {
       return { type: 'cancelled' };
     }
+
+    screenshot = undefined;
+
     switch (action.type) {
       case 'click':
         await computer.click(action.x, action.y, action.button, runContext);
@@ -1547,7 +1552,7 @@ async function _runComputerActionAndScreenshot(
         await computer.move(action.x, action.y, runContext);
         break;
       case 'screenshot':
-        await computer.screenshot(runContext);
+        screenshot = await computer.screenshot(runContext);
         break;
       case 'scroll':
         await computer.scroll(
@@ -1577,7 +1582,7 @@ async function _runComputerActionAndScreenshot(
     return { type: 'cancelled' };
   }
   if (typeof computer.screenshot === 'function') {
-    const screenshot = await computer.screenshot(runContext);
+    screenshot ??= await computer.screenshot(runContext);
     if (signal?.aborted) {
       return { type: 'cancelled' };
     }

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1018,6 +1018,7 @@ describe('executeComputerActions', () => {
       new RunContext(),
     );
     expect(items).toHaveLength(1);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
   });
 
@@ -2034,7 +2035,7 @@ describe('executeComputerActions', () => {
 
     expect(items).toHaveLength(1);
     expect(items[0]).toBeInstanceOf(ToolCallOutputItem);
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('passes RunContext to computer actions', async () => {
@@ -2248,7 +2249,7 @@ describe('executeComputerActions', () => {
     expect(items).toHaveLength(1);
     expect(items[0]).toBeInstanceOf(ToolCallOutputItem);
     expect(needsApproval).not.toHaveBeenCalled();
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/agents-core/test/runner/toolExecution.test.ts
+++ b/packages/agents-core/test/runner/toolExecution.test.ts
@@ -1728,6 +1728,104 @@ describe('executeComputerActions', () => {
     expect((items[0] as any).output).toBe('data:image/png;base64,img');
   });
 
+  it('captures a fresh final screenshot when a screenshot is followed by another action', async () => {
+    const invocations: string[] = [];
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          invocations.push('screenshot:first');
+          return 'first';
+        })
+        .mockImplementationOnce(async () => {
+          invocations.push('screenshot:final');
+          return 'final';
+        }),
+      click: vi.fn().mockImplementation(async () => {
+        invocations.push('click');
+      }),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+
+    const tool = computerTool({ computer: fakeComputer });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'c-screenshot-then-click',
+      status: 'completed',
+      actions: [
+        { type: 'screenshot' },
+        { type: 'click', x: 1, y: 2, button: 'left' },
+      ],
+    };
+
+    const items = await executeComputerActions(
+      new Agent({ name: 'Comp' }),
+      [{ toolCall: call, computer: tool }],
+      new Runner(),
+      new RunContext(),
+    );
+
+    expect(invocations).toEqual([
+      'screenshot:first',
+      'click',
+      'screenshot:final',
+    ]);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect((items[0] as any).output).toBe('data:image/png;base64,final');
+  });
+
+  it('reuses an explicit screenshot when it is the final batched action', async () => {
+    const invocations: string[] = [];
+    const fakeComputer = {
+      environment: 'mac',
+      dimensions: [1, 1] as [number, number],
+      screenshot: vi.fn().mockImplementation(async () => {
+        invocations.push('screenshot');
+        return 'final';
+      }),
+      click: vi.fn().mockImplementation(async () => {
+        invocations.push('click');
+      }),
+      doubleClick: vi.fn(),
+      drag: vi.fn(),
+      keypress: vi.fn(),
+      move: vi.fn(),
+      scroll: vi.fn(),
+      type: vi.fn(),
+      wait: vi.fn(),
+    } as any;
+
+    const tool = computerTool({ computer: fakeComputer });
+    const call: protocol.ComputerUseCallItem = {
+      type: 'computer_call',
+      callId: 'c-click-then-screenshot',
+      status: 'completed',
+      actions: [
+        { type: 'click', x: 1, y: 2, button: 'left' },
+        { type: 'screenshot' },
+      ],
+    };
+
+    const items = await executeComputerActions(
+      new Agent({ name: 'Comp' }),
+      [{ toolCall: call, computer: tool }],
+      new Runner(),
+      new RunContext(),
+    );
+
+    expect(invocations).toEqual(['click', 'screenshot']);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
+    expect((items[0] as any).output).toBe('data:image/png;base64,final');
+  });
+
   it.each(['fulfills', 'rejects'] as const)(
     'does not start later batched computer actions when the active action %s after cancellation',
     async (settlement) => {

--- a/packages/agents-core/test/runner/turnResolution.test.ts
+++ b/packages/agents-core/test/runner/turnResolution.test.ts
@@ -1517,7 +1517,7 @@ describe('resolveInterruptedTurn', () => {
     expect(
       (toolOutputs[0].rawItem as protocol.ComputerCallResultItem).callId,
     ).toBe(computerCall.callId);
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('resumes approved computer actions after restoring legacy approval aliases', async () => {
@@ -1605,7 +1605,7 @@ describe('resolveInterruptedTurn', () => {
     expect(result.newStepItems).not.toContainEqual(
       expect.objectContaining({ type: 'tool_approval_item' }),
     );
-    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(2);
+    expect(fakeComputer.screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('skips rerunning already completed computer actions when resuming an interruption', async () => {

--- a/packages/agents-core/test/toolInvocationReplay.test.ts
+++ b/packages/agents-core/test/toolInvocationReplay.test.ts
@@ -1466,7 +1466,7 @@ describe('tool invocation replay binding', () => {
     const runner = new Runner();
 
     const interrupted = await runner.run(agent, 'start');
-    expect(screenshot).toHaveBeenCalledTimes(2);
+    expect(screenshot).toHaveBeenCalledTimes(1);
     const serialized = interrupted.state.toJSON() as any;
     serialized.$schemaVersion = '1.17';
     delete serialized.currentResponseGeneratedItemOwnership;
@@ -1481,7 +1481,7 @@ describe('tool invocation replay binding', () => {
     const result = await runner.run(agent, restored);
 
     expect(result.finalOutput).toBe('done');
-    expect(screenshot).toHaveBeenCalledTimes(2);
+    expect(screenshot).toHaveBeenCalledTimes(1);
   });
 
   it('reconstructs unapproved apply-patch completion from schema 1.17 state', async () => {


### PR DESCRIPTION
## Summary

Avoid duplicate screenshots when a computer tool action is itself a `screenshot`.

Previously, an explicit screenshot action called `computer.screenshot()` during action execution and then captured another screenshot immediately afterward for the tool result.

This change preserves the screenshot returned by an explicit screenshot action and reuses it as the final observation when appropriate.

## Changes

- reuse the screenshot returned by an explicit `screenshot` action
- continue capturing a final screenshot for non-screenshot computer actions
- preserve correct final-observation semantics for batched actions
- add regression coverage for:
  - `[screenshot, action]`
  - `[action, screenshot]`
- update existing expectations that encoded the previous double-capture behavior

## Validation

- full repository code-change verification passed
- 220 test files passed
- 6705 tests passed
- 2 skipped
- lint/build/type checks passed

Fixes #1735