### PR TITLE
ci: restrict workflow token permissions

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     steps:
       - name: Resolve PR context
         id: pr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,12 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   changes:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
### Summary

Restricts workflow token permissions to the jobs and API operations that use them. The changeset label job retains `issues: write` and drops redundant `pull-requests: write`; CI grants `pull-requests: read` only to the changed-file job that calls `pulls.listFiles`.

Release, tagging, Pages, and stale-maintenance grants remain intact. This PR changes only workflow permission mappings; repository settings are handled separately. Please include maintainer security review of the token permissions.

### Test plan

- Actionlint v1.7.12 passed for all seven workflows (shellcheck and pyflakes disabled; embedded scripts are unchanged).
- Prettier 3.9.4 and `git diff --check` passed for the changed files.
- Parsed YAML comparison confirmed all non-permission workflow behavior is unchanged and verified the explicit permissions for all 11 jobs.
- Two consecutive clean adversarial/security review rounds, each with two independent fresh-context reviewers.
- GitHub documents `issues: write` as sufficient for the shared [PR-label endpoint](https://docs.github.com/en/rest/issues/labels#set-labels-for-an-issue).

### Checks

- [x] Applicable focused verification passed.
- [x] Independent security/adversarial review completed.
- SDK tests, documentation changes, and changesets are not applicable to these permission-only workflow changes.

<!-- codex-thread: 01a092b4-8890-7331-aabc-b5fef27148bb -->
