### PR TITLE
fix: use a generic error response in Cloudflare tracing example

### DIFF
--- a/examples/docs/tracing/cloudflareWorkers.ts
+++ b/examples/docs/tracing/cloudflareWorkers.ts
@@ -8,7 +8,7 @@ export default {
       return new Response(`success`);
     } catch (error) {
       console.error(error);
-      return new Response(String(error), { status: 500 });
+      return new Response('Internal Server Error', { status: 500 });
     } finally {
       // make sure to flush any remaining traces before exiting
       ctx.waitUntil(getGlobalTraceProvider().forceFlush());


### PR DESCRIPTION
## Summary

Return a generic `Internal Server Error` response with HTTP 500 in the Cloudflare tracing example. Full exception details remain in server-side `console.error(error)` logs; the success response and `finally` trace flushing are unchanged.

## Validation

- Focused success and documented-use failure fixture passed; the original response fails the generic-body assertion.
- Focused ESLint, Prettier, and whitespace checks passed.
- Independent security and lifecycle review completed; two fresh-context pre-push review rounds completed without blocking findings.
- Local full verification is blocked by the sandbox denying the `tsx` IPC socket during SDK prebuild (`listen EPERM`), including with a worktree-local temporary directory. Documentation typechecking consequently lacks generated SDK declarations. CI must supply the remaining build and test evidence.

Maintainer security review requested for the exception-to-HTTP-response boundary.

<!-- codex-thread: 01a096c7-624e-75e3-98b0-f1be24312ac5 -->
