### PR TITLE
fix: trim Blaxel S3-compatible bucket prefixes in linear time

### DIFF
--- a/.changeset/tidy-blaxel-bucket-prefix.md
+++ b/.changeset/tidy-blaxel-bucket-prefix.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: trim Blaxel S3-compatible bucket prefixes in linear time while preserving mount targets.

--- a/packages/agents-extensions/src/sandbox/blaxel/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/mounts.ts
@@ -461,9 +461,18 @@ function buildS3FuseMountScript(config: BlaxelCloudBucketMountConfig): string {
           config.sessionToken ? `:${config.sessionToken}` : ''
         }`
       : undefined;
-  const bucket = config.prefix
-    ? `${config.bucket}:/${config.prefix.replace(/^\/+|\/+$/gu, '')}`
-    : config.bucket;
+  let bucket = config.bucket;
+  if (config.prefix) {
+    let start = 0;
+    let end = config.prefix.length;
+    while (start < end && config.prefix[start] === '/') {
+      start++;
+    }
+    while (end > start && config.prefix[end - 1] === '/') {
+      end--;
+    }
+    bucket = `${config.bucket}:/${config.prefix.slice(start, end)}`;
+  }
   const options = [
     'allow_other',
     'nonempty',

--- a/packages/agents-extensions/test/sandbox/blaxel.test.ts
+++ b/packages/agents-extensions/test/sandbox/blaxel.test.ts
@@ -1701,6 +1701,74 @@ describe('BlaxelSandboxClient', () => {
     );
   });
 
+  test.each([
+    { prefix: undefined, bucket: 'agent-logs' },
+    { prefix: '', bucket: 'agent-logs' },
+    { prefix: 'reports/daily', bucket: 'agent-logs:/reports/daily' },
+    { prefix: '///reports/daily///', bucket: 'agent-logs:/reports/daily' },
+    { prefix: '///', bucket: 'agent-logs:/' },
+    { prefix: '/reports//daily/', bucket: 'agent-logs:/reports//daily' },
+    { prefix: '/résumé/ daily /', bucket: 'agent-logs:/résumé/ daily ' },
+  ])('preserves S3 mount prefix $prefix', async ({ prefix, bucket }) => {
+    const client = new BlaxelSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 's3_mount',
+            bucket: 'agent-logs',
+            prefix,
+            mountPath: 'mounted/logs',
+            mountStrategy: new BlaxelCloudBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+
+    const mountCommand = processExecMock.mock.calls
+      .map(([params]) => String(params.command))
+      .find((command) => command.includes('s3fs'));
+    expect(mountCommand).toContain(
+      `s3fs '${bucket}' '/workspace/mounted/logs'`,
+    );
+    await session.close();
+  });
+
+  test.each([
+    {
+      type: 'r2_mount' as const,
+      accountId: 'test-account',
+    },
+    {
+      type: 'gcs_mount' as const,
+      accessId: 'test-access-id',
+      secretAccessKey: 'test-secret-key',
+    },
+  ])('trims prefixes for S3-compatible $type mounts', async (entry) => {
+    const client = new BlaxelSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            ...entry,
+            bucket: 'agent-logs',
+            prefix: '///reports//daily///',
+            mountPath: 'mounted/logs',
+            mountStrategy: new BlaxelCloudBucketMountStrategy(),
+          },
+        },
+      }).withInContainerMountCredentialExposureAcknowledged('mounted/logs'),
+    );
+
+    const mountCommand = processExecMock.mock.calls
+      .map(([params]) => String(params.command))
+      .find((command) => command.includes('s3fs'));
+    expect(mountCommand).toContain(
+      "s3fs 'agent-logs:/reports//daily' '/workspace/mounted/logs'",
+    );
+    await session.close();
+  });
+
   test.each<{
     label: string;
     command: string;


### PR DESCRIPTION
## Summary

Blaxel S3-compatible mounts now trim prefix boundary slashes with a linear scan while preserving the existing mount target. This covers S3, R2, and GCS HMAC mounts, including empty prefixes and interior slashes, without changing public APIs or credential handling.

Adds nine regression cases through public client creation and a patch changeset for `@openai/agents-extensions`.

## Validation

- Full repository verification passed: build, workspace/declaration type checks, lint, formatting, and 6,898 tests across 225 files.
- Docker tests ran against local Colima with a shared temporary directory.
- Independent security and compatibility review completed; two consecutive adversarial-review rounds passed.

Please include maintainer security review of the sandbox mount-command boundary.

<!-- codex-thread: 01a093d6-88cf-7953-94c7-ae5412179711 -->
