### PR TITLE
fix: preserve sandbox workdirs for shell command lists

### DIFF
--- a/.changeset/tidy-shell-workdirs.md
+++ b/.changeset/tidy-shell-workdirs.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: Preserve the requested working directory for Cloudflare and Runloop shell command lists and stop execution if the directory transition fails.

--- a/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/cloudflare/sandbox.ts
@@ -1364,7 +1364,7 @@ function buildShellCommand(
     assertShellEnvironmentName(key);
     return `export ${key}=${shellQuote(value)}`;
   });
-  return [`cd ${shellQuote(cwd)}`, ...exports, command].join(' && ');
+  return `cd ${shellQuote(cwd)} || exit $?\n${[...exports, command].join(' && ')}`;
 }
 
 function encodeSandboxPath(path: string): string {

--- a/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
+++ b/packages/agents-extensions/src/sandbox/runloop/sandbox.ts
@@ -2754,9 +2754,7 @@ function buildShellCommand(
     assertShellEnvironmentName(key);
     return `export ${key}=${shellQuote(value)}`;
   });
-  const shellCommand = [`cd ${shellQuote(cwd)}`, ...exports, command].join(
-    ' && ',
-  );
+  const shellCommand = `cd ${shellQuote(cwd)} || exit $?\n${[...exports, command].join(' && ')}`;
   return runloopShellCommandForUser(shellCommand, user, userParameters);
 }
 

--- a/packages/agents-extensions/test/sandbox/cloudflare.test.ts
+++ b/packages/agents-extensions/test/sandbox/cloudflare.test.ts
@@ -8,10 +8,17 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ONE_BY_ONE_PNG } from './imageFixture';
-import { CloudflareSandboxClient } from '../../src/sandbox/cloudflare';
+import {
+  CloudflareSandboxClient,
+  CloudflareSandboxSession,
+} from '../../src/sandbox/cloudflare';
 import { CloudflareBucketMountStrategy } from '../../src/sandbox/cloudflare/mounts';
 import { resolvedRemotePathFromValidationCommand } from './remotePathValidation';
 import { makeTarArchive } from './tarFixture';
+import {
+  shellWorkdirCases,
+  withShellWorkdirFixture,
+} from './shellWorkdirFixture';
 
 const originalFetch = global.fetch;
 const originalWebSocket = globalThis.WebSocket;
@@ -291,6 +298,95 @@ describe('CloudflareSandboxClient', () => {
       }),
     );
   });
