### PR TITLE
fix: recover deferred tools during response continuation

### DIFF
--- a/.changeset/fresh-deferred-tool-continuation.md
+++ b/.changeset/fresh-deferred-tool-continuation.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-core': patch
+'@openai/agents-openai': patch
+---
+
+fix: recover unloaded deferred calls through opt-in model-visible errors and built-in client search, with required Responses wire defaults, live source-Agent ownership, and server-side search preserved for deferred hosted MCP tools (#1855).

--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -132,7 +132,10 @@ import {
   mapPendingInputAfterContextProcessing,
   selectPendingInputForAdmission,
 } from './runner/pendingInput';
-import { prepareAgentArtifacts } from './runner/modelPreparation';
+import {
+  prepareAgentArtifacts,
+  trackDeferredToolRecovery,
+} from './runner/modelPreparation';
 import {
   applyTurnResult,
   assertAcceptedResponseContinuationAuthority,
@@ -300,7 +303,7 @@ export type {
 } from './runner/outputGuardrailBlockedMessage';
 
 /**
- * SDK-side execution settings for local tool calls.
+ * Behavior for missing function tools and deferred function tools that are not loaded.
  */
 export type ToolNotFoundBehavior = 'raise_error' | 'return_error_to_model';
 
@@ -393,10 +396,18 @@ export type RunConfig = {
   toolExecution?: ToolExecutionConfig;
 
   /**
-   * Controls unresolved function tool calls emitted by the model.
+   * Controls missing function tools and deferred function tools that are not loaded.
    *
    * - `raise_error` preserves the default behavior and raises a `ModelBehaviorError`.
    * - `return_error_to_model` returns a model-visible tool error and lets the run continue.
+   *   Unloaded deferred tools must be loaded through tool_search before they can execute.
+   *   Hosted search with the default query schema uses the built-in client loader on
+   *   the recovery turn when no deferred hosted MCP tools are configured, to return
+   *   definitions already known to the server. Recovery is model-driven;
+   *   instruct the model to retry errors rather than treat them as
+   *   successful function results. Recovery intent is local to the source Agent and
+   *   live RunState; a restored state needs a fresh unloaded call before switching
+   *   to client search.
    */
   toolNotFoundBehavior?: ToolNotFoundBehavior;
 
@@ -2081,6 +2092,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
               processedResponse.newItems,
             );
             state._lastProcessedResponse = processedResponse;
+            trackDeferredToolRecovery(
+              state,
+              state._currentAgent,
+              processedResponse,
+            );
             const suppressedToolCalls = preflightToolInvocations(
               state._currentAgent,
               state,
@@ -3270,6 +3286,11 @@ export class Runner extends RunHooks<any, AgentOutputType<unknown>> {
             processedResponse.newItems,
           );
           result.state._lastProcessedResponse = processedResponse;
+          trackDeferredToolRecovery(
+            result.state,
+            currentAgent,
+            processedResponse,
+          );
           const suppressedToolCalls = preflightToolInvocations(
             currentAgent,
             result.state,

--- a/packages/agents-core/src/runState.ts
+++ b/packages/agents-core/src/runState.ts
@@ -1690,6 +1690,8 @@ const serializedProcessedResponseSchema = z.object({
       z.object({
         toolCall: z.any(),
         toolName: z.string(),
+        // Describes the error only; persisted input cannot select search execution.
+        reason: z.literal('not_loaded').optional(),
       }),
     )
     .optional(),

--- a/packages/agents-core/src/runner/modelOutputs.ts
+++ b/packages/agents-core/src/runner/modelOutputs.ts
@@ -310,12 +310,14 @@ function recordMissingFunctionTool(
   items: RunItem[],
   toolsUsed: string[],
   functionToolsNotFound: ToolRunFunctionNotFound[],
+  reason?: ToolRunFunctionNotFound['reason'],
 ): void {
   toolsUsed.push(toolName);
   items.push(new RunToolCallItem(output, agent));
   functionToolsNotFound.push({
     toolCall: output,
     toolName,
+    ...(reason ? { reason } : {}),
   });
 }
 
@@ -633,14 +635,15 @@ async function buildGeneratedClientToolSearchOutputMapAsync<TContext>(args: {
   return generatedOutputs;
 }
 
-function ensureDeferredFunctionToolLoaded(
+function checkDeferredFunctionToolLoaded(
   toolCall: protocol.FunctionCallItem,
   tool: FunctionTool<any>,
   loadedToolNames: Set<string>,
   agent: Agent<any, any>,
-): void {
+  behavior: ToolNotFoundBehavior,
+): boolean {
   if (tool.deferLoading !== true) {
-    return;
+    return true;
   }
 
   const explicitNamespace = getFunctionToolNamespace(tool);
@@ -651,7 +654,11 @@ function ensureDeferredFunctionToolLoaded(
       loadedToolNames.has(tool.name));
 
   if (isLoaded) {
-    return;
+    return true;
+  }
+
+  if (behavior === 'return_error_to_model') {
+    return false;
   }
 
   const toolName = qualifiedName ?? tool.name;
@@ -991,12 +998,26 @@ export function processModelResponse<TContext>(
         getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
         agent,
       );
-      ensureDeferredFunctionToolLoaded(
-        output,
-        resolved.tool,
-        loadedDeferredToolState.loadedToolNames,
-        agent,
-      );
+      if (
+        !checkDeferredFunctionToolLoaded(
+          output,
+          resolved.tool,
+          loadedDeferredToolState.loadedToolNames,
+          agent,
+          toolNotFoundBehavior,
+        )
+      ) {
+        recordMissingFunctionTool(
+          normalizeFunctionToolCallForStorage(output, resolved.tool),
+          getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
+          agent,
+          items,
+          toolsUsed,
+          functionToolsNotFound,
+          'not_loaded',
+        );
+        continue;
+      }
       const normalizedToolCall = normalizeFunctionToolCallForStorage(
         output,
         resolved.tool,
@@ -1387,12 +1408,26 @@ export async function processModelResponseAsync<TContext>(
         getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
         agent,
       );
-      ensureDeferredFunctionToolLoaded(
-        output,
-        resolved.tool,
-        loadedDeferredToolState.loadedToolNames,
-        agent,
-      );
+      if (
+        !checkDeferredFunctionToolLoaded(
+          output,
+          resolved.tool,
+          loadedDeferredToolState.loadedToolNames,
+          agent,
+          toolNotFoundBehavior,
+        )
+      ) {
+        recordMissingFunctionTool(
+          normalizeFunctionToolCallForStorage(output, resolved.tool),
+          getFunctionToolQualifiedName(resolved.tool) ?? resolved.tool.name,
+          agent,
+          items,
+          toolsUsed,
+          functionToolsNotFound,
+          'not_loaded',
+        );
+        continue;
+      }
       const normalizedToolCall = normalizeFunctionToolCallForStorage(
         output,
         resolved.tool,

--- a/packages/agents-core/src/runner/modelPreparation.ts
+++ b/packages/agents-core/src/runner/modelPreparation.ts
@@ -11,14 +11,38 @@ import {
 } from '../toolIdentity';
 import { serializeHandoff, serializeTool } from '../utils/serialize';
 import { ensureAgentSpan } from './tracing';
-import { validateClientToolSearchSupport } from './toolSearch';
-import { AgentArtifacts } from './types';
+import {
+  isDeferredHostedMcpTool,
+  validateClientToolSearchSupport,
+} from './toolSearch';
+import { AgentArtifacts, ProcessedResponse } from './types';
 import type { ToolNameCollisionPolicy } from './runConfig';
 
 const computerInitPromisesByRunState = new WeakMap<
   RunState<any, any>,
   WeakMap<Computer, Promise<void>>
 >();
+
+// Recovery intent is owned by a live run and its public source Agent, never by
+// serialized processing metadata or a prepared capability clone.
+const deferredToolRecoveryAgents = new WeakMap<
+  RunState<any, any>,
+  Agent<any, any>
+>();
+
+export function trackDeferredToolRecovery(
+  state: RunState<any, any>,
+  sourceAgent: Agent<any, any>,
+  response: ProcessedResponse<any>,
+): void {
+  if (
+    response.functionToolsNotFound?.some((call) => call.reason === 'not_loaded')
+  ) {
+    deferredToolRecoveryAgents.set(state, sourceAgent);
+  } else {
+    deferredToolRecoveryAgents.delete(state);
+  }
+}
 
 function getComputerInitMap(
   state: RunState<any, any>,
@@ -77,6 +101,26 @@ export async function prepareAgentArtifacts<
     collectedCapabilities.handoffs,
     toolNameCollisionPolicy,
   );
+  if (
+    deferredToolRecoveryAgents.get(state) === state._currentAgent &&
+    !capabilities.tools.some(isDeferredHostedMcpTool)
+  ) {
+    // A hosted search may omit definitions already loaded in the response chain.
+    // Use the existing local loader for this recovery turn so the active Agent
+    // receives fresh discovery before any deferred function can execute.
+    // Keep deferred MCP on server search: client output serializes its credentials.
+    capabilities.tools = capabilities.tools.map((tool) =>
+      tool.type === 'hosted_tool' &&
+      tool.providerData?.type === 'tool_search' &&
+      tool.providerData.execution !== 'client' &&
+      tool.providerData.parameters == null
+        ? {
+            ...tool,
+            providerData: { ...tool.providerData, execution: 'client' },
+          }
+        : tool,
+    );
+  }
   validateClientToolSearchSupport(capabilities.tools);
   await warmUpComputerTools(capabilities.tools, state._context);
   await initializeComputerTools(capabilities.tools, state);

--- a/packages/agents-core/src/runner/toolSearch.ts
+++ b/packages/agents-core/src/runner/toolSearch.ts
@@ -47,7 +47,9 @@ function isTopLevelDeferredFunctionTool(
   );
 }
 
-function isDeferredHostedMcpTool(tool: Tool<any>): tool is HostedMCPTool<any> {
+export function isDeferredHostedMcpTool(
+  tool: Tool<any>,
+): tool is HostedMCPTool<any> {
   return (
     tool.type === 'hosted_tool' &&
     tool.providerData?.type === 'mcp' &&

--- a/packages/agents-core/src/runner/turnResolution.ts
+++ b/packages/agents-core/src/runner/turnResolution.ts
@@ -338,7 +338,10 @@ async function resolveToolNotFoundMessage<TContext>(
   toolRun: ToolRunFunctionNotFound,
   toolErrorFormatter?: ToolErrorFormatter<TContext>,
 ): Promise<string> {
-  const defaultMessage = DEFAULT_TOOL_NOT_FOUND_MESSAGE(toolRun.toolName);
+  const defaultMessage =
+    toolRun.reason === 'not_loaded'
+      ? `Error: Tool ${toolRun.toolName} is not loaded for the current agent. The requested function was not executed. Call tool_search to load it, then retry the original function call with the same arguments.`
+      : DEFAULT_TOOL_NOT_FOUND_MESSAGE(toolRun.toolName);
   if (!toolErrorFormatter) {
     return defaultMessage;
   }

--- a/packages/agents-core/src/runner/types.ts
+++ b/packages/agents-core/src/runner/types.ts
@@ -63,6 +63,7 @@ export function createToolRunFunction<TContext>(args: {
 export type ToolRunFunctionNotFound = {
   toolCall: protocol.FunctionCallItem;
   toolName: string;
+  reason?: 'not_loaded';
 };
 
 export type ToolRunComputer = {

--- a/packages/agents-core/test/deferredToolContinuation.test.ts
+++ b/packages/agents-core/test/deferredToolContinuation.test.ts
@@ -1,0 +1,619 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import {
+  Agent,
+  MaxTurnsExceededError,
+  MemorySession,
+  ModelBehaviorError,
+  Runner,
+  RunState,
+  attachClientToolSearchExecutor,
+  handoff,
+  hostedMcpTool,
+  tool,
+  toolNamespace,
+} from '../src';
+import { ScriptedModel } from '../src/testing';
+import type * as protocol from '../src/types/protocol';
+import type { ModelRequest } from '../src/model';
+
+const searchTool = {
+  type: 'hosted_tool',
+  name: 'tool_search',
+  providerData: { type: 'tool_search' },
+} as const;
+const search = (): protocol.ToolSearchOutputItem => ({
+  type: 'tool_search_output',
+  id: 'search-output',
+  execution: 'server',
+  status: 'completed',
+  tools: [
+    {
+      type: 'namespace',
+      name: 'syntax',
+      tools: [{ type: 'function', name: 'lookup', defer_loading: true }],
+    },
+  ],
+});
+const call = (callId = 'lookup-call'): protocol.FunctionCallItem => ({
+  type: 'function_call',
+  name: 'lookup',
+  namespace: 'syntax',
+  callId,
+  arguments: '{}',
+});
+const load = (paths = ['syntax']): protocol.ToolSearchCallItem => ({
+  type: 'tool_search_call',
+  execution: 'client',
+  callId: 'reload',
+  arguments: { paths },
+});
+const done = (): protocol.AssistantMessageItem => ({
+  type: 'message',
+  role: 'assistant',
+  content: [{ type: 'output_text', text: 'DONE' }],
+  status: 'completed',
+});
+function makeAgent(
+  model: ScriptedModel,
+  execute = vi.fn(async () => 'found'),
+  name = 'LookupAgent',
+) {
+  return new Agent({
+    name,
+    model,
+    tools: [
+      ...toolNamespace({
+        name: 'syntax',
+        description: 'Syntax lookups.',
+        tools: [
+          tool({
+            name: 'lookup',
+            description: 'Look up syntax.',
+            parameters: z.object({}),
+            deferLoading: true,
+            execute,
+          }),
+        ],
+      }),
+      searchTool,
+    ],
+  });
+}
+const recoveryMessage =
+  'Error: Tool syntax.lookup is not loaded for the current agent. The requested function was not executed. Call tool_search to load it, then retry the original function call with the same arguments.';
+
+async function finish(
+  runner: Runner,
+  agent: Agent,
+  input: string,
+  stream: boolean,
+  options: { previousResponseId?: string; maxTurns?: number } = {},
+) {
+  if (stream) {
+    const result = await runner.run(agent, input, { ...options, stream: true });
+    await result.completed;
+    return result;
+  }
+  return runner.run(agent, input, options);
+}
+
+describe('deferred tool continuation recovery', () => {
+  it.each([false, true])(
+    'keeps deferred MCP credentials out of automatic recovery output (stream: %s)',
+    async (stream) => {
+      const authorization = 'synthetic-mcp-authorization';
+      const header = 'synthetic-mcp-header';
+      const execute = vi.fn(async () => 'found');
+      const session = new MemorySession();
+      const model = new ScriptedModel([
+        [call('unloaded')],
+        {
+          type: 'responder',
+          respond: ({ request }) => {
+            // Exercise the model-controlled path exposed by client execution.
+            const clientSearch = request.tools.some(
+              (tool) =>
+                tool.type === 'hosted_tool' &&
+                tool.providerData?.type === 'tool_search' &&
+                tool.providerData.execution === 'client',
+            );
+            return clientSearch
+              ? [load(['private_server'])]
+              : [search(), call('loaded')];
+          },
+        },
+        [done()],
+      ]);
+      const agent = makeAgent(model, execute);
+      agent.tools.push(
+        hostedMcpTool({
+          serverLabel: 'private_server',
+          serverUrl: 'https://mcp.example.test',
+          authorization,
+          headers: { 'X-Api-Key': header },
+          deferLoading: true,
+        }),
+      );
+      const runner = new Runner({
+        tracingDisabled: true,
+        toolNotFoundBehavior: 'return_error_to_model',
+      });
+      const result = stream
+        ? await runner.run(agent, 'look up syntax', { session, stream: true })
+        : await runner.run(agent, 'look up syntax', { session });
+      if ('completed' in result) {
+        await result.completed;
+      }
+
+      const sinks = {
+        modelInput: JSON.stringify(
+          model.calls.map((call) => call.request.input),
+        ),
+        history: JSON.stringify(result.history),
+        session: JSON.stringify(await session.getItems()),
+        state: result.state.toString(),
+      };
+      for (const [name, value] of Object.entries(sinks)) {
+        expect.soft(value, name).not.toContain(authorization);
+        expect.soft(value, name).not.toContain(header);
+      }
+      expect(model.calls[1].request.tools).toContainEqual(searchTool);
+      expect(execute).toHaveBeenCalledOnce();
+      expect(result.finalOutput).toBe('DONE');
+    },
+  );
+
+  it.each([false, true])(
+    'recovers a fresh response-ID continuation only after new discovery (stream: %s)',
+    async (stream) => {
+      const execute = vi.fn(async () => 'found');
+      const first = await new Runner({ tracingDisabled: true }).run(
+        makeAgent(
+          new ScriptedModel([[search(), call('first')], [done()]]),
+          execute,
+        ),
+        'first',
+      );
+      expect(execute).toHaveBeenCalledTimes(1);
+      const formatter = vi.fn(() => undefined);
+      const model = new ScriptedModel([
+        [call('unloaded')],
+        {
+          type: 'responder',
+          respond: ({ request }) => {
+            expect(execute).toHaveBeenCalledTimes(1);
+            expect(request.tools).toContainEqual(
+              expect.objectContaining({
+                providerData: expect.objectContaining({
+                  type: 'tool_search',
+                  execution: 'client',
+                }),
+              }),
+            );
+            expect(request.input).toEqual([
+              expect.objectContaining({
+                type: 'function_call_result',
+                callId: 'unloaded',
+                output: { type: 'text', text: recoveryMessage },
+              }),
+            ]);
+            return [load()];
+          },
+        },
+        {
+          type: 'responder',
+          respond: ({ request }) => {
+            expect(request.tools).toContainEqual(searchTool);
+            expect(request.input).toContainEqual(
+              expect.objectContaining({ type: 'tool_search_output' }),
+            );
+            return [call('loaded')];
+          },
+        },
+        [done()],
+      ]);
+      const result = await finish(
+        new Runner({
+          tracingDisabled: true,
+          toolNotFoundBehavior: 'return_error_to_model',
+          toolErrorFormatter: formatter,
+        }),
+        makeAgent(model, execute),
+        'second',
+        stream,
+        { previousResponseId: first.lastResponseId },
+      );
+      expect(model.firstCall?.request.previousResponseId).toBe(
+        first.lastResponseId,
+      );
+      expect(model.firstCall?.request.input).toEqual([
+        expect.objectContaining({ role: 'user', content: 'second' }),
+      ]);
+      expect(result.finalOutput).toBe('DONE');
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(formatter).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: 'tool_not_found',
+          toolName: 'syntax.lookup',
+          callId: 'unloaded',
+          defaultMessage: recoveryMessage,
+        }),
+      );
+      expect(
+        result.history.filter((item) => item.type === 'function_call_result'),
+      ).toHaveLength(2);
+    },
+  );
+
+  it.each([false, true])(
+    'keeps default rejection before execution (stream: %s)',
+    async (stream) => {
+      const execute = vi.fn(async () => 'found');
+      await expect(
+        finish(
+          new Runner({ tracingDisabled: true }),
+          makeAgent(new ScriptedModel([[call()]]), execute),
+          'again',
+          stream,
+          { previousResponseId: 'previous' },
+        ),
+      ).rejects.toThrow(ModelBehaviorError);
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not transfer discovery through a handoff when recovery is enabled', async () => {
+    const execute = vi.fn(async () => 'found');
+    const model = new ScriptedModel([
+      [call('unloaded')],
+      {
+        type: 'responder',
+        respond: ({ request }) => {
+          expect(execute).not.toHaveBeenCalled();
+          expect(JSON.stringify(request.input)).toContain(recoveryMessage);
+          return [load()];
+        },
+      },
+      [call('loaded')],
+      [done()],
+    ]);
+    const b = makeAgent(model, execute, 'B');
+    const a = makeAgent(
+      new ScriptedModel([
+        [
+          search(),
+          {
+            type: 'function_call',
+            name: handoff(b).toolName,
+            callId: 'handoff',
+            arguments: '{}',
+          },
+        ],
+      ]),
+      undefined,
+      'A',
+    );
+    a.handoffs = [b];
+    const result = await new Runner({ tracingDisabled: true }).run(a, 'start', {
+      toolNotFoundBehavior: 'return_error_to_model',
+    });
+    expect(result.finalOutput).toBe('DONE');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([false, true])(
+    'keeps target search configuration after a mixed unloaded call and handoff (stream: %s)',
+    async (stream) => {
+      const sourceExecute = vi.fn(async () => 'source');
+      const targetExecute = vi.fn(async () => 'target');
+      const target = makeAgent(
+        new ScriptedModel([
+          {
+            type: 'responder',
+            respond: ({ request }) => {
+              expect(request.tools).toContainEqual(searchTool);
+              expect(sourceExecute).not.toHaveBeenCalled();
+              return [search(), call('target')];
+            },
+          },
+          [done()],
+        ]),
+        targetExecute,
+        'SameName',
+      );
+      const source = makeAgent(
+        new ScriptedModel([
+          [
+            call('source-unloaded'),
+            {
+              type: 'function_call',
+              name: handoff(target).toolName,
+              callId: 'transfer',
+              arguments: '{}',
+            },
+          ],
+        ]),
+        sourceExecute,
+        'SameName',
+      );
+      source.handoffs = [target];
+      const result = await finish(
+        new Runner({
+          tracingDisabled: true,
+          toolNotFoundBehavior: 'return_error_to_model',
+        }),
+        source,
+        'start',
+        stream,
+      );
+      expect(result.finalOutput).toBe('DONE');
+      expect(sourceExecute).not.toHaveBeenCalled();
+      expect(targetExecute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('does not use a serialized recovery reason to change search execution', async () => {
+    const model = new ScriptedModel([
+      [
+        {
+          type: 'function_call',
+          name: 'missing',
+          callId: 'missing',
+          arguments: '{}',
+        },
+        {
+          type: 'function_call',
+          name: 'approve_me',
+          callId: 'approval',
+          arguments: '{}',
+        },
+      ],
+      {
+        type: 'responder',
+        respond: ({ request }) => {
+          expect(request.tools).toContainEqual(searchTool);
+          return [done()];
+        },
+      },
+    ]);
+    const agent = makeAgent(model);
+    agent.tools.push(
+      tool({
+        name: 'approve_me',
+        description: 'Request approval.',
+        parameters: z.object({}),
+        needsApproval: true,
+        execute: async () => 'approved',
+      }),
+    );
+    const runner = new Runner({
+      tracingDisabled: true,
+      toolNotFoundBehavior: 'return_error_to_model',
+    });
+    const paused = await runner.run(agent, 'start');
+    const serialized = JSON.parse(paused.state.toString());
+    serialized.lastProcessedResponse.functionToolsNotFound[0].reason =
+      'not_loaded';
+    const restored = await RunState.fromString(
+      agent,
+      JSON.stringify(serialized),
+    );
+    restored.approve(restored.getInterruptions()[0]);
+    const result = await runner.run(agent, restored);
+    expect(result.finalOutput).toBe('DONE');
+  });
+
+  it('does not convert caller restrictions into recoverable loading errors', async () => {
+    const execute = vi.fn(async () => 'found');
+    const agent = new Agent({
+      name: 'ProgramOnly',
+      model: new ScriptedModel([
+        [
+          {
+            type: 'function_call',
+            name: 'lookup',
+            namespace: 'lookup',
+            callId: 'direct',
+            arguments: '{}',
+          },
+        ],
+      ]),
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Programmatic lookup.',
+          parameters: z.object({}),
+          deferLoading: true,
+          allowedCallers: ['programmatic'],
+          execute,
+        }),
+        searchTool,
+      ],
+    });
+    await expect(
+      new Runner({
+        tracingDisabled: true,
+        toolNotFoundBehavior: 'return_error_to_model',
+      }).run(agent, 'start'),
+    ).rejects.toThrow(/caller direct/);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('recovers self-namespaced top-level deferred calls without changing call identity', async () => {
+    const execute = vi.fn(async () => 'found');
+    const topLevelCall = { ...call(), namespace: 'lookup' };
+    const model = new ScriptedModel([
+      [topLevelCall],
+      {
+        type: 'responder',
+        respond: ({ request }) => {
+          expect(execute).not.toHaveBeenCalled();
+          expect(request.input).toContainEqual(
+            expect.objectContaining({
+              type: 'function_call_result',
+              callId: 'lookup-call',
+              name: 'lookup',
+              namespace: 'lookup',
+            }),
+          );
+          return [load(['lookup'])];
+        },
+      },
+      [{ ...topLevelCall, callId: 'loaded' }],
+      [done()],
+    ]);
+    const agent = new Agent({
+      name: 'TopLevel',
+      model,
+      tools: [
+        tool({
+          name: 'lookup',
+          description: 'Look up a record.',
+          parameters: z.object({}),
+          deferLoading: true,
+          execute,
+        }),
+        searchTool,
+      ],
+    });
+    const result = await new Runner({
+      tracingDisabled: true,
+      toolNotFoundBehavior: 'return_error_to_model',
+    }).run(agent, 'start');
+    expect(result.finalOutput).toBe('DONE');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounds repeated unloaded calls with maxTurns', async () => {
+    const execute = vi.fn(async () => 'found');
+    await expect(
+      new Runner({
+        tracingDisabled: true,
+        toolNotFoundBehavior: 'return_error_to_model',
+      }).run(
+        makeAgent(new ScriptedModel([[call('one')], [call('two')]]), execute),
+        'start',
+        { maxTurns: 2 },
+      ),
+    ).rejects.toThrow(MaxTurnsExceededError);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('uses recovery in custom client-search processing without loading an unrelated tool', async () => {
+    const execute = vi.fn(async () => 'found');
+    const searchExecute = vi.fn(async () => []);
+    const model = new ScriptedModel([
+      [
+        {
+          type: 'tool_search_call',
+          execution: 'client',
+          callId: 'client-search',
+          arguments: { paths: ['other'] },
+        },
+        call('unloaded'),
+      ],
+      [done()],
+    ]);
+    const agent = makeAgent(model, execute);
+    agent.tools[1] = attachClientToolSearchExecutor(
+      {
+        ...searchTool,
+        providerData: { type: 'tool_search', execution: 'client' },
+      },
+      searchExecute,
+    );
+    const result = await new Runner({
+      tracingDisabled: true,
+      toolNotFoundBehavior: 'return_error_to_model',
+    }).run(agent, 'start');
+    expect(result.finalOutput).toBe('DONE');
+    expect(execute).not.toHaveBeenCalled();
+    expect(searchExecute).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(model.calls[1].request.input)).toContain(
+      recoveryMessage,
+    );
+  });
+
+  it.each([false, true])(
+    'preserves approval recovery without trusting restored metadata (serialized: %s)',
+    async (serialized) => {
+      const execute = vi.fn(async () => 'found');
+      const approvedExecute = vi.fn(async () => 'approved');
+      const model = new ScriptedModel([
+        [
+          call('unloaded'),
+          {
+            type: 'function_call',
+            name: 'approve_me',
+            callId: 'approval',
+            arguments: '{}',
+          },
+        ],
+        ...(serialized
+          ? [
+              {
+                type: 'responder' as const,
+                respond: ({ request }: { request: ModelRequest }) => {
+                  expect(request.tools).toContainEqual(searchTool);
+                  return [call('fresh-unloaded')];
+                },
+              },
+            ]
+          : []),
+        {
+          type: 'responder',
+          respond: ({ request }) => {
+            expect(request.tools).toContainEqual(
+              expect.objectContaining({
+                providerData: expect.objectContaining({ execution: 'client' }),
+              }),
+            );
+            return [load()];
+          },
+        },
+        [call('loaded')],
+        [done()],
+      ]);
+      const agent = makeAgent(model, execute);
+      agent.tools.push(
+        tool({
+          name: 'approve_me',
+          description: 'An approval tool.',
+          parameters: z.object({}),
+          needsApproval: true,
+          execute: approvedExecute,
+        }),
+      );
+      const runner = new Runner({
+        tracingDisabled: true,
+        toolNotFoundBehavior: 'return_error_to_model',
+      });
+      const paused = await runner.run(agent, 'start');
+      expect(execute).not.toHaveBeenCalled();
+      expect(paused.interruptions).toHaveLength(1);
+      const json = JSON.parse(paused.state.toString());
+      expect(JSON.stringify(json)).toContain('not_loaded');
+      const restored = serialized
+        ? await RunState.fromString<undefined, typeof agent>(
+            agent,
+            JSON.stringify(json),
+          )
+        : paused.state;
+      expect(JSON.stringify(JSON.parse(restored.toString()))).toContain(
+        'not_loaded',
+      );
+      restored.approve(restored.getInterruptions()[0]);
+      const result = await runner.run(agent, restored);
+      expect(result.finalOutput).toBe('DONE');
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(approvedExecute).toHaveBeenCalledTimes(1);
+      expect(
+        result.history.filter(
+          (item) =>
+            item.type === 'function_call_result' && item.callId === 'unloaded',
+        ),
+      ).toHaveLength(1);
+    },
+  );
+});

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1231,12 +1231,29 @@ function convertTool<_TContext = unknown>(
           : undefined,
       };
     } else if (tool.providerData?.type === 'tool_search') {
+      // Client search requires an explicit schema even for the built-in loader.
+      const isClient = tool.providerData.execution === 'client';
       return {
         tool: {
           type: 'tool_search',
           execution: tool.providerData.execution,
-          description: tool.providerData.description,
-          parameters: tool.providerData.parameters,
+          description:
+            tool.providerData.description ??
+            (isClient
+              ? 'Load tools by namespace or tool name before calling them.'
+              : undefined),
+          parameters:
+            tool.providerData.parameters ??
+            (isClient
+              ? {
+                  type: 'object',
+                  properties: {
+                    paths: { type: 'array', items: { type: 'string' } },
+                  },
+                  required: ['paths'],
+                  additionalProperties: false,
+                }
+              : undefined),
         },
         include: undefined,
       };

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -4043,6 +4043,49 @@ describe('OpenAIResponsesModel', () => {
     });
   });
 
+  it('supplies the built-in client search schema required by Responses', async () => {
+    await withTrace('test', async () => {
+      const create = vi.fn().mockResolvedValue({
+        id: 'client-search-defaults',
+        usage: {},
+        output: [],
+      });
+      const model = new OpenAIResponsesModel(
+        { responses: { create } } as unknown as OpenAI,
+        'gpt-5.4',
+      );
+      await model.getResponse({
+        systemInstructions: undefined,
+        input: 'Load syntax',
+        modelSettings: {},
+        tools: [
+          {
+            type: 'hosted_tool',
+            name: 'tool_search',
+            providerData: { type: 'tool_search', execution: 'client' },
+          },
+        ],
+        outputType: 'text',
+        handoffs: [],
+        tracing: false,
+      });
+      expect(create.mock.calls[0][0].tools).toEqual([
+        {
+          type: 'tool_search',
+          execution: 'client',
+          description:
+            'Load tools by namespace or tool name before calling them.',
+          parameters: {
+            type: 'object',
+            properties: { paths: { type: 'array', items: { type: 'string' } } },
+            required: ['paths'],
+            additionalProperties: false,
+          },
+        },
+      ]);
+    });
+  });
+
   it('keeps explicit client toolSearchTool even without deferred local tools', async () => {
     await withTrace('test', async () => {
       const fakeResponse = {


### PR DESCRIPTION
This pull request fixes #1855, where a fresh Agent continuing with `previousResponseId` rejected a deferred call despite `toolNotFoundBehavior: 'return_error_to_model'`.

Unloaded calls now produce a model-visible error. For default hosted searches, the recovery turn uses the existing client loader and requires fresh Agent-scoped discovery before execution. Responses also supplies the required defaults for built-in client search.

Default exceptions, caller restrictions, explicit custom search configuration, and approval handling remain unchanged. Recovery is model-driven, so instructions should tell the model to retry tool errors.