### PR TITLE
fix: log SSE request errors on the server

### DIFF
--- a/examples/mcp/sse-example.ts
+++ b/examples/mcp/sse-example.ts
@@ -64,11 +64,11 @@ async function startLocalSseServer(): Promise<LocalSseServer> {
 
         res.writeHead(404).end('Not found');
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        console.error('Error handling SSE request:', error);
         if (!res.headersSent) {
           res.writeHead(500);
         }
-        res.end(message);
+        res.end('Internal server error');
       }
     },
   );


### PR DESCRIPTION
Caught request errors in the bundled SSE example now go to the server console so developers can inspect the original error while debugging. HTTP clients receive a generic `Internal server error` response, with existing status handling and successful request behavior preserved.

Validation: two clean independent review rounds, focused checks for server diagnostics and client responses, and the full verification stack (6,889 tests across 225 files). This changes only the example; no package release is required.

<!-- codex-thread: 01a093f5-4b72-7ad1-a3b2-ae499421c5f1 -->
