### PR TITLE
fix(extensions): treat blank CODEX_API_KEY as unconfigured

### DIFF
--- a/.changeset/blank-codex-api-key.md
+++ b/.changeset/blank-codex-api-key.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: treat a blank CODEX_API_KEY as unconfigured so OPENAI_API_KEY can be used

--- a/packages/agents-extensions/src/experimental/codex/index.ts
+++ b/packages/agents-extensions/src/experimental/codex/index.ts
@@ -325,7 +325,10 @@ function resolveDefaultCodexApiKey(options?: CodexOptions): string | undefined {
   }
 
   const env = loadEnv();
-  return env.CODEX_API_KEY ?? env.OPENAI_API_KEY;
+  if (env.CODEX_API_KEY) {
+    return env.CODEX_API_KEY;
+  }
+  return env.OPENAI_API_KEY;
 }
 
 function resolveCodexOptions(

--- a/packages/agents-extensions/test/experimental/codex/index.test.ts
+++ b/packages/agents-extensions/test/experimental/codex/index.test.ts
@@ -432,6 +432,43 @@ describe('codexTool', () => {
     expect(options?.apiKey).toBe('openai-key');
   });
 
+  test('defaults Codex api key to OPENAI_API_KEY when CODEX_API_KEY is blank', async () => {
+    process.env.OPENAI_API_KEY = 'openai-key';
+    process.env.CODEX_API_KEY = '';
+
+    codexMockState.events = [
+      { type: 'thread.started', thread_id: 'thread-1' },
+      {
+        type: 'item.completed',
+        item: { id: 'agent-1', type: 'agent_message', text: 'Codex done.' },
+      },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ];
+
+    const tool = codexTool();
+    const runContext = new RunContext();
+
+    await tool.invoke(
+      runContext,
+      JSON.stringify({
+        inputs: [
+          {
+            type: 'text',
+            text: 'Check blank api key.',
+          },
+        ],
+      }),
+    );
+
+    const options = codexConstructorState.options as
+      | { apiKey?: string }
+      | undefined;
+    expect(options?.apiKey).toBe('openai-key');
+  });
+
   test('accepts a Zod output schema descriptor', async () => {
     codexMockState.events = [
       { type: 'thread.started', thread_id: 'thread-1' },


### PR DESCRIPTION
### Summary

`.env` files often contain `CODEX_API_KEY=` (empty). Docs and the `codexOptions.env` override already treat a missing/empty Codex key as “use `OPENAI_API_KEY`”. The process-env path used `??`, so an empty `CODEX_API_KEY` was treated as configured, then dropped, and Codex never received `OPENAI_API_KEY`.

This matches the Python SDK’s `if env_codex:` check: only a non-empty Codex key wins.

### Test plan

- Added a regression test: blank `CODEX_API_KEY` + set `OPENAI_API_KEY` → constructor gets `apiKey: 'openai-key'`.
- `pnpm exec vitest run packages/agents-extensions/test/experimental/codex/index.test.ts` → 36 passed.
- ESLint on the two touched TS files passed.

`pnpm test:review` still fails on this Windows machine in unrelated UnixLocal/Docker suites (`spawn /bin/sh ENOENT`, symlink `EPERM`). The Codex file stays green.

### Issue number

None. Existing-behavior bug; CONTRIBUTING allows a direct PR.

### Checks

- [x] I've added new tests (if relevant)
- [ ] I've added/updated the relevant documentation
- [ ] I've run `pnpm test` and `pnpm test:examples`
  - [ ] (If you made a major change) I've run `pnpm test:integration` [(see details)](https://github.com/openai/openai-agents-js/tree/main/integration-tests)
- [ ] I've run `.agents/skills/code-change-verification/scripts/run.sh`
- [ ] I've confirmed all verification steps pass
- [ ] If using Codex, I've run `/review` before submitting this PR
- [x] I've added a changeset using `pnpm changeset` to indicate my changes
