### PR TITLE
fix(extensions): trim sandbox metadata paths and in-container mount prefixes in linear time

### DIFF
--- a/.changeset/linear-sandbox-extensions-paths.md
+++ b/.changeset/linear-sandbox-extensions-paths.md
@@ -1,0 +1,5 @@
+---
+'@openai/agents-extensions': patch
+---
+
+fix: trim sandbox metadata paths and in-container mount prefixes in linear time

--- a/packages/agents-extensions/src/sandbox/shared/inContainerMounts.ts
+++ b/packages/agents-extensions/src/sandbox/shared/inContainerMounts.ts
@@ -1313,7 +1313,18 @@ function joinShellArgs(args: string[]): string {
 }
 
 function joinRemotePath(base: string, prefix: string | undefined): string {
-  const normalizedPrefix = prefix?.replace(/^\/+|\/+$/gu, '');
+  let normalizedPrefix = prefix;
+  if (normalizedPrefix) {
+    let start = 0;
+    let end = normalizedPrefix.length;
+    while (start < end && normalizedPrefix[start] === '/') {
+      start++;
+    }
+    while (end > start && normalizedPrefix[end - 1] === '/') {
+      end--;
+    }
+    normalizedPrefix = normalizedPrefix.slice(start, end);
+  }
   return normalizedPrefix ? `${base}/${normalizedPrefix}` : base;
 }
 
@@ -1494,5 +1505,12 @@ function sanitizeRemoteName(value: string): string {
 }
 
 function normalizeBoxRemotePath(path: string | undefined): string {
-  return path?.replace(/^\/+/gu, '') ?? '';
+  if (!path) {
+    return '';
+  }
+  let start = 0;
+  while (start < path.length && path[start] === '/') {
+    start++;
+  }
+  return path.slice(start);
 }

--- a/packages/agents-extensions/src/sandbox/shared/metadata.ts
+++ b/packages/agents-extensions/src/sandbox/shared/metadata.ts
@@ -135,5 +135,9 @@ function joinSandboxPath(parent: string, child: string): string {
   if (!parent || parent === '.') {
     return normalizedChild;
   }
-  return `${parent.replace(/\/+$/u, '')}/${normalizedChild}`;
+  let parentEnd = parent.length;
+  while (parentEnd > 0 && parent[parentEnd - 1] === '/') {
+    parentEnd--;
+  }
+  return `${parent.slice(0, parentEnd)}/${normalizedChild}`;
 }

--- a/packages/agents-extensions/test/sandbox/shared.test.ts
+++ b/packages/agents-extensions/test/sandbox/shared.test.ts
@@ -5035,6 +5035,33 @@ describe('remote sandbox path helpers', () => {
     ).toThrowError(SandboxUnsupportedFeatureError);
   });
 
+  test.each([
+    ['', 'run.sh'],
+    ['.', 'run.sh'],
+    ['parent', 'parent/run.sh'],
+    ['parent/', 'parent/run.sh'],
+    ['parent///', 'parent/run.sh'],
+    ['parent//nested///', 'parent//nested/run.sh'],
+  ])(
+    'preserves child diagnostic path under parent %j in linear time',
+    (parent, expectedPath) => {
+      expect(() =>
+        assertSandboxEntryMetadataSupported('Provider', parent, {
+          type: 'dir',
+          children: {
+            'run.sh': {
+              type: 'file',
+              content: '#!/bin/sh\n',
+              group: { name: 'sandbox-group' },
+            },
+          },
+        }),
+      ).toThrowError(
+        `Provider does not support sandbox entry group ownership yet: ${expectedPath}`,
+      );
+    },
+  );
+
   test('guards unsupported mount entries for remote providers', () => {
     expect(() =>
       assertSandboxEntryMetadataSupported(


### PR DESCRIPTION
### Summary

Trim sandbox metadata parent paths and in-container mount prefixes with linear boundary scans while preserving path normalization and mount target behavior.

The previous trailing-slash regex in \joinSandboxPath\ (\parent.replace(/\/+$/u, '')\) and prefix trimming regexes in \joinRemotePath\ / ormalizeBoxRemotePath\ can backtrack quadratically on runs of slashes. This replaces those regexes with linear-time boundary scans (moving index forward/backward and slicing once), matching similar linear-time bounds introduced in #1888, #1889, #1898, and #1899.

### Test plan

- Added regression tests in \packages/agents-extensions/test/sandbox/shared.test.ts\ verifying \joinSandboxPath\ path normalization under parents with empty strings, dots, single trailing slashes, multiple trailing slashes, and nested segments.
- Verified test suite passes: px vitest run packages/agents-extensions/test/sandbox/shared.test.ts -t 'in linear time'\ (6 passed).
- Verified formatting and lint: \prettier --check\ and \slint\ passed.
- Added patch changeset for \@openai/agents-extensions\.

Note: The changeset validation check passed (\Package changes detected with 1 changeset file(s)\). The later label-sync step returns 403 on fork PRs due to workflow token permissions, matching the known behavior on #1890 and #1898.

### Checks

- [x] I've added new tests (if relevant)
- [x] I've added a changeset using \pnpm changeset\ to indicate my changes
