### PR TITLE
feat: support the image generation tool action option

### DIFF
--- a/.changeset/image-generation-action.md
+++ b/.changeset/image-generation-action.md
@@ -1,0 +1,6 @@
+---
+'@openai/agents-openai': patch
+'@openai/agents': patch
+---
+
+feat: support the image generation tool action option

--- a/packages/agents-openai/src/openaiResponsesModel.ts
+++ b/packages/agents-openai/src/openaiResponsesModel.ts
@@ -1268,6 +1268,7 @@ function convertTool<_TContext = unknown>(
       return {
         tool: {
           type: 'image_generation',
+          action: tool.providerData.action,
           background: tool.providerData.background,
           input_fidelity: tool.providerData.input_fidelity,
           input_image_mask: tool.providerData.input_image_mask,

--- a/packages/agents-openai/src/tools.ts
+++ b/packages/agents-openai/src/tools.ts
@@ -301,6 +301,7 @@ export function toolSearchTool<Context = unknown>(
 export type ImageGenerationTool = {
   type: 'image_generation';
   name?: 'image_generation' | (string & {});
+  action?: OpenAI.Responses.Tool.ImageGeneration['action'];
   background?: 'transparent' | 'opaque' | 'auto' | (string & {});
   inputFidelity?: 'high' | 'low' | null;
   inputImageMask?: OpenAI.Responses.Tool.ImageGeneration.InputImageMask;
@@ -324,6 +325,7 @@ export function imageGenerationTool(
   const providerData: ProviderData.ImageGenerationTool = {
     type: 'image_generation',
     name: options.name ?? 'image_generation',
+    action: options.action,
     background: options.background,
     input_fidelity: options.inputFidelity,
     input_image_mask: options.inputImageMask,

--- a/packages/agents-openai/test/openaiResponsesModel.test.ts
+++ b/packages/agents-openai/test/openaiResponsesModel.test.ts
@@ -6,7 +6,7 @@ import {
 import { HEADERS } from '../src/defaults';
 import { ResponsesWebSocketInternalError } from '../src/responsesWebSocketConnection';
 import OpenAI from 'openai';
-import { fileSearchTool, webSearchTool } from '../src';
+import { fileSearchTool, imageGenerationTool, webSearchTool } from '../src';
 import {
   Agent,
   retryPolicies,
@@ -129,6 +129,93 @@ describe('OpenAIResponsesModel', () => {
     setTracingDisabled(true);
     setTraceProcessors([]);
   });
+
+  describe.each([false, true])(
+    'image generation requests (stream=%s)',
+    (stream) => {
+      it.each(['generate', 'edit', 'auto', undefined] as const)(
+        'serializes action %s without changing existing options',
+        async (action) => {
+          const bodies: Record<string, unknown>[] = [];
+          const response = {
+            id: 'resp_image_generation',
+            object: 'response',
+            status: 'completed',
+            output: [],
+            usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+          };
+          // Capture the real client's serialized payload without network requests.
+          const client = new OpenAI({
+            apiKey: 'test-key',
+            fetch: async (_url, init) => {
+              bodies.push(JSON.parse(init!.body as string));
+              const body = stream
+                ? `event: response.completed\ndata: ${JSON.stringify({ type: 'response.completed', sequence_number: 0, response })}\n\n`
+                : JSON.stringify(response);
+              return new Response(body, {
+                headers: {
+                  'content-type': stream
+                    ? 'text/event-stream'
+                    : 'application/json',
+                },
+              });
+            },
+          });
+          const model = new OpenAIResponsesModel(client, 'gpt-test');
+          const request: ModelRequest = {
+            systemInstructions: undefined,
+            input: 'Create an image.',
+            modelSettings: {},
+            tools: [
+              imageGenerationTool(
+                action === undefined
+                  ? {}
+                  : {
+                      action,
+                      inputFidelity: 'high',
+                      inputImageMask: { file_id: 'file_mask' },
+                      outputCompression: 80,
+                      outputFormat: 'webp',
+                      partialImages: 1,
+                    },
+              ),
+            ],
+            outputType: 'text',
+            handoffs: [],
+            tracing: false,
+          };
+          if (stream) {
+            for await (const event of model.getStreamedResponse(request)) {
+              if (event.type === 'response_done') {
+                expect(event.response.output).toEqual([]);
+              }
+            }
+          } else {
+            const result = await withTrace('image generation request', () =>
+              model.getResponse(request),
+            );
+            expect(result.output).toEqual([]);
+          }
+
+          expect(bodies).toHaveLength(1);
+          expect(bodies[0].stream).toBe(stream);
+          expect(bodies[0].tools).toEqual([
+            action === undefined
+              ? { type: 'image_generation' }
+              : {
+                  type: 'image_generation',
+                  action,
+                  input_fidelity: 'high',
+                  input_image_mask: { file_id: 'file_mask' },
+                  output_compression: 80,
+                  output_format: 'webp',
+                  partial_images: 1,
+                },
+          ]);
+        },
+      );
+    },
+  );
 
   describe.each([false, true])(
     'web search image requests (stream=%s)',

--- a/packages/agents-openai/test/tools.test.ts
+++ b/packages/agents-openai/test/tools.test.ts
@@ -145,6 +145,20 @@ describe('Tool', () => {
     expect(t.providerData!.model).toBeUndefined();
   });
 
+  it.each(['generate', 'edit', 'auto'] as const)(
+    'imageGenerationTool preserves action %s',
+    (action) => {
+      expect(imageGenerationTool({ action }).providerData?.action).toBe(action);
+    },
+  );
+
+  it('imageGenerationTool leaves action undefined by default', () => {
+    expect(imageGenerationTool().providerData?.action).toBeUndefined();
+    expectTypeOf<
+      NonNullable<Parameters<typeof imageGenerationTool>[0]>['action']
+    >().toEqualTypeOf<'generate' | 'edit' | 'auto' | undefined>();
+  });
+
   it('toolSearchTool', () => {
     const t = toolSearchTool();
     expect(t).toBeDefined();

--- a/packages/agents/test/index.test.ts
+++ b/packages/agents/test/index.test.ts
@@ -61,6 +61,16 @@ describe('isZodObject', () => {
   });
 });
 
+describe('Image generation exports', () => {
+  test('imageGenerationTool accepts the action option', () => {
+    expect(Agents.imageGenerationTool({ action: 'edit' })).toMatchObject({
+      type: 'hosted_tool',
+      name: 'image_generation',
+      providerData: { type: 'image_generation', action: 'edit' },
+    });
+  });
+});
+
 describe('Tool search exports', () => {
   test('toolNamespace and toolSearchTool should be available', () => {
     expect(typeof Agents.toolNamespace).toBe('function');


### PR DESCRIPTION
This pull request adds the optional `action` setting to `imageGenerationTool()`, allowing callers to select `generate`, `edit`, or `auto`.

The selected value is forwarded through the existing Responses conversion for streaming and non-streaming requests. Omitting the option preserves the API default.