### PR TITLE
fix: return generic Cloudflare worker errors

### DIFF
--- a/integration-tests/cloudflare-workers/worker.test.ts
+++ b/integration-tests/cloudflare-workers/worker.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { run } from '@openai/agents';
+import worker from './worker/src/index';
+
+const { forceFlush } = vi.hoisted(() => ({ forceFlush: vi.fn() }));
+
+// Stub the SDK boundary to exercise HTTP handling without external services.
+vi.mock('@openai/agents', () => ({
+  Agent: vi.fn(),
+  Runner: vi.fn(),
+  run: vi.fn(),
+  setDefaultOpenAIKey: vi.fn(),
+  withTrace: vi.fn((_name, callback) => callback()),
+  getCurrentTrace: vi.fn(),
+  getGlobalTraceProvider: () => ({ forceFlush }),
+}));
+vi.mock('@openai/agents-extensions/ai-sdk', () => ({ aisdk: vi.fn() }));
+
+describe('Cloudflare worker HTTP responses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    forceFlush.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('keeps exception details in server diagnostics and returns a generic 500', async () => {
+    const error = new Error('Synthetic internal diagnostic');
+    vi.mocked(run).mockRejectedValueOnce(error);
+    const logError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const waitUntil = vi.fn();
+
+    const response = await worker.fetch(
+      new Request('https://worker.example/'),
+      { OPENAI_API_KEY: 'synthetic-test-key' },
+      { waitUntil } as Parameters<typeof worker.fetch>[2],
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.text()).toBe('Internal Server Error');
+    expect(logError).toHaveBeenCalledWith(error);
+    expect(forceFlush).toHaveBeenCalledOnce();
+    expect(waitUntil).toHaveBeenCalledWith(forceFlush.mock.results[0].value);
+  });
+
+  it('preserves successful responses and schedules trace flushing', async () => {
+    vi.mocked(run).mockResolvedValueOnce({
+      finalOutput: 'Hello there!',
+    } as Awaited<ReturnType<typeof run>>);
+    const waitUntil = vi.fn();
+
+    const response = await worker.fetch(
+      new Request('https://worker.example/'),
+      { OPENAI_API_KEY: 'synthetic-test-key' },
+      { waitUntil } as Parameters<typeof worker.fetch>[2],
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('[RESPONSE]Hello there![/RESPONSE]');
+    expect(forceFlush).toHaveBeenCalledOnce();
+    expect(waitUntil).toHaveBeenCalledWith(forceFlush.mock.results[0].value);
+  });
+});

--- a/integration-tests/cloudflare-workers/worker/src/index.ts
+++ b/integration-tests/cloudflare-workers/worker/src/index.ts
@@ -145,7 +145,7 @@ export default {
       });
     } catch (error) {
       console.error(error);
-      return new Response(String(error), { status: 500 });
+      return new Response('Internal Server Error', { status: 500 });
     } finally {
       // make sure to flush any remaining traces before exiting
       ctx.waitUntil(getGlobalTraceProvider().forceFlush());

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -98,6 +98,7 @@ function createProjects(reviewTestProfile: boolean) {
         maxConcurrency: 4,
         include: [
           'helpers/tests/consoleGuard.test.ts',
+          'integration-tests/cloudflare-workers/worker.test.ts',
           'helpers/vitest/codeChangeVerificationPolicy.test.ts',
           'helpers/vitest/reviewTestProfile.test.ts',
           'helpers/vitest/testConcurrency.test.ts',


### PR DESCRIPTION
### Summary

Return a generic HTTP 500 body from the Cloudflare integration worker when request handling fails. Preserve server-side diagnostics, successful responses, and trace flushing.

Add two regression tests through the exported worker handler and include them in the normal test suite, without requiring live API calls or the integration registry.

### Test plan

- The failure-response regression fails against the original implementation and passes with the change; the success control passes in both cases.
- Focused handler tests pass on Vitest 5.
- Full repository verification, including Docker tests with local Colima.
- Independent security/compatibility review and two rounds of fresh-context adversarial review.

### Checks

- [x] Added relevant tests.
- [x] Reviewed documentation requirements: no documentation changes needed for this private test fixture.
- [x] Ran the required install, build, type, declaration, lint, test, and format checks.
- [x] Completed independent review before submission.
- Changeset and live integration runs are not applicable: no published packages changed.

Maintainer review requested for the worker's error-response boundary.

<!-- codex-thread: 01a09354-b2e6-7753-9a5c-de8d0319230b -->
