### PR TITLE
fix: trim Blaxel GCS mount prefixes in linear time

### DIFF
--- a/.changeset/tidy-gcs-prefix.md
+++ b/.changeset/tidy-gcs-prefix.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: trim Blaxel GCS mount prefixes in linear time while preserving mount behavior.

--- a/packages/agents-extensions/src/sandbox/blaxel/mounts.ts
+++ b/packages/agents-extensions/src/sandbox/blaxel/mounts.ts
@@ -526,10 +526,18 @@ function buildGcsFuseMountScript(config: BlaxelCloudBucketMountConfig): string {
           ? [`--token-url=${tokenUrl}`]
           : ['--anonymous-access']),
     ...(config.readOnly ? ['-o', 'ro'] : []),
-    ...(config.prefix
-      ? [`--only-dir=${config.prefix.replace(/^\/+|\/+$/gu, '')}`]
-      : []),
   ];
+  if (config.prefix) {
+    let start = 0;
+    let end = config.prefix.length;
+    while (start < end && config.prefix[start] === '/') {
+      start++;
+    }
+    while (end > start && config.prefix[end - 1] === '/') {
+      end--;
+    }
+    options.push(`--only-dir=${config.prefix.slice(start, end)}`);
+  }
   const command = [
     ensureBlaxelToolCommand('gcsfuse'),
     `mkdir -p -- ${shellQuote(config.mountPath)}`,

--- a/packages/agents-extensions/test/sandbox/blaxel.test.ts
+++ b/packages/agents-extensions/test/sandbox/blaxel.test.ts
@@ -1769,6 +1769,43 @@ describe('BlaxelSandboxClient', () => {
     await session.close();
   });
 
+  test.each([
+    { prefix: undefined, onlyDir: undefined },
+    { prefix: '', onlyDir: undefined },
+    { prefix: 'reports/daily', onlyDir: 'reports/daily' },
+    { prefix: '///reports/daily///', onlyDir: 'reports/daily' },
+    { prefix: '///', onlyDir: '' },
+    { prefix: '/reports//daily/', onlyDir: 'reports//daily' },
+    { prefix: '/résumé/ daily /', onlyDir: 'résumé/ daily ' },
+  ])('preserves GCS mount prefix $prefix', async ({ prefix, onlyDir }) => {
+    const client = new BlaxelSandboxClient();
+    const session = await client.create(
+      new Manifest({
+        entries: {
+          data: {
+            type: 'gcs_mount',
+            bucket: 'agent-logs',
+            prefix,
+            mountPath: 'mounted/logs',
+            mountStrategy: new BlaxelCloudBucketMountStrategy(),
+          },
+        },
+      }),
+    );
+
+    const mountCommand = processExecMock.mock.calls
+      .map(([params]) => String(params.command))
+      .find((command) => command.includes("'--anonymous-access'"));
+    expect(mountCommand).toContain('gcsfuse');
+    if (onlyDir === undefined) {
+      expect(mountCommand).not.toContain('--only-dir=');
+    } else {
+      expect(mountCommand).toContain(`'--only-dir=${onlyDir}'`);
+    }
+    expect(mountCommand).toContain("'agent-logs' '/workspace/mounted/logs'");
+    await session.close();
+  });
+
   test.each<{
     label: string;
     command: string;


### PR DESCRIPTION
### Summary

Trim Blaxel GCS mount prefixes with a linear boundary scan while preserving the generated `--only-dir` argument. Add caller-level coverage for omitted, empty, slash-only, internal-slash, Unicode, and whitespace prefixes, plus an extensions patch changeset.

### Test plan

- Full install, build, type, distribution, lint, test, and formatting stack passed locally: 6,912 tests across 225 files.
- Docker tests used the existing local Colima daemon and a temporary directory shared with that daemon.
- Two consecutive review rounds, each with two independent reviewers, were clean; reviews covered compatibility, performance, and command safety.

### Checks

- [x] Added regression tests and a patch changeset.
- [x] Completed `pnpm test`, `pnpm -r build-check`, and the full verification script.
- [x] Completed independent review before submission.
- Documentation and public APIs are unchanged.

Maintainer review requested for the GCS mount command construction; argument quoting and credential lifecycle are unchanged.

<!-- codex-thread: 01a096c8-f3d5-7962-985d-43bc7ce5d571 -->
