### PR TITLE
fix(realtime): preserve agent_end response ownership

### DIFF
--- a/.changeset/calm-responses-finish.md
+++ b/.changeset/calm-responses-finish.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-realtime': patch
+---
+
+fix: attribute Realtime turn completion to its response agent

--- a/packages/agents-realtime/src/realtimeSession.ts
+++ b/packages/agents-realtime/src/realtimeSession.ts
@@ -1675,8 +1675,8 @@ export class RealtimeSession<
         };
         itemId = typeof lastItem?.id === 'string' ? lastItem.id : '';
       }
-      this.emit('agent_end', this.#context, this.#currentAgent, textOutput);
-      this.#currentAgent.emit('agent_end', this.#context, textOutput);
+      this.emit('agent_end', this.#context, sourceAgent, textOutput);
+      sourceAgent.emit('agent_end', this.#context, textOutput);
 
       this.#scheduleOutputGuardrails(
         textOutput,

--- a/packages/agents-realtime/test/realtimeSession.test.ts
+++ b/packages/agents-realtime/test/realtimeSession.test.ts
@@ -869,6 +869,66 @@ describe('RealtimeSession', () => {
     expect(agentAgentEnd.mock.calls[0][1]).toBe(transcript);
   });
 
+  it('attributes agent_end to the response agent after a handoff', async () => {
+    const transport = new FakeTransport();
+    const targetAgent = new RealtimeAgent({ name: 'Billing' });
+    const sourceAgent = new RealtimeAgent({
+      name: 'Triage',
+      handoffs: [targetAgent],
+    });
+    const scenarioSession = new RealtimeSession(sourceAgent, { transport });
+    const sessionAgentEnd = vi.fn();
+    const sourceAgentEnd = vi.fn();
+    const targetAgentEnd = vi.fn();
+    const transcript = 'I will transfer you to billing.';
+
+    scenarioSession.on('agent_end', sessionAgentEnd);
+    sourceAgent.on('agent_end', sourceAgentEnd);
+    targetAgent.on('agent_end', targetAgentEnd);
+    await scenarioSession.connect({ apiKey: 'test-key' });
+
+    transport.emit('turn_started', {
+      type: 'response_started',
+      providerData: { response: { id: 'source-response' } },
+    });
+    transport.emit('function_call', {
+      type: 'function_call',
+      name: 'transfer_to_Billing',
+      callId: 'handoff-call',
+      arguments: '{}',
+      responseId: 'source-response',
+    } as any);
+
+    await vi.waitFor(() => {
+      expect(scenarioSession.currentAgent).toBe(targetAgent);
+    });
+
+    transport.emit('turn_done', {
+      response: {
+        id: 'source-response',
+        output: [
+          {
+            id: 'msg-1',
+            type: 'message',
+            role: 'assistant',
+            status: 'completed',
+            content: [{ type: 'output_audio', transcript }],
+          },
+        ],
+        usage: new Usage(),
+      },
+    } as any);
+
+    expect(sessionAgentEnd).toHaveBeenCalledWith(
+      expect.anything(),
+      sourceAgent,
+      transcript,
+    );
+    expect(sourceAgentEnd).toHaveBeenCalledWith(expect.anything(), transcript);
+    expect(targetAgentEnd).not.toHaveBeenCalled();
+    expect(scenarioSession.currentAgent).toBe(targetAgent);
+  });
+
   it('merges completed audio transcripts into history', async () => {
     const transport = new FakeTransport();
     const agent = new RealtimeAgent({ name: 'Listener' });


### PR DESCRIPTION
### Summary

When a Realtime response completes after a handoff, the session already uses the response's captured dispatch snapshot for output guardrails, but emits `agent_end` through the newly current agent. This attributes the completed response to an agent that did not produce it.

This change emits both the session-level and agent-level `agent_end` events through the response snapshot's source agent. The regression starts a response, performs a handoff, then completes that original response and verifies that only its source agent receives the event.

### Test plan

- frozen dependency installation
- build and recursive package build checks (`pnpm -r build-check`)
- distribution declaration checks
- lint and changed-file formatting checks
- complete isolated-HOME `pnpm test`: 221/221 files and 6,757/6,757 tests
- two independent reviews of the immutable candidate

### Issue number

None.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation (no documentation change is needed)
- [x] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests) (not a major change)
- [x] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [x] I've confirmed all verification steps pass
- [x] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
