### PR TITLE
fix(sandbox): trim local workspace logical paths in linear time

### DIFF
--- a/.changeset/linear-local-workspace-paths.md
+++ b/.changeset/linear-local-workspace-paths.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-core': patch
+---
+
+fix: Trim local workspace logical path separators in linear time.

--- a/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
+++ b/packages/agents-core/src/sandbox/sandboxes/shared/localWorkspace.ts
@@ -1270,7 +1270,11 @@ function joinLogicalPath(parent: string, child: string): string {
   if (!parent || parent === '.') {
     return normalizedChild;
   }
-  return `${parent.replace(/\/+$/u, '')}/${normalizedChild}`;
+  let parentEnd = parent.length;
+  while (parentEnd > 0 && parent[parentEnd - 1] === '/') {
+    parentEnd--;
+  }
+  return `${parent.slice(0, parentEnd)}/${normalizedChild}`;
 }
 
 async function applyEntryPermissions(

--- a/packages/agents-core/test/sandboxes/localWorkspace.logicalPath.test.ts
+++ b/packages/agents-core/test/sandboxes/localWorkspace.logicalPath.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Manifest, UnixLocalSandboxSession } from '../../src/sandbox/local';
+import { materializeLocalWorkspaceManifestEntry } from '../../src/sandbox/sandboxes/shared/localWorkspace';
+
+describe('local workspace logical paths', () => {
+  // Inspect diagnostics at the materialization boundary because public session
+  // paths are normalized before they reach the recursive materializer.
+  it.each([
+    ['', 'leaf.txt'],
+    ['.', 'leaf.txt'],
+    ['parent', 'parent/leaf.txt'],
+    ['parent/', 'parent/leaf.txt'],
+    ['parent//nested///', 'parent//nested/leaf.txt'],
+    ['parent/\n', 'parent/\n/leaf.txt'],
+  ])('preserves child diagnostics under %j', async (parent, expectedPath) => {
+    await expect(
+      materializeLocalWorkspaceManifestEntry('/unused', parent, {
+        type: 'dir',
+        children: {
+          './leaf.txt/': {
+            type: 'file',
+            content: '',
+            group: { name: 'unsupported-group' },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      `Local sandbox materialization does not support sandbox entry group ownership yet: ${expectedPath}`,
+    );
+  });
+
+  it('materializes nested files through a session with normalized paths', async () => {
+    const workspaceRootPath = await mkdtemp(
+      join(tmpdir(), 'logical-path-test-'),
+    );
+    const session = new UnixLocalSandboxSession({
+      state: {
+        manifest: new Manifest(),
+        workspaceRootPath,
+        workspaceRootOwned: false,
+        environment: {},
+      },
+    });
+    try {
+      await session.materializeEntry({
+        path: 'parent//nested/',
+        entry: {
+          type: 'dir',
+          children: {
+            './leaf.txt/': { type: 'file', content: 'hello' },
+          },
+        },
+      });
+      expect(
+        await readFile(
+          join(workspaceRootPath, 'parent/nested/leaf.txt'),
+          'utf8',
+        ),
+      ).toBe('hello');
+    } finally {
+      await session.close();
+      await rm(workspaceRootPath, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Summary

Improve the worst-case cost of joining local workspace logical paths while preserving the resulting paths.

The previous trailing-slash regex, `/\/+$/u`, can retry a match at successive starting positions in a slash run that is followed by another path component. For a run of `k` slashes, a backtracking matcher can repeat roughly `k + (k - 1) + ... + 1` work: quadratic growth.

The replacement starts at the end of the parent path and moves its cursor backward exactly once per trailing slash. It stops at the first non-slash character, then slices once. Each trailing character is examined at most once; including string construction, the operation is linear in path length. The improvement is this bound on repeated work, rather than replacing regex syntax with a loop. Child normalization, internal separators, empty/dot parents, and diagnostic paths are preserved.

This is a bounded performance improvement; it does not assert that the previous worst case was reachable by an untrusted caller.

### Test plan

- 65 focused tests passed, including exact diagnostic paths and public-session nested file materialization.
- `pnpm lint`, `pnpm format:check:changed`, and changeset validation passed.
- Independent security and compatibility reviews completed.
- Local full verification was attempted, but `pnpm build` stopped when the sandbox denied the `tsx` metadata generator's local IPC socket (`listen EPERM`). CI subsequently passed build, declaration checks, example compilation, and tests on Node 22 and 24.3, plus Windows sandbox-path tests and all CodeQL checks. Coverage passed 6,912 tests across 226 files.
- The changeset content check passed. The base workflow now grants the pull-request write permission needed for automated label synchronization.

### Checks

- [x] Added focused tests and a patch changeset for `@openai/agents-core`.
- [x] Existing user-facing documentation remains accurate; no documentation change needed.
- [x] Independent reviews completed before submission.
- [x] Ran the full verification wrapper and recorded its environment blocker above.
- [x] Build, full type checks, and full test suite pass in CI.
- [x] The separate label-sync workflow permission fix has landed on `main`.

<!-- codex-thread: 01a096c9-6f33-7093-9a42-eb6f2db07fb9 -->

