### PR TITLE
fix(core): treat blank OPENAI_AGENTS_PYTHON as unconfigured for file I/O

### DIFF
--- a/.changeset/blank-agents-python-fileio.md
+++ b/.changeset/blank-agents-python-fileio.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: treat a blank OPENAI_AGENTS_PYTHON as unconfigured for Unix host file I/O

--- a/packages/agents-core/src/sandbox/sandboxes/shared/unixLocalFiles.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/unixLocalFiles.ts
@@ -46,7 +46,7 @@ function pythonExecutable(mode: LocalFileIOProtection): string | undefined {
       );
     return undefined;
   }
-  const configured = process.env.OPENAI_AGENTS_PYTHON;
+  const configured = process.env.OPENAI_AGENTS_PYTHON?.trim();
   const candidates = configured
     ? isAbsolute(configured)
       ? [configured]

--- a/packages/agents-core/test/sandboxes/unixLocalFiles.test.ts
+++ b/packages/agents-core/test/sandboxes/unixLocalFiles.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UnixLocalFiles } from '../../src/sandbox/sandboxes/shared/unixLocalFiles';
+
+const fsMocks = vi.hoisted(() => ({
+  realpathSync: vi.fn((path: string) => path),
+  accessSync: vi.fn(),
+}));
+
+const childProcessMocks = vi.hoisted(() => ({
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    realpathSync: fsMocks.realpathSync,
+    accessSync: fsMocks.accessSync,
+  };
+});
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawnSync: childProcessMocks.spawnSync,
+  };
+});
+
+const processPlatformDescriptor = Object.getOwnPropertyDescriptor(
+  process,
+  'platform',
+);
+
+function pretendUnixHost() {
+  Object.defineProperty(process, 'platform', {
+    value: 'linux',
+    configurable: true,
+  });
+}
+
+describe('UnixLocalFiles python discovery', () => {
+  beforeEach(() => {
+    pretendUnixHost();
+    childProcessMocks.spawnSync.mockReturnValue({
+      status: 0,
+      error: undefined,
+      stdout: 'ready',
+      stderr: '',
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    childProcessMocks.spawnSync.mockReset();
+    fsMocks.realpathSync.mockClear();
+    fsMocks.accessSync.mockClear();
+    if (processPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', processPlatformDescriptor);
+    }
+  });
+
+  it.each(['', '   '])(
+    'discovers the default python3 when OPENAI_AGENTS_PYTHON is %j',
+    (value) => {
+      vi.stubEnv('OPENAI_AGENTS_PYTHON', value);
+      expect(new UnixLocalFiles().backend).toBe('python');
+      expect(childProcessMocks.spawnSync).toHaveBeenCalled();
+    },
+  );
+
+  it('uses a configured absolute OPENAI_AGENTS_PYTHON after trim', () => {
+    vi.stubEnv('OPENAI_AGENTS_PYTHON', '  /custom/python3  ');
+    expect(new UnixLocalFiles().backend).toBe('python');
+    expect(childProcessMocks.spawnSync).toHaveBeenCalledWith(
+      '/custom/python3',
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it('does not fall back to default discovery for a relative override', () => {
+    vi.stubEnv('OPENAI_AGENTS_PYTHON', './python3');
+    expect(new UnixLocalFiles().backend).toBe('node');
+    expect(childProcessMocks.spawnSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
A whitespace-only .env value was treated as configured, produced no absolute candidates, and skipped the trusted python3 search used for Unix host file protection.