### PR TITLE
chore(deps): cover the pnpm workspace with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,34 @@
 version: 2
 updates:
+  # The root pnpm workspace includes packages/*, examples/*, and docs.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "09:00"
+      timezone: "UTC"
+    # Match the seven-day ordinary-update policy in pnpm-workspace.yaml.
+    # Dependabot cooldowns do not apply to security updates:
+    # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown
+    cooldown:
+      default-days: 7
+    groups:
+      npm-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
       time: "09:00"
       timezone: "UTC"
+    # Apply the same ordinary-update cooldown to Actions releases.
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
### Summary

Adds monthly npm Dependabot updates for the root pnpm workspace, covering SDK packages, docs, and examples through native workspace discovery. Groups ordinary minor/patch updates while keeping major updates individual.

Applies a seven-day ordinary-update cooldown to npm and GitHub Actions, matching the existing pnpm release-age policy. Security updates remain exempt; current upstream pnpm updater code also bypasses the native release-age gate for security jobs. Existing Actions scheduling and grouping remain intact.

Maintainer security review requested for dependency-update selection and cooldown behavior. pnpm 11 support remains beta upstream; verify the first hosted npm job and generated manifest/lockfile diff after merge.

### Test plan

- Validated YAML against the Dependabot configuration schema.
- Confirmed all 31 root/workspace manifests match shared lockfile importers.
- Checked preservation of Actions scheduling/grouping and version-only minor/patch grouping.
- Passed formatting and `git diff --check`.
- Completed two consecutive clean adversarial review rounds with two independent reviewers per round, including security review.
- Verified security updates are enabled and unpaused through GitHub's read-only API.

### Issue number

None.

### Checks

- [x] Documented cooldown semantics in configuration comments.
- [x] Completed applicable focused validation and independent review.
- [x] Confirmed the submitted diff matches the reviewed content.
- SDK tests, examples, integration tests, the full SDK verification stack, and changesets are not applicable: only Dependabot configuration changes.

<!-- codex-thread: 01a092b4-9291-7780-8ce2-2bbddd6d8258 -->
