### PR TITLE
fix(openai): treat blank OPENAI_WEBSOCKET_BASE_URL as unconfigured

### DIFF
--- a/.changeset/blank-websocket-base-url.md
+++ b/.changeset/blank-websocket-base-url.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-openai': patch
+---
+
+fix: treat a blank OPENAI_WEBSOCKET_BASE_URL as unconfigured so the client base URL can be used

--- a/packages/agents-openai/src/defaults.ts
+++ b/packages/agents-openai/src/defaults.ts
@@ -55,7 +55,8 @@ export function getDefaultOpenAIKey(): string | undefined {
 }
 
 export function getDefaultOpenAIWebSocketBaseURL(): string | undefined {
-  return loadEnv().OPENAI_WEBSOCKET_BASE_URL;
+  const configured = loadEnv().OPENAI_WEBSOCKET_BASE_URL?.trim();
+  return configured ? configured : undefined;
 }
 
 export const HEADERS = {

--- a/packages/agents-openai/test/defaults.test.ts
+++ b/packages/agents-openai/test/defaults.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'vitest';
+import { afterEach, describe, test, expect, vi } from 'vitest';
 import {
   DEFAULT_OPENAI_MODEL,
   setTracingExportApiKey,
@@ -11,8 +11,13 @@ import {
   setDefaultOpenAIClient,
   setDefaultOpenAIKey,
   getDefaultOpenAIKey,
+  getDefaultOpenAIWebSocketBaseURL,
 } from '../src/defaults';
 import OpenAI from 'openai';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('Defaults', () => {
   test('Default OpenAI model is gpt-5.6-luna', () => {
@@ -42,5 +47,18 @@ describe('Defaults', () => {
   test('get/setDefaultOpenAIKey', async () => {
     setDefaultOpenAIKey('foo');
     expect(getDefaultOpenAIKey()).toBe('foo');
+  });
+  test.each(['', '   '])(
+    'treats OPENAI_WEBSOCKET_BASE_URL %j as unconfigured',
+    (value) => {
+      vi.stubEnv('OPENAI_WEBSOCKET_BASE_URL', value);
+      expect(getDefaultOpenAIWebSocketBaseURL()).toBeUndefined();
+    },
+  );
+  test('returns a trimmed OPENAI_WEBSOCKET_BASE_URL when set', () => {
+    vi.stubEnv('OPENAI_WEBSOCKET_BASE_URL', '  wss://proxy.example.test/v1  ');
+    expect(getDefaultOpenAIWebSocketBaseURL()).toBe(
+      'wss://proxy.example.test/v1',
+    );
   });
 });


### PR DESCRIPTION
### Summary

`.env` files often contain `OPENAI_WEBSOCKET_BASE_URL=` (empty). Docs treat a missing websocket URL as “use the OpenAI client base URL”. The env helper returned the empty string, so `new URL(websocketBaseURL ?? client.baseURL)` kept `""` and threw instead of falling back.

This matches the blank-`CODEX_API_KEY` contract: only a non-empty value is configured.

### Test plan

- Added regression tests: blank / whitespace-only `OPENAI_WEBSOCKET_BASE_URL` → `undefined`; a real URL is still returned after trim.
- `pnpm exec vitest run packages/agents-openai/test/defaults.test.ts` — 9 passed.

### Issue number

None. Existing-behavior fix; CONTRIBUTING allows a direct PR.
