### PR TITLE
fix(extensions): keep tar name trimming linear

### DIFF
--- a/.changeset/tidy-tar-string-trimming.md
+++ b/.changeset/tidy-tar-string-trimming.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: preserve tar name trimming with a linear suffix scan.

--- a/packages/agents-extensions/src/sandbox/shared/archive.ts
+++ b/packages/agents-extensions/src/sandbox/shared/archive.ts
@@ -782,7 +782,24 @@ function readTarString(
 }
 
 function trimTarString(value: string): string {
-  return value.replace(/\0.*$/u, '').replace(/\n$/u, '');
+  // Only trim NUL suffixes after the last line terminator, matching the tar
+  // parser's existing dot-without-dotAll behavior without repeated scans.
+  let end = value.length;
+  for (let index = value.length - 1; index >= 0; index -= 1) {
+    const char = value[index];
+    if (
+      char === '\n' ||
+      char === '\r' ||
+      char === '\u2028' ||
+      char === '\u2029'
+    ) {
+      break;
+    }
+    if (char === '\0') {
+      end = index;
+    }
+  }
+  return value.slice(0, end).replace(/\n$/u, '');
 }
 
 function decodeBytes(bytes: Uint8Array): string {

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -2839,6 +2839,26 @@ describe('remote sandbox path helpers', () => {
     ).toThrow(/symlink member not allowed: workspace\/keep\/link/);
   });
 
+  test.each([
+    ['safe/file.txt', 'safe/file.txt'],
+    ['safe/file.txt\0\0', 'safe/file.txt'],
+    ['safe/file.txt\n', 'safe/file.txt'],
+    ['safe/line\nname.txt\0', 'safe/line\nname.txt'],
+    ['safe/line\rname.txt\0', 'safe/line\rname.txt'],
+    ['safe/line\u2028name.txt\0', 'safe/line\u2028name.txt'],
+    ['safe/line\u2029name.txt\0', 'safe/line\u2029name.txt'],
+  ])('preserves GNU long-name trimming for %j', (content, path) => {
+    const archive = makeTarArchive([
+      { name: 'long-name', type: 'L', content },
+      { name: 'fallback.txt', content: 'ok' },
+    ]);
+
+    expect(() => validateWorkspaceTarArchive(archive)).not.toThrow();
+    expect(() =>
+      validateWorkspaceTarArchive(archive, { rejectRelPaths: [path] }),
+    ).toThrow(`archive member overlaps protected path: ${path}`);
+  });
+
   test.each(['path', 'linkpath'])('rejects global PAX %s overrides', (key) => {
     const archive = makeTarArchive([
       {


### PR DESCRIPTION
### Summary

Replaces repeated regular-expression matching in tar-name trimming with a linear suffix scan while preserving NUL and newline handling. Adds regression tests that verify GNU long-name interpretation through archive validation and protected-path checks, plus a patch changeset for `@openai/agents-extensions`.

Maintainer security review is requested for the host-side archive parsing boundary. Public APIs, archive limits, and extraction policy are unchanged.

### Test plan

- Full repository verification passed using local Colima: installation, build, recursive type checks, distribution checks, lint, the test suite, and formatting.
- Focused shared sandbox tests: 147 passed on the rebased head. Four Docker tests passed separately with Colima before rebasing; the final local run skipped those three optional integration cases after the Colima endpoint became unavailable.
- Independent security and implementation reviews passed; two consecutive adversarial-review rounds passed on the unchanged commit.
- Changeset validation and normal commit hooks passed.

### Checks

- [x] Added relevant regression tests.
- [x] Ran `pnpm test` and `pnpm -r build-check`.
- [x] Ran `.agents/skills/code-change-verification/scripts/run.sh` and confirmed all steps pass.
- [x] Completed independent and adversarial reviews.
- [x] Added a patch changeset.
- Documentation and separate live integration checks are not required for this internal change.

<!-- codex-thread: 01a093d6-7329-7240-bdae-934ab59ce25a -->