+
+  describe.skipIf(process.platform === 'win32')(
+    'shell command list workdirs',
+    () => {
+      for (const tty of [false, true]) {
+        for (const directory of [
+          'existing',
+          'missing',
+          'inaccessible',
+        ] as const) {
+          test
+            .skipIf(directory === 'inaccessible' && process.getuid?.() === 0)
+            .each(shellWorkdirCases)(
+            `$name list with ${directory} workdir (tty=${tty})`,
+            async ({ command }) => {
+              await withShellWorkdirFixture(
+                command,
+                directory,
+                async (fixture) => {
+                  const created = await new CloudflareSandboxClient({
+                    apiKey: '',
+                  }).create(
+                    new Manifest({ environment: fixture.environment }),
+                    { workerUrl: 'https://worker.example.com' },
+                  );
+                  // Relocate only the execution fixture; the provider's /workspace does not exist on the test host.
+                  const session = new CloudflareSandboxSession({
+                    state: {
+                      ...created.state,
+                      manifest: new Manifest({ root: fixture.workdir }),
+                    },
+                    apiKey: '',
+                  });
+                  if (!tty) {
+                    global.fetch = vi.fn(async (_input, init) => {
+                      const { argv } = JSON.parse(String(init?.body));
+                      const result = fixture.runShell(argv);
+                      return sseExecResponse([
+                        {
+                          event: 'stdout',
+                          data: Buffer.from(result.stdout).toString('base64'),
+                        },
+                        {
+                          event: 'stderr',
+                          data: Buffer.from(result.stderr).toString('base64'),
+                        },
+                        {
+                          event: 'exit',
+                          data: JSON.stringify({ exit_code: result.exitCode }),
+                        },
+                      ]);
+                    });
+                    return await session.execCommand({
+                      cmd: fixture.cmd,
+                      workdir: fixture.workdir,
+                    });
+                  }
+                  globalThis.WebSocket =
+                    TestWebSocket as unknown as typeof globalThis.WebSocket;
+                  const pending = session.execCommand({
+                    cmd: fixture.cmd,
+                    workdir: fixture.workdir,
+                    tty: true,
+                    yieldTimeMs: 250,
+                  });
+                  const socket = await TestWebSocket.nextInstance();
+                  const sent = socket.nextSend();
+                  socket.open();
+                  socket.message(JSON.stringify({ type: 'ready' }));
+                  const payload = new TextDecoder().decode(
+                    (await sent) as Uint8Array,
+                  );
+                  const result = fixture.runShell(['/bin/sh', '-c', payload]);
+                  socket.message(
+                    new TextEncoder().encode(result.stdout + result.stderr),
+                  );
+                  socket.message(
+                    JSON.stringify({ type: 'exit', code: result.exitCode }),
+                  );
+                  socket.close();
+                  return await pending;
+                },
+              );
+            },
+          );
+        }
+      }
+    },
+  );
 
   test('passes filesystem runAs through worker exec operations', async () => {
     const client = new CloudflareSandboxClient();
@@ -1307,7 +1403,7 @@ describe('CloudflareSandboxClient', () => {
       'wss://worker.example.com/v1/sandbox/cf_test/pty?cols=80&rows=24',
     );
     expect(new TextDecoder().decode(socket.sent[0] as Uint8Array)).toBe(
-      "/bin/sh -c 'cd '\\''/workspace'\\'' && echo ready'\n",
+      "/bin/sh -c 'cd '\\''/workspace'\\'' || exit $?\necho ready'\n",
     );
     expect(new TextDecoder().decode(socket.sent[1] as Uint8Array)).toBe(
       'echo next\n',
@@ -1672,7 +1768,7 @@ describe('CloudflareSandboxClient', () => {
     await startedPromise;
 
     expect(new TextDecoder().decode(socket.sent[0] as Uint8Array)).toBe(
-      "/bin/sh -c 'cd '\\''/workspace/app'\\'' && export NODE_ENV='\\''test'\\'' && npm test'\n",
+      "/bin/sh -c 'cd '\\''/workspace/app'\\'' || exit $?\nexport NODE_ENV='\\''test'\\'' && npm test'\n",
     );
   });
 

--- a/packages/agents-extensions/test/sandbox/runloop.test.ts
+++ b/packages/agents-extensions/test/sandbox/runloop.test.ts
@@ -12,6 +12,7 @@ import { liveMountCredentialAuthorityMatches } from '@openai/agents-core/sandbox
 import {
   RunloopCloudBucketMountStrategy,
   RunloopSandboxClient,
+  RunloopSandboxSession,
   type RunloopUserParameters,
 } from '../../src/sandbox/runloop';
 import { decodeNativeSnapshotRef } from '../../src/sandbox/shared';
@@ -20,6 +21,10 @@ import {
   resolvedRemotePathFromValidationCommand,
 } from './remotePathValidation';
 import { makeTarArchive } from './tarFixture';
+import {
+  shellWorkdirCases,
+  withShellWorkdirFixture,
+} from './shellWorkdirFixture';
 
 const runloopSdkConstructorMock = vi.fn();
 const createMock = vi.fn();
@@ -126,7 +131,8 @@ function runloopRealpathResult(command: string) {
   if (!command.includes('OPENAI_AGENTS_REALPATH_HOME=')) {
     return undefined;
   }
-  const home = command.match(/^cd '([^']+)' && /u)?.[1] ?? RUNLOOP_HOME;
+  const home =
+    command.match(/^cd '([^']+)' \|\| exit \$\?\n/u)?.[1] ?? RUNLOOP_HOME;
   const root = command.match(/mkdir -p -- '([^']+)'/u)?.[1] ?? home;
   return execResult({
     exitCode: 0,
@@ -418,7 +424,7 @@ describe('RunloopSandboxClient', () => {
       path: '/root/README.md',
       file: expect.any(File),
     });
-    expect(execMock).toHaveBeenCalledWith("cd '/root' && ls", {
+    expect(execMock).toHaveBeenCalledWith("cd '/root' || exit $?\nls", {
       last_n: '2000',
     });
     expect(output).toContain('README.md');
@@ -451,7 +457,10 @@ describe('RunloopSandboxClient', () => {
         const realpathResult = runloopRealpathResult(command);
         return realpathResult ?? execResult({ exitCode: 0 });
       }
-      if (command.startsWith("cd '/home/user/project' &&") && !rootCreated) {
+      if (
+        command.startsWith("cd '/home/user/project' || exit $?\n") &&
+        !rootCreated
+      ) {
         return execResult({
           exitCode: 1,
           stderr: 'cd: /home/user/project: No such file or directory',
@@ -589,7 +598,7 @@ describe('RunloopSandboxClient', () => {
 
     await session.execCommand({ cmd: 'ls' });
     expect(execMock).toHaveBeenLastCalledWith(
-      "cd '/home/user' && ls",
+      "cd '/home/user' || exit $?\nls",
       {
         last_n: '2000',
       },
@@ -2067,6 +2076,65 @@ describe('RunloopSandboxClient', () => {
     expect(benchmarkUpdateMock).toHaveBeenCalledWith({ name: 'updated' });
     expect(benchmarkStartRunMock).toHaveBeenCalledWith({ input: 'run' });
   });
+
+  describe.skipIf(process.platform === 'win32')(
+    'shell command list workdirs',
+    () => {
+      for (const runAs of [undefined, 'other-user']) {
+        for (const directory of [
+          'existing',
+          'missing',
+          'inaccessible',
+        ] as const) {
+          test
+            .skipIf(directory === 'inaccessible' && process.getuid?.() === 0)
+            .each(shellWorkdirCases)(
+            `$name list with ${directory} workdir (runAs=${runAs})`,
+            async ({ command }) => {
+              await withShellWorkdirFixture(
+                command,
+                directory,
+                async (fixture) => {
+                  const created = await new RunloopSandboxClient().create(
+                    runloopManifest({ environment: fixture.environment }),
+                  );
+                  // The execution boundary uses a local fixture root because Runloop homes do not exist on the test host.
+                  const session = new RunloopSandboxSession({
+                    state: {
+                      ...created.state,
+                      manifest: new Manifest({ root: fixture.workdir }),
+                    },
+                    sdk: {} as ConstructorParameters<
+                      typeof RunloopSandboxSession
+                    >[0]['sdk'],
+                    devbox: mockRunloopDevbox(),
+                  });
+                  execMock.mockImplementation(async (payload: string) => {
+                    // Stand in for sudo without changing host users; execute the nested shell unchanged.
+                    const sudo = runAs
+                      ? 'sudo() { [ "$1" = -n ] && [ "$2" = -u ] && [ "$3" = other-user ] && [ "$4" = -- ] || exit 99; shift 4; "$@"; };\n'
+                      : '';
+                    if (runAs)
+                      expect(payload).toMatch(
+                        /^sudo -n -u 'other-user' -- sh -lc /,
+                      );
+                    return execResult(
+                      fixture.runShell(['/bin/sh', '-c', sudo + payload]),
+                    );
+                  });
+                  return await session.execCommand({
+                    cmd: fixture.cmd,
+                    workdir: fixture.workdir,
+                    runAs,
+                  });
+                },
+              );
+            },
+          );
+        }
+      }
+    },
+  );
 
   test('rejects unsafe environment names before building shell commands', async () => {
     const client = new RunloopSandboxClient();

--- a/packages/agents-extensions/test/sandbox/shellWorkdirFixture.ts
+++ b/packages/agents-extensions/test/sandbox/shellWorkdirFixture.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from 'node:child_process';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+} from 'node:fs/promises';
+import { join } from 'node:path';
+import { expect } from 'vitest';
+
+export const shellWorkdirCases = [
+  { name: 'semicolon', command: 'pwd > first; pwd > second' },
+  { name: 'newline', command: 'pwd > first\npwd > second' },
+  { name: 'background', command: 'pwd > first & wait; pwd > second' },
+];
+
+// Execute provider wire payloads locally; never contact a sandbox service.
+export async function withShellWorkdirFixture(
+  command: string,
+  directory: 'existing' | 'missing' | 'inaccessible',
+  execute: (fixture: {
+    workdir: string;
+    cmd: string;
+    environment: Record<string, string>;
+    runShell: (argv: string[]) => {
+      exitCode: number;
+      stdout: string;
+      stderr: string;
+    };
+  }) => Promise<string>,
+): Promise<void> {
+  const root = await realpath(
+    await mkdtemp(join(process.cwd(), '.tmp-shell-workdir-')),
+  );
+  const fallback = join(root, 'fallback');
+  const workdir = join(root, "requested ' directory");
+  await mkdir(fallback);
+  if (directory !== 'missing') {
+    await mkdir(workdir);
+  }
+  if (directory === 'inaccessible') {
+    await chmod(workdir, 0);
+  }
+  const value = "literal ' ; $HOME value";
+  try {
+    const output = await execute({
+      workdir,
+      cmd: `printf '%s' "$WORKDIR_TEST" > environment && ${command}\nexit 23`,
+      environment: { WORKDIR_TEST: value },
+      runShell: (argv) => {
+        const result = spawnSync(argv[0], argv.slice(1), {
+          cwd: fallback,
+          env: { PATH: '/usr/bin:/bin', HOME: root },
+          encoding: 'utf8',
+          timeout: 5000,
+        });
+        if (result.error) throw result.error;
+        expect(result.signal).toBeNull();
+        expect(result.status).not.toBeNull();
+        return {
+          exitCode: result.status!,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        };
+      },
+    });
+    expect(await readdir(fallback)).toEqual([]);
+    if (directory === 'existing') {
+      expect(output).toContain('Process exited with code 23');
+      expect(await readFile(join(workdir, 'first'), 'utf8')).toBe(
+        `${workdir}\n`,
+      );
+      expect(await readFile(join(workdir, 'second'), 'utf8')).toBe(
+        `${workdir}\n`,
+      );
+      expect(await readFile(join(workdir, 'environment'), 'utf8')).toBe(value);
+    } else {
+      expect(output).toMatch(/Process exited with code [1-9]\d*/);
+      expect(output).not.toContain('Process exited with code 23');
+      expect(output).toContain('cd:');
+      if (directory === 'inaccessible') {
+        await chmod(workdir, 0o700);
+        expect(await readdir(workdir)).toEqual([]);
+      }
+    }
+  } finally {
+    if (directory === 'inaccessible') await chmod(workdir, 0o700);
+    await rm(root, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
This pull request fixes Cloudflare and Runloop shell command lists executing later segments in the provider's default directory. The directory transition now completes before caller commands run, and a failed transition exits with its original status.

The fix covers Cloudflare PTY and non-PTY execution and Runloop alternate-user commands while preserving existing command text, environment setup, and shell wrappers.